### PR TITLE
feat: support CFBundleTypeRole for MacOS CFBundleURLTypes

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -557,6 +557,11 @@ export interface Protocol {
   readonly name: string
 
   /*
+  *macOS-only* The app’s role with respect to the type. The value can be `Editor`, `Viewer`, `Shell`, or `None`. Defaults to `Editor`.
+  */
+  readonly role?: string
+
+  /*
   The schemes. e.g. `["irc", "ircs"]`.
   */
   readonly schemes: Array<string>

--- a/src/packager/mac.ts
+++ b/src/packager/mac.ts
@@ -102,6 +102,7 @@ export async function createApp(packager: PlatformPackager<any>, appOutDir: stri
       }
       return {
         CFBundleURLName: protocol.name,
+        CFBundleTypeRole: protocol.role || "Editor",
         CFBundleURLSchemes: schemes.slice()
       }
     })


### PR DESCRIPTION
Adding support for CFBundleTypeRole for MacOS CFBundleURLTypes (protocols).
This key appears as required in Apple's documentation.

https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102207-TPXREF115