### PR TITLE
Update electron-osx-sign version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^2.6.8",
     "electron-download-tf": "4.3.1",
     "electron-is-dev": "^0.1.2",
-    "electron-osx-sign": "0.4.4",
+    "electron-osx-sign": "0.4.5",
     "fs-extra-p": "^4.3.0",
     "hosted-git-info": "^2.4.2",
     "ini": "^1.3.4",


### PR DESCRIPTION
Update `electron-osx-sign` to `0.4.5` in order to solve [this issue](https://github.com/electron-userland/electron-osx-sign/issues/132).

