### PR TITLE
Publishing always fails on circleci #1303

### DIFF
--- a/packages/electron-builder/src/publish/PublishManager.ts
+++ b/packages/electron-builder/src/publish/PublishManager.ts
@@ -401,7 +401,7 @@ function sha256(file: string) {
 function isPullRequest() {
   // TRAVIS_PULL_REQUEST is set to the pull request number if the current job is a pull request build, or false if it’s not.
   function isSet(value: string) {
-    return value != null && value !== "false"
+    return value && value !== "false"
   }
 
   return isSet(process.env.TRAVIS_PULL_REQUEST) || isSet(process.env.CI_PULL_REQUEST) || isSet(process.env.CI_PULL_REQUESTS)


### PR DESCRIPTION
I'm pretty sure that value is either `undefined` or empty (`''`) instead of `null` if the env var is not set.