### PR TITLE
fix: enable GH_TOKEN env variable for releases

### DIFF
--- a/src/publish/gitHubPublisher.ts
+++ b/src/publish/gitHubPublisher.ts
@@ -42,9 +42,8 @@ export class GitHubPublisher implements Publisher {
   }
 
   constructor(private info: GithubOptions, private version: string, options?: PublishOptions, private isPublishOptionGuessed: boolean = false, config?: GithubOptions | null) {
-    let token = info.token
+    let token = info.token || process.env.GH_TOKEN
     if (isEmptyOrSpaces(token)) {
-      token = process.env.GH_TOKEN
       throw new Error(`GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"`)
     }
 


### PR DESCRIPTION
A bug was introduced in the previous release where the token was set to env.GH_TOKEN but then an error thrown immediately. This change ensures that the token is set in the right place and an error is only thrown if no token exists

[Link to commit where this was introduced](https://github.com/electron-userland/electron-builder/commit/b1ae7d5b3c00de2305d6f8b2cb1981ceb574b4d0#diff-942adfda4f3ed355d1699273799dba23R47)