### PR TITLE
fix: fix productName with utf8 characters cause dmg icon position error

### DIFF
--- a/packages/electron-builder/templates/dmg/dmgProperties.pl
+++ b/packages/electron-builder/templates/dmg/dmgProperties.pl
@@ -4,6 +4,7 @@ use Mac::Finder::DSStore qw( writeDSDBEntries makeEntries );
 use Mac::Memory qw( );
 use Mac::Files qw( NewAliasMinimal );
 use Encode ();
+use utf8;
 
 my($backgroundWidth, $backgroundHeight);
 


### PR DESCRIPTION
Fix https://github.com/electron-userland/electron-builder/issues/1369