### PR TITLE
I'd like to make computeSignToolArgs usable in custom signing.

### DIFF
--- a/packages/electron-builder-lib/src/winPackager.ts
+++ b/packages/electron-builder-lib/src/winPackager.ts
@@ -28,9 +28,6 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   readonly cscInfo = new Lazy<FileCodeSigningInfo | CertificateFromStoreInfo | null>(() => {
     const platformSpecificBuildOptions = this.platformSpecificBuildOptions
     if (platformSpecificBuildOptions.certificateSubjectName != null || platformSpecificBuildOptions.certificateSha1 != null) {
-      if (platformSpecificBuildOptions.sign != null) {
-        return BluebirdPromise.resolve(null)
-      }
       return this.vm.value.then(vm => getCertificateFromStoreInfo(platformSpecificBuildOptions, vm))
     }
 


### PR DESCRIPTION
computeSignToolArgs is available on the configuration object passed into a custom signing method. This was really helpful to me, but in order to make it usable I had to remove the custom sign check from the winPackager.

I'm not sure if it's the best way to solve the issue, but in my view we can just leave out certificateSubjectName and certificateSha1 and certificateFile for the same effect. Either way, I wanted to create this pull request so that it could be discussed.

Thanks for all of your fantastic work - this tool has been awesome.