### PR TITLE
feat(appx): attempt to use identityName for manifest name

### DIFF
--- a/packages/electron-builder/src/targets/appx.ts
+++ b/packages/electron-builder/src/targets/appx.ts
@@ -125,7 +125,7 @@ export default class AppXTarget extends Target {
             return appInfo.versionInWeirdWindowsForm
 
           case "name":
-            return appInfo.name
+            return options.identityName || appInfo.name
 
           case "identityName":
             return options.identityName  || appInfo.name


### PR DESCRIPTION
It is very useful to set a custom `identityName` when the name of the
app in package.json contains hyphens (which are not permitted in
`appxmanifest.yml`).

Even if you set a non-hyphenated name as `identityName`,
electron-builder will still use the package.json's `name` property for
the `name` appxmanifest.yml value.

Thus, we attempt to re-use `identityName` for that case as well.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>