### PR TITLE
appx, use arch from parameters instead of process.arch

### DIFF
--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -63,7 +63,7 @@ export default class AppXTarget extends Target {
     use(this.options.makeappxArgs, (it: Array<string>) => args.push(...it))
     // wine supports only ia32 binary in any case makeappx crashed on wine
     // await execWine(path.join(await getSignVendorPath(), "windows-10", process.platform === "win32" ? process.arch : "ia32", "makeappx.exe"), args)
-    await spawn(path.join(await getSignVendorPath(), "windows-10", arch == Arch.ia32 ? "ia32" : "x64", "makeappx.exe"), args)
+    await spawn(path.join(await getSignVendorPath(), "windows-10", arch === Arch.ia32 ? "ia32" : "x64", "makeappx.exe"), args)
 
     await packager.sign(destination)
     packager.dispatchArtifactCreated(destination, packager.generateName("appx", arch, true))
@@ -102,7 +102,7 @@ export default class AppXTarget extends Target {
             return safeName
             
           case "arch":
-            return arch == Arch.ia32 ? "x86" : "x64"
+            return arch === Arch.ia32 ? "x86" : "x64"
 
           default:
             throw new Error(`Macro ${p1} is not defined`)

--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -63,7 +63,7 @@ export default class AppXTarget extends Target {
     use(this.options.makeappxArgs, (it: Array<string>) => args.push(...it))
     // wine supports only ia32 binary in any case makeappx crashed on wine
     // await execWine(path.join(await getSignVendorPath(), "windows-10", process.platform === "win32" ? process.arch : "ia32", "makeappx.exe"), args)
-    await spawn(path.join(await getSignVendorPath(), "windows-10", arch, "makeappx.exe"), args)
+    await spawn(path.join(await getSignVendorPath(), "windows-10", arch === Arch.ia32 ? "ia32" : "x64", "makeappx.exe"), args)
 
     await packager.sign(destination)
     packager.dispatchArtifactCreated(destination, packager.generateName("appx", arch, true))

--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -69,7 +69,7 @@ export default class AppXTarget extends Target {
     packager.dispatchArtifactCreated(destination, packager.generateName("appx", arch, true))
   }
 
-  private async writeManifest(templatePath: string, preAppx: string, safeName: string, arch: string) {
+  private async writeManifest(templatePath: string, preAppx: string, safeName: string, arch: Arch) {
     const appInfo = this.packager.appInfo
     const manifest = (await readFile(path.join(templatePath, "appxmanifest.xml"), "utf8"))
       .replace(/\$\{([a-zA-Z]+)\}/g, (match, p1): string => {

--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -63,7 +63,7 @@ export default class AppXTarget extends Target {
     use(this.options.makeappxArgs, (it: Array<string>) => args.push(...it))
     // wine supports only ia32 binary in any case makeappx crashed on wine
     // await execWine(path.join(await getSignVendorPath(), "windows-10", process.platform === "win32" ? process.arch : "ia32", "makeappx.exe"), args)
-    await spawn(path.join(await getSignVendorPath(), "windows-10", arch === Arch.ia32 ? "ia32" : "x64", "makeappx.exe"), args)
+    await spawn(path.join(await getSignVendorPath(), "windows-10", arch == Arch.ia32 ? "ia32" : "x64", "makeappx.exe"), args)
 
     await packager.sign(destination)
     packager.dispatchArtifactCreated(destination, packager.generateName("appx", arch, true))
@@ -102,7 +102,7 @@ export default class AppXTarget extends Target {
             return safeName
             
           case "arch":
-            return arch === Arch.ia32 ? "x86" : "x64"
+            return arch == Arch.ia32 ? "x86" : "x64"
 
           default:
             throw new Error(`Macro ${p1} is not defined`)

--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -55,7 +55,7 @@ export default class AppXTarget extends Target {
         return copy(path.join(templatePath, "assets", `SampleAppx.${size}.png`), target)
       }),
       copyDir(appOutDir, path.join(preAppx, "app")),
-      this.writeManifest(templatePath, preAppx, safeName)
+      this.writeManifest(templatePath, preAppx, safeName, arch)
     ])
 
     const destination = path.join(this.outDir, packager.generateName("appx", arch, false))
@@ -69,7 +69,7 @@ export default class AppXTarget extends Target {
     packager.dispatchArtifactCreated(destination, packager.generateName("appx", arch, true))
   }
 
-  private async writeManifest(templatePath: string, preAppx: string, safeName: string) {
+  private async writeManifest(templatePath: string, preAppx: string, safeName: string, arch: string) {
     const appInfo = this.packager.appInfo
     const manifest = (await readFile(path.join(templatePath, "appxmanifest.xml"), "utf8"))
       .replace(/\$\{([a-zA-Z]+)\}/g, (match, p1): string => {
@@ -100,6 +100,9 @@ export default class AppXTarget extends Target {
 
           case "safeName":
             return safeName
+            
+          case "arch":
+            return arch === "x86" ? arch : "x64"
 
           default:
             throw new Error(`Macro ${p1} is not defined`)

--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -63,7 +63,7 @@ export default class AppXTarget extends Target {
     use(this.options.makeappxArgs, (it: Array<string>) => args.push(...it))
     // wine supports only ia32 binary in any case makeappx crashed on wine
     // await execWine(path.join(await getSignVendorPath(), "windows-10", process.platform === "win32" ? process.arch : "ia32", "makeappx.exe"), args)
-    await spawn(path.join(await getSignVendorPath(), "windows-10", process.arch, "makeappx.exe"), args)
+    await spawn(path.join(await getSignVendorPath(), "windows-10", arch, "makeappx.exe"), args)
 
     await packager.sign(destination)
     packager.dispatchArtifactCreated(destination, packager.generateName("appx", arch, true))

--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -102,7 +102,7 @@ export default class AppXTarget extends Target {
             return safeName
             
           case "arch":
-            return arch === "x86" ? arch : "x64"
+            return arch === Arch.ia32 ? "x86" : "x64"
 
           default:
             throw new Error(`Macro ${p1} is not defined`)

--- a/templates/appx/appxmanifest.xml
+++ b/templates/appx/appxmanifest.xml
@@ -4,7 +4,7 @@
    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
   <Identity Name="${name}"
-    ProcessorArchitecture="x64"
+    ProcessorArchitecture="${arch}"
     Publisher="${publisher}"
     Version="${version}" />
   <Properties>


### PR DESCRIPTION
Use the architecture (ia32 / x64) that's been passed as a parameter instead of process.arch when calling makeappx.exe. Allows for 32-bit builds on 64-bit machines.