### PR TITLE
fix(linux): use full path in .desktop file

### DIFF
--- a/src/linuxPackager.ts
+++ b/src/linuxPackager.ts
@@ -12,6 +12,7 @@ const template = require("lodash.template")
 const __awaiter = require("./awaiter")
 
 const tmpDir = BluebirdPromise.promisify(<(config: TmpOptions, callback: (error: Error, path: string, cleanupCallback: () => void) => void) => void>_tpmDir)
+const installPrefix = "/opt"
 
 export class LinuxPackager extends PlatformPackager<LinuxBuildOptions> {
   private readonly debOptions: LinuxBuildOptions
@@ -77,7 +78,7 @@ export class LinuxPackager extends PlatformPackager<LinuxBuildOptions> {
     await outputFile(tempFile, this.debOptions.desktop || `[Desktop Entry]
 Name=${this.appName}
 Comment=${this.debOptions.description}
-Exec="${this.appName}"
+Exec="${installPrefix}/${this.appName}/${this.appName}"
 Terminal=false
 Type=Application
 Icon=${this.metadata.name}
@@ -218,7 +219,7 @@ Icon=${this.metadata.name}
 
     use(options.fpm, it => args.push(...<any>it))
 
-    args.push(`${appOutDir}/=/opt/${this.appName}`)
+    args.push(`${appOutDir}/=${installPrefix}/${this.appName}`)
     args.push(...<any>(await this.packageFiles)!)
     await exec(await this.fpmPath, args)
     return destination


### PR DESCRIPTION
In previous version, "Exec" parameter of .desktop file used only executable name.
This depends on user's $PATH, that might cause the problem when launching the app.
So this commit uses the full path for "Exec" parameter.