### PR TITLE
Make BUILD_NUMBER higher priority than CI-defined build numbers

### DIFF
--- a/packages/electron-builder/src/appInfo.ts
+++ b/packages/electron-builder/src/appInfo.ts
@@ -20,7 +20,7 @@ export class AppInfo {
       buildVersion = info.config.buildVersion
     }
 
-    this.buildNumber = process.env.TRAVIS_BUILD_NUMBER || process.env.APPVEYOR_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM || process.env.BUILD_NUMBER
+    this.buildNumber = process.env.BUILD_NUMBER || process.env.TRAVIS_BUILD_NUMBER || process.env.APPVEYOR_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM
     if (buildVersion == null) {
       buildVersion = this.version
       if (!isEmptyOrSpaces(this.buildNumber)) {


### PR DESCRIPTION
This change allows having custom BUILD_NUMBERs even when running in a CI environment, without having to modify packages.json.
For instance, to have BUILD_NUMBER based on UTC timestamp instead of sequential ID, a build script only needs to do the following:
```
BUILD_NUMBER=$(date -u +"%Y%m%d%H%M%S")
```