### PR TITLE
fix(linux): executable breakes if productName given

### DIFF
--- a/src/targets/fpm.ts
+++ b/src/targets/fpm.ts
@@ -50,6 +50,7 @@ export default class FpmTarget extends Target {
     const templateOptions = Object.assign({
       // old API compatibility
       executable: this.packager.executableName,
+      productName: this.packager.info.metadata.productName
     }, packager.platformSpecificBuildOptions)
 
     function getResource(value: string | n, defaultFile: string) {

--- a/templates/linux/after-install.tpl
+++ b/templates/linux/after-install.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Link to the binary
-ln -sf '/opt/<%= executable %>/<%= executable %>' '/usr/local/bin/<%= executable %>'
+ln -sf '/opt/<%= productName %>/<%= executable %>' '/usr/local/bin/<%= executable %>'


### PR DESCRIPTION
Change the path to the executable so the symlink in /usr/local/bin does not break