### PR TITLE
Use libnotify-bin as depends, not libnotify

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -105,7 +105,7 @@ MAS (Mac Application Store) specific options (in addition to `build.osx`).
 | maintainer | <a name="LinuxBuildOptions-maintainer"></a>The maintainer. Defaults to [author](#AppMetadata-author).
 | vendor | <a name="LinuxBuildOptions-vendor"></a>The vendor. Defaults to [author](#AppMetadata-author).
 | compression | <a name="LinuxBuildOptions-compression"></a>*deb-only.* The compression type, one of `gz`, `bzip2`, `xz` (default: `xz`).
-| depends | <a name="LinuxBuildOptions-depends"></a>Package dependencies. Defaults to `["libappindicator1", "libnotify"]`.
+| depends | <a name="LinuxBuildOptions-depends"></a>Package dependencies. Defaults to `["libappindicator1", "libnotify-bin"]`.
 
 <a name="MetadataDirectories"></a>
 ## `.directories`

--- a/src/linuxPackager.ts
+++ b/src/linuxPackager.ts
@@ -216,7 +216,7 @@ Icon=${this.metadata.name}
 
     let depends = options.depends
     if (depends == null) {
-      depends = ["libappindicator1", "libnotify"]
+      depends = ["libappindicator1", "libnotify-bin"]
     }
     else if (!Array.isArray(depends)) {
       if (typeof depends === "string") {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -285,7 +285,7 @@ export interface LinuxBuildOptions {
   readonly compression?: string | null
 
   /*
-   Package dependencies. Defaults to `["libappindicator1", "libnotify"]`.
+   Package dependencies. Defaults to `["libappindicator1", "libnotify-bin"]`.
    */
   readonly depends?: string[] | null
 }

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -144,7 +144,7 @@ async function checkLinuxResult(projectDir: string, packager: Packager, packager
     Vendor: "Foo Bar <foo@example.com>",
     Package: "testapp",
     Description: " \n   Test Application (test quite \" #378)",
-    Depends: checkOptions == null || checkOptions.expectedDepends == null ? "libappindicator1, libnotify" : checkOptions.expectedDepends,
+    Depends: checkOptions == null || checkOptions.expectedDepends == null ? "libappindicator1, libnotify-bin" : checkOptions.expectedDepends,
   })
 }
 


### PR DESCRIPTION
Debian and Ubuntu have a libnotify-bin package that install the libnotify binary.