### PR TITLE
Add support for additional certificate file

### DIFF
--- a/packages/electron-builder/src/options/winOptions.ts
+++ b/packages/electron-builder/src/options/winOptions.ts
@@ -7,14 +7,14 @@ export interface WinBuildOptions extends PlatformSpecificBuildOptions {
   /**
    * Target package type: list of `nsis`, `nsis-web` (Web installer), `portable` (portable app without installation), `appx`, `squirrel`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`. Defaults to `nsis`.
    * AppX package can be built only on Windows 10.
-   * 
+   *
    * To use Squirrel.Windows please install `electron-builder-squirrel-windows` dependency.
   */
   readonly target?: TargetConfigType
 
   /**
    * Array of signing algorithms used. Defaults to `['sha1', 'sha256']`
-   * 
+   *
    * For AppX `sha256` is always used.
    */
   readonly signingHashAlgorithms?: Array<"sha1" | "sha256"> | null
@@ -53,6 +53,11 @@ export interface WinBuildOptions extends PlatformSpecificBuildOptions {
   readonly certificateSha1?: string
 
   /**
+   * The path to an additional certificate file you want to add to the signature block.
+   */
+  readonly additionalCertificateFile?: string
+
+  /**
    * The URL of the RFC 3161 time stamp server. Defaults to `http://timestamp.comodoca.com/rfc3161`.
    */
   readonly rfc3161TimeStampServer?: string
@@ -87,9 +92,9 @@ export interface NsisOptions extends CommonNsisOptions, TargetSpecificOptions {
    */
   readonly oneClick?: boolean
 
-  /*** 
+  /***
    * If `oneClick` is `true` (default): Install per all users (per-machine).
-   * 
+   *
    * If `oneClick` is `false`: no install mode installer page (choice per-machine or per-user), always install per-machine.
    * @default false
    */
@@ -160,10 +165,10 @@ export interface NsisOptions extends CommonNsisOptions, TargetSpecificOptions {
 
   /**
    * The path to EULA license file. Defaults to `license.rtf` or `license.txt` or `eula.rtf` or `eula.txt` (or uppercase variants, e.g. `EULA.txt` or `LICENSE.TXT`).
-   * 
+   *
    * Multiple license files in different languages are supported — use lang postfix (e.g. `_de`, `_ru`)). For example, create files `license_de.txt` and `license_en.txt` in the build resources.
    * If OS language is german, `license_de.txt` will be displayed. See map of [language code to name](https://github.com/meikidd/iso-639-1/blob/master/src/data.js).
-   * 
+   *
    * Appropriate license file will be selected by user OS language.
    */
   readonly license?: string | null
@@ -226,15 +231,15 @@ export interface PortableOptions extends TargetSpecificOptions, CommonNsisOption
   readonly requestExecutionLevel?: "user" | "highest" | "admin"
 }
 
-/** 
+/**
  * Web Installer Specific Options ([nsisWeb](#Config-nsisWeb)).
  */
 export interface NsisWebOptions extends NsisOptions {
   /**
    * The application package download URL. Optional — by default computed using publish configuration.
-   * 
+   *
    * URL like `https://example.com/download/latest` allows web installer to be version independent (installer will download latest application package).
-   * 
+   *
    * Custom `X-Arch` http header is set to `32` or `64`.
    */
   readonly appPackageUrl?: string | null
@@ -253,9 +258,9 @@ export interface NsisWebOptions extends NsisOptions {
 export interface SquirrelWindowsOptions extends WinBuildOptions {
   /**
    * A URL to an ICO file to use as the application icon (displayed in Control Panel > Programs and Features). Defaults to the Electron icon.
-   * 
+   *
    * Please note — [local icon file url is not accepted](https://github.com/atom/grunt-electron-installer/issues/73), must be https/http.
-   * 
+   *
    * If you don't plan to build windows installer, you can omit it.
    * If your project repository is public on GitHub, it will be `https://github.com/${u}/${p}/blob/master/build/icon.ico?raw=true` by default.
    */

--- a/packages/electron-builder/src/windowsCodeSign.ts
+++ b/packages/electron-builder/src/windowsCodeSign.ts
@@ -128,6 +128,10 @@ async function spawnSign(options: SignOptions, inputPath: string, outputPath: st
     args.push(isWin ? "/p" : "-pass", options.password)
   }
 
+  if (options.options.additionalCertificateFile) {
+    args.push(isWin ? "/ac" : "-ac", options.options.additionalCertificateFile)
+  }
+
   if (isWin) {
     // must be last argument
     args.push(inputPath)


### PR DESCRIPTION
I had the need to add an additional certificate file via the `/ac|-ac` option (similar to [this SO question](http://stackoverflow.com/questions/16571978/signed-using-pfx-file-but-uac-still-prompts-for-unknown-publisher)). This PR adds a new `additionalCertificateFile` option to `WinBuildOptions`.