### PR TITLE
Clean macOsVersion before gte comparison

### DIFF
--- a/packages/electron-builder/src/util/macosVersion.ts
+++ b/packages/electron-builder/src/util/macosVersion.ts
@@ -23,5 +23,5 @@ export async function isOsVersionGreaterThanOrEqualTo(input: string) {
 
 /** @internal */
 export async function isMacOsSierra() {
-  return process.platform === "darwin" && await isOsVersionGreaterThanOrEqualTo("10.12")
+  return process.platform === "darwin" && await isOsVersionGreaterThanOrEqualTo("10.12.0")
 }

--- a/packages/electron-builder/src/util/macosVersion.ts
+++ b/packages/electron-builder/src/util/macosVersion.ts
@@ -17,7 +17,7 @@ function clean(version: string) {
 
 /** @internal */
 export async function isOsVersionGreaterThanOrEqualTo(input: string) {
-  const version = await macOsVersion.value;
+  const version = await macOsVersion.value
   return semver.gte(clean(version), clean(input))
 }
 

--- a/packages/electron-builder/src/util/macosVersion.ts
+++ b/packages/electron-builder/src/util/macosVersion.ts
@@ -17,7 +17,8 @@ function clean(version: string) {
 
 /** @internal */
 export async function isOsVersionGreaterThanOrEqualTo(input: string) {
-  return semver.gte(await macOsVersion.value, clean(input))
+  const version = await macOsVersion.value;
+  return semver.gte(clean(version), clean(input))
 }
 
 /** @internal */


### PR DESCRIPTION
Since 10.12 is a possible Sierra version, clean before doing comparison to avoid "Invalid Version" error from SemVer