### PR TITLE
Show welcome and finish page duing uninstall for boring uninstall

### DIFF
--- a/packages/electron-builder/templates/nsis/boringInstaller.nsh
+++ b/packages/electron-builder/templates/nsis/boringInstaller.nsh
@@ -47,10 +47,12 @@
   !insertmacro MUI_PAGE_INSTFILES
   !insertmacro MUI_PAGE_FINISH
 !else
+  !insertmacro MUI_UNPAGE_WELCOME
   !ifndef INSTALL_MODE_PER_ALL_USERS
     !insertmacro PAGE_INSTALL_MODE
   !endif
   !insertmacro MUI_UNPAGE_INSTFILES
+  !insertmacro MUI_UNPAGE_FINISH
 !endif
 
 !macro initMultiUser

--- a/packages/electron-builder/templates/nsis/uninstaller.nsh
+++ b/packages/electron-builder/templates/nsis/uninstaller.nsh
@@ -2,10 +2,10 @@ Function un.onInit
   !insertmacro check64BitAndSetRegView
 
   ${IfNot} ${Silent}
-    MessageBox MB_OKCANCEL "Are you sure you want to uninstall ${PRODUCT_NAME}?" IDOK +2
-    Quit
-
     !ifdef ONE_CLICK
+      MessageBox MB_OKCANCEL "Are you sure you want to uninstall ${PRODUCT_NAME}?" IDOK +2
+      Quit
+
       # one-click installer executes uninstall section in the silent mode, but we must show message dialog if silent mode was not explicitly set by user (using /S flag)
       !insertmacro CHECK_APP_RUNNING "uninstall"
       SetSilent silent
@@ -62,5 +62,7 @@ Section "un.install"
     !insertmacro customUnInstall
   !endif
 
-  !insertmacro quitSuccess
+  !ifdef ONE_CLICK
+    !insertmacro quitSuccess
+  !endif
 SectionEnd


### PR DESCRIPTION
This change will show a welcome and finish page during the uninstall process if using the boring installer.
The welcome page removes the need to have the message box asking if you are sure you want to uninstall.
The finish page makes it more clear that it was successfully uninstalled. It also makes it possible to customise the finish page as seen in the screenshot.

![image](https://cloud.githubusercontent.com/assets/5689874/22325073/6b1154fa-e3a4-11e6-9c63-3bc53bb842ba.png)


![image](https://cloud.githubusercontent.com/assets/5689874/22325165/d281f6ee-e3a4-11e6-8119-a4d1953aa5b3.png)



To show the remove user data box you can add an include script that contains something like the following, which closes #885 :

```
!ifdef BUILD_UNINSTALLER
  Function un.AddAppData
    RMDir /r "$APPDATA\Rocket.Chat+"
  FunctionEnd

  ; Using the read me setting to add option to remove app data
  !define MUI_FINISHPAGE_SHOWREADME
  !define MUI_FINISHPAGE_SHOWREADME_TEXT "Remove user data"
  !define MUI_FINISHPAGE_SHOWREADME_NOTCHECKED
  !define MUI_FINISHPAGE_SHOWREADME_FUNCTION un.AddAppData

!endif
```