### PR TITLE
Use BUILD_BUILDNUMBER env var as buildNumber for VSTS CI

### DIFF
--- a/packages/electron-builder/src/appInfo.ts
+++ b/packages/electron-builder/src/appInfo.ts
@@ -20,7 +20,7 @@ export class AppInfo {
       buildVersion = info.config.buildVersion
     }
 
-    this.buildNumber = process.env.BUILD_NUMBER || process.env.TRAVIS_BUILD_NUMBER || process.env.APPVEYOR_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM
+    this.buildNumber = process.env.BUILD_NUMBER || process.env.TRAVIS_BUILD_NUMBER || process.env.APPVEYOR_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM || process.env.BUILD_BUILDNUMBER
     if (buildVersion == null) {
       buildVersion = this.version
       if (!isEmptyOrSpaces(this.buildNumber)) {


### PR DESCRIPTION
In VSTS Builds, the build variable containing the build number is `BUILD_BUILDNUMBER`

https://docs.microsoft.com/en-us/vsts/build-release/concepts/definitions/build/variables