### PR TITLE
WIP feat(linux): accept distribution and component Bintray options

### DIFF
--- a/docs/Publishing Artifacts.md
+++ b/docs/Publishing Artifacts.md
@@ -88,6 +88,8 @@ Bintray options.
 * <a name="BintrayOptions-package"></a>`package` String - The Bintray package name.
 * <a name="BintrayOptions-repo"></a>`repo` = `generic` String - The Bintray repository name.
 * <a name="BintrayOptions-owner"></a>`owner` String - The owner.
+* <a name="BintrayOptions-distribution"></a>`distribution` = `stable` String - The Bintray distribution (Debian only).
+* <a name="BintrayOptions-component"></a>`component` String - The Bintray component (Debian only).
 * <a name="BintrayOptions-user"></a>`user` String - The Bintray user account. Used in cases where the owner is an organization.
 * <a name="BintrayOptions-token"></a>`token` String
 * <a name="BintrayOptions-provider"></a>**`provider`** "github" | "bintray" | "s3" | "generic" - The provider.

--- a/packages/electron-builder-http/src/bintray.ts
+++ b/packages/electron-builder-http/src/bintray.ts
@@ -23,6 +23,8 @@ export class BintrayClient {
 
   readonly owner: string
   readonly user: string
+  readonly component: string | null
+  readonly distribution: string | null
   readonly packageName: string
 
   private requestHeaders: RequestHeaders | null
@@ -43,6 +45,8 @@ export class BintrayClient {
     this.packageName = options.package
     this.owner = options.owner
     this.user = options.user || options.owner
+    this.component = options.component || null
+    this.distribution = options.distribution || "stable"
     this.auth = apiKey == null ? null : `Basic ${new Buffer(`${this.user}:${apiKey}`).toString("base64")}`
     this.basePath = `/packages/${this.owner}/${this.repo}/${this.packageName}`
   }

--- a/packages/electron-builder-http/src/publishOptions.ts
+++ b/packages/electron-builder-http/src/publishOptions.ts
@@ -180,6 +180,16 @@ export interface BintrayOptions extends PublishConfiguration {
   readonly owner?: string | null
 
   /**
+   * The Debian component.
+   */
+  readonly component?: string | null
+
+  /**
+   * The Debian distribution.
+   */
+  readonly distribution?: string | null
+
+  /**
    * The Bintray user account. Used in cases where the owner is an organization.
    */
   readonly user?: string | null

--- a/packages/electron-builder/src/publish/PublishManager.ts
+++ b/packages/electron-builder/src/publish/PublishManager.ts
@@ -16,7 +16,7 @@ import * as path from "path"
 import { WriteStream as TtyWriteStream } from "tty"
 import * as url from "url"
 import { UrlObject } from "url"
-import { Arch, Platform, Target } from "../core"
+import { Arch, Platform, Target, toLinuxArchString } from "../core"
 import { PlatformSpecificBuildOptions, ReleaseInfo } from "../metadata"
 import { Packager } from "../packager"
 import { ArtifactCreated } from "../packagerApi"
@@ -142,10 +142,10 @@ export class PublishManager implements PublishContext {
         }
 
         if (eventFile == null) {
-          this.taskManager.addTask((publisher as HttpPublisher).uploadData(event.data!, event.safeArtifactName!))
+          this.taskManager.addTask((publisher as HttpPublisher).uploadData(event.data!, toLinuxArchString(event.arch || Arch.x64), event.safeArtifactName!))
         }
         else {
-          this.taskManager.addTask(publisher.upload(eventFile!, event.safeArtifactName))
+          this.taskManager.addTask(publisher.upload(eventFile!, toLinuxArchString(event.arch || Arch.x64), event.safeArtifactName))
         }
       }
     }

--- a/packages/electron-publish/src/BintrayPublisher.ts
+++ b/packages/electron-publish/src/BintrayPublisher.ts
@@ -54,7 +54,7 @@ export class BintrayPublisher extends HttpPublisher {
     }
   }
 
-  protected async doUpload(fileName: string, dataLength: number, requestProcessor: (request: ClientRequest, reject: (error: Error) => void) => void) {
+  protected async doUpload(fileName: string, arch: string, dataLength: number, requestProcessor: (request: ClientRequest, reject: (error: Error) => void) => void) {
     const version = await this._versionPromise
     if (version == null) {
       debug(`Version ${this.version} doesn't exist and is not created, artifact ${fileName} is not published`)
@@ -72,6 +72,7 @@ export class BintrayPublisher extends HttpPublisher {
             "Content-Length": dataLength,
             "X-Bintray-Override": "1",
             "X-Bintray-Publish": "1",
+            "X-Bintray-Debian-Architecture": arch
           }
         }, this.client.auth), this.context.cancellationToken, requestProcessor)
       }

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -99,7 +99,7 @@ export class GitHubPublisher extends HttpPublisher {
     return this.createRelease()
   }
 
-  protected async doUpload(fileName: string, dataLength: number, requestProcessor: (request: ClientRequest, reject: (error: Error) => void) => void): Promise<void> {
+  protected async doUpload(fileName: string, arch: string, dataLength: number, requestProcessor: (request: ClientRequest, reject: (error: Error) => void) => void): Promise<void> {
     const release = await this.releasePromise
     if (release == null) {
       debug(`Release with tag ${this.tag} doesn't exist and is not created, artifact ${fileName} is not published`)

--- a/packages/electron-publish/src/publisher.ts
+++ b/packages/electron-publish/src/publisher.ts
@@ -32,7 +32,7 @@ export abstract class Publisher {
 
   abstract get providerName(): string
 
-  abstract upload(file: string, safeArtifactName?: string): Promise<any>
+  abstract upload(file: string, arch: string, safeArtifactName?: string): Promise<any>
 
   protected createProgressBar(fileName: string, fileStat: Stats): ProgressBar | null {
     if (this.context.progress == null) {
@@ -66,12 +66,12 @@ export abstract class HttpPublisher extends Publisher {
     super(context)
   }
 
-  async upload(file: string, safeArtifactName?: string): Promise<any> {
+  async upload(file: string, arch: string, safeArtifactName?: string): Promise<any> {
     const fileName = (this.useSafeArtifactName ? safeArtifactName : null) || basename(file)
     const fileStat = await stat(file)
 
     const progressBar = this.createProgressBar(fileName, fileStat)
-    await this.doUpload(fileName, fileStat.size, (request, reject) => {
+    await this.doUpload(fileName, arch, fileStat.size, (request, reject) => {
       if (progressBar != null) {
         // reset (because can be called several times (several attempts)
         progressBar.update(0)
@@ -80,12 +80,12 @@ export abstract class HttpPublisher extends Publisher {
     }, file)
   }
 
-  uploadData(data: Buffer, fileName: string): Promise<any> {
+  uploadData(data: Buffer, arch: string, fileName: string): Promise<any> {
     if (data == null || fileName == null) {
       throw new Error("data or fileName is null")
     }
-    return this.doUpload(fileName, data.length, it => it.end(data))
+    return this.doUpload(fileName, arch, data.length, it => it.end(data))
   }
 
-  protected abstract doUpload(fileName: string, dataLength: number, requestProcessor: (request: ClientRequest, reject: (error: Error) => void) => void, file?: string): Promise<any>
+  protected abstract doUpload(fileName: string, arch: string, dataLength: number, requestProcessor: (request: ClientRequest, reject: (error: Error) => void) => void, file?: string): Promise<any>
 }

--- a/test/src/ArtifactPublisherTest.ts
+++ b/test/src/ArtifactPublisherTest.ts
@@ -86,8 +86,8 @@ test("Bintray upload", async () => {
   //noinspection SpellCheckingInspection
   const publisher = new BintrayPublisher(publishContext, {provider: "bintray", owner: "actperepo", package: "test", repo: "generic", token: "5df2cadec86dff91392e4c419540785813c3db15"}, version)
   try {
-    await publisher.upload(artifactPath)
-    await publisher.upload(artifactPath)
+    await publisher.upload(artifactPath, "amd64")
+    await publisher.upload(artifactPath, "amd64")
   }
   finally {
     try {
@@ -102,9 +102,9 @@ test("Bintray upload", async () => {
 testAndIgnoreApiRate("GitHub upload", async () => {
   const publisher = new GitHubPublisher(publishContext, {provider: "github", owner: "actperepo", repo: "ecb2", token: token}, versionNumber())
   try {
-    await publisher.upload(iconPath)
+    await publisher.upload(iconPath, "amd64")
     // test overwrite
-    await publisher.upload(iconPath)
+    await publisher.upload(iconPath, "amd64")
   }
   finally {
     await publisher.deleteRelease()
@@ -114,9 +114,9 @@ testAndIgnoreApiRate("GitHub upload", async () => {
 if (process.env.AWS_ACCESS_KEY_ID != null && process.env.AWS_SECRET_ACCESS_KEY != null) {
   test("S3 upload", async () => {
     const publisher = createPublisher(publishContext, "0.0.1", <S3Options>{provider: "s3", bucket: "electron-builder-test"}, {})
-      await publisher.upload(iconPath)
+      await publisher.upload(iconPath, "amd64")
       // test overwrite
-      await publisher.upload(iconPath)
+      await publisher.upload(iconPath, "amd64")
   })
 }
 
@@ -126,7 +126,7 @@ testAndIgnoreApiRate("prerelease", async () => {
     prerelease: true,
   })
   try {
-    await publisher.upload(iconPath)
+    await publisher.upload(iconPath, "amd64")
     const r = await publisher.getRelease()
     expect(r).toMatchObject({
       prerelease: true,
@@ -142,7 +142,7 @@ testAndIgnoreApiRate("GitHub upload org", async () => {
   //noinspection SpellCheckingInspection
   const publisher = new GitHubPublisher(publishContext, {provider: "github", owner: "builder-gh-test", repo: "darpa", token: token}, versionNumber())
   try {
-    await publisher.upload(iconPath)
+    await publisher.upload(iconPath, "amd64")
   }
   finally {
     await publisher.deleteRelease()


### PR DESCRIPTION
This options are needed to correctly publish Debian packages to a
Bintray Debian repository.
    
Fixes: https://github.com/electron-userland/electron-builder/issues/1702
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>