### PR TITLE
Add dependencies for supporting Electron Tray (libappindicator) & Notifications (libnotify) for more Linux targets

### DIFF
--- a/packages/electron-builder/src/targets/fpm.ts
+++ b/packages/electron-builder/src/targets/fpm.ts
@@ -135,6 +135,8 @@ export default class FpmTarget extends Target {
       else if (target === "pacman") {
         depends = ["c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk2", "libappindicator-gtk3", "libappindicator-sharp"]
       }
+      else if (target === "rpm") {
+        depends = ["libnotify", "libappindicator"]
       }
       else {
         depends = []

--- a/packages/electron-builder/src/targets/fpm.ts
+++ b/packages/electron-builder/src/targets/fpm.ts
@@ -133,7 +133,8 @@ export default class FpmTarget extends Target {
         depends = ["gconf2", "gconf-service", "libnotify4", "libappindicator1", "libxtst6", "libnss3"]
       }
       else if (target === "pacman") {
-        depends = ["c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy"]
+        depends = ["c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk2", "libappindicator-gtk3", "libappindicator-sharp"]
+      }
       }
       else {
         depends = []


### PR DESCRIPTION
I added the default package dependencies for supporting Electron [Tray Menus](https://github.com/electron/electron/blob/master/docs/api/tray.md) and [Notifications](https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md) when building `pacman` and `rpm` Linux targets (currently, this only works for deb packages, which includes `libnotify4`, `libappindicator1` per default).

The required packages **libappindicator** and **libnotify** have different names on these platforms:

 - **pacman**
  `libappindicator-gtk2`, `libappindicator-gtk3`, `libappindicator-sharp`, `libnotify`
 - **rpm**
  `libappindicator`, `libnotify`