### PR TITLE
README note about optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Complete solution to package and build ready for distribution and "auto update" 
 [electron-packager](https://github.com/electron-userland/electron-packager) and
 [appdmg](https://github.com/LinusU/node-appdmg) are used under the hood.
 
+_Note: `appdmg` (and the platform specific `7zip-bin-*` packages) are `optionalDependencies`, which may require manual install if you have npm configured to [not install optional deps by default](https://docs.npmjs.com/misc/config#optional)._
+
 Real project example — [onshape-desktop-shell](https://github.com/develar/onshape-desktop-shell).
 
 # Two package.json structure


### PR DESCRIPTION
Add note to README about `appdmg` and `7zip` packages being optional dependencies.

Ref: https://github.com/electron-userland/electron-builder/issues/95#issuecomment-226819644