### PR TITLE
Ensure folder paths to have trailing path separator

### DIFF
--- a/packages/electron-builder/src/util/appFileCopier.ts
+++ b/packages/electron-builder/src/util/appFileCopier.ts
@@ -8,6 +8,8 @@ import { copyFileOrData } from "./asarUtil"
 import { AsyncTaskManager } from "./asyncTaskManager"
 
 export async function copyAppFiles(fileSet: FileSet, packager: Packager) {
+  const pathSeparator = path.sep
+
   const metadata = fileSet.metadata
   const transformedFiles = fileSet.transformedFiles
   // search auto unpacked dir
@@ -25,7 +27,11 @@ export async function copyAppFiles(fileSet: FileSet, packager: Packager) {
       continue
     }
 
-    const relativePath = file.replace(fileSet.src, fileSet.destination)
+    // sometimes, destination may not contain path separator in the end (path to folder), but the src does. So let's ensure paths have path separators in the end
+    const src = fileSet.src.endsWith(pathSeparator) ? fileSet.src : fileSet.src + pathSeparator
+    const destination = fileSet.destination.endsWith(pathSeparator) ? fileSet.destination : fileSet.destination + pathSeparator
+
+    const relativePath = file.replace(src, destination)
     if (stat.isFile()) {
       const fileParent = path.dirname(file)
       // const dirNode = this.fs.getOrCreateNode(this.getRelativePath(fileParent))
@@ -37,7 +43,7 @@ export async function copyAppFiles(fileSet: FileSet, packager: Packager) {
 
       if (!dirToCreateForUnpackedFiles.has(fileParent)) {
         dirToCreateForUnpackedFiles.add(fileParent)
-        await ensureDir(fileParent.replace(fileSet.src, fileSet.destination))
+        await ensureDir(fileParent.replace(src, destination))
       }
 
       taskManager.addTask(copyFileOrData(fileCopier, newData, file, relativePath, stat))

--- a/packages/electron-builder/src/util/asarUtil.ts
+++ b/packages/electron-builder/src/util/asarUtil.ts
@@ -371,7 +371,7 @@ function getRelativePath(fileSet: FileSet, p: string) {
   const relative = p.substring(checkedSrc.length)
 
   if (pathSeparator === "\\") {
-    if (relative.startsWith('\\')) {
+    if (relative.startsWith("\\")) {
       // windows problem: double backslash, the above substring call removes root path with a single slash, so here can me some leftovers
       return relative.substring(1)
     }
@@ -387,4 +387,3 @@ function getTargetPath(fileSet: FileSet, p: string, to: string) {
 
   return p.replace(src, destination)
 }
-

--- a/packages/electron-builder/src/util/filter.ts
+++ b/packages/electron-builder/src/util/filter.ts
@@ -30,7 +30,7 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
 
     let relative = it.substring(checkedSrc.length)
     if (pathSeparator === "\\") {
-      if (relative.startsWith('\\')) {
+      if (relative.startsWith("\\")) {
         // windows problem: double backslash, the above substring call removes root path with a single slash, so here can me some leftovers
         relative = relative.substring(1)
       }

--- a/packages/electron-builder/src/util/filter.ts
+++ b/packages/electron-builder/src/util/filter.ts
@@ -30,6 +30,10 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
 
     let relative = it.substring(checkedSrc.length)
     if (pathSeparator === "\\") {
+      if (relative.startsWith('\\')) {
+        // windows problem: double backslash, the above substring call removes root path with a single slash, so here can me some leftovers
+        relative = relative.substring(1)
+      }
       relative = relative.replace(/\\/g, "/")
     }
 


### PR DESCRIPTION
After my recent pull request, have noticed, that windows file system is doing some tricky magic with double backslashes (path separator), and sometimes does not. so here is the fix for filter.js, and for file copier as well. 