### PR TITLE
feat: adding dot asar option

### DIFF
--- a/src/asarUtil.ts
+++ b/src/asarUtil.ts
@@ -14,6 +14,7 @@ export async function createAsarArchive(src: string, resourcesPath: string, opti
   const files = (await new BluebirdPromise<Array<string>>((resolve, reject) => {
     glob = new Glob("**/*", {
       cwd: src,
+      dot: options.dot
     }, (error, matches) => {
       if (error == null) {
         resolve(matches)

--- a/typings/asar.d.ts
+++ b/typings/asar.d.ts
@@ -14,6 +14,7 @@ declare module "asar" {
   interface AsarOptions {
     unpack?: string
     unpackDir?: string
+    dot?: boolean
   }
 
   export function listPackage(archive: string): Array<string>


### PR DESCRIPTION
This will allow users to have the ability to include dot folders into their asar file. This should maintain existing default functionality.