### PR TITLE
Installing kernel extensions using scripts

### DIFF
--- a/docs/Kernel extensions.md
+++ b/docs/Kernel extensions.md
@@ -1,0 +1,33 @@
+# Kernel extensions
+
+Installing macOS kernel extensions with `electron-builder` can be done using scripts.
+
+First, make sure you're building a package:
+
+```json
+"mac": {
+	{
+		"target": "pkg",
+		"arch": [ "x64" ]
+	}
+}
+```
+
+Place your script and the kernel extensions in `resources/pkg-scripts`, or [define a custom directory](https://github.com/electron-userland/electron-builder/wiki/Options#PkgOptions-scripts). Note that the script **must** be called either `preinstall` or `postinstall`.  Remember to use ` #!/bin/sh` as the first line in your script. Also, your script must be executable (`chmod +x <filename>`).
+
+An example script:
+```sh
+#!/bin/sh
+
+echo "Unloading and uninstalling old extensions..."
+# unload old extensions
+sudo kextunload /Library/Extensions/myExt.kext
+
+# delete old extensions
+sudo rm -rf /Library/Extensions/myExtension.kext
+
+# install new extensions
+echo "Installing and loading new extensions..."
+sudo cp -R myExt.kext /Library/Extensions/myExt.kext
+sudo kextload /Library/Extensions/myExt.kext/
+```

--- a/docs/Kernel extensions.md
+++ b/docs/Kernel extensions.md
@@ -2,18 +2,15 @@
 
 Installing macOS kernel extensions with `electron-builder` can be done using scripts.
 
-First, make sure you're building a package:
+First, in `package.json`, make sure you're building a package (.pkg) and not the default .dmg:
 
 ```json
-"mac": {
-	{
-		"target": "pkg",
-		"arch": [ "x64" ]
-	}
+"mac": { 
+	"target": "pkg"
 }
 ```
 
-Place your script and the kernel extensions in `resources/pkg-scripts`, or [define a custom directory](https://github.com/electron-userland/electron-builder/wiki/Options#PkgOptions-scripts). Note that the script **must** be called either `preinstall` or `postinstall`.  Remember to use ` #!/bin/sh` as the first line in your script. Also, your script must be executable (`chmod +x <filename>`).
+Place your script and the kernel extensions in `build/pkg-scripts`, or [define a custom directory](https://github.com/electron-userland/electron-builder/wiki/Options#PkgOptions-scripts). Note that the script **must** be called either `preinstall` or `postinstall`.  Remember to use ` #!/bin/sh` as the first line in your script. Also, your script must be executable (`chmod +x <filename>`).
 
 An example script:
 ```sh


### PR DESCRIPTION
This PR for the wiki describes how to install macOS kernel extensions using a script.