### PR TITLE
fix: remove tslint from production dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "sanitize-filename": "^1.6.0",
     "semver": "^5.3.0",
     "source-map-support": "^0.4.2",
-    "tslint": "^3.14.0-dev.1",
     "update-notifier": "^1.0.2",
     "uuid-1345": "^0.99.6",
     "yargs": "^4.8.1"
@@ -122,7 +121,7 @@
     "json8": "^0.9.2",
     "pre-git": "^3.10.0",
     "ts-babel": "^1.0.4",
-    "tslint": "3.14.0",
+    "tslint": "^3.14.0-dev.1",
     "typescript": "^2.1.0-dev.20160802",
     "whitespace": "^2.1.0"
   },


### PR DESCRIPTION
This PR fixes next issue for non-TypeScript projects:

```
npm WARN tslint@3.14.0 requires a peer of typescript@>=1.7.3 but none was installed.
```

Also, this warning is critical for programmatic API as it fails while create executables w/o installed typescript dependency.