### PR TITLE
update v8 headers URL

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -23,7 +23,7 @@ export function installDependencies(appDir: string, electronVersion: string, arc
 export function getGypEnv(electronVersion: string, arch: string): any {
   const gypHome = path.join(homedir(), ".electron-gyp")
   return Object.assign({}, process.env, {
-    npm_config_disturl: "https://atom.io/download/atom-shell",
+    npm_config_disturl: "https://atom.io/download/electron",
     npm_config_target: electronVersion,
     npm_config_runtime: "electron",
     npm_config_arch: arch,


### PR DESCRIPTION
Renames the distribution URL used for downloading the v8 headers from `https://atom.io/download/atom-shell` to `https://atom.io/download/electron`.

Both URLs will be supported going forward but the old one may possibly be removed in Electron 2.0.

https://github.com/electron/electron/pull/7881

☝️ This PR is currently pending but the new endpoint is already live in production.