### PR TITLE
Cloning packager.config to prevent override

### DIFF
--- a/packages/electron-builder/src/targets/nsis.ts
+++ b/packages/electron-builder/src/targets/nsis.ts
@@ -88,7 +88,7 @@ export class NsisTarget extends Target {
 
     this.packageHelper.refCount++
 
-    let options = this.packager.config.nsis || Object.create(null)
+    let options = Object.assign({}, this.packager.config.nsis) || Object.create(null)
     if (targetName !== "nsis") {
       options = Object.assign(options, (<any>this.packager.config)[targetName === "nsis-web" ? "nsisWeb" : targetName])
     }


### PR DESCRIPTION
This will fix the last issue of #1340 when targets artifact's names are changed.