### PR TITLE
feat: throw error when token contains invalid characters

### DIFF
--- a/packages/electron-builder-util/src/util.ts
+++ b/packages/electron-builder-util/src/util.ts
@@ -163,8 +163,12 @@ export function getTempName(prefix?: string | null | undefined): string {
   return `${prefix == null ? "" : `${prefix}-`}${tempDirPrefix}-${(tmpDirCounter++).toString(16)}`
 }
 
-export function isEmptyOrSpaces(s: string | null | undefined) {
+export function isEmptyOrSpaces(s: string | null | undefined): s is "" | null | undefined {
   return s == null || s.trim().length === 0
+}
+
+export function isTokenCharValid(token: string) {
+  return /^[\w\/=+-]+$/.test(token)
 }
 
 export function asArray<T>(v: null | undefined | T | Array<T>): Array<T> {

--- a/packages/electron-publish/src/BintrayPublisher.ts
+++ b/packages/electron-publish/src/BintrayPublisher.ts
@@ -2,7 +2,7 @@ import BluebirdPromise from "bluebird-lst"
 import { configureRequestOptions, HttpError } from "electron-builder-http"
 import { BintrayClient, Version } from "electron-builder-http/out/bintray"
 import { BintrayOptions } from "electron-builder-http/out/publishOptions"
-import { debug, isEmptyOrSpaces, log } from "electron-builder-util"
+import { debug, isEmptyOrSpaces, isTokenCharValid, log } from "electron-builder-util"
 import { httpExecutor } from "electron-builder-util/out/nodeHttpExecutor"
 import { ClientRequest } from "http"
 import { HttpPublisher, PublishContext, PublishOptions } from "./publisher"
@@ -22,6 +22,10 @@ export class BintrayPublisher extends HttpPublisher {
       token = process.env.BT_TOKEN
       if (isEmptyOrSpaces(token)) {
         throw new Error(`Bintray token is not set, neither programmatically, nor using env "BT_TOKEN"`)
+      }
+
+      if (!isTokenCharValid(token)) {
+        throw new Error(`Bintray token (${JSON.stringify(token)}) contains invalid characters, please check env "BT_TOKEN"`)
       }
     }
 

--- a/packages/electron-publish/src/BintrayPublisher.ts
+++ b/packages/electron-publish/src/BintrayPublisher.ts
@@ -24,6 +24,8 @@ export class BintrayPublisher extends HttpPublisher {
         throw new Error(`Bintray token is not set, neither programmatically, nor using env "BT_TOKEN"`)
       }
 
+      token = token.trim()
+
       if (!isTokenCharValid(token)) {
         throw new Error(`Bintray token (${JSON.stringify(token)}) contains invalid characters, please check env "BT_TOKEN"`)
       }

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -1,7 +1,7 @@
 import BluebirdPromise from "bluebird-lst"
 import { configureRequestOptions, HttpError } from "electron-builder-http"
 import { GithubOptions } from "electron-builder-http/out/publishOptions"
-import { debug, isEmptyOrSpaces, log, warn } from "electron-builder-util"
+import { debug, isEmptyOrSpaces, isTokenCharValid, log, warn } from "electron-builder-util"
 import { httpExecutor } from "electron-builder-util/out/nodeHttpExecutor"
 import { ClientRequest } from "http"
 import mime from "mime"
@@ -49,6 +49,10 @@ export class GitHubPublisher extends HttpPublisher {
       token = process.env.GH_TOKEN
       if (isEmptyOrSpaces(token)) {
         throw new Error(`GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"`)
+      }
+
+      if (!isTokenCharValid(token)) {
+        throw new Error(`GitHub Personal Access Token (${JSON.stringify(token)}) contains invalid characters, please check env "GH_TOKEN"`)
       }
     }
 

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -51,6 +51,8 @@ export class GitHubPublisher extends HttpPublisher {
         throw new Error(`GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"`)
       }
 
+      token = token.trim()
+
       if (!isTokenCharValid(token)) {
         throw new Error(`GitHub Personal Access Token (${JSON.stringify(token)}) contains invalid characters, please check env "GH_TOKEN"`)
       }


### PR DESCRIPTION
I was building my app on Windows, but it failed with `The header content contains invalid characters`. 
After debugging, I found that the env `GH_TOKEN` on my WIndows was wrong, it ends with `\n` (`xxxxxxxx\n`), not a valid HTTP header value.

So I am adding characters checking before request, making the case clear.
