### PR TITLE
fix(electron-auto-updater) Checking for updates from github was failing

### DIFF
--- a/nsis-auto-updater/src/GitHubProvider.ts
+++ b/nsis-auto-updater/src/GitHubProvider.ts
@@ -23,7 +23,7 @@ export class GitHubProvider implements Provider<VersionInfo> {
       version = (version.startsWith("v")) ? version.substring(1) : version
     }
     catch (e) {
-      throw new Error(`Cannot parse extract version from location "${version}": ${e.stack || e.message}`)
+      throw new Error(`Cannot parse determine latest version from github "${version}": ${e.stack || e.message}`)
     }
 
     let result: UpdateInfo | null = null

--- a/src/util/httpExecutor.ts
+++ b/src/util/httpExecutor.ts
@@ -24,7 +24,7 @@ export class HttpExecutorHolder {
 }
 
 export interface HttpExecutor {
-  request<T>(url: Url, token?: string | null, data?: {[name: string]: any; } | null, method?: string): Promise<T>
+  request<T>(url: Url, token?: string | null, data?: {[name: string]: any; } | null, method?: string, headers?: any): Promise<T>
 
   download(url: string, destination: string, options?: DownloadOptions | null): Promise<string>
 }
@@ -59,8 +59,8 @@ export function githubRequest<T>(path: string, token: string | null, data: {[nam
   return request<T>({hostname: "api.github.com", path: path}, token, data, method)
 }
 
-export function request<T>(url: Url, token: string | null = null, data: {[name: string]: any; } | null = null, method: string = "GET"): Promise<T> {
-  return executorHolder.httpExecutor.request(url, token, data, method)
+export function request<T>(url: Url, token: string | null = null, data: {[name: string]: any; } | null = null, method: string = "GET", headers: any = {}): Promise<T> {
+  return executorHolder.httpExecutor.request(url, token, data, method, headers)
 }
 
 export function checkSha2(sha2Header: string | null | undefined, sha2: string | null | undefined, callback: (error: Error | null) => void): boolean {

--- a/src/util/nodeHttpExecutor.ts
+++ b/src/util/nodeHttpExecutor.ts
@@ -18,15 +18,16 @@ export class NodeHttpExecutor implements HttpExecutor {
 
   private httpsAgent: Promise<Agent> | null = null
 
-  request<T>(url: Url, token: string | null = null, data: {[name: string]: any; } | null = null, method: string = "GET"): Promise<T> {
+  request<T>(url: Url, token: string | null = null, data: {[name: string]: any; } | null = null, method: string = "GET", headers: any = {}): Promise<T> {
+
+    headers = Object.assign({"User-Agent": "electron-builder"}, headers)
+
     const options: any = Object.assign({
       method: method,
-      headers: {
-        "User-Agent": "electron-builder"
-      }
+      headers: headers
     }, url)
 
-    if (url.hostname!!.includes("github") && !url.path!.endsWith(".yml")) {
+    if (url.hostname!!.includes("github") && !url.path!.endsWith(".yml") && !headers.Accept) {
       options.headers.Accept = "application/vnd.github.v3+json"
     }
 

--- a/src/util/nodeHttpExecutor.ts
+++ b/src/util/nodeHttpExecutor.ts
@@ -160,14 +160,10 @@ Please double check that your authentication token is correct. Due to security r
               return
             }
 
-            if (options.path!.endsWith("/latest")) {
-              resolve(<any>{location: redirectUrl})
-            }
-            else {
-              this.doApiRequest(Object.assign({}, options, parseUrl(redirectUrl)), token, requestProcessor)
-                .then(<any>resolve)
-                .catch(reject)
-            }
+            this.doApiRequest(Object.assign({}, options, parseUrl(redirectUrl)), token, requestProcessor)
+              .then(<any>resolve)
+              .catch(reject)
+
             return
           }
 
@@ -181,6 +177,7 @@ Please double check that your authentication token is correct. Due to security r
             try {
               const contentType = response.headers["content-type"]
               const isJson = contentType != null && contentType.includes("json")
+              const isYaml = options.path!.includes(".yml")
               if (response.statusCode >= 400) {
                 if (isJson) {
                   reject(new HttpError(response, JSON.parse(data)))
@@ -190,7 +187,7 @@ Please double check that your authentication token is correct. Due to security r
                 }
               }
               else {
-                resolve(data.length === 0 ? null : (isJson || !options.path!.includes(".yml")) ? JSON.parse(data) : safeLoad(data))
+                resolve(data.length === 0 ? null : (isJson ? JSON.parse(data) : isYaml ? safeLoad(data) : data))
               }
             }
             catch (e) {


### PR DESCRIPTION
Appears that github are now more strict about the `Accept` header, and invalid requests are resulting in a [406 response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406)

I've adjusted the httpExecutor.request method to allow for custom header objects to be passed, so user can specify header (eg. `Accept: application/json`)

I've also updated the way we retrieve the latest version tag; 
when sending `Accept: application/json` to `/:user/:repo/releases/latest` github will respond with a JSON payload like below

```json
{
  "tag_name": "v1.0.0",
  ...
}
```

So it can be easily extracted without relying on redirect headers or the official API

#1038 #1058 