### PR TITLE
feat(nsins): create pre initialization hook in installer.nsi

### DIFF
--- a/docs/NSIS.md
+++ b/docs/NSIS.md
@@ -9,10 +9,15 @@ Two options are available — [include](https://github.com/electron-userland/ele
 Keep in mind — if you customize NSIS script, you should always state about it in the issue reports. And don't expect that your issue will be resolved.
 
 1. Add file `build/installer.nsh`.
-2. Define wanted macro to customise: `customHeader`, `customInit`, `customUnInit`, `customInstall`, `customUnInstall`. Example:
+2. Define wanted macro to customise: `customHeader`, `preInit`, `customInit`, `customUnInit`, `customInstall`, `customUnInstall`. Example:
    ```nsis
     !macro customHeader
       !system "echo '' > ${BUILD_RESOURCES_DIR}/customHeader"
+    !macroend
+
+    !macro preInit
+      ; This macro is inserted at the beginning of the NSIS .OnInit callback
+      !system "echo '' > ${BUILD_RESOURCES_DIR}/preInit"
     !macroend
   
     !macro customInit

--- a/packages/electron-builder/templates/nsis/installer.nsi
+++ b/packages/electron-builder/templates/nsis/installer.nsi
@@ -33,6 +33,9 @@ Var desktopLink
 !endif
 
 Function .onInit
+  !ifmacrodef preInit
+    !insertmacro preInit
+  !endif
   !ifdef BUILD_UNINSTALLER
     WriteUninstaller "${UNINSTALLER_OUT_FILE}"
     !insertmacro quitSuccess


### PR DESCRIPTION
Create a 'preInit' hook in the NSIS installer script that is inserted before
any other code or macros. This allows customs macros to access the initial
state of global variables.

No breaking changes