### PR TITLE
fix: Arch & pacman use i686 instead of i386 and pkg.tar.xz

### DIFF
--- a/packages/electron-builder/src/platformPackager.ts
+++ b/packages/electron-builder/src/platformPackager.ts
@@ -398,6 +398,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
   generateName(ext: string | null, arch: Arch, deployment: boolean, classifier: string | null = null): string {
     let c: string | null = null
+    let e: string | null = null
     if (arch === Arch.x64) {
       if (ext === "AppImage") {
         c = "x86_64"
@@ -409,6 +410,12 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     else if (arch === Arch.ia32 && ext === "deb") {
       c = "i386"
     }
+    else if (ext === "pacman") {
+      if (arch === Arch.ia32) {
+        c = "i686"
+      }
+      e = "pkg.tar.xz"
+    }
     else {
       c = Arch[arch]
     }
@@ -419,7 +426,10 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     else if (classifier != null) {
       c += `-${classifier}`
     }
-    return this.generateName2(ext, c, deployment)
+    if (e == null) {
+      e = ext
+    }
+    return this.generateName2(e, c, deployment)
   }
 
   generateName2(ext: string | null, classifier: string | n, deployment: boolean): string {

--- a/packages/electron-builder/src/targets/fpm.ts
+++ b/packages/electron-builder/src/targets/fpm.ts
@@ -98,7 +98,7 @@ export default class FpmTarget extends Target {
     const args = [
       "-s", "dir",
       "-t", target,
-      "--architecture", toLinuxArchString(arch),
+      "--architecture", (target === "pacman" && arch === Arch.ia32) ? "i686" : toLinuxArchString(arch),
       "--name", appInfo.name,
       "--force",
       "--after-install", scripts[0],
@@ -132,6 +132,9 @@ export default class FpmTarget extends Target {
     if (depends == null) {
       if (target === "deb") {
         depends = ["gconf2", "gconf-service", "libnotify4", "libappindicator1", "libxtst6", "libnss3"]
+      }
+      else if (target === "pacman") {
+        depends = ["c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy"]
       }
       else {
         depends = []


### PR DESCRIPTION
Digging through the code, this is probably not the ideal way to do this but it follows what was done for the 'deb' packaging.

Arch Linux (pacman) does not have packages available for i386 and only builds for i686 architecture or better.

Also added in the dependencies of Electron on Arch and changed the filename from ".pacman" to the correct "pkg.tar.xz".