### PR TITLE
Support calling from renderer process

### DIFF
--- a/nsis-auto-updater/src/NsisUpdater.ts
+++ b/nsis-auto-updater/src/NsisUpdater.ts
@@ -28,7 +28,7 @@ export class NsisUpdater extends EventEmitter {
   constructor(options?: PublishConfiguration | BintrayOptions | GithubOptions) {
     super()
 
-    this.app = (<any>global).__test_app || require("electron").app
+    this.app = (<any>global).__test_app || require("electron").app || require("electron").remote.app
 
     if (options == null) {
       this.clientPromise = this.loadUpdateConfig()


### PR DESCRIPTION
I am handling the auto update code from the renderer process (using redux-saga). I added an additional OR condition: `require("electron").remote.app`.

Do you think this is useful? And is this the correct way to handle this?