### PR TITLE
add proxy authentication support to electron-updater

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -94,7 +94,10 @@ export abstract class AppUpdater extends EventEmitter {
     }
     else {
       this.app = require("electron").app
-      executorHolder.httpExecutor = new ElectronHttpExecutor()
+      executorHolder.httpExecutor = new ElectronHttpExecutor((authInfo: Electron.LoginAuthInfo,
+        callback: (username: string, password: string) => void) => {
+          this.emit("login", authInfo, callback)
+      })
       this.untilAppReady = new BluebirdPromise(resolve => {
         if (this.app.isReady()) {
           if (this.logger != null) {

--- a/packages/electron-updater/src/api.ts
+++ b/packages/electron-updater/src/api.ts
@@ -60,6 +60,11 @@ export class UpdaterSignal {
   constructor(private emitter: EventEmitter) {
   }
 
+  login(handler: (event: Event, request: Electron.LoginRequest, authInfo: Electron.LoginAuthInfo,
+        callback: (username: string, password: string) => void) => void) {
+    addHandler(this.emitter, "login", handler)
+  }
+
   progress(handler: (info: ProgressInfo) => void) {
     addHandler(this.emitter, DOWNLOAD_PROGRESS, handler)
   }

--- a/packages/electron-updater/src/electronHttpExecutor.ts
+++ b/packages/electron-updater/src/electronHttpExecutor.ts
@@ -45,6 +45,7 @@ export class ElectronHttpExecutor extends HttpExecutor<Electron.RequestOptions, 
     if (debug.enabled) {
       debug(`request: ${dumpRequestOptions(options)}`)
     }
+    options.session = options.session || session.fromPartition(NET_SESSION_NAME)
 
     return cancellationToken.createPromise<T>((resolve, reject, onCancel) => {
       const request = net.request(options, response => {


### PR DESCRIPTION
With this approach we simply relay the login event from the electron requests to the `autoUpdater` instance through a callback provided by an (optional) constructor parameter of `ElectronHttpExecutor`.
The test suite runs; but I haven't had time to test the change specifically, but uploaded it in order to allow for early feedback on the general approach.

resolves #1528