### PR TITLE
#2330

### DIFF
--- a/packages/electron-builder-lib/src/util/packageMetadata.ts
+++ b/packages/electron-builder-lib/src/util/packageMetadata.ts
@@ -59,12 +59,10 @@ export function checkMetadata(metadata: Metadata, devMetadata: any | null, appPa
   }
   checkNotEmpty("version", metadata.version)
 
-  if (devMetadata != null) {
-    checkDependencies(devMetadata.dependencies, errors)
+  if (metadata != null) {
+    checkDependencies(metadata.dependencies, errors)
   }
   if (metadata !== devMetadata) {
-    checkDependencies(metadata.dependencies, errors)
-
     if (metadata.build != null) {
       errors.push(`'build' in the application package.json (${appPackageFile}) is not supported since 3.0 anymore. Please move 'build' into the development package.json (${devAppPackageFile})`)
     }


### PR DESCRIPTION
If devPackageFile and appPackageFile are both defined, only check electron dependencies in appPackageFile.