### PR TITLE
fix(publish): cache publishers based on the target name

### DIFF
--- a/packages/electron-builder/src/publish/PublishManager.ts
+++ b/packages/electron-builder/src/publish/PublishManager.ts
@@ -135,7 +135,7 @@ export class PublishManager implements PublishContext {
           break
         }
 
-        const publisher = this.getOrCreatePublisher(publishConfig, packager)
+        const publisher = this.getOrCreatePublisher(publishConfig, packager, event.target)
         if (publisher == null) {
           debug(`${eventFile} is not published: publisher is null, ${safeStringifyJson(publishConfig)}`)
           continue
@@ -158,8 +158,12 @@ export class PublishManager implements PublishContext {
     }
   }
 
-  private getOrCreatePublisher(publishConfig: PublishConfiguration, platformPackager: PlatformPackager<any>): Publisher | null {
-    const providerCacheKey = `${publishConfig.provider}-${platformPackager.platform.name}`
+  private getOrCreatePublisher(publishConfig: PublishConfiguration, platformPackager: PlatformPackager<any>, target: Target | null): Publisher | null {
+    let providerCacheKey = `${publishConfig.provider}-${platformPackager.platform.name}`
+    if (target) {
+      providerCacheKey += `-${target.name}`
+    }
+
     let publisher = this.nameToPublisher.get(providerCacheKey)
     if (publisher == null) {
       publisher = createPublisher(this, platformPackager.info.metadata.version!, publishConfig, this.publishOptions)


### PR DESCRIPTION
Publishers are currently cached by the publisher provider (e.g.
"bintray") and by the platform name (e.g. "linux"). This means that if
the user has different publish configurations for targets that belong to
the same OS (e.g. deb and rpm), then one will override the other on the
cache.

Fixes: https://github.com/electron-userland/electron-builder/issues/1951
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>