### PR TITLE
fix (nsis-web): package url incomplete when using appPackageUrl

### DIFF
--- a/packages/electron-builder/src/targets/WebInstallerTarget.ts
+++ b/packages/electron-builder/src/targets/WebInstallerTarget.ts
@@ -28,10 +28,9 @@ export class WebInstallerTarget extends NsisTarget {
       }
 
       appPackageUrl = computeDownloadUrl(publishConfigs[0], null, packager)
-
-      defines.APP_PACKAGE_URL_IS_INCOMLETE = null
     }
 
+    defines.APP_PACKAGE_URL_IS_INCOMLETE = null
     defines.APP_PACKAGE_URL = appPackageUrl
   }
 


### PR DESCRIPTION
Installer did not find the file to download when using appPackageUrl, because the installer
script was missing the file name.
Fix #1810