### PR TITLE
refactor: warn when skipping mac app signing due to unsupported platform

### DIFF
--- a/src/macPackager.ts
+++ b/src/macPackager.ts
@@ -94,7 +94,7 @@ export default class MacPackager extends PlatformPackager<MacOptions> {
 
   private async sign(appOutDir: string, masOptions: MasBuildOptions | null): Promise<void> {
     if (process.platform !== "darwin") {
-      warn('Mac application signing not supported on this platform, skipping.')
+      warn("Mac application signing not supported on this platform, skipping.")
       return
     }
 

--- a/src/macPackager.ts
+++ b/src/macPackager.ts
@@ -94,6 +94,7 @@ export default class MacPackager extends PlatformPackager<MacOptions> {
 
   private async sign(appOutDir: string, masOptions: MasBuildOptions | null): Promise<void> {
     if (process.platform !== "darwin") {
+      warn('Mac application signing not supported on this platform, skipping.')
       return
     }
 


### PR DESCRIPTION
Be explict and avoid confusion when mac signing is aborted re: platform.
Previously, no warning was logged.