### PR TITLE
fix(docker): add missing libcurl3 for osslsigncode

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -20,7 +20,7 @@ ENV FORCE_COLOR true
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN curl -L https://yarnpkg.com/latest.tar.gz | tar xvz && mv dist yarn && apt-get update -y && apt-get upgrade -y && \
-  apt-get install --no-install-recommends -y xvfb git snapcraft qtbase5-dev xorriso bsdtar build-essential autoconf libssl-dev icnsutils libopenjp2-7 graphicsmagick gcc-multilib g++-multilib libgnome-keyring-dev lzip rpm yasm python && \
+  apt-get install --no-install-recommends -y xvfb git snapcraft qtbase5-dev xorriso bsdtar build-essential autoconf libssl-dev icnsutils libopenjp2-7 graphicsmagick gcc-multilib g++-multilib libgnome-keyring-dev lzip rpm yasm python libcurl3 && \
   curl -O http://mirrors.kernel.org/ubuntu/pool/universe/libi/libicns/libicns1_0.8.1-3.1_amd64.deb && dpkg --install libicns1_0.8.1-3.1_amd64.deb && unlink libicns1_0.8.1-3.1_amd64.deb && \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
   apt-get update && apt-get install -y google-chrome-stable && \


### PR DESCRIPTION
Windows build *without* code signing works fine but when code signing is
enabled `osslsigncode` fails. It's apparently due to libcurl shared
dependency mismatch.

    /root/.cache/electron-builder/winCodeSign/winCodeSign-1.6.0/linux/osslsigncode:
    error while loading shared libraries: libcurl.so.4: cannot open
    shared object file: No such file or directory

Installing libcurl3 fixes the issue.