### PR TITLE
Fix LoginHandler definition

### DIFF
--- a/packages/electron-updater/src/api.ts
+++ b/packages/electron-updater/src/api.ts
@@ -57,7 +57,7 @@ export interface UpdateCheckResult {
 
 export const DOWNLOAD_PROGRESS = "download-progress"
 
-export type LoginHandler = (event: Event, request: Electron.LoginRequest, authInfo: Electron.LoginAuthInfo, callback: LoginCallback) => void
+export type LoginHandler = (authInfo: Electron.LoginAuthInfo, callback: LoginCallback) => void
 
 export class UpdaterSignal {
   constructor(private emitter: EventEmitter) {

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -1,5 +1,6 @@
 // autoUpdater to mimic electron bundled autoUpdater
 import { AppUpdater } from "./AppUpdater"
+export { NET_SESSION_NAME } from "./electronHttpExecutor"
 
 let impl
 if (process.platform === "win32") {


### PR DESCRIPTION
Fixes a small oversight from #1530, I'm sorry for the inconvenience.
I also re-exported the NET_SESSION_NAME symbol from the api header file so it can be used without relying on implementation details (the existence of electronHttpExecutor)
