### PR TITLE
feat: custom Windows sign tool timeout via SIGNTOOL_TIMEOUT

### DIFF
--- a/packages/electron-builder/src/windowsCodeSign.ts
+++ b/packages/electron-builder/src/windowsCodeSign.ts
@@ -139,7 +139,7 @@ async function spawnSign(options: SignOptions, inputPath: string, outputPath: st
 
   const toolInfo = await getToolPath()
   return await exec(toolInfo.path, args, {
-    timeout: +(process.env.SIGNTOOL_TIMEOUT || 120 * 1000),
+    timeout: parseInt(process.env.SIGNTOOL_TIMEOUT as any, 10) || 120 * 1000,
     env: toolInfo.env || process.env
   })
 }

--- a/packages/electron-builder/src/windowsCodeSign.ts
+++ b/packages/electron-builder/src/windowsCodeSign.ts
@@ -139,7 +139,7 @@ async function spawnSign(options: SignOptions, inputPath: string, outputPath: st
 
   const toolInfo = await getToolPath()
   return await exec(toolInfo.path, args, {
-    timeout: 120 * 1000,
+    timeout: +(process.env.SIGNTOOL_TIMEOUT || 120 * 1000),
     env: toolInfo.env || process.env
   })
 }


### PR DESCRIPTION
Hello,

Since we use EV cert for singing Windows binaries, we have to use a USB token for it, so we wrote a custom tool (used via `SIGNTOOL_PATH`), which copies the file to sign into Parallels, which then asks the developer to enter the PIN code, signs, and then copies the signed file back to macOS. Unfortunately, 2 minutes is sometimes not enough to finish the signing, so I'd like to make it customizable. Would this work for you?

Thank you!