### PR TITLE
AutoUpdate: Port support for downloads, Protocol support for generic backend

### DIFF
--- a/packages/electron-auto-updater/src/GenericProvider.ts
+++ b/packages/electron-auto-updater/src/GenericProvider.ts
@@ -16,7 +16,7 @@ export class GenericProvider implements Provider<UpdateInfo> {
     const channelFile = getChannelFilename(this.channel)
     const pathname = path.posix.resolve(this.baseUrl.pathname || "/", `${channelFile}`)
     try {
-      result = await request<UpdateInfo>({hostname: this.baseUrl.hostname, port: this.baseUrl.port || "443", path: `${pathname}${this.baseUrl.search || ""}`})
+      result = await request<UpdateInfo>({hostname: this.baseUrl.hostname, port: this.baseUrl.port || "443", path: `${pathname}${this.baseUrl.search || ""}`, protocol: this.baseUrl.protocol})
     }
     catch (e) {
       if (e instanceof HttpError && e.response.statusCode === 404) {

--- a/packages/electron-auto-updater/src/electronHttpExecutor.ts
+++ b/packages/electron-auto-updater/src/electronHttpExecutor.ts
@@ -41,6 +41,7 @@ export class ElectronHttpExecutor extends HttpExecutor<Electron.RequestOptions, 
       protocol: parsedUrl.protocol,
       hostname: parsedUrl.hostname,
       path: parsedUrl.path,
+      port: parsedUrl.port ? +parsedUrl.port : undefined,
       headers: {
         "User-Agent": "electron-builder"
       },
@@ -80,7 +81,7 @@ export class ElectronHttpExecutor extends HttpExecutor<Electron.RequestOptions, 
       (<any>requestOptions.headers).authorization = token.startsWith("Basic") ? token : `token ${token}`
     }
 
-    requestOptions.protocol = "https:"
+    requestOptions.protocol = options.Protocol || "https:"
     return new BluebirdPromise<T>((resolve, reject, onCancel) => {
       const request = net.request(options, response => {
         try {


### PR DESCRIPTION
Hi -

Love the work you guys are doing here! I've made a couple of quick changes to allow easier local testing for auto-updating, and for non-standard internal environments.

The first is to allow the options to doApiRequest to include the Protocol, and use https: if unspecified. This allows the usage of a local http server for testing. I was surprised to see that RequestOptions includes Protocol with a capital P, but it's what I needed to get this to work. Previously, I was attempting to use a self-signed certificate for a local server, but the request either stalls or fails silently (unsure which), and I don't have access to an SSL server for this internal testing.

The second is that doDownload() was not passing through the port number. This would cause a scenario where the latest version would be fetched correctly, but the download would use the standard port, and fail.

Thanks again for this builder/updater framework. Having written similar systems in the past, using electron-builder is such a breeze!

Cheers,
-Courtland