### PR TITLE
appx, added more custom props

### DIFF
--- a/src/options/winOptions.ts
+++ b/src/options/winOptions.ts
@@ -185,4 +185,6 @@ export interface AppXOptions {
   readonly makeappxArgs?: Array<string> | null
 
   readonly publisher?: string | null
+  readonly publisherDisplayName=: string | null
+  readonly identityName?: string | null
 }

--- a/src/options/winOptions.ts
+++ b/src/options/winOptions.ts
@@ -185,6 +185,6 @@ export interface AppXOptions {
   readonly makeappxArgs?: Array<string> | null
 
   readonly publisher?: string | null
-  readonly publisherDisplayName=: string | null
+  readonly publisherDisplayName?: string | null
   readonly identityName?: string | null
 }

--- a/src/targets/appx.ts
+++ b/src/targets/appx.ts
@@ -85,12 +85,18 @@ export default class AppXTarget extends Target {
 
           case "name":
             return appInfo.name
+            
+          case "identityName":
+            return this.options.identityName ? this.options.identityName : appInfo.name;
 
           case "executable":
             return `app\\${appInfo.productFilename}.exe`
 
           case "displayName":
-            return appInfo.productName
+            return this.options.displayName ? this.options.displayName : appInfo.productName
+            
+          case "publisherDisplayName":
+            return this.options.publisherDisplayName ? this.options.publisherDisplayName : appInfo.companyName
 
           case "description":
             return appInfo.description || appInfo.productName

--- a/templates/appx/appxmanifest.xml
+++ b/templates/appx/appxmanifest.xml
@@ -3,13 +3,13 @@
    xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
-  <Identity Name="${name}"
+  <Identity Name="${identityName}"
     ProcessorArchitecture="x64"
     Publisher="${publisher}"
     Version="${version}" />
   <Properties>
     <DisplayName>${displayName}</DisplayName>
-    <PublisherDisplayName>${author}</PublisherDisplayName>
+    <PublisherDisplayName>${publisherDisplayName}</PublisherDisplayName>
     <Description>${description}</Description>
     <Logo>assets\${safeName}.50x50.png</Logo>
   </Properties>


### PR DESCRIPTION
Allow for more customizable manifest fields:

+ Package.Identity.Name (default name) - build.win.identityName
+ Package.Properties.DisplayName (default productName) - build.win.displayName
+ Package.Properties.PublisherDisplayName (default companyName) - build.win.publisherDisplayName