### PR TITLE
feat: add ability to specify additional npm rebuild args

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -84,6 +84,7 @@ Don't customize paths to background and icon, — just follow conventions.
 | afterPack | <a name="BuildMetadata-afterPack"></a>*programmatic API only* The function to be run after pack (but before pack into distributable format and sign). Promise must be returned.
 | npmRebuild | <a name="BuildMetadata-npmRebuild"></a>*two package.json structure only* Whether to [rebuild](https://docs.npmjs.com/cli/rebuild) native dependencies (`npm rebuild`) before starting to package the app. Defaults to `true`.
 | npmSkipBuildFromSource | <a name="BuildMetadata-npmSkipBuildFromSource"></a>*two package.json structure only* Whether to omit using [--build-from-source](https://github.com/mapbox/node-pre-gyp#options) flag when installing app native deps. Defaults to `false`.
+| npmArgs | <a name="BuildMetadata-npmArgs"></a>*two package.json structure only* Additional command line arguments to use when installing app native deps. Defaults to `null`.
 | nodeGypRebuild | <a name="BuildMetadata-nodeGypRebuild"></a>Whether to execute `node-gyp rebuild` before starting to package the app. Defaults to `false`.
 | electronDist | <a name="BuildMetadata-electronDist"></a>The path to custom Electron build (e.g. `~/electron/out/R`). Only macOS supported, file issue if need for Linux or Windows.
 | publish | <a name="BuildMetadata-publish"></a>See [.build.publish](#PublishConfiguration).

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -208,6 +208,11 @@ export interface BuildMetadata {
   readonly npmSkipBuildFromSource?: boolean
 
   /*
+   *two package.json structure only* Additional command line arguments to use when installing app native deps. Defaults to `null`.
+   */
+  readonly npmArgs?: Array<string> | string | null
+
+  /*
    Whether to execute `node-gyp rebuild` before starting to package the app. Defaults to `false`.
    */
   readonly nodeGypRebuild?: boolean

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -237,12 +237,11 @@ export class Packager implements BuildInfo {
       }
       else {
         const forceBuildFromSource = this.devMetadata.build.npmSkipBuildFromSource !== true
-        const additionalArgs = this.devMetadata.build.npmArgs
         if (platform.nodeName !== process.platform && forceBuildFromSource) {
           log("Skip app dependencies rebuild because platform is different")
         }
         else {
-          await installDependencies(this.appDir, this.electronVersion, Arch[arch], forceBuildFromSource, (await statOrNull(path.join(this.appDir, "node_modules"))) == null ? "install" : "rebuild", additionalArgs)
+          await installDependencies(this.appDir, this.electronVersion, Arch[arch], forceBuildFromSource, (await statOrNull(path.join(this.appDir, "node_modules"))) == null ? "install" : "rebuild", this.devMetadata.build.npmArgs)
         }
       }
     }

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -237,11 +237,12 @@ export class Packager implements BuildInfo {
       }
       else {
         const forceBuildFromSource = this.devMetadata.build.npmSkipBuildFromSource !== true
+        const additionalArgs = this.devMetadata.build.npmArgs
         if (platform.nodeName !== process.platform && forceBuildFromSource) {
           log("Skip app dependencies rebuild because platform is different")
         }
         else {
-          await installDependencies(this.appDir, this.electronVersion, Arch[arch], forceBuildFromSource, (await statOrNull(path.join(this.appDir, "node_modules"))) == null ? "install" : "rebuild")
+          await installDependencies(this.appDir, this.electronVersion, Arch[arch], forceBuildFromSource, (await statOrNull(path.join(this.appDir, "node_modules"))) == null ? "install" : "rebuild", additionalArgs)
         }
       }
     }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -16,8 +16,8 @@ export const debug7z: Debugger = _debug("electron-builder:7z")
 
 const DEFAULT_APP_DIR_NAMES = ["app", "www"]
 
-export function installDependencies(appDir: string, electronVersion: string, arch: string = process.arch, forceBuildFromSource: boolean, command: string = "install"): Promise<any> {
-  return task(`${(command === "install" ? "Installing" : "Rebuilding")} app dependencies for arch ${arch} to ${appDir}`, spawnNpmProduction(command, appDir, forceBuildFromSource, getGypEnv(electronVersion, arch)))
+export function installDependencies(appDir: string, electronVersion: string, arch: string = process.arch, forceBuildFromSource: boolean, command: string = "install", additionalArgs?: any): Promise<any> {
+  return task(`${(command === "install" ? "Installing" : "Rebuilding")} app dependencies for arch ${arch} to ${appDir}`, spawnNpmProduction(command, appDir, forceBuildFromSource, getGypEnv(electronVersion, arch), additionalArgs))
 }
 
 export function getGypEnv(electronVersion: string, arch: string): any {
@@ -32,7 +32,7 @@ export function getGypEnv(electronVersion: string, arch: string): any {
   })
 }
 
-export function spawnNpmProduction(command: string, appDir: string, forceBuildFromSource: boolean, env?: any): Promise<any> {
+export function spawnNpmProduction(command: string, appDir: string, forceBuildFromSource: boolean, env?: any, additionalArgs?: any): Promise<any> {
   let npmExecPath = process.env.npm_execpath || process.env.NPM_CLI_JS
   const npmExecArgs = [command, "--production"]
 
@@ -52,6 +52,14 @@ export function spawnNpmProduction(command: string, appDir: string, forceBuildFr
   }
   if (forceBuildFromSource) {
     npmExecArgs.push("--build-from-source")
+  }
+
+  if (additionalArgs) {
+    if (Array.isArray(additionalArgs)) {
+      additionalArgs.forEach(arg => npmExecArgs.push(arg))
+    } else {
+      additionalArgs.push(additionalArgs)
+    }
   }
 
   return spawn(npmExecPath, npmExecArgs, {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -56,8 +56,9 @@ export function spawnNpmProduction(command: string, appDir: string, forceBuildFr
 
   if (additionalArgs) {
     if (Array.isArray(additionalArgs)) {
-      additionalArgs.forEach(arg => npmExecArgs.push(arg))
-    } else {
+      additionalArgs.push(...additionalArgs)
+    }
+    else {
       additionalArgs.push(additionalArgs)
     }
   }


### PR DESCRIPTION
I am building an electron app that uses native dependencies targeting multiple platforms. [Prebuild](https://github.com/mafintosh/prebuild) binaries are available for all of them. 

However when `npmSkipBuildFromSource` is enabled, `prebuild` downloads the binary for the installed node version instead of the electron version. This can be easily handled by specifying a `--abi=ELECTRON_ABI_VERSION` argument, but electron-builder does not allow this.

**This PR adds support for specifying any number of additional `npm rebuild` arguments to allow working around issues outlined above.**