### PR TITLE
fix: extra resources copied to wrong folder on linux/windows

### DIFF
--- a/src/codeSign.ts
+++ b/src/codeSign.ts
@@ -54,7 +54,7 @@ export function createKeychain(keychainName: string, cscLink: string, cscKeyPass
 
 async function importCerts(keychainName: string, paths: Array<string>, keyPasswords: Array<string | null | undefined>, importAppleCerts: boolean): Promise<CodeSigningInfo> {
   for (let f of paths.slice(0, -keyPasswords.length)) {
-    await exec("security", ["import", f, "-k", keychainName, "-T", "/usr/bin/codesign"])
+    await exec("security", ["import", f!, "-k", keychainName, "-T", "/usr/bin/codesign"])
   }
 
   if (importAppleCerts) {

--- a/src/platformPackager.ts
+++ b/src/platformPackager.ts
@@ -209,7 +209,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     if (this.platform === Platform.OSX) {
       return path.join(appOutDir, this.appName + ".app", "Contents", "Resources")
     }
-    return path.join(appOutDir, 'resources')
+    return path.join(appOutDir, "resources")
   }
 
   private async statFileInPackage(appOutDir: string, packageFile: string, isAsar: boolean): Promise<any> {

--- a/src/platformPackager.ts
+++ b/src/platformPackager.ts
@@ -180,10 +180,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
   }
 
   protected async copyExtraResources(appOutDir: string, arch: string, customBuildOptions: DC): Promise<Array<string>> {
-    let resourcesDir = appOutDir
-    if (this.platform === Platform.OSX) {
-      resourcesDir = this.getOSXResourcesDir(appOutDir)
-    }
+    let resourcesDir = this.getResourcesDir(appOutDir)
     return await BluebirdPromise.map(await this.getExtraResources(arch, customBuildOptions), it => copy(path.join(this.projectDir, it), path.join(resourcesDir, it)))
   }
 
@@ -208,13 +205,16 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return this.devMetadata.build["build-version"] || process.env.TRAVIS_BUILD_NUMBER || process.env.APPVEYOR_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM || process.env.BUILD_NUMBER
   }
 
-  private getOSXResourcesDir(appOutDir: string): string {
-    return path.join(appOutDir, this.appName + ".app", "Contents", "Resources")
+  private getResourcesDir(appOutDir: string): string {
+    if (this.platform === Platform.OSX) {
+      return path.join(appOutDir, this.appName + ".app", "Contents", "Resources")
+    }
+    return path.join(appOutDir, 'resources')
   }
 
   private async statFileInPackage(appOutDir: string, packageFile: string, isAsar: boolean): Promise<any> {
     const relativeFile = path.relative(this.info.appDir, path.resolve(this.info.appDir, packageFile))
-    const resourcesDir = this.platform === Platform.OSX ? this.getOSXResourcesDir(appOutDir) : path.join(appOutDir, "resources")
+    const resourcesDir = this.getResourcesDir(appOutDir)
     if (isAsar) {
       try {
         return statFile(path.join(resourcesDir, "app.asar"), relativeFile) != null


### PR DESCRIPTION
Note: I wasn't able to get the tests passing on my local machine. I encountered a ton of 'unsupported file type' errors (on the unmodified master branch). So it's possible that this breaks tests that I'm not aware of.

Closes #379.