### PR TITLE
Clarify that simple auto-update works on Windows

### DIFF
--- a/docs/Auto Update.md
+++ b/docs/Auto Update.md
@@ -1,6 +1,6 @@
 See the [Publishing Artifacts](https://github.com/electron-userland/electron-builder/wiki/Publishing-Artifacts) section of the [Wiki](https://github.com/electron-userland/electron-builder/wiki) for more information on how to configure your CI environment for automated deployments.
 
-Simplified auto-update is not supported for Squirrel.Windows.
+Simplified auto-update is supported on Windows if you use the default NSIS setup, but is not supported for Squirrel.Windows.
 
 ## Quick Setup Guide
 


### PR DESCRIPTION
I was sent on a bit of a boondoggle by the sentence "simplified auto-update is not supported for Squirrel.Windows". I misinterpreted this to mean it wasn't supported on Windows at all. Perhaps I'm the only one dumb enough to make this mistake, but I wanted to clarify the sentence for those poor clods as thick headed as I am.