### PR TITLE
add Jenkins build number support

### DIFF
--- a/src/platformPackager.ts
+++ b/src/platformPackager.ts
@@ -205,7 +205,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
   }
 
   protected computeBuildNumber(): string {
-    return this.devMetadata.build["build-version"] || process.env.TRAVIS_BUILD_NUMBER || process.env.APPVEYOR_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM
+    return this.devMetadata.build["build-version"] || process.env.TRAVIS_BUILD_NUMBER || process.env.APPVEYOR_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM || process.env.BUILD_NUMBER
   }
 
   private getOSXResourcesDir(appOutDir: string): string {


### PR DESCRIPTION
Jenkins stores the build number in the `BUILD_NUMBER` environment variable