### PR TITLE
enable file association for nsis installer

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -131,6 +131,8 @@ See [NSIS target notes](https://github.com/electron-userland/electron-builder/wi
 | oneClick | <a name="NsisOptions-oneClick"></a>One-click installation. Defaults to `true`.
 | installerHeader | <a name="NsisOptions-installerHeader"></a>*boring installer only.* `MUI_HEADERIMAGE`, relative to the project directory. Defaults to `build/installerHeader.bmp`
 | installerHeaderIcon | <a name="NsisOptions-installerHeaderIcon"></a>*one-click installer only.* The path to header icon (above the progress bar), relative to the project directory. Defaults to `build/installerHeaderIcon.ico` or application icon.
+| extension | <a name="NsisOptions-extension"></a>Optional, file association extension. Ex. .yourapp
+| fileType | <a name="NsisOptions-fileType"></a>Optional, file assocation file type. If given extension, you should also give this file extension a name.
 
 <a name="LinuxBuildOptions"></a>
 ### `.build.linux`

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -378,6 +378,16 @@ export interface NsisOptions {
    *one-click installer only.* The path to header icon (above the progress bar), relative to the project directory. Defaults to `build/installerHeaderIcon.ico` or application icon.
    */
   readonly installerHeaderIcon?: string | null
+
+  /*
+  Optional, file association extension. Ex. .yourapp
+   */
+  readonly extension?: string | null
+
+  /*
+  Optional, file assocation file type. If given extension, you should also give this file extension a name.
+   */
+  readonly fileType?: string | null
 }
 
 /*

--- a/src/targets/nsis.ts
+++ b/src/targets/nsis.ts
@@ -48,13 +48,14 @@ export default class NsisTarget extends Target {
 
   private async buildInstaller(): Promise<any> {
     const packager = this.packager
+    const options = this.options
 
     const iconPath = await packager.getIconPath()
     const appInfo = packager.appInfo
     const version = appInfo.version
     const installerPath = path.join(this.outDir, `${appInfo.productFilename} Setup ${version}.exe`)
 
-    const guid = this.options.guid || await BluebirdPromise.promisify(uuid5)({namespace: ELECTRON_BUILDER_NS_UUID, name: appInfo.id})
+    const guid = options.guid || await BluebirdPromise.promisify(uuid5)({namespace: ELECTRON_BUILDER_NS_UUID, name: appInfo.id})
     const defines: any = {
       APP_ID: appInfo.id,
       APP_GUID: guid,
@@ -67,6 +68,9 @@ export default class NsisTarget extends Target {
       MUI_UNICON: iconPath,
 
       COMPANY_NAME: appInfo.companyName,
+
+      EXTENSION: options.extension,
+      FILE_TYPE: options.fileType
     }
 
     for (let [arch, file] of this.archs) {

--- a/templates/nsis/installer.nsi
+++ b/templates/nsis/installer.nsi
@@ -4,6 +4,7 @@
 !include "nsProcess.nsh"
 !include "allowOnlyOneInstallerInstace.nsh"
 !include "checkAppRunning.nsh"
+!include "FileAssociation.nsh"
 !include x64.nsh
 !include WinVer.nsh
 
@@ -85,10 +86,10 @@ Section "install"
     Nsis7z::Extract "$PLUGINSDIR\app-32.7z"
   ${EndIf}
 
-#  <% if(fileAssociation){ %>
+  !ifdef fileAssociation
     # specify file association
-#    ${registerExtension} "$INSTDIR\${PRODUCT_FILENAME}.exe" "<%= fileAssociation.extension %>" "<%= fileAssociation.fileType %>"
-#  <% } %>
+    ${registerExtension} "$INSTDIR\${PRODUCT_FILENAME}.exe" "<%= fileAssociation.extension %>" "<%= fileAssociation.fileType %>"
+  !endif
 
   WriteUninstaller "${UNINSTALL_FILENAME}"
   !insertmacro MULTIUSER_RegistryAddInstallInfo
@@ -123,6 +124,11 @@ Section "un.install"
 
   Delete "$startMenuLink"
   Delete "$desktopLink"
+
+  !ifdef fileAssociation
+    # unregister file extension
+    ${unregisterExtension} "<%= fileAssociation.extension %>" "<%= fileAssociation.fileType %>"
+  !endif
 
   # delete the installed files
   RMDir /r $INSTDIR

--- a/templates/nsis/installer.nsi
+++ b/templates/nsis/installer.nsi
@@ -86,9 +86,10 @@ Section "install"
     Nsis7z::Extract "$PLUGINSDIR\app-32.7z"
   ${EndIf}
 
-  !ifdef fileAssociation
-    # specify file association
-    ${registerExtension} "$INSTDIR\${PRODUCT_FILENAME}.exe" "<%= fileAssociation.extension %>" "<%= fileAssociation.fileType %>"
+
+  # specify file association
+  !ifdef EXTENSION & FILE_TYPE
+    ${registerExtension} "$INSTDIR\${PRODUCT_FILENAME}.exe" "${EXTENSION}" "${FILE_TYPE}"
   !endif
 
   WriteUninstaller "${UNINSTALL_FILENAME}"
@@ -125,9 +126,9 @@ Section "un.install"
   Delete "$startMenuLink"
   Delete "$desktopLink"
 
-  !ifdef fileAssociation
-    # unregister file extension
-    ${unregisterExtension} "<%= fileAssociation.extension %>" "<%= fileAssociation.fileType %>"
+  # unregister file extension
+  !ifdef EXTENSION & FILE_TYPE
+    ${unregisterExtension} "${EXTENSION}" "${FILE_TYPE}"
   !endif
 
   # delete the installed files


### PR DESCRIPTION
Allow user to add “fileAssociation” object under “win” to specify
“extension” and “fileType” for an associated file to be open by
Electron app