### PR TITLE
feat(AppImage): publish patterned name if it conforms to GitHub rules

### DIFF
--- a/packages/electron-builder/src/platformPackager.ts
+++ b/packages/electron-builder/src/platformPackager.ts
@@ -350,6 +350,11 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     await this.checkFileInPackage(resourcesDir, "package.json", "Application", isAsar)
   }
 
+  isSafeArtifactName(name: string) {
+    // GitHub only allows the listed characters in file names.
+    return /^[0-9A-Za-z._-]+$/.test(name)
+  }
+
   computeSafeArtifactName(ext: string, arch?: Arch | null, skipArchIfX64 = true) {
     // tslint:disable:no-invalid-template-strings
     return this.computeArtifactName("${name}-${version}-${arch}.${ext}", ext, skipArchIfX64 && arch === Arch.x64 ? null : arch)

--- a/packages/electron-builder/src/targets/appImage.ts
+++ b/packages/electron-builder/src/targets/appImage.ts
@@ -36,7 +36,8 @@ export default class AppImageTarget extends Target {
 
     // https://github.com/electron-userland/electron-builder/issues/775
     // https://github.com/electron-userland/electron-builder/issues/1726
-    const resultFile = path.join(this.outDir, this.options.artifactName == null ? packager.computeSafeArtifactName("AppImage", arch, false) : packager.expandArtifactNamePattern(this.options, "AppImage", arch))
+    const artifactName = this.options.artifactName == null ? packager.computeSafeArtifactName("AppImage", arch, false) : packager.expandArtifactNamePattern(this.options, "AppImage", arch)
+    const resultFile = path.join(this.outDir, artifactName)
     await unlinkIfExists(resultFile)
 
     const appImagePath = await appImagePathPromise
@@ -99,6 +100,6 @@ export default class AppImageTarget extends Target {
 
     await chmod(resultFile, "0755")
 
-    packager.dispatchArtifactCreated(resultFile, this, arch, packager.computeSafeArtifactName("AppImage", arch, false))
+    packager.dispatchArtifactCreated(resultFile, this, arch, packager.isSafeArtifactName(artifactName) ? artifactName : packager.computeSafeArtifactName("AppImage", arch, false))
   }
 }


### PR DESCRIPTION
The safe artifact name must match the following regex: ^[0-9A-Za-z._-]+$

Otherwise, use a hardcoded safe artifact name pattern.