### PR TITLE
Document mas-dev build target and code signing instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ A complete solution to package and build a ready for distribution Electron app f
 * [Auto Update](auto-update.md) ready application packaging.
 * Numerous target formats:
   * All platforms: `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir` (unpacked directory).
-  * [macOS](configuration/mac.md#MacConfiguration-target): `dmg`, `pkg`, `mas`.
+  * [macOS](configuration/mac.md#MacConfiguration-target): `dmg`, `pkg`, `mas`, `mas-dev`.
   * [Linux](configuration/linux.md#LinuxConfiguration-target): [AppImage](http://appimage.org), [snap](http://snapcraft.io), debian package (`deb`), `rpm`, `freebsd`, `pacman`, `p5p`, `apk`.
   * [Windows](configuration/win.md#WindowsConfiguration-target): `nsis` (Installer), `nsis-web` (Web installer), `portable` (portable app without installation), AppX (Windows Store), Squirrel.Windows.
 * [Two package.json structure](tutorials/two-package-structure.md) is supported, but you are not forced to use it even if you have native production dependencies.  

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -48,6 +48,7 @@ Please note — Gatekeeper only recognises [Apple digital certificates](http://s
    * `Developer ID Application:` to sign app for macOS.
    * `3rd Party Mac Developer Application:` and `3rd Party Mac Developer Installer:` to sign app for MAS (Mac App Store).
    * `Developer ID Application:` and `Developer ID Installer` to sign app and installer for distribution outside of the Mac App Store.
+   * `Mac Developer:` to sign development builds for testing Mac App Store submissions (`mas-dev` target). You also need a provisioning profile in the working directory that matches this certificated and the device being used for testing.
 
    Please note – you can select as many certificates, as need. No restrictions on electron-builder side.
    All selected certificates will be imported into temporary keychain on CI server.

--- a/docs/configuration/mac.md
+++ b/docs/configuration/mac.md
@@ -6,7 +6,7 @@ The top-level [mac](configuration.md#Configuration-mac) key contains set of opti
   For example, `"category": "public.app-category.developer-tools"` will set the application category to *Developer Tools*.
   
   Valid values are listed in [Apple's documentation](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW8).
-* <code id="MacConfiguration-target">target</code> String | [TargetConfiguration](target.md#targetconfiguration) - The target package type: list of `default`, `dmg`, `mas`, `pkg`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`. Defaults to `default` (dmg and zip for Squirrel.Mac).
+* <code id="MacConfiguration-target">target</code> String | [TargetConfiguration](target.md#targetconfiguration) - The target package type: list of `default`, `dmg`, `mas`, `mas-dev`, `pkg`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`. Defaults to `default` (dmg and zip for Squirrel.Mac).
 * <code id="MacConfiguration-identity">identity</code> String - The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](/code-signing.md) instead of specifying this option. MAS installer identity is specified in the [mas](mas.md).
 * <code id="MacConfiguration-icon">icon</code> = `build/icon.icns` String - The path to application icon.
 * <code id="MacConfiguration-entitlements">entitlements</code> String - The path to entitlements file for signing the app. `build/entitlements.mac.plist` will be used if exists (it is a recommended way to set). MAS entitlements is specified in the [mas](mas.md).

--- a/packages/electron-builder/src/options/macOptions.ts
+++ b/packages/electron-builder/src/options/macOptions.ts
@@ -14,7 +14,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   readonly category?: string | null
 
   /**
-   * The target package type: list of `default`, `dmg`, `mas`, `pkg`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`. Defaults to `default` (dmg and zip for Squirrel.Mac).
+   * The target package type: list of `default`, `dmg`, `mas`, `mas-dev`, `pkg`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`. Defaults to `default` (dmg and zip for Squirrel.Mac).
   */
   readonly target?: Array<MacOsTargetName | TargetConfiguration> | MacOsTargetName | TargetConfiguration | null
 


### PR DESCRIPTION
This should resolve the "help wanted" at the end of #1196 and prevent more issues like #1967 cropping up.

This process could be improved in future by adding a configuration option for the location of the provisioning profile to pass on to electron-osx-codesign, as well as various suggestions for improvements to `electron-osx-codesign` validation.