### PR TITLE
fix: wine version processing

### DIFF
--- a/src/packager.ts
+++ b/src/packager.ts
@@ -305,6 +305,10 @@ async function checkWineVersion(checkPromise: Promise<string>) {
     wineVersion = wineVersion.substring("wine-".length)
   }
 
+  if (wineVersion.split(" ").length > 1) {
+    wineVersion = wineVersion.split(" ")[0]
+  }
+
   if (wineVersion.split(".").length === 2) {
     wineVersion += ".0"
   }


### PR DESCRIPTION
If wine is installed on Fedora 24/25 over the repository, the version string is rather uncommon:
$ wine --version
wine-1.9.23 (Staging)

The version comparison fails with "TypeError: Invalid Version: 1.9.23 (Staging)" if you try to create a windows build. This pull should fix the problem by cutting the version string on the first whitespace.


