### PR TITLE
fix: allow passing absolute and relative path as userAppDir option

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -181,7 +181,7 @@ export async function statOrNull(file: string): Promise<Stats | null> {
 
 export async function computeDefaultAppDirectory(projectDir: string, userAppDir: string | null | undefined): Promise<string> {
   if (userAppDir != null) {
-    const absolutePath = path.join(projectDir, userAppDir)
+    const absolutePath = path.resolve(projectDir, userAppDir)
     const stat = await statOrNull(absolutePath)
     if (stat == null) {
       throw new Error(`Application directory ${userAppDir} doesn't exists`)


### PR DESCRIPTION
This addresses #514. Allow to pass absolute path to electron-builder during programmatic usage. Currently this leads to an error with invalid reason/message.