### PR TITLE
feat: Support finding electron version in package config

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -109,6 +109,9 @@ export function spawn(command: string, args?: Array<string> | null, options?: Sp
 }
 
 export async function getElectronVersion(packageData: any, packageJsonPath: string): Promise<string> {
+  if (packageData.config['electron-version']) {
+    return packageData.config['electron-version']
+  }
   try {
     return (await readJson(path.join(path.dirname(packageJsonPath), "node_modules", "electron-prebuilt", "package.json"))).version
   }


### PR DESCRIPTION
Allows the user to avoid extra downloads of electron for current
platform when he might not need to. Also allows using versions that
are not released on electron-prebuilt

https://github.com/electron-userland/electron-packager/pull/374