### PR TITLE
feat: use 7za to produce Squirrel.mac zip (smaller size — the same ti…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.ico filter=lfs diff=lfs merge=lfs -text
 *.icns filter=lfs diff=lfs merge=lfs -text
+vendor/**/* filter=lfs diff=lfs merge=lfs -text

--- a/docs/options.md
+++ b/docs/options.md
@@ -4,9 +4,6 @@ In the development `package.json` custom `build` field can be specified to custo
 ```json
 "build": {
   "osx": {
-    "icon": "build/icon.icns",
-    "icon-size": 80,
-    "background": "build/background.png",
     "contents": [
       {
         "x": 410,
@@ -26,42 +23,62 @@ In the development `package.json` custom `build` field can be specified to custo
 ```
 
 As you can see, you need to customize OS X options only if you want to provide custom `x, y`.
-Don't customize paths to background and icon, — just follow conventions (if you don't want to use `build` as directory of resources — please create issue to ask ability to customize it).
+Don't customize paths to background and icon, — just follow conventions.
 
 Here documented only `electron-builder` specific options:
 
 <!-- do not edit. start of generated block -->
 
-<a name="#AppMetadata"></a>
+<a name="AppMetadata"></a>
 # Application `package.json`
 | Name | Description
 | --- | ---
-| <a name="#AppMetadata-name"></a>name | The application name.
-| <a name="#AppMetadata-productName"></a>productName | <p>As [name](#AppMetadata-name), but allows you to specify a product name for your executable which contains spaces and other special characters not allowed in the [name property](https://docs.npmjs.com/files/package.json#name}).</p>
+| name | <a name="AppMetadata-name"></a>The application name.
+| productName | <a name="AppMetadata-productName"></a><p>As [name](#AppMetadata-name), but allows you to specify a product name for your executable which contains spaces and other special characters not allowed in the [name property](https://docs.npmjs.com/files/package.json#name}).</p>
 
-<a name="#DevMetadata"></a>
+<a name="DevMetadata"></a>
 # Development `package.json`
 | Name | Description
 | --- | ---
-| <a name="#DevMetadata-homepage"></a>homepage | <p>The url to the project [homepage](https://docs.npmjs.com/files/package.json#homepage) (NuGet Package <code>projectUrl</code> (optional) or Linux Package URL (required)).</p> <p>If not specified and your project repository is public on GitHub, it will be <code>https://github.com/${user}/${project}</code> by default.</p>
-| <a name="#DevMetadata-license"></a>license | *linux-only.* The [license](https://docs.npmjs.com/files/package.json#license) name for this package.
-| <a name="#DevMetadata-build"></a>build | See [.build](#BuildMetadata).
+| homepage | <a name="DevMetadata-homepage"></a><p>The url to the project [homepage](https://docs.npmjs.com/files/package.json#homepage) (NuGet Package <code>projectUrl</code> (optional) or Linux Package URL (required)).</p> <p>If not specified and your project repository is public on GitHub, it will be <code>https://github.com/${user}/${project}</code> by default.</p>
+| license | <a name="DevMetadata-license"></a>*linux-only.* The [license](https://docs.npmjs.com/files/package.json#license) name for this package.
+| build | <a name="DevMetadata-build"></a>See [.build](#BuildMetadata).
+| directories | <a name="DevMetadata-directories"></a>See [.directories](#MetadataDirectories)
 
-<a name="#BuildMetadata"></a>
+<a name="BuildMetadata"></a>
 ## `.build`
 | Name | Description
 | --- | ---
-| <a name="#BuildMetadata-iconUrl"></a>iconUrl | <p>*windows-only.* A URL to an ICO file to use as the application icon (displayed in Control Panel &gt; Programs and Features). Defaults to the Atom icon.</p> <p>Please note — [local icon file url is not accepted](https://github.com/atom/grunt-electron-installer/issues/73), must be https/http.</p> <ul> <li>If you don’t plan to build windows installer, you can omit it.</li> <li>If your project repository is public on GitHub, it will be <code>https://raw.githubusercontent.com/${user}/${project}/master/build/icon.ico</code> by default.</li> </ul>
-| <a name="#BuildMetadata-productName"></a>productName | See [AppMetadata.productName](#AppMetadata-productName).
-| <a name="#BuildMetadata-extraResources"></a>extraResources | <p>A [glob expression](https://www.npmjs.com/package/glob#glob-primer), when specified, copy the file or directory with matching names directly into the app’s directory (<code>Contents/Resources</code> for OS X).</p> <p>You can use <code>${os}</code> (expanded to osx, linux or win according to current platform) and <code>${arch}</code> in the pattern.</p> <p>If directory matched, all contents are copied. So, you can just specify <code>foo</code> to copy <code>&lt;project_dir&gt;/foo</code> directory.</p> <p>May be specified in the platform options (i.e. in the <code>build.osx</code>).</p>
-| <a name="#BuildMetadata-osx"></a>osx | See [OS X options](https://www.npmjs.com/package/appdmg#json-specification)
-| <a name="#BuildMetadata-win"></a>win | See [windows-installer options](https://github.com/electronjs/windows-installer#usage)
-| <a name="#BuildMetadata-linux"></a>linux | See [.linux](#DebOptions).
+| app-bundle-id | <a name="BuildMetadata-app-bundle-id"></a>The bundle identifier to use in the application's plist.
+| app-category-type | <a name="BuildMetadata-app-category-type"></a><p>The application category type, as shown in the Finder via *View -&gt; Arrange by Application Category* when viewing the Applications directory.</p> <p>For example, <code>app-category-type=public.app-category.developer-tools</code> will set the application category to *Developer Tools*.</p> <p>Valid values are listed in [Apple’s documentation](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW8).</p>
+| iconUrl | <a name="BuildMetadata-iconUrl"></a><p>*windows-only.* A URL to an ICO file to use as the application icon (displayed in Control Panel &gt; Programs and Features). Defaults to the Atom icon.</p> <p>Please note — [local icon file url is not accepted](https://github.com/atom/grunt-electron-installer/issues/73), must be https/http.</p> <ul> <li>If you don’t plan to build windows installer, you can omit it.</li> <li>If your project repository is public on GitHub, it will be <code>https://raw.githubusercontent.com/${user}/${project}/master/build/icon.ico</code> by default.</li> </ul>
+| productName | <a name="BuildMetadata-productName"></a>See [AppMetadata.productName](#AppMetadata-productName).
+| extraResources | <a name="BuildMetadata-extraResources"></a><p>A [glob expression](https://www.npmjs.com/package/glob#glob-primer), when specified, copy the file or directory with matching names directly into the app’s directory (<code>Contents/Resources</code> for OS X).</p> <p>You can use <code>${os}</code> (expanded to osx, linux or win according to current platform) and <code>${arch}</code> in the pattern.</p> <p>If directory matched, all contents are copied. So, you can just specify <code>foo</code> to copy <code>&lt;project_dir&gt;/foo</code> directory.</p> <p>May be specified in the platform options (i.e. in the <code>build.osx</code>).</p>
+| osx | <a name="BuildMetadata-osx"></a>See [.build.osx](#OsXBuildOptions).
+| win | <a name="BuildMetadata-win"></a>See [windows-installer options](https://github.com/electronjs/windows-installer#usage).
+| linux | <a name="BuildMetadata-linux"></a>See [.build.linux](#LinuxBuildOptions).
+| compression | <a name="BuildMetadata-compression"></a>The compression level, one of `store`, `normal`, `maximum` (default: `normal`). If you want to rapidly test build, `store` can reduce build time significantly.
 
-<a name="#DebOptions"></a>
+<a name="OsXBuildOptions"></a>
+### `.build.osx`
+
+See all [appdmg options](https://www.npmjs.com/package/appdmg#json-specification).
+
+| Name | Description
+| --- | ---
+| icon | <a name="OsXBuildOptions-icon"></a>The path to icon, which will be shown when mounted (default: `build/icon.icns`).
+| background | <a name="OsXBuildOptions-background"></a>The path to background (default: `build/background.png`).
+
+<a name="LinuxBuildOptions"></a>
 ### `.build.linux`
 | Name | Description
 | --- | ---
-| <a name="#DebOptions-compression"></a>compression | *deb-only.* The compression type to use, must be one of gz, bzip2, xz. (default: `xz`)
+| compression | <a name="LinuxBuildOptions-compression"></a>*deb-only.* The compression type, one of `gz`, `bzip2`, `xz`. (default: `xz`).
+
+<a name="MetadataDirectories"></a>
+## `.directories`
+| Name | Description
+| --- | ---
+| buildResources | <a name="MetadataDirectories-buildResources"></a>The path to build resources, default `build`.
 
 <!-- end of generated block -->

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "out/index.js",
   "files": [
     "out",
-    "templates"
+    "templates",
+    "vendor"
   ],
   "bin": {
     "build": "./out/build-cli.js",
@@ -55,14 +56,14 @@
     "bluebird": "^3.3.4",
     "command-line-args": "^2.1.6",
     "electron-packager": "^6.0.0",
-    "electron-winstaller-fixed": "^2.0.6-beta.6",
+    "electron-winstaller-fixed": "^2.0.6-beta.7",
     "fs-extra": "^0.26.7",
     "fs-extra-p": "^0.2.0",
     "globby": "^4.0.0",
     "gm": "^1.21.1",
     "hosted-git-info": "^2.1.4",
     "image-size": "^0.5.0",
-    "lodash.template": "^4.2.3",
+    "lodash.template": "^4.2.4",
     "mime": "^1.3.4",
     "progress": "^1.1.8",
     "progress-stream": "^1.2.0",
@@ -79,17 +80,17 @@
     "babel-plugin-transform-es2015-parameters": "^6.7.0",
     "babel-plugin-transform-es2015-spread": "^6.6.5",
     "decompress-zip": "^0.3.0",
-    "electron-download": "^2.1.0",
+    "electron-download": "^2.1.1",
     "json-parse-helpfulerror": "^1.0.3",
     "path-sort": "^0.1.0",
     "plist": "^1.2.0",
     "pre-commit": "^1.1.2",
     "semantic-release": "^4.3.5",
     "should": "^8.3.0",
-    "ts-babel": "^0.6.8",
+    "ts-babel": "^0.6.9",
     "tsconfig-glob": "^0.4.3",
     "tslint": "next",
-    "typescript": "^1.9.0-dev.20160402",
+    "typescript": "^1.9.0-dev.20160405",
     "validate-commit-msg": "^2.5.0"
   },
   "babel": {
@@ -109,5 +110,8 @@
   "typings": "./out/electron-builder.d.ts",
   "precommit": [
     "validate-commit-msg"
-  ]
+  ],
+  "publishConfig": {
+    "tag": "next"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Packager } from "./packager"
 export { PackagerOptions, ArtifactCreated } from "./platformPackager"
 export { BuildOptions, build, createPublisher } from "./builder"
-export { AppMetadata, DevMetadata, Platform, getProductName, BuildMetadata, DebOptions } from "./metadata"
+export { AppMetadata, DevMetadata, Platform, getProductName, BuildMetadata, OsXBuildOptions, LinuxBuildOptions } from "./metadata"

--- a/src/linuxPackager.ts
+++ b/src/linuxPackager.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import { Promise as BluebirdPromise } from "bluebird"
 import { PlatformPackager, BuildInfo } from "./platformPackager"
-import { Platform, DebOptions } from "./metadata"
+import { Platform, LinuxBuildOptions } from "./metadata"
 import { dir as _tpmDir, TmpOptions } from "tmp"
 import { exec, log } from "./util"
 import { outputFile, readFile, readdir } from "fs-extra-p"
@@ -13,8 +13,8 @@ const __awaiter = require("./awaiter")
 
 const tmpDir = BluebirdPromise.promisify(<(config: TmpOptions, callback: (error: Error, path: string, cleanupCallback: () => void) => void) => void>_tpmDir)
 
-export class LinuxPackager extends PlatformPackager<DebOptions> {
-  private readonly debOptions: DebOptions
+export class LinuxPackager extends PlatformPackager<LinuxBuildOptions> {
+  private readonly debOptions: LinuxBuildOptions
 
   private readonly packageFiles: Promise<Array<string>>
   private readonly scriptFiles: Promise<Array<string>>
@@ -167,7 +167,7 @@ Icon=${this.metadata.name}
       .then(it => this.dispatchArtifactCreated(it))
   }
 
-  private async buildDeb(options: DebOptions, outDir: string, appOutDir: string, arch: string): Promise<string> {
+  private async buildDeb(options: LinuxBuildOptions, outDir: string, appOutDir: string, arch: string): Promise<string> {
     const archName = arch === "ia32" ? "i386" : "amd64"
     const target = "deb"
     const destination = path.join(outDir, `${this.metadata.name}-${this.metadata.version}-${archName}.${target}`)
@@ -191,7 +191,7 @@ Icon=${this.metadata.name}
       "--maintainer", options.maintainer || `${this.metadata.author.name} <${this.metadata.author.email}>`,
       "--version", this.metadata.version,
       "--package", destination,
-      "--deb-compression", options.compression || "xz",
+      "--deb-compression", options.compression || (this.devMetadata.build.compression === "store" ? "gz" : "xz"),
       "--url", projectUrl,
     ]
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -2,18 +2,18 @@ export interface Metadata {
   readonly repository: string | RepositoryInfo
 }
 
-/**
+/*
  # Application `package.json`
  */
 export interface AppMetadata extends Metadata {
   readonly version: string
 
-  /**
+  /*
    The application name.
    */
   readonly name: string
 
-  /**
+  /*
    As [name](#AppMetadata-name), but allows you to specify a product name for your executable which contains spaces and other special characters
    not allowed in the [name property](https://docs.npmjs.com/files/package.json#name}).
    */
@@ -24,27 +24,30 @@ export interface AppMetadata extends Metadata {
   readonly author: AuthorMetadata
 }
 
-/**
+/*
  # Development `package.json`
  */
 export interface DevMetadata extends Metadata {
-  /**
+  /*
    The url to the project [homepage](https://docs.npmjs.com/files/package.json#homepage) (NuGet Package `projectUrl` (optional) or Linux Package URL (required)).
 
    If not specified and your project repository is public on GitHub, it will be `https://github.com/${user}/${project}` by default.
    */
   readonly homepage?: string
 
-  /**
+  /*
    *linux-only.* The [license](https://docs.npmjs.com/files/package.json#license) name for this package.
    */
   readonly license?: string
 
-  /**
+  /*
    See [.build](#BuildMetadata).
    */
-  readonly build?: BuildMetadata
+  readonly build: BuildMetadata
 
+  /*
+   See [.directories](#MetadataDirectories)
+   */
   readonly directories?: MetadataDirectories
 }
 
@@ -57,18 +60,24 @@ export interface AuthorMetadata {
   readonly email: string
 }
 
-export interface MetadataDirectories {
-  readonly buildResources?: string
-}
-
-/**
+/*
  ## `.build`
  */
 export interface BuildMetadata {
+  /*
+   The bundle identifier to use in the application's plist.
+   */
   readonly "app-bundle-id": string
+  /*
+   The application category type, as shown in the Finder via *View -> Arrange by Application Category* when viewing the Applications directory.
+
+   For example, `app-category-type=public.app-category.developer-tools` will set the application category to *Developer Tools*.
+
+   Valid values are listed in [Apple's documentation](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW8).
+   */
   readonly "app-category-type": string
 
-  /**
+  /*
    *windows-only.* A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Atom icon.
 
    Please note — [local icon file url is not accepted](https://github.com/atom/grunt-electron-installer/issues/73), must be https/http.
@@ -78,7 +87,7 @@ export interface BuildMetadata {
    */
   readonly iconUrl: string
 
-  /**
+  /*
    See [AppMetadata.productName](#AppMetadata-productName).
    */
   readonly productName?: string
@@ -94,26 +103,48 @@ export interface BuildMetadata {
    */
   readonly extraResources?: Array<string>
 
-  /**
-   See [OS X options](https://www.npmjs.com/package/appdmg#json-specification)
+  /*
+   See [.build.osx](#OsXBuildOptions).
    */
-  readonly osx?: appdmg.Specification
+  readonly osx?: OsXBuildOptions
 
   /**
-   See [windows-installer options](https://github.com/electronjs/windows-installer#usage)
+   See [windows-installer options](https://github.com/electronjs/windows-installer#usage).
    */
   readonly win?: any,
 
-  /**
-   See [.linux](#DebOptions).
+  /*
+   See [.build.linux](#LinuxBuildOptions).
    */
-  readonly linux?: any
+  readonly linux?: LinuxBuildOptions
+
+  /*
+   The compression level, one of `store`, `normal`, `maximum` (default: `normal`). If you want to rapidly test build, `store` can reduce build time significantly.
+   */
+  readonly compression?: "store" | "normal" | "maximum"
 }
 
-/**
+/*
+ ### `.build.osx`
+
+ See all [appdmg options](https://www.npmjs.com/package/appdmg#json-specification).
+ */
+export interface OsXBuildOptions extends PlatformSpecificBuildOptions {
+  /*
+   The path to icon, which will be shown when mounted (default: `build/icon.icns`).
+   */
+  icon?: string
+
+  /*
+   The path to background (default: `build/background.png`).
+   */
+  background?: string
+}
+
+/*
  ### `.build.linux`
  */
-export interface DebOptions {
+export interface LinuxBuildOptions {
   name: string
   comment: string
 
@@ -126,9 +157,19 @@ export interface DebOptions {
   afterRemove?: string
 
   /*
-  *deb-only.* The compression type to use, must be one of gz, bzip2, xz. (default: `xz`)
+  *deb-only.* The compression type, one of `gz`, `bzip2`, `xz`. (default: `xz`).
    */
   readonly compression?: string
+}
+
+/*
+ ## `.directories`
+ */
+export interface MetadataDirectories {
+  /*
+   The path to build resources, default `build`.
+   */
+  readonly buildResources?: string
 }
 
 export interface PlatformSpecificBuildOptions {

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -148,7 +148,7 @@ export class Packager implements BuildInfo {
     else if (appMetadata.version == null) {
       reportError("version")
     }
-    else if (appMetadata !== this.devMetadata && (<any>appMetadata).build != null) {
+    else if ((<any>appMetadata) !== this.devMetadata && (<any>appMetadata).build != null) {
       throw new Error(util.format(errorMessages.buildInAppSpecified, appPackageFile, devAppPackageFile))
     }
     else if (this.devMetadata.build == null) {

--- a/test/fixtures/test-app-one/package.json
+++ b/test/fixtures/test-app-one/package.json
@@ -16,10 +16,7 @@
     "app-bundle-id": "your.id",
     "app-category-type": "your.app.category.type",
     "iconUrl": "https://raw.githubusercontent.com/szwacz/electron-boilerplate/master/resources/windows/icon.ico",
-    "linux": {
-      "//": "gz is much faster, in tests we don't need efficient compression",
-      "compression": "gz"
-    },
+    "compression": "store",
     "win": {
       "title": "My App"
     }

--- a/test/fixtures/test-app/package.json
+++ b/test/fixtures/test-app/package.json
@@ -10,9 +10,6 @@
     "app-bundle-id": "your.id",
     "app-category-type": "your.app.category.type",
     "iconUrl": "https://raw.githubusercontent.com/szwacz/electron-boilerplate/master/resources/windows/icon.ico",
-    "linux": {
-      "//": "gz is much faster, in tests we don't need efficient compression",
-      "compression": "gz"
-    }
+    "compression": "store"
   }
 }

--- a/typings/appdmg.d.ts
+++ b/typings/appdmg.d.ts
@@ -1,7 +1,7 @@
 declare namespace appdmg {
   interface Specification {
     title: string
-    background: string
+    background?: string
     icon: string
     "icon-size": number
 

--- a/vendor/osx/7za
+++ b/vendor/osx/7za
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ee47fe33aece30af6baf9826eebcdea60ceecaa9559ee5bd305c62bea279a74
+size 1667792


### PR DESCRIPTION
…me to compress)

Also, add compression option to set compression level in one place (currently, only Linux and OS X supported)