### PR TITLE
fix PrivateGitHubProvider not support enterprise Github

### DIFF
--- a/packages/electron-updater/src/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/PrivateGitHubProvider.ts
@@ -84,7 +84,9 @@ export class PrivateGitHubProvider extends BaseGitHubProvider<PrivateGitHubUpdat
   }
 
   private get basePath() {
-    return `/repos/${this.options.owner}/${this.options.repo}/releases`
+    const result = `/repos/${this.options.owner}/${this.options.repo}/releases`;
+    const host = this.options.host;
+    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3/repos${result}` : result;
   }
 
   async getUpdateFile(versionInfo: PrivateGitHubUpdateInfo): Promise<FileInfo> {

--- a/packages/electron-updater/src/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/PrivateGitHubProvider.ts
@@ -86,7 +86,7 @@ export class PrivateGitHubProvider extends BaseGitHubProvider<PrivateGitHubUpdat
   private get basePath() {
     const result = `/repos/${this.options.owner}/${this.options.repo}/releases`;
     const host = this.options.host;
-    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3/repos${result}` : result;
+    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result;
   }
 
   async getUpdateFile(versionInfo: PrivateGitHubUpdateInfo): Promise<FileInfo> {

--- a/packages/electron-updater/src/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/PrivateGitHubProvider.ts
@@ -84,9 +84,9 @@ export class PrivateGitHubProvider extends BaseGitHubProvider<PrivateGitHubUpdat
   }
 
   private get basePath() {
-    const result = `/repos/${this.options.owner}/${this.options.repo}/releases`;
-    const host = this.options.host;
-    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result;
+    const result = `/repos/${this.options.owner}/${this.options.repo}/releases`
+    const host = this.options.host
+    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result
   }
 
   async getUpdateFile(versionInfo: PrivateGitHubUpdateInfo): Promise<FileInfo> {


### PR DESCRIPTION
I used private enterprise Github not support get release laster version api. I found GitHubProvider.js is support. So commit this pr, hope you can approval, thanks.