### PR TITLE
fix: file already in use error during unzip

### DIFF
--- a/src/util/httpRequest.ts
+++ b/src/util/httpRequest.ts
@@ -85,7 +85,7 @@ function doDownload(url: string, destination: string, redirectCount: number, opt
             .pipe(fileOut)
         }
 
-        fileOut.on("finish", callback)
+        fileOut.on("close", callback)
       })
       .catch(callback)
 


### PR DESCRIPTION
I got an error in Windows during 7zip invokation (The process cannot access the file because it is being used by another process). I changed the finish stream event to close to ensure that the file descriptor is closed after download.