### PR TITLE
All platform targets use the same app output folder pattern

### DIFF
--- a/src/platformPackager.ts
+++ b/src/platformPackager.ts
@@ -144,8 +144,8 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return use(this.devMetadata.directories, it => it!.buildResources) || "build"
   }
 
-  protected computeAppOutDir(outDir: string, arch: Arch): string {
-    return path.join(outDir, `${this.platform.buildConfigurationKey}${getArchSuffix(arch)}${this.platform === Platform.MAC ? "" : "-unpacked"}`)
+  protected computeAppOutDir(outDir:string, arch:Arch):string {
+    return path.join(outDir, this.platform.buildConfigurationKey, getArchSuffix(arch), `${ this.platform === Platform.MAC ? "" : "unpacked" }`);
   }
 
   dispatchArtifactCreated(file: string, artifactName?: string) {

--- a/src/winPackager.ts
+++ b/src/winPackager.ts
@@ -117,10 +117,6 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
     this.packageInDistributableFormat(outDir, appOutDir, arch, targets, postAsyncTasks)
   }
 
-  protected computeAppOutDir(outDir: string, arch: Arch): string {
-    return path.join(outDir, `win${getArchSuffix(arch)}-unpacked`)
-  }
-
   async sign(file: string) {
     const cscInfo = await this.cscInfo
     if (cscInfo != null) {


### PR DESCRIPTION
- Remove redundant computeAppOutDir function as it duplicates parent functionality
- PlatformPacker.computeAppOutDir now uses platform and architecture as subdirectories instead of making them part of the distributable name

This creates a consistent output pattern for all platform. Mac builds were already following this structure and it makes it easier to handle output on a CI servers when all targets follow the same output pattern