### PR TITLE
Fixing problem with passing variables to docker

### DIFF
--- a/docs/multi-platform-build.md
+++ b/docs/multi-platform-build.md
@@ -87,6 +87,8 @@ To build Linux or Windows on any platform. You cannot build for Windows using Do
    ```sh
    docker run --rm -ti \
      --env-file <(env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|GH_|GITHUB_|BT_|AWS_|STRIP|BUILD_') \
+     --env ELECTRON_CACHE="/root/.cache/electron" \
+     --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
      -v ${PWD}:/project \
      -v ${PWD##*/}-node-modules:/project/node_modules \
      -v ~/.cache/electron:/root/.cache/electron \


### PR DESCRIPTION
Making sure that ELECTRON_CACHE and ELECTRON_BUILDER_CACHE are using /root/.cache instead of /home/travis/.cache (which is valid in the travis runner environment, but not on inside electronuserland/builder:wine).
Also fixed in example file on https://github.com/develar/onshape-desktop-shell/pull/50