### PR TITLE
feature: specification of signing algorithms

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -96,6 +96,8 @@ MAS (Mac Application Store) specific options (in addition to `build.osx`).
 | msi | <a name="WinBuildOptions-msi"></a>Whether to create an MSI installer. Defaults to `false` (MSI is not created).
 | remoteReleases | <a name="WinBuildOptions-remoteReleases"></a>A URL to your existing updates. If given, these will be downloaded to create delta updates.
 | remoteToken | <a name="WinBuildOptions-remoteToken"></a>Authentication token for remote updates
+| signingHashAlgorithms | array of signing algorithms used. Defaults to [ 'sha1', 'sha256' ]
+| signcodePath | path to codesigning tool. Defaults to bundled signtool.exe.
 
 <a name="LinuxBuildOptions"></a>
 ### `.build.linux`

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -97,7 +97,6 @@ MAS (Mac Application Store) specific options (in addition to `build.osx`).
 | remoteReleases | <a name="WinBuildOptions-remoteReleases"></a>A URL to your existing updates. If given, these will be downloaded to create delta updates.
 | remoteToken | <a name="WinBuildOptions-remoteToken"></a>Authentication token for remote updates
 | signingHashAlgorithms | array of signing algorithms used. Defaults to `[ 'sha1', 'sha256' ]`
-| signcodePath | path to codesigning tool. Defaults to bundled `signtool.exe`.
 
 <a name="LinuxBuildOptions"></a>
 ### `.build.linux`

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -96,8 +96,8 @@ MAS (Mac Application Store) specific options (in addition to `build.osx`).
 | msi | <a name="WinBuildOptions-msi"></a>Whether to create an MSI installer. Defaults to `false` (MSI is not created).
 | remoteReleases | <a name="WinBuildOptions-remoteReleases"></a>A URL to your existing updates. If given, these will be downloaded to create delta updates.
 | remoteToken | <a name="WinBuildOptions-remoteToken"></a>Authentication token for remote updates
-| signingHashAlgorithms | array of signing algorithms used. Defaults to [ 'sha1', 'sha256' ]
-| signcodePath | path to codesigning tool. Defaults to bundled signtool.exe.
+| signingHashAlgorithms | array of signing algorithms used. Defaults to `[ 'sha1', 'sha256' ]`
+| signcodePath | path to codesigning tool. Defaults to bundled `signtool.exe`.
 
 <a name="LinuxBuildOptions"></a>
 ### `.build.linux`

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -32,6 +32,7 @@ export async function build(originalOptions?: BuildOptions): Promise<void> {
     cscLink: process.env.CSC_LINK,
     csaLink: process.env.CSA_LINK,
     cscKeyPassword: process.env.CSC_KEY_PASSWORD,
+    cscSigntoolPath: process.env.CSC_SIGNTOOL_PATH,
     githubToken: process.env.GH_TOKEN || process.env.GH_TEST_TOKEN,
   }, originalOptions)
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -258,7 +258,6 @@ export interface WinBuildOptions extends PlatformSpecificBuildOptions {
   readonly remoteToken?: string | null
   
   readonly signingHashAlgorithms?: Array<string> | null
-  readonly signcodePath?: string | null
 }
 
 /*

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -256,6 +256,9 @@ export interface WinBuildOptions extends PlatformSpecificBuildOptions {
    Authentication token for remote updates
    */
   readonly remoteToken?: string | null
+  
+  readonly signingHashAlgorithms?: Array<string> | null
+  readonly signcodePath?: string | null
 }
 
 /*

--- a/src/platformPackager.ts
+++ b/src/platformPackager.ts
@@ -48,10 +48,11 @@ export interface PackagerOptions {
   cscLink?: string | null
   csaLink?: string | null
   cscKeyPassword?: string | null
+  cscSigntoolPath?: string | null
 
   cscInstallerLink?: string | null
   cscInstallerKeyPassword?: string | null
-
+  
   platformPackagerFactory?: ((packager: Packager, platform: Platform, cleanupTasks: Array<() => Promise<any>>) => PlatformPackager<any>) | n
 
   /**

--- a/src/winPackager.ts
+++ b/src/winPackager.ts
@@ -104,7 +104,7 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
         site: await this.computePackageUrl(),
         overwrite: true,
         hash: this.customBuildOptions.signingHashAlgorithms,
-        signcodePath: this.customBuildOptions.signcodePath
+        signcodePath: this.options.cscSigntoolPath
       })
     }
   }
@@ -160,7 +160,7 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
         site: projectUrl,
         overwrite: true,
         hash: this.customBuildOptions.signingHashAlgorithms,
-        signcodePath: this.customBuildOptions.signcodePath
+        signcodePath: this.options.cscSigntoolPath
       },
       rcedit: rceditOptions,
     }, this.customBuildOptions)

--- a/src/winPackager.ts
+++ b/src/winPackager.ts
@@ -103,6 +103,8 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
         name: this.appName,
         site: await this.computePackageUrl(),
         overwrite: true,
+        hash: this.customBuildOptions.signingHashAlgorithms,
+        signcodePath: this.customBuildOptions.signcodePath
       })
     }
   }
@@ -157,6 +159,8 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
         name: this.appName,
         site: projectUrl,
         overwrite: true,
+        hash: this.customBuildOptions.signingHashAlgorithms,
+        signcodePath: this.customBuildOptions.signcodePath
       },
       rcedit: rceditOptions,
     }, this.customBuildOptions)

--- a/typings/signcode.d.ts
+++ b/typings/signcode.d.ts
@@ -6,6 +6,7 @@ declare module "signcode-tf" {
     password: string
     site?: string | null
     hash?: Array<string> | null
+    signcodePath?: string | null
     overwrite?: boolean
   }
 


### PR DESCRIPTION
added options for windows signing: signingHashAlgorithms (sha1, sha256) and signcodePath (path to signtool.exe)

**note**: sha256 only signing works only in conjunction with pull request for signcode-tf