### PR TITLE
disable dual-signing for .msi installer

### DIFF
--- a/src/windowsCodeSign.ts
+++ b/src/windowsCodeSign.ts
@@ -92,7 +92,10 @@ async function spawnSign(options: SignOptions, inputPath: string, outputPath: st
   }
 
   if (nest) {
-    args.push(isWin ? "/as" : "-nest")
+    // msi does not support dual-signing
+    if (path.extname(inputPath) !== ".msi") {
+      args.push(isWin ? "/as" : "-nest")
+    }
   }
 
   if (options.password) {


### PR DESCRIPTION
MSI file format does not support dual signing.

see: http://social.technet.microsoft.com/wiki/contents/articles/32288.windows-enforcement-of-authenticode-code-signing-and-timestamping.aspx#How_to_handle_MSI_files