### PR TITLE
Added fpm documentation to deb configuration

### DIFF
--- a/docs/generated/DebOptions.md
+++ b/docs/generated/DebOptions.md
@@ -2,3 +2,4 @@
 * <code id="DebOptions-depends">depends</code> Array&lt;String&gt; - Package dependencies. Defaults to `["gconf2", "gconf-service", "libnotify4", "libappindicator1", "libxtst6", "libnss3"]`.
 * <code id="DebOptions-packageCategory">packageCategory</code> String - The [package category](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Section).
 * <code id="DebOptions-priority">priority</code> String - The [Priority](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Priority) attribute.
+* <code id="DebOptions-fpm">fpm</code> Array - Advanced [fpm options](https://github.com/jordansissel/fpm/wiki#usage). Example: `["--before-install=build/deb-preinstall.sh", "--after-upgrade=build/deb-postinstall.sh"]`


### PR DESCRIPTION
There is way to actually include pre/post hook scripts (and more), it is just not documented yet.
It probably does work for rpm and other as well since. (deb.fpm should be moved to linux.fpm).