### PR TITLE
docs: add missing certificateFile and certificatePassword options description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 /.idea/encodings.xml
 /.idea/copyright/profiles_settings.xml
 /.idea/workspace.xml
+/.idea/deployment.xml
 /typings/browser/
 /typings/browser.d.ts
 /typings/main.d.ts

--- a/docs/Code Signing.md
+++ b/docs/Code Signing.md
@@ -1,12 +1,13 @@
 macOS and Windows code signing is supported. Windows is dual code-signed (SHA1 & SHA256 hashing algorithms).
-
 On a macOS development machine valid and appropriate identity from your keychain will be automatically used.
 
 | Env name       |  Description
 | -------------- | -----------
-| `CSC_LINK`                   | The HTTPS link (or base64-encoded data, or `file://` link) to certificate (`*.p12` file).
+| `CSC_LINK`                   | The HTTPS link (or base64-encoded data, or `file://` link) to certificate (`*.p12` or `*.pfx` file).
 | `CSC_KEY_PASSWORD`           | The password to decrypt the certificate given in `CSC_LINK`.
 | `CSC_NAME`                   | *macOS-only* Name of certificate (to retrieve from login.keychain). Useful on a development machine (not on CI) if you have several identities (otherwise don't specify it).
+
+If you are building Windows on Mac and need to set a different certificate and password (than the ones set in `CSC_*` env vars) you can use [`certificateFile`](https://github.com/electron-userland/electron-builder/wiki/Options#WinBuildOptions-certificateFile) and [`certificatePassword`](https://github.com/electron-userland/electron-builder/wiki/Options#WinBuildOptions-certificatePassword) in `.build.win` section.
 
 ## Travis, AppVeyor and other CI Servers
 To sign app on build server you need to set `CSC_LINK`, `CSC_KEY_PASSWORD` (and `CSC_INSTALLER_LINK`, `CSC_INSTALLER_KEY_PASSWORD` if you build for Mac App Store):
@@ -33,7 +34,7 @@ Please note — Gatekeeper only recognises [Apple digital certificates](http://s
 3. Select all required certificates (hint: use cmd-click to select several):
    * `Developer ID Application:` to sign app for macOS.
    * `3rd Party Mac Developer Application:` and `3rd Party Mac Developer Installer:` to sign app for MAS (Mac App Store).
-   
-   Please note – you can select as many certificates, as need. No restrictions on electron-builder side. 
+
+   Please note – you can select as many certificates, as need. No restrictions on electron-builder side.
    All selected certificates will be imported into temporary keychain on CI server.
-4. Open context menu and `Export`.   
+4. Open context menu and `Export`.

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -193,6 +193,8 @@ Windows specific build options.
 | remoteReleases | <a name="WinBuildOptions-remoteReleases"></a>*Squirrel.Windows-only.* A URL to your existing updates. Or `true` to automatically set to your GitHub repository. If given, these will be downloaded to create delta updates.
 | remoteToken | <a name="WinBuildOptions-remoteToken"></a>*Squirrel.Windows-only.* Authentication token for remote updates
 | signingHashAlgorithms | <a name="WinBuildOptions-signingHashAlgorithms"></a>Array of signing algorithms used. Defaults to `['sha1', 'sha256']`
+| certificateFile | <a name="WinBuildOptions-certificateFile"></a> Path to the *.pfx certificate you want to sign with. Required only if you build on MAC and need different certificate than the one set in `CSC_LINK` - see [Code Signing](https://github.com/electron-userland/electron-builder/wiki/Code-Signing).
+| certificatePassword | <a name="WinBuildOptions-certificatePassword"></a> Password to the certificate provided in `certificateFile`. Required only if you build on MAC and need to use a different password than the one set in `CSC_KEY_PASSWORD` - see [Code Signing](https://github.com/electron-userland/electron-builder/wiki/Code-Signing).
 | icon | <a name="WinBuildOptions-icon"></a>The path to application icon. Defaults to `build/icon.ico` (consider using this convention instead of complicating your configuration).
 | legalTrademarks | <a name="WinBuildOptions-legalTrademarks"></a>The trademarks and registered trademarks.
 | certificateSubjectName | <a name="WinBuildOptions-certificateSubjectName"></a>The name of the subject of the signing certificate. Required only for EV Code Signing and works only on Windows.


### PR DESCRIPTION
I was just trying to code sign on Windows and spent a moment to find whether it is already supported and how to use it so I allowed myself to update the docs.