### PR TITLE
Fixed --force-run

### DIFF
--- a/packages/electron-builder/templates/nsis/common.nsh
+++ b/packages/electron-builder/templates/nsis/common.nsh
@@ -72,3 +72,19 @@ Name "${PRODUCT_NAME}"
 
   !define MUI_PAGE_CUSTOMFUNCTION_PRE licensePre
 !macroend
+
+
+!macro StartApp
+  Var /GLOBAL startAppArgs
+  ${if} ${isUpdated}
+    StrCpy $startAppArgs "--updated"
+  ${else}
+    StrCpy $startAppArgs ""
+  ${endif}
+
+  !ifdef INSTALL_MODE_PER_ALL_USERS
+    ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$startAppArgs"
+  !else
+    ExecShell "" "$launchLink" "$startAppArgs"
+  !endif
+!macroend

--- a/packages/electron-builder/templates/nsis/installSection.nsh
+++ b/packages/electron-builder/templates/nsis/installSection.nsh
@@ -75,14 +75,23 @@ ${endIf}
   !insertmacro customInstall
 !endif
 
+Var /GLOBAL isOneClickRun
+StrCpy $isOneClickRun "false"
 !ifdef ONE_CLICK
   !ifdef RUN_AFTER_FINISH
     ${IfNot} ${Silent}
-    ${OrIf} ${isForceRun}
-      # otherwise app window will be in background
-      HideWindow
-      !insertmacro StartApp
+	  StrCpy $isOneClickRun "true"
     ${EndIf}
   !endif
+!endif
+
+${If} ${isForceRun}
+${OrIf} $isOneClickRun == "true"
+  # otherwise app window will be in background
+  HideWindow
+  !insertmacro StartApp
+${EndIf}
+
+!ifdef ONE_CLICK
   !insertmacro quitSuccess
 !endif

--- a/packages/electron-builder/templates/nsis/oneClick.nsh
+++ b/packages/electron-builder/templates/nsis/oneClick.nsh
@@ -1,21 +1,4 @@
 !ifndef BUILD_UNINSTALLER
-  !ifdef RUN_AFTER_FINISH
-    !macro StartApp
-      Var /GLOBAL startAppArgs
-      ${if} ${isUpdated}
-        StrCpy $startAppArgs "--updated"
-      ${else}
-        StrCpy $startAppArgs ""
-      ${endif}
-
-      !ifdef INSTALL_MODE_PER_ALL_USERS
-        ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$startAppArgs"
-      !else
-        ExecShell "" "$launchLink" "$startAppArgs"
-      !endif
-    !macroend
-  !endif
-
   !ifmacrodef licensePage
     !insertmacro licensePageHelper
     !insertmacro licensePage


### PR DESCRIPTION
Moved StartApp macro to common.nsh
Got --force-run (isForceRun) working in all configurations
Setup isOneClickRun for ONE_CLICK + RUN_AFTER_FINISH
When isForceRun is defined or when isOneClickRun is true the installer will start the app after the installation is complete

Note: this PR fixes #2179 