### PR TITLE
Create private GitHub provider, resolves #1266

### DIFF
--- a/docs/Auto Update.md
+++ b/docs/Auto Update.md
@@ -26,6 +26,12 @@ Simplified auto-update is not supported for Squirrel.Windows.
 
 `latest.yml` (or `latest-mac.json` for macOS) will be generated and uploaded for all providers except `bintray` (because not required, `bintray` doesn't use `latest.yml`).
 
+## Private Update Repo
+
+You can use a private repository for updates with electron-updater by setting the `GH_TOKEN` environment variable. If `GH_TOKEN` is set, electron-updater will use the GitHub API for updates allowing private repositories to work.
+
+**Note:** The GitHub API currently has a rate limit of 5000 requests per user per hour. An update check uses up to 3 requests per check. If you are worried about hitting your rate limit, consider using [conditional requests](https://developer.github.com/v3/#conditional-requests) before checking for updates to reduce rate limit usage.
+
 ## Debugging
 
 You don't need to listen all events to understand what's wrong. Just set `logger`.

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -13,6 +13,7 @@ import { BintrayProvider } from "./BintrayProvider"
 import { ElectronHttpExecutor } from "./electronHttpExecutor"
 import { GenericProvider } from "./GenericProvider"
 import { GitHubProvider } from "./GitHubProvider"
+import { PrivateGitHubProvider } from "./PrivateGitHubProvider"
 
 export interface Logger {
   info(message?: any): void
@@ -254,8 +255,11 @@ function createClient(data: string | PublishConfiguration) {
   const provider = (<PublishConfiguration>data).provider
   switch (provider) {
     case "github":
-      return new GitHubProvider(<GithubOptions>data)
-
+      if (process.env.GH_TOKEN != null) {
+        return new PrivateGitHubProvider(<GithubOptions>data)
+      } else {
+        return new GitHubProvider(<GithubOptions>data)
+      }
     case "s3": {
       const s3 = <S3Options>data
       return new GenericProvider({

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -26,6 +26,14 @@ export class MacUpdater extends AppUpdater {
   }
 
   protected onUpdateAvailable(versionInfo: VersionInfo, fileInfo: FileInfo) {
+    if (fileInfo.headers != null) {
+      if (this.requestHeaders != null) {
+        Object.assign(fileInfo.headers, this.requestHeaders)
+      } else {
+        this.requestHeaders = fileInfo.headers;
+      }
+    }
+    
     this.nativeUpdater.setFeedURL((<any>versionInfo).releaseJsonUrl, Object.assign({"Cache-Control": "no-cache"}, this.requestHeaders))
     super.onUpdateAvailable(versionInfo, fileInfo)
   }

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -30,10 +30,10 @@ export class MacUpdater extends AppUpdater {
       if (this.requestHeaders != null) {
         Object.assign(fileInfo.headers, this.requestHeaders)
       } else {
-        this.requestHeaders = fileInfo.headers;
+        this.requestHeaders = fileInfo.headers
       }
     }
-    
+
     this.nativeUpdater.setFeedURL((<any>versionInfo).releaseJsonUrl, Object.assign({"Cache-Control": "no-cache"}, this.requestHeaders))
     super.onUpdateAvailable(versionInfo, fileInfo)
   }

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -23,6 +23,15 @@ export class NsisUpdater extends AppUpdater {
    * @returns {Promise<string>} Path to downloaded file.
    */
   protected async doDownloadUpdate(versionInfo: VersionInfo, fileInfo: FileInfo, cancellationToken: CancellationToken) {
+    //allow custom headers from provider
+    if (fileInfo.headers != null) {
+      if (this.requestHeaders != null) {
+        Object.assign(fileInfo.headers, this.requestHeaders)
+      } else {
+        this.requestHeaders = fileInfo.headers;
+      }
+    }
+
     const downloadOptions: DownloadOptions = {
       skipDirCreation: true,
       headers: this.requestHeaders || undefined,

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -28,7 +28,7 @@ export class NsisUpdater extends AppUpdater {
       if (this.requestHeaders != null) {
         Object.assign(fileInfo.headers, this.requestHeaders)
       } else {
-        this.requestHeaders = fileInfo.headers;
+        this.requestHeaders = fileInfo.headers
       }
     }
 

--- a/packages/electron-updater/src/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/PrivateGitHubProvider.ts
@@ -37,7 +37,7 @@ export class PrivateGitHubProvider extends Provider<VersionInfo> {
       result = await request<UpdateInfo>(requestOptions, cancellationToken)
       //Maybe better to parse in httpExecutor ?
       if (typeof result === "string") {
-        if (getCurrentPlatform() === "darwin"){
+        if (getCurrentPlatform() === "darwin") {
           result = JSON.parse(result)
         } else {
           result = safeLoad(result)

--- a/packages/electron-updater/src/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/PrivateGitHubProvider.ts
@@ -82,7 +82,7 @@ export class PrivateGitHubProvider extends Provider<VersionInfo> {
     // space is not supported on GitHub
     if (getCurrentPlatform() === "darwin") {
       let info = <any>versionInfo
-      const name = info.url.split('/').pop()
+      const name = info.url.split("/").pop()
       
       const assetPath = parseUrl(this.apiResult.assets.find( (elem: any) => {
                   return elem.name == name

--- a/packages/electron-updater/src/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/PrivateGitHubProvider.ts
@@ -1,0 +1,116 @@
+import { Provider, FileInfo, getDefaultChannelName, getChannelFilename, getCurrentPlatform } from "./api"
+import { VersionInfo, GithubOptions, UpdateInfo } from "electron-builder-http/out/publishOptions"
+import { validateUpdateInfo } from "./GenericProvider"
+import * as path from "path"
+import { HttpError, request } from "electron-builder-http"
+import { CancellationToken } from "electron-builder-http/out/CancellationToken"
+import { Url, parse as parseUrl, format as buggyFormat }  from "url"
+import { RequestOptions } from "http"
+import { safeLoad } from "js-yaml"
+
+export class PrivateGitHubProvider extends Provider<VersionInfo> {
+  // so, we don't need to parse port (because node http doesn't support host as url does)
+  private readonly baseUrl: RequestOptions
+  private apiResult: any
+
+  constructor(private readonly options: GithubOptions) {
+    super()
+
+    const baseUrl = parseUrl(`${options.protocol || "https"}://${options.host || "api.github.com"}`)
+    this.baseUrl = {
+      protocol: baseUrl.protocol,
+      hostname: baseUrl.hostname,
+      port: <any>baseUrl.port,
+    }
+  }
+
+  async getLatestVersion(): Promise<UpdateInfo> {
+    const basePath = this.getBasePath()
+    const cancellationToken = new CancellationToken()
+    let result: any
+    const channelFile = getChannelFilename(getDefaultChannelName())
+    const versionUrl = await this.getLatestVersionUrl(basePath, cancellationToken, channelFile)
+    const assetPath = parseUrl(versionUrl).path
+    const requestOptions = Object.assign({path: `${assetPath}?access_token=${process.env.GH_TOKEN}`,
+      headers: Object.assign({Accept: "application/octet-stream", "User-Agent": this.options.owner}, this.requestHeaders)}, this.baseUrl)
+    try {
+      result = await request<UpdateInfo>(requestOptions, cancellationToken)
+      //Maybe better to parse in httpExecutor ?
+      if (typeof result === "string") {
+        if (getCurrentPlatform() === "darwin"){
+          result = JSON.parse(result)
+        } else {
+          result = safeLoad(result)
+        }
+      }        
+    }
+    catch (e) {
+      if (e instanceof HttpError && e.response.statusCode === 404) {
+        throw new Error(`Cannot find ${channelFile} in the latest release artifacts (${formatUrl(<any>requestOptions)}): ${e.stack || e.message}`)
+      }
+      throw e
+    }
+
+    validateUpdateInfo(result)
+    if (getCurrentPlatform() === "darwin") {
+      result.releaseJsonUrl = `${this.options.protocol || "https"}://${this.options.host || "api.github.com"}${requestOptions.path}`
+    }
+    return result
+  }
+
+  private async getLatestVersionUrl(basePath: string, cancellationToken: CancellationToken, channelFile: string): Promise<string> {
+    const requestOptions: RequestOptions = Object.assign({
+      path: `${basePath}/latest?access_token=${process.env.GH_TOKEN}`, headers: Object.assign({Accept: "application/json", "User-Agent": this.options.owner}, this.requestHeaders)
+    }, this.baseUrl)
+    try {
+      this.apiResult = (await request<any>(requestOptions, cancellationToken))
+      return this.apiResult.assets.find( (elem: any) => {
+        return elem.name == channelFile
+      }).url
+    }
+    catch (e) {
+      throw new Error(`Unable to find latest version on GitHub (${formatUrl(<any>requestOptions)}), please ensure a production release exists: ${e.stack || e.message}`)
+    }
+  }
+
+  private getBasePath() {
+    return `/repos/${this.options.owner}/${this.options.repo}/releases`
+  }
+
+  async getUpdateFile(versionInfo: UpdateInfo): Promise<FileInfo> {
+
+    // space is not supported on GitHub
+    if (getCurrentPlatform() === "darwin") {
+      let info = <any>versionInfo
+      const name = info.url.split('/').pop()
+      
+      const assetPath = parseUrl(this.apiResult.assets.find( (elem: any) => {
+                  return elem.name == name
+                }).url).path
+
+      info.url = formatUrl(Object.assign({path: `${assetPath}`}, this.baseUrl)) + `?access_token=${process.env.GH_TOKEN}`
+      info.headers = {Accept: "application/octet-stream", "User-Agent": this.options.owner}
+      return info
+    } else {
+      const name = versionInfo.githubArtifactName || path.posix.basename(versionInfo.path).replace(/ /g, "-")
+      const assetPath = parseUrl(this.apiResult.assets.find( (elem: any) => {
+                  return elem.name == name
+                }).url).path
+
+      return {
+        name: name,
+        url: formatUrl(Object.assign({path: `${assetPath}`}, this.baseUrl)) + `?access_token=${process.env.GH_TOKEN}`,
+        sha2: versionInfo.sha2,
+        headers: {Accept: "application/octet-stream", "User-Agent": this.options.owner},
+      }
+    }
+  }
+}
+
+// url.format doesn't correctly use path and requires explicit pathname
+function formatUrl(url: Url) {
+  if (url.path != null && url.pathname == null) {
+    url.pathname = url.path
+  }
+  return buggyFormat(url)
+}

--- a/packages/electron-updater/src/api.ts
+++ b/packages/electron-updater/src/api.ts
@@ -8,6 +8,7 @@ export interface FileInfo {
   readonly name: string
   readonly url: string
   readonly sha2?: string
+  readonly headers?: Object
 }
 
 export abstract class Provider<T extends VersionInfo> {


### PR DESCRIPTION
Creates a PrivateGitHubProvider for auto updater. Private GitHub Provider is used if the `GH_TOKEN`
environment variable is set. Necessarily uses the GitHub API with the provided `GH_TOKEN`. Rate limiting can become less of a worry via [conditional requests](https://developer.github.com/v3/#conditional-requests) (will update with example code for this).

Also adds the ability to all providers to pass custom headers to the download for the update file.