### PR TITLE
feat(nsis): add --no-desktop-shortcut argument

### DIFF
--- a/packages/electron-builder/templates/nsis/installSection.nsh
+++ b/packages/electron-builder/templates/nsis/installSection.nsh
@@ -168,7 +168,7 @@ StrCpy $appExe "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
 CreateShortCut "$startMenuLink" "$appExe" "" "$appExe" 0 "" "" "${APP_DESCRIPTION}"
 
 ${GetParameters} $R0
-${GetOptions} $R0 "/nodesktopshortcut" $R1
+${GetOptions} $R0 "--no-desktop-shortcut" $R1
 ${If} ${Errors}
   CreateShortCut "$desktopLink" "$appExe" "" "$appExe" 0 "" "" "${APP_DESCRIPTION}"
 ${EndIf}

--- a/packages/electron-builder/templates/nsis/installSection.nsh
+++ b/packages/electron-builder/templates/nsis/installSection.nsh
@@ -166,7 +166,12 @@ StrCpy $appExe "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
 # create shortcuts in the start menu and on the desktop
 # shortcut for uninstall is bad cause user can choose this by mistake during search, so, we don't add it
 CreateShortCut "$startMenuLink" "$appExe" "" "$appExe" 0 "" "" "${APP_DESCRIPTION}"
-CreateShortCut "$desktopLink" "$appExe" "" "$appExe" 0 "" "" "${APP_DESCRIPTION}"
+
+${GetParameters} $R0
+${GetOptions} $R0 "/nodesktopshortcut" $R1
+${If} ${Errors}
+  CreateShortCut "$desktopLink" "$appExe" "" "$appExe" 0 "" "" "${APP_DESCRIPTION}"
+${EndIf}
 
 WinShell::SetLnkAUMI "$startMenuLink" "${APP_ID}"
 WinShell::SetLnkAUMI "$desktopLink" "${APP_ID}"


### PR DESCRIPTION
I have a user who wants to do an unattended install (workflowproducts/postage#177), but they don't want the desktop shortcut.
This commit adds a command line switch that I tested to work.