### PR TITLE
Repeat upload when it fails with ECONNRESET error

### DIFF
--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -173,7 +173,7 @@ export class GitHubPublisher extends HttpPublisher {
             continue
           }
         }
-        else if (attemptNumber++ < 3 && e.code === "EPIPE") {
+        else if (attemptNumber++ < 3 && (e.code === "EPIPE" || e.code === "ECONNRESET")) {
           continue
         }
 


### PR DESCRIPTION
When publishing from AppVeyor, the upload to GitHub sometimes fails with an `ECONNRESET` error. This is random and, when it happens, it is safe to repeat the request.