### PR TITLE
Mention how to disable code-signing on macos

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -10,7 +10,7 @@ On a macOS development machine valid and appropriate identity from your keychain
 | `CSC_IDENTITY_AUTO_DISCOVERY`| `true` or `false`. Defaults to `true` — on a macOS development machine valid and appropriate identity from your keychain will be automatically used.
 | `CSC_KEYCHAIN`| The keychain name. Used if `CSC_LINK` is not specified. Defaults to system default keychain.
 
-If you are building Windows on macOS and need to set a different certificate and password (than the ones set in `CSC_*` env vars) you can use `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD`.
+If you are building Windows on macOS and need to set a different certificate and password (than the ones set in `CSC_*` env vars) you can use `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD`. 
 
 ## Windows
 
@@ -54,3 +54,9 @@ Please note — Gatekeeper only recognises [Apple digital certificates](http://s
    Please note – you can select as many certificates, as need. No restrictions on electron-builder side.
    All selected certificates will be imported into temporary keychain on CI server.
 4. Open context menu and `Export`.
+
+# How to disable Code Signing during the build process on macOS
+
+To disable Code Signing when building for OS X leave all the above vars unset except for CSC_IDENTITY_AUTO_DISCOVERY which needs to be set to 'false'
+
+This can be done by running `export CSC_IDENTITY_AUTO_DISCOVERY=false` 

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -10,7 +10,7 @@ On a macOS development machine valid and appropriate identity from your keychain
 | `CSC_IDENTITY_AUTO_DISCOVERY`| `true` or `false`. Defaults to `true` — on a macOS development machine valid and appropriate identity from your keychain will be automatically used.
 | `CSC_KEYCHAIN`| The keychain name. Used if `CSC_LINK` is not specified. Defaults to system default keychain.
 
-If you are building Windows on macOS and need to set a different certificate and password (than the ones set in `CSC_*` env vars) you can use `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD`. 
+If you are building Windows on macOS and need to set a different certificate and password (than the ones set in `CSC_*` env vars) you can use `WIN_CSC_LINK` and `WIN_CSC_KEY_PASSWORD`.
 
 ## Windows
 

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -57,6 +57,6 @@ Please note — Gatekeeper only recognises [Apple digital certificates](http://s
 
 # How to disable Code Signing during the build process on macOS
 
-To disable Code Signing when building for OS X leave all the above vars unset except for CSC_IDENTITY_AUTO_DISCOVERY which needs to be set to 'false'
+To disable Code Signing when building for macOS leave all the above vars unset except for CSC_IDENTITY_AUTO_DISCOVERY which needs to be set to 'false'
 
 This can be done by running `export CSC_IDENTITY_AUTO_DISCOVERY=false` 

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -55,8 +55,8 @@ Please note — Gatekeeper only recognises [Apple digital certificates](http://s
    All selected certificates will be imported into temporary keychain on CI server.
 4. Open context menu and `Export`.
 
-# How to disable Code Signing during the build process on macOS
+# How to Disable Code Signing During the Build Process on macOS
 
-To disable Code Signing when building for macOS leave all the above vars unset except for CSC_IDENTITY_AUTO_DISCOVERY which needs to be set to 'false'
+To disable Code Signing when building for macOS leave all the above vars unset except for `CSC_IDENTITY_AUTO_DISCOVERY` which needs to be set to `false`. This can be done by running `export CSC_IDENTITY_AUTO_DISCOVERY=false`. 
 
-This can be done by running `export CSC_IDENTITY_AUTO_DISCOVERY=false` 
+Another way — set `mac.identity` to `null`. You can pass adiitional configuration using CLI as well: `-c.mac.identity=null`.


### PR DESCRIPTION
It's previously implied but people seem to struggle with figuring this out.