### PR TITLE
fix: S3 urls on mac

### DIFF
--- a/packages/electron-builder/src/publish/PublishManager.ts
+++ b/packages/electron-builder/src/publish/PublishManager.ts
@@ -236,7 +236,7 @@ async function writeUpdateInfo(event: ArtifactCreated, _publishConfigs: Array<Pu
       await (<any>outputJson)(updateInfoFile, <VersionInfo>{
         version: version,
         releaseDate: new Date().toISOString(),
-        url: computeDownloadUrl(publishConfig, packager.generateName2("zip", "mac", isGitHub), packager),
+        url: await computeDownloadUrl(publishConfig, packager.generateName2("zip", "mac", isGitHub), packager),
       }, {spaces: 2})
 
       packager.info.dispatchArtifactCreated({
@@ -326,7 +326,7 @@ function requireProviderClass(provider: string): any | null {
   }
 }
 
-export function computeDownloadUrl(publishConfig: PublishConfiguration, fileName: string | null, packager: PlatformPackager<any>) {
+export async function computeDownloadUrl(publishConfig: PublishConfiguration, fileName: string | null, packager: PlatformPackager<any>) {
   if (publishConfig.provider === "generic") {
     const baseUrlString = (<GenericServerOptions>publishConfig).url
     if (fileName == null) {
@@ -339,6 +339,10 @@ export function computeDownloadUrl(publishConfig: PublishConfiguration, fileName
 
   let baseUrl
   if (publishConfig.provider === "s3") {
+    const providerClass = requireProviderClass(publishConfig.provider)
+    if (providerClass != null && providerClass.modifyPublishConfig != null) {
+      publishConfig = await providerClass.modifyPublishConfig(publishConfig)
+    }
     baseUrl = s3Url((<S3Options>publishConfig))
   }
   else {

--- a/packages/electron-builder/src/targets/WebInstaller.ts
+++ b/packages/electron-builder/src/targets/WebInstaller.ts
@@ -26,7 +26,7 @@ export default class WebInstallerTarget extends NsisTarget {
         throw new Error("Cannot compute app package download URL")
       }
 
-      appPackageUrl = computeDownloadUrl(publishConfigs[0], null, packager)
+      appPackageUrl = await computeDownloadUrl(publishConfigs[0], null, packager)
 
       defines.APP_PACKAGE_URL_IS_INCOMLETE = null
     }


### PR DESCRIPTION
(follow-up to #1373, only an issue for S3 bucket names with dots)

Releasing for macOS results in the following error:

```bash
Publishing to S3 (bucket: <bucket-name-with-dots>)
[====================] 100% 0.0s | App-0.2.3.dmg to S3
Error: Bucket name "<bucket-name-with-dots>" includes a dot, but S3 region is missing
    at s3Url (/<...>/desktop-app-prototype/node_modules/electron-builder-http/src/publishOptions.ts:129:13)
    at computeDownloadUrl (/<...>/desktop-app-prototype/node_modules/electron-builder/src/publish/PublishManager.ts:344:15)
    at /<...>/desktop-app-prototype/node_modules/electron-builder/src/publish/PublishManager.ts:241:14
From previous event:
    at writeUpdateInfo (/<...>/desktop-app-prototype/node_modules/electron-builder/out/publish/PublishManager.js:86:22)
    at /<...>/desktop-app-prototype/node_modules/electron-builder/src/publish/PublishManager.ts:137:22
From previous event:
    at PublishManager.artifactCreated (/<...>/desktop-app-prototype/node_modules/electron-builder/out/publish/PublishManager.js:388:11)
```
=> So, for macOS releases the field `options.region` is not set automatically! 

At the same time, the **windows release works** (incl. `app-update.yml` being automatically populated with the bucket's region).

A **workaround** for the mentioned error is to manually add `publish.region` to the `package.json`.

This pull request tries to introduce a fix - **but I couldn't test it locally** (see bottom of this post for error). 

After implementing my path approach, I discovered the line: https://github.com/electron-userland/electron-builder/blob/94951fef1c68ba43000bdf277b2896006ec80fef/packages/electron-builder/src/publish/PublishManager.ts#L63 
I imagine that the **if condition becomes true in my macOS case** which leads to the `options.region` not being generated and the error takes place. **If I'm correct, reformulating this if condition would be a better and simpler bug fix.**

Appreciate some feedback.

---------
#### "Appendix": Error when trying to test locally 

Whenever I added my local `electron-builder` to my project (after running `npm run compile` on the local `electron-builder`) and tried to build my local project for macOS, I ran into the following error:

```bash
Signing app (identity: Developer ID Application: <...>)
Building macOS zip
Building DMG
Error: Exit code: 255. Command failed: /usr/bin/perl /var/folders/59/j5b7r9d931gb5cxwbqxzl1hc0000gn/T/electron-builder-dSaFRF/0-2-dmgProperties.pl
Error: Error querying file
Cannot query image dimensions at /var/folders/59/j5b7r9d931gb5cxwbqxzl1hc0000gn/T/electron-builder-dSaFRF/0-2-dmgProperties.pl line 22.

Error: Error querying file
Cannot query image dimensions at /var/folders/59/j5b7r9d931gb5cxwbqxzl1hc0000gn/T/electron-builder-dSaFRF/0-2-dmgProperties.pl line 22.

    at /<...>/desktop-app-prototype/node_modules/electron-builder-util/src/util.ts:75:16
    at ChildProcess.exithandler (child_process.js:218:5)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:192:7)
    at maybeClose (internal/child_process.js:890:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
From previous event:
    at exec (/<...>/desktop-app-prototype/node_modules/electron-builder-util/src/util.ts:53:3)
    at /<...>/desktop-app-prototype/node_modules/electron-builder/src/targets/dmg.ts:153:7
```

`brew remove perl` like suggested in https://github.com/electron-userland/electron-builder/issues/815 did not fix this error for me. 