### PR TITLE
Use productName for FileDescription on Windows

### DIFF
--- a/src/winPackager.ts
+++ b/src/winPackager.ts
@@ -149,7 +149,7 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
     const args = [
       file,
       "--set-version-string", "CompanyName", appInfo.companyName,
-      "--set-version-string", "FileDescription", appInfo.description,
+      "--set-version-string", "FileDescription", appInfo.productName,
       "--set-version-string", "ProductName", appInfo.productName,
       "--set-version-string", "InternalName", path.basename(appInfo.productFilename, ".exe"),
       "--set-version-string", "LegalCopyright", appInfo.copyright,


### PR DESCRIPTION
`FileDescription` is used when right-clicking on a program in the task bar for example:

<img width="257" alt="screen shot 2016-12-02 at 18 52 27" src="https://cloud.githubusercontent.com/assets/69485/20846311/f6dca8cc-b8c0-11e6-8299-c97d26f29b6c.png">

So I believe we should be displaying `appInfo.productName` there, as `appInfo.description` is more like a one-sentence description of your app, which could be used in an *About* dialog.

Edge, Internet Explorer, etc. use the same value for `ProductName` and `FileDescription`:

<img width="405" alt="screen shot 2016-12-02 at 18 49 17" src="https://cloud.githubusercontent.com/assets/69485/20846359/38be1f8c-b8c1-11e6-8318-29336fe3d8a6.png">
