### PR TITLE
Added path normalization for file filter

### DIFF
--- a/packages/electron-builder/src/util/filter.ts
+++ b/packages/electron-builder/src/util/filter.ts
@@ -1,7 +1,7 @@
 import { Filter } from "electron-builder-util/out/fs"
 import { Stats } from "fs-extra-p"
 import { Minimatch } from "minimatch"
-import { sep } from "path"
+import * as path from "path"
 
 /** @internal */
 export function hasMagic(pattern: Minimatch) {
@@ -21,14 +21,15 @@ export function hasMagic(pattern: Minimatch) {
 
 /** @internal */
 export function createFilter(src: string, patterns: Array<Minimatch>, excludePatterns?: Array<Minimatch> | null): Filter {
-  const checkedSrc = src.endsWith(sep) ? src : src + sep
+  const pathSeparator = path.sep
+  const checkedSrc = src.endsWith(pathSeparator) ? src : src + pathSeparator
   return (it, stat) => {
     if (src === it) {
       return true
     }
 
     let relative = it.substring(checkedSrc.length)
-    if (sep === "\\") {
+    if (pathSeparator === "\\") {
       relative = relative.replace(/\\/g, "/")
     }
 

--- a/packages/electron-builder/src/util/filter.ts
+++ b/packages/electron-builder/src/util/filter.ts
@@ -1,7 +1,7 @@
 import { Filter } from "electron-builder-util/out/fs"
 import { Stats } from "fs-extra-p"
 import { Minimatch } from "minimatch"
-import * as path from "path"
+import { sep } from "path"
 
 /** @internal */
 export function hasMagic(pattern: Minimatch) {
@@ -21,13 +21,14 @@ export function hasMagic(pattern: Minimatch) {
 
 /** @internal */
 export function createFilter(src: string, patterns: Array<Minimatch>, excludePatterns?: Array<Minimatch> | null): Filter {
+  const checkedSrc = src.endsWith(sep) ? src : src + sep
   return (it, stat) => {
     if (src === it) {
       return true
     }
 
-    let relative = it.substring(src.length + 1)
-    if (path.sep === "\\") {
+    let relative = it.substring(checkedSrc.length)
+    if (sep === "\\") {
       relative = relative.replace(/\\/g, "/")
     }
 


### PR DESCRIPTION
The problem occurs on Windows, when the project files are extracted in local drive root. 
That way, the _src_ argument may become 'Z:\' (drive path), which will lead to filtering out all node modules, because of taking incorrect start index in substring (_it.substring(src.length + 1)_).