### PR TITLE
feat(squirrel.windows): set version-string, product-version and icon to Update.exe

### DIFF
--- a/packages/electron-builder/src/winPackager.ts
+++ b/packages/electron-builder/src/winPackager.ts
@@ -256,6 +256,10 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
     }
   }
 
+  async editResources(args: Array<string>) {
+    await execWine(path.join(await getSignVendorPath(), "rcedit.exe"), args)
+  }
+
   async signAndEditResources(file: string, arch: Arch, outDir: string) {
     const appInfo = this.appInfo
 
@@ -308,7 +312,7 @@ export class WinPackager extends PlatformPackager<WinBuildOptions> {
     }
 
     const timer = time("wine&sign")
-    await execWine(path.join(await getSignVendorPath(), "rcedit.exe"), args)
+    await this.editResources(args)
     await this.sign(file)
     timer.end()
 


### PR DESCRIPTION
Show application's information instead of GitHub's one in the task manager.

For example, that's meaningful when Update.exe is registered to startup via `node-auto-launch`.
(I used `mattermost/desktop` as an example)

v19.16.3:
<img width="441" alt="before" src="https://user-images.githubusercontent.com/1412057/28571495-17aaa75e-717e-11e7-86d6-ba58d9127e54.png">

This PR:
<img width="441" alt="after" src="https://user-images.githubusercontent.com/1412057/28571497-195e3d7c-717e-11e7-9e61-b4f0123c1a00.png">
