### PR TITLE
Snap for extra after parts and build packages support

### DIFF
--- a/packages/electron-builder/src/options/linuxOptions.ts
+++ b/packages/electron-builder/src/options/linuxOptions.ts
@@ -21,9 +21,9 @@ export interface LinuxBuildOptions extends PlatformSpecificBuildOptions, CommonL
 
   /**
    * Target package type: list of `AppImage`, `snap`, `deb`, `rpm`, `freebsd`, `pacman`, `p5p`, `apk`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`.
-   * 
+   *
    * electron-builder [docker image](https://github.com/electron-userland/electron-builder/wiki/Docker) can be used to build Linux targets on any platform. See [Multi platform build](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build).
-   * 
+   *
    * @see [Please do not put an AppImage into another archive like a .zip or .tar.gz](https://github.com/probonopd/AppImageKit/wiki/Creating-AppImages#common-mistake)
    * @default AppImage
    */
@@ -147,9 +147,14 @@ export interface SnapOptions extends LinuxBuildOptions {
   readonly assumes?: Array<string> | null
 
   /**
+   * The list of debian packages needs to be installed for building this snap.
+   */
+  readonly buildPackages?: Array<string> | null
+
+  /**
    * The list of Ubuntu packages to use that are needed to support the `app` part creation. Like `depends` for `deb`.
    * Defaults to `["libnotify4", "libappindicator1", "libxtst6", "libnss3", "libxss1", "fontconfig-config", "gconf2", "libasound2", "pulseaudio"]`.
-   * 
+   *
    * If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom package `foo` in addition to defaults.
    */
   readonly stagePackages?: Array<string> | null
@@ -157,10 +162,18 @@ export interface SnapOptions extends LinuxBuildOptions {
   /**
    * The list of [plugs](https://snapcraft.io/docs/reference/interfaces).
    * Defaults to `["home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"]`.
-   * 
+   *
    * If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom plug `foo` in addition to defaults.
    */
   readonly plugs?: Array<string> | null
+
+  /**
+   * Specifies any [parts](https://snapcraft.io/docs/reference/parts) that should be built before this part.
+   * Defaults to `["desktop-only""]`.
+   *
+   * If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom parts `foo` in addition to defaults.
+   */
+  readonly after?: Array<string> | null
 
   /**
    * Specify `ubuntu-app-platform1` to use [ubuntu-app-platform](https://insights.ubuntu.com/2016/11/17/how-to-create-snap-packages-on-qt-applications/).

--- a/packages/electron-builder/src/targets/snap.ts
+++ b/packages/electron-builder/src/targets/snap.ts
@@ -82,8 +82,8 @@ export default class SnapTarget extends Target {
     const isUseDocker = process.platform !== "linux"
 
     const defaultStagePackages = (isUseUbuntuPlatform ? ["libnss3"] : ["libnotify4", "libappindicator1", "libxtst6", "libnss3", "libxss1", "fontconfig-config", "gconf2", "libasound2", "pulseaudio"])
-    const defaultAfter = isUseUbuntuPlatform ? ["extra", "desktop-ubuntu-app-platform"] : ["desktop-glib-only"];
-    const after = replaceDefault(options.after, defaultAfter);
+    const defaultAfter = isUseUbuntuPlatform ? ["extra", "desktop-ubuntu-app-platform"] : ["desktop-glib-only"]
+    const after = replaceDefault(options.after, defaultAfter)
     snap.parts = {
       app: {
         plugin: "dump",
@@ -112,10 +112,10 @@ export default class SnapTarget extends Target {
 
     function mayInstallBuildPackagesCmd() {
       if (options.buildPackages && options.buildPackages.length > 0) {
-        return `apt-get update && apt-get install -y ${options.buildPackages.join(" ")}`;
+        return `apt-get update && apt-get install -y ${options.buildPackages.join(" ")}`
       }
       else {
-        return "";
+        return ""
       }
     }
 
@@ -133,8 +133,8 @@ export default class SnapTarget extends Target {
     }
     else {
       if (options.buildPackages && options.buildPackages.length > 0) {
-        await spawn("apt-get", ["update"]);
-        await spawn("apt-get", ["install", "-y"].concat(options.buildPackages));
+        await spawn("apt-get", ["update"])
+        await spawn("apt-get", ["install", "-y"].concat(options.buildPackages))
       }
       await spawn("snapcraft", ["snap", "--target-arch", toLinuxArchString(arch), "-o", resultFile], {
         cwd: stageDir,

--- a/packages/electron-builder/src/targets/snap.ts
+++ b/packages/electron-builder/src/targets/snap.ts
@@ -82,12 +82,14 @@ export default class SnapTarget extends Target {
     const isUseDocker = process.platform !== "linux"
 
     const defaultStagePackages = (isUseUbuntuPlatform ? ["libnss3"] : ["libnotify4", "libappindicator1", "libxtst6", "libnss3", "libxss1", "fontconfig-config", "gconf2", "libasound2", "pulseaudio"])
+    const defaultAfter = isUseUbuntuPlatform ? ["extra", "desktop-ubuntu-app-platform"] : ["desktop-glib-only"];
+    const after = replaceDefault(options.after, defaultAfter);
     snap.parts = {
       app: {
         plugin: "dump",
         "stage-packages": replaceDefault(options.stagePackages, defaultStagePackages),
         source: isUseDocker ? `/out/${path.basename(appOutDir)}` : appOutDir,
-        after: isUseUbuntuPlatform ? ["extra", "desktop-ubuntu-app-platform"] : ["desktop-glib-only"]
+        after: after
       }
     }
 
@@ -108,6 +110,15 @@ export default class SnapTarget extends Target {
     const snapFileName = `${snap.name}_${snap.version}_${toLinuxArchString(arch)}.snap`
     const resultFile = path.join(this.outDir, snapFileName)
 
+    function mayInstallBuildPackagesCmd() {
+      if (options.buildPackages && options.buildPackages.length > 0) {
+        return `apt-get update && apt-get install -y ${options.buildPackages.join(" ")}`;
+      }
+      else {
+        return "";
+      }
+    }
+
     if (isUseDocker) {
       await spawn("docker", ["run", "--rm",
         "-v", `${packager.info.projectDir}:/project`,
@@ -115,12 +126,16 @@ export default class SnapTarget extends Target {
         // dist dir can be outside of project dir
         "-v", `${this.outDir}:/out`,
         "electronuserland/electron-builder:latest",
-        "/bin/bash", "-c", `snapcraft --version && cp -R /out/${path.basename(stageDir)} /s/ && cd /s && snapcraft snap --target-arch ${toLinuxArchString(arch)} -o /out/${snapFileName}`], {
+        "/bin/bash", "-c", `${mayInstallBuildPackagesCmd()} && snapcraft --version && cp -R /out/${path.basename(stageDir)} /s/ && cd /s && snapcraft snap --target-arch ${toLinuxArchString(arch)} -o /out/${snapFileName}`], {
         cwd: packager.info.projectDir,
         stdio: ["ignore", "inherit", "inherit"],
       })
     }
     else {
+      if (options.buildPackages && options.buildPackages.length > 0) {
+        await spawn("apt-get", ["update"]);
+        await spawn("apt-get", ["install", "-y"].concat(options.buildPackages));
+      }
       await spawn("snapcraft", ["snap", "--target-arch", toLinuxArchString(arch), "-o", resultFile], {
         cwd: stageDir,
         stdio: ["ignore", "inherit", "pipe"],


### PR DESCRIPTION
For support unity global menubar integration, it needs to specify which [launcher](https://developer.ubuntu.com/en/blog/2016/07/06/announcing-new-snap-desktop-launchers/)  the app use. 

In our case, we need to specify `desktop-gtk2` in `after` in snapcraft.yaml.

This patch extends SnapBuildOption for specify after parts and necessary packages in building step.