### PR TITLE
Add support for custom AppX assets and asset resolutions.

### DIFF
--- a/packages/electron-builder/templates/appx/appxmanifest.xml
+++ b/packages/electron-builder/templates/appx/appxmanifest.xml
@@ -12,7 +12,7 @@
     <DisplayName>${displayName}</DisplayName>
     <PublisherDisplayName>${publisherDisplayName}</PublisherDisplayName>
     <Description>${description}</Description>
-    <Logo>assets\${safeName}.50x50.png</Logo>
+    <Logo>${logo}</Logo>
   </Properties>
   <Resources>
     <Resource Language="en-us" />
@@ -28,10 +28,12 @@
       <uap:VisualElements
        BackgroundColor="${backgroundColor}"
        DisplayName="${displayName}"
-       Square150x150Logo="assets\${safeName}.150x150.png"
-       Square44x44Logo="assets\${safeName}.44x44.png"
+       Square150x150Logo="${square150x150Logo}"
+       Square44x44Logo="${square44x44Logo}"
        Description="${description}">
-        <uap:DefaultTile Wide310x150Logo="assets\${safeName}.310x150.png" />
+        ${lockScreen}
+        ${defaultTile}
+        ${splashScreen}
       </uap:VisualElements>
     </Application>
   </Applications>


### PR DESCRIPTION
This PR includes custom the ability to add a custom `assets` folder for `AppX` builds, along with support to specify the names for the `AppX` assets. This is based on https://github.com/electron-userland/electron-builder/issues/987#issuecomment-267406485

It leaves the default behavior untouched.

**Should I add option notes for the builds in this issue, or should I be updating the wiki directly?**

**Note:** this doesn't add support for the `BadgeLogo` visual asset option.

**Related:** https://github.com/electron-userland/electron-builder-binaries/pull/3

**Some Reference Docs:**
https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/how-to-create-a-basic-package-manifest
https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/what-s-changed-in-windows-10

cc @feens 