### PR TITLE
fix: macOS failing when there is no old icon

### DIFF
--- a/packages/electron-builder/src/packager/mac.ts
+++ b/packages/electron-builder/src/packager/mac.ts
@@ -3,7 +3,7 @@ import BluebirdPromise from "bluebird-lst"
 import { asArray, getPlatformIconFileName, use } from "electron-builder-util"
 import { copyFile, copyOrLinkFile, unlinkIfExists } from "electron-builder-util/out/fs"
 import { warn } from "electron-builder-util/out/log"
-import { readFile, rename, unlink, utimes, writeFile } from "fs-extra-p"
+import { readFile, rename, deleteFile, utimes, writeFile } from "fs-extra-p"
 import * as path from "path"
 import { build as buildPlist, parse as parsePlist } from "plist"
 import { normalizeExt, PlatformPackager } from "../platformPackager"
@@ -151,7 +151,7 @@ export async function createApp(packager: PlatformPackager<any>, appOutDir: stri
   ]
 
   if (icon != null) {
-    promises.push(unlink(path.join(resourcesPath, oldIcon)))
+    promises.push(deleteFile(path.join(resourcesPath, oldIcon), true))
     promises.push(copyFile(icon, path.join(resourcesPath, appPlist.CFBundleIconFile)))
   }
 

--- a/packages/electron-builder/src/packager/mac.ts
+++ b/packages/electron-builder/src/packager/mac.ts
@@ -3,7 +3,7 @@ import BluebirdPromise from "bluebird-lst"
 import { asArray, getPlatformIconFileName, use } from "electron-builder-util"
 import { copyFile, copyOrLinkFile, unlinkIfExists } from "electron-builder-util/out/fs"
 import { warn } from "electron-builder-util/out/log"
-import { readFile, rename, deleteFile, utimes, writeFile } from "fs-extra-p"
+import { readFile, rename, utimes, writeFile } from "fs-extra-p"
 import * as path from "path"
 import { build as buildPlist, parse as parsePlist } from "plist"
 import { normalizeExt, PlatformPackager } from "../platformPackager"
@@ -151,7 +151,7 @@ export async function createApp(packager: PlatformPackager<any>, appOutDir: stri
   ]
 
   if (icon != null) {
-    promises.push(deleteFile(path.join(resourcesPath, oldIcon), true))
+    promises.push(unlinkIfExists(path.join(resourcesPath, oldIcon)))
     promises.push(copyFile(icon, path.join(resourcesPath, appPlist.CFBundleIconFile)))
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,9 +1231,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fcopy-pre-bundled@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/fcopy-pre-bundled/-/fcopy-pre-bundled-0.1.2.tgz#656baeb0d0c450cafa9c902664d440ceb99bcde1"
+fcopy-pre-bundled@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/fcopy-pre-bundled/-/fcopy-pre-bundled-0.2.0.tgz#846195cb53cf0a987ca9ebee4d70f81277c10f8a"
 
 feature-detect-es6@^1.3.1:
   version "1.3.1"
@@ -2948,13 +2948,9 @@ sanitize-filename@^1.6.1:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-sax@1.2.1:
+sax@1.2.1, sax@>=0.6.0, sax@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-
-sax@>=0.6.0, sax@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This avoids throwing an ENOENT exception, if for any reason the old icon is not found to be deleted during the mac installer creation process.
```
Error: ENOENT: no such file or directory, unlink '/mypath/dist/canary/mac/Electron.app/Contents/Resources/myapp.icns'
    at Object.<anonymous> (/mypath/node_modules/electron-builder/src/packager/mac.ts:154:19)
From previous event:
    at Object.createApp (/mypath/node_modules/electron-builder/out/packager/mac.js:138:21)
```