### PR TITLE
Make packager handle available native deps when building on non-native platforms

### DIFF
--- a/src/packager.ts
+++ b/src/packager.ts
@@ -231,12 +231,14 @@ export class Packager implements BuildInfo {
       if (this.devMetadata.build.npmRebuild === false) {
         log("Skip app dependencies rebuild because npmRebuild is set to false")
       }
-      else if (platform.nodeName === process.platform) {
-        const forceBuildFromSource = this.devMetadata.build.npmSkipBuildFromSource !== true
-        await installDependencies(this.appDir, this.electronVersion, Arch[arch], forceBuildFromSource, (await statOrNull(path.join(this.appDir, "node_modules"))) == null ? "install" : "rebuild")
-      }
       else {
-        log("Skip app dependencies rebuild because platform is different")
+        const forceBuildFromSource = this.devMetadata.build.npmSkipBuildFromSource !== true
+
+        if (platform.nodeName !== process.platform && forceBuildFromSource) {
+          log("Skip app dependencies rebuild because platform is different")
+        } else {
+          await installDependencies(this.appDir, this.electronVersion, Arch[arch], forceBuildFromSource, (await statOrNull(path.join(this.appDir, "node_modules"))) == null ? "install" : "rebuild")
+        }
       }
     }
     else {


### PR DESCRIPTION
Hi,

Given the skip build flag handling you've merged previously, I was able to successfully use precompiled binaries when creating package for native platform. However, I've stumbled upon an issue when I was trying to package app with native deps for Windows on Mac. It just skipped deps installation and wrapped stuff I've got after initial `npm install` (Mac-related) into Windows build, which of course didn't run. This change should allow the making of a truly crossplatform build on the same machine.