### PR TITLE
fix(mac): ENOENT for symlinks because directory was not created

### DIFF
--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -174,12 +174,7 @@ export function copyDir(src: string, destination: string, filter?: Filter, isUse
   const createdSourceDirs = new Set<string>()
   const fileCopier = new FileCopier(isUseHardLink)
   return walk(src, filter, async (file, stat, parent) => {
-    if (stat.isSymbolicLink()) {
-      await symlink(await readlink(file), file.replace(src, destination))
-      return
-    }
-
-    if (!stat.isFile()) {
+    if (!stat.isFile() && !stat.isSymbolicLink()) {
       return
     }
 
@@ -188,6 +183,10 @@ export function copyDir(src: string, destination: string, filter?: Filter, isUse
       createdSourceDirs.add(parent)
     }
 
-    await fileCopier.copy(file, file.replace(src, destination), stat)
+    if (stat.isSymbolicLink()) {
+      await symlink(await readlink(file), file.replace(src, destination))      
+    } else if (stat.isFile()) {
+      await fileCopier.copy(file, file.replace(src, destination), stat)  
+    }
   })
 }


### PR DESCRIPTION
We got a problem while building with the latest version of electron builder. Our extraResources contains symbolic links and electron builder failed to create those links with:

    Error: ENOENT: no such file or directory, symlink 'Resources/x2go-X11/lib/' -> '/Users/fastlane/devel/rl3client/client/dist/mac/RemoteLabs3Client.app/Contents/Resources/electron-app/x2goclient.app/Contents/lib'
        at Error (native)
    From previous event:
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/util/fs.ts:178:13
        at next (native)
    From previous event:
        at walk (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/util/fs.js:236:26)
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/util/fs.ts:74:44
    From previous event:
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/util/fs.ts:62:10
        at /Users/fastlane/devel/rl3client/client/node_modules/graceful-fs/polyfills.js:287:18
    From previous event:
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/util/fs.ts:59:27
        at next (native)
        at go$readdir$cb (/Users/fastlane/devel/rl3client/client/node_modules/graceful-fs/graceful-fs.js:149:14)
        at FSReqWrap.oncomplete (fs.js:123:15)
    From previous event:
        at walk (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/util/fs.js:90:22)
        at copyDir (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/util/fs.ts:176:3)
        at default.map.pattern (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/platformPackager.ts:349:14)
    From previous event:
        at MacPackager.doCopyExtraFiles (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/platformPackager.ts:345:28)
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/platformPackager.ts:281:16
        at next (native)
        at runCallback (timers.js:637:20)
        at tryOnImmediate (timers.js:610:5)
        at processImmediate [as _immediateCallback] (timers.js:582:5)
    From previous event:
        at MacPackager.doPack (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/platformPackager.js:321:11)
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/macPackager.ts:78:28
        at next (native)
    From previous event:
        at MacPackager.pack (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/macPackager.js:162:11)
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/packager.ts:146:22
    From previous event:
        at Packager.doBuild (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/packager.js:271:11)
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/packager.ts:114:38
        at next (native)
        at runCallback (timers.js:637:20)
        at tryOnImmediate (timers.js:610:5)
        at processImmediate [as _immediateCallback] (timers.js:582:5)
    From previous event:
        at Packager.build (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/packager.js:223:11)
        at /Users/fastlane/devel/rl3client/client/node_modules/electron-builder/src/builder.ts:241:40
        at next (native)
    From previous event:
        at build (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/builder.js:89:21)
        at Object.<anonymous> (/Users/fastlane/devel/rl3client/client/node_modules/electron-builder/out/cli/build-cli.js:68:41)
        at Module._compile (module.js:570:32)
        at Object.Module._extensions..js (module.js:579:10)
        at Module.load (module.js:487:32)
        at tryModuleLoad (module.js:446:12)
        at Function.Module._load (module.js:438:3)
        at Module.runMain (module.js:604:10)
        at run (bootstrap_node.js:394:7)
        at startup (bootstrap_node.js:149:9)
        at bootstrap_node.js:509:3
    child process exited with code 255

The fix creates the directory before attempting to create the symlinks.