### PR TITLE
fix: add missing Exec variable for passing URLs as arguments

### DIFF
--- a/packages/electron-builder/src/targets/LinuxTargetHelper.ts
+++ b/packages/electron-builder/src/targets/LinuxTargetHelper.ts
@@ -109,7 +109,7 @@ export class LinuxTargetHelper {
     const desktopMeta: any = Object.assign({
       Name: appInfo.productName,
       Comment: this.getDescription(targetSpecificOptions),
-      Exec: exec == null ? `"${installPrefix}/${productFilename}/${this.packager.executableName}"` : exec,
+      Exec: exec == null ? `"${installPrefix}/${productFilename}/${this.packager.executableName}" %U` : exec,
       Terminal: "false",
       Type: "Application",
       Icon: this.packager.executableName,


### PR DESCRIPTION
Add Exec variable '%U' to desktop file generation to match AppImage generated desktop file.