### PR TITLE
fix: Windows shortcut doesn't work when `productName` contains a space

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "deep-assign": "^2.0.0",
     "electron-osx-sign-tf": "^0.4.0-beta.0",
     "electron-packager-tf": "^7.0.2-beta.0",
-    "electron-winstaller-fixed": "~2.3.0-beta.4",
+    "electron-winstaller-fixed": "~2.4.0-beta.0",
     "fs-extra-p": "^0.3.0",
     "globby": "^4.0.0",
     "hosted-git-info": "^2.1.4",
@@ -70,11 +70,11 @@
     "mime": "^1.3.4",
     "progress": "^1.1.8",
     "progress-stream": "^1.2.0",
-    "read-package-json": "^2.0.3",
-    "signcode": "^0.4.0",
+    "read-package-json": "^2.0.4",
+    "signcode-tf": "^0.5.0",
     "source-map-support": "^0.4.0",
     "tmp": "0.0.28",
-    "typescript": "^1.9.0-dev.20160425"
+    "typescript": "1.9.0-dev.20160425"
   },
   "optionalDependencies": {
     "appdmg": "^0.3.7"

--- a/src/winPackager.ts
+++ b/src/winPackager.ts
@@ -5,7 +5,7 @@ import { Platform, WinBuildOptions } from "./metadata"
 import * as path from "path"
 import { log, statOrNull, use } from "./util"
 import { readFile, deleteFile, stat, rename, copy, emptyDir, writeFile, open, close, read } from "fs-extra-p"
-import { sign } from "signcode"
+import { sign } from "signcode-tf"
 
 //noinspection JSUnusedLocalSymbols
 const __awaiter = require("./awaiter")

--- a/test/fixtures/test-app-one/index.js
+++ b/test/fixtures/test-app-one/index.js
@@ -1,8 +1,77 @@
-'use strict';
+'use strict'
+
+const app = require('app')
+
+// this should be placed at top of main.js to handle setup events quickly
+if (handleSquirrelEvent()) {
+  // squirrel event handled and app will exit in 1000ms, so don't do anything else
+  return;
+}
+
+function handleSquirrelEvent() {
+  if (process.argv.length === 1) {
+    return false;
+  }
+
+  const ChildProcess = require('child_process');
+  const path = require('path');
+
+  const appFolder = path.resolve(process.execPath, '..');
+  const rootAtomFolder = path.resolve(appFolder, '..');
+  const updateDotExe = path.resolve(path.join(rootAtomFolder, 'Update.exe'));
+  const exeName = path.basename(process.execPath);
+
+  const spawn = function(command, args) {
+    let spawnedProcess, error;
+
+    try {
+      spawnedProcess = ChildProcess.spawn(command, args, {detached: true});
+    } catch (error) {}
+
+    return spawnedProcess;
+  };
+
+  const spawnUpdate = function(args) {
+    return spawn(updateDotExe, args);
+  };
+
+  const squirrelEvent = process.argv[1];
+  switch (squirrelEvent) {
+    case '--squirrel-install':
+    case '--squirrel-updated':
+      // Optionally do things such as:
+      // - Add your .exe to the PATH
+      // - Write to the registry for things like file associations and
+      //   explorer context menus
+
+      // Install desktop and start menu shortcuts
+      spawnUpdate(['--createShortcut', exeName]);
+
+      setTimeout(app.quit, 1000);
+      return true;
+
+    case '--squirrel-uninstall':
+      // Undo anything you did in the --squirrel-install and
+      // --squirrel-updated handlers
+
+      // Remove desktop and start menu shortcuts
+      spawnUpdate(['--removeShortcut', exeName]);
+
+      setTimeout(app.quit, 1000);
+      return true;
+
+    case '--squirrel-obsolete':
+      // This is called on the outgoing version of your app before
+      // we update to the new version - it's the opposite of
+      // --squirrel-updated
+
+      app.quit();
+      return true;
+  }
+}
 
 const electron = require('electron');
 // Module to control application life.
-const app = electron.app;
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow;
 

--- a/typings/signcode.d.ts
+++ b/typings/signcode.d.ts
@@ -1,4 +1,4 @@
-declare module "signcode" {
+declare module "signcode-tf" {
   export interface SignOptions {
     path: string
     cert: string


### PR DESCRIPTION
Fixed in Squirrel.Windows

Closes #339