### PR TITLE
fix(tar): fix invalid sym-/hardlink targets in archive

### DIFF
--- a/packages/electron-builder/src/targets/archive.ts
+++ b/packages/electron-builder/src/targets/archive.ts
@@ -33,7 +33,7 @@ export async function tar(compression: CompressionLevel | n, format: string, out
 
   const args = [info.flag, "-cf", outFile]
   if (!isMacApp) {
-    args.push("--transform", `s,^\.,${path.basename(outFile, "." + format)},`)
+    args.push("--transform", `s,^\\.,${path.basename(outFile, "." + format)},`)
   }
   args.push(isMacApp ? path.basename(dirToArchive) : ".")
   await spawn(process.platform === "darwin" || process.platform === "freebsd" ? "gtar" : "tar", args, {


### PR DESCRIPTION
The tar --transform expression did not work as intended, leading to broken sym-/hardlinks inside the archive. The intention is to match `^\.`, but the escape character is evaluated in JS before the expression is passed to tar. As a result, the first character of all paths is transformed (`^.`).

The expression still works for regular files, as all paths begin with a `.`. However, tar also transforms sym-/hardlink targets. This e.g. means that a `foo -> bar` symlink is transformed to `foo -> appname-1.0.0ar`.

Adding an extra escape character, so that the correct transform expression is used.