### PR TITLE
fix: increase maxBuffer for xorriso child process

### DIFF
--- a/packages/electron-builder/src/targets/appImage.ts
+++ b/packages/electron-builder/src/targets/appImage.ts
@@ -76,7 +76,9 @@ export default class AppImageTarget extends Target {
       return
     }
 
-    await exec(process.arch !== "x64" || (process.env.USE_SYSTEM_XORRISO === "true" || process.env.USE_SYSTEM_XORRISO === "") ? "xorriso" : path.join(appImagePath, "xorriso"), args)
+    await exec(process.arch !== "x64" || (process.env.USE_SYSTEM_XORRISO === "true" || process.env.USE_SYSTEM_XORRISO === "") ? "xorriso" : path.join(appImagePath, "xorriso"), args, {
+      maxBuffer: 2 * 1024 * 1024
+    })
 
     await new BluebirdPromise((resolve, reject) => {
       const rd = createReadStream(path.join(appImagePath, arch === Arch.ia32 ? "32" : "64", "runtime"))


### PR DESCRIPTION
I got the following error when trying to build AppImage on my Ubuntu VM. The same error occurred in Travis CI.

```
Error: Exit code: undefined. stderr maxBuffer exceeded
GNU xorriso 1.4.4 : RockRidge filesystem manipulator, libburnia project.
```

Increasing the maxBuffer size fixed the problem.