### PR TITLE
fix(builder): use the same artifact name for AppImage when publishing

### DIFF
--- a/packages/electron-builder/src/targets/appImage.ts
+++ b/packages/electron-builder/src/targets/appImage.ts
@@ -36,7 +36,8 @@ export default class AppImageTarget extends Target {
 
     // https://github.com/electron-userland/electron-builder/issues/775
     // https://github.com/electron-userland/electron-builder/issues/1726
-    const resultFile = path.join(this.outDir, this.options.artifactName == null ? packager.computeSafeArtifactName("AppImage", arch, false) : packager.expandArtifactNamePattern(this.options, "AppImage", arch))
+    const safeArtifactName = this.options.artifactName == null ? packager.computeSafeArtifactName("AppImage", arch, false) : packager.expandArtifactNamePattern(this.options, "AppImage", arch)
+    const resultFile = path.join(this.outDir, safeArtifactName)
     await unlinkIfExists(resultFile)
 
     const appImagePath = await appImagePathPromise
@@ -99,6 +100,6 @@ export default class AppImageTarget extends Target {
 
     await chmod(resultFile, "0755")
 
-    packager.dispatchArtifactCreated(resultFile, this, arch, packager.computeSafeArtifactName("AppImage", arch, false))
+    packager.dispatchArtifactCreated(resultFile, this, arch, safeArtifactName)
   }
 }


### PR DESCRIPTION
AppImages had a different name when published on GitHub than on the disk.

(Note: I haven't tested these changes yet, but I believe they will solve the problem.)