### PR TITLE
fix(electron-auto-updater): use Github public API on Github provider

### DIFF
--- a/nsis-auto-updater/src/GitHubProvider.ts
+++ b/nsis-auto-updater/src/GitHubProvider.ts
@@ -11,7 +11,7 @@ export class GitHubProvider implements Provider<VersionInfo> {
   async getLatestVersion(): Promise<UpdateInfo> {
     // do not use API to avoid limit
     const basePath = this.getBasePath()
-    let version = (await request<Redirect>({hostname: "github.com", path: `${basePath}/latest`})).location
+    let version = (await request<ReleaseInfo>({hostname: "api.github.com", path: `repos${basePath}/latest`})).html_url
     const versionPosition = version.lastIndexOf("/") + 1
     try {
       version = version.substring(version[versionPosition] === "v" ? versionPosition + 1 : versionPosition)
@@ -51,6 +51,6 @@ export class GitHubProvider implements Provider<VersionInfo> {
   }
 }
 
-interface Redirect {
-  readonly location: string
+interface ReleaseInfo {
+  readonly html_url: string
 }


### PR DESCRIPTION
It's possible to get the latest release using the github api, see [reference](https://developer.github.com/v3/repos/releases/#get-the-latest-release)

I believe this method to be more robust and efficient than reading the redirect location of a request to the /:owner/:repo/releases/latest endpoint.

EDIT: I'm going to open an issue instead because I just saw that you had already decided to not use the API due to the rate limit, sorry for the rushed PR.