### PR TITLE
Updating docs: `download-progress` works on MacOS

### DIFF
--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -114,7 +114,7 @@ Emitted when there is no available update.
   * `total`
   * `transferred`
 
-Emitted on progress. Only supported over Windows build, since `Squirrel.Mac` [does not provide](https://github.com/electron-userland/electron-builder/issues/1167) this data.
+Emitted on progress.
 
 #### Event: `update-downloaded`
 


### PR DESCRIPTION
Related to https://github.com/electron-userland/electron-builder/issues/1167#issuecomment-340384415 - I can verify that I am receiving observing these events on MacOS now.