### PR TITLE
Update doc for download-progress event support

### DIFF
--- a/docs/Auto Update.md
+++ b/docs/Auto Update.md
@@ -86,7 +86,7 @@ Emitted when there is no available update.
   * `total`
   * `transferred`
 
-Emitted on progress.
+Emitted on progress. Only supported over Windows build, since `Squirrel.Mac` does not provide this data.
 
 #### Event: `update-downloaded`
 


### PR DESCRIPTION
Just a note why electron-updater `download-progress` event is not supported on Mac yet.