### PR TITLE
fix(config): use json5 parser for json5 build configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "is-ci": "^1.0.10",
     "isbinaryfile": "^3.0.2",
     "js-yaml": "^3.8.4",
+    "json5": "^0.5.1",
     "mime": "^1.3.6",
     "minimatch": "^3.0.4",
     "node-emoji": "^1.5.1",

--- a/packages/electron-builder/src/util/readPackageJson.ts
+++ b/packages/electron-builder/src/util/readPackageJson.ts
@@ -9,6 +9,8 @@ import { Config } from "../metadata"
 import AdditionalPropertiesParams = ajv.AdditionalPropertiesParams
 import ErrorObject = ajv.ErrorObject
 import TypeParams = ajv.TypeParams
+//import JSON5 from "json5" // throws "Could not find a declaration file for module"
+const JSON5 = require("json5")
 
 const normalizeData = require("normalize-package-data")
 
@@ -45,7 +47,11 @@ function getConfigFromPackageData(metadata: any) {
 }
 
 export async function doLoadConfig(configFile: string, projectDir: string) {
-  const result = safeLoad(await readFile(configFile, "utf8"))
+  let result = null
+  if (configFile.endsWith(".json5"))
+    result = JSON5.parse(await readFile(configFile, "utf8"))
+  else
+    result = safeLoad(await readFile(configFile, "utf8"))
   const relativePath = path.relative(projectDir, configFile)
   log(`Using ${relativePath.startsWith("..") ? configFile : relativePath} configuration file`)
   return result

--- a/yarn.lock
+++ b/yarn.lock
@@ -2097,7 +2097,7 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -2330,17 +2330,13 @@ mimic-fn@^1.0.0:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp2@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Use json5 parser to parse json5 build configs (i. e. files ending on
"json5").
Json5 can have javascript-style comments whereas yaml does not. Thus we
cannot
use the yaml parser for json5.