### PR TITLE
Change the default desktop helper to desktop-gtk2 for snaps

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -11,8 +11,8 @@ RUN curl -L https://yarnpkg.com/latest.tar.gz | tar xvz && mv yarn-* /yarn && ln
   # python for node-gyp
   # rpm is required for FPM to build rpm package
   # libpng16-16 is required for libicns1_0.8.1-3.1 (on xenial)
-  # libglib2.0-dev for snap desktop-glib-only (see https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml#L248)
-  apt-get install --no-install-recommends -y libsecret-1-0 git snapcraft qtbase5-dev bsdtar build-essential autoconf libssl-dev icnsutils libopenjp2-7 graphicsmagick gcc-multilib g++-multilib libgnome-keyring-dev lzip rpm python libcurl3 git git-lfs ssh libpng16-16 unzip libglib2.0-dev && \
+  # libgtk2.0-dev for snap desktop-gtk2 (see https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml#L248)
+  apt-get install --no-install-recommends -y libsecret-1-0 git snapcraft qtbase5-dev bsdtar build-essential autoconf libssl-dev icnsutils libopenjp2-7 graphicsmagick gcc-multilib g++-multilib libgnome-keyring-dev lzip rpm python libcurl3 git git-lfs ssh libpng16-16 unzip libgtk2.0-dev && \
   # libicns
   curl -O http://mirrors.kernel.org/ubuntu/pool/universe/libi/libicns/libicns1_0.8.1-3.1_amd64.deb && dpkg --install libicns1_0.8.1-3.1_amd64.deb && unlink libicns1_0.8.1-3.1_amd64.deb && \
   git lfs install && \

--- a/docs/configuration/snap.md
+++ b/docs/configuration/snap.md
@@ -12,7 +12,7 @@ The top-level [snap](configuration.md#Configuration-snap) key contains set of op
 * <code id="SnapOptions-plugs">plugs</code> Array&lt;String&gt; - The list of [plugs](https://snapcraft.io/docs/reference/interfaces). Defaults to `["home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"]`.
   
   If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom plug `foo` in addition to defaults.
-* <code id="SnapOptions-after">after</code> Array&lt;String&gt; - Specifies any [parts](https://snapcraft.io/docs/reference/parts) that should be built before this part. Defaults to `["desktop-only""]`.
+* <code id="SnapOptions-after">after</code> Array&lt;String&gt; - Specifies any [parts](https://snapcraft.io/docs/reference/parts) that should be built before this part. Defaults to `["desktop-gtk2""]`.
   
   If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom parts `foo` in addition to defaults.
 * <code id="SnapOptions-ubuntuAppPlatformContent">ubuntuAppPlatformContent</code> String - Specify `ubuntu-app-platform1` to use [ubuntu-app-platform](https://insights.ubuntu.com/2016/11/17/how-to-create-snap-packages-on-qt-applications/). Snap size will be greatly reduced, but it is not recommended for now because "the snaps must be connected before running uitk-gallery for the first time".

--- a/packages/electron-builder-lib/src/options/SnapOptions.ts
+++ b/packages/electron-builder-lib/src/options/SnapOptions.ts
@@ -47,7 +47,7 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
 
   /**
    * Specifies any [parts](https://snapcraft.io/docs/reference/parts) that should be built before this part.
-   * Defaults to `["desktop-only""]`.
+   * Defaults to `["desktop-gtk2""]`.
    *
    * If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom parts `foo` in addition to defaults.
    */

--- a/packages/electron-builder-lib/src/targets/snap.ts
+++ b/packages/electron-builder-lib/src/targets/snap.ts
@@ -78,7 +78,7 @@ export default class SnapTarget extends Target {
     const isUseDocker = process.platform !== "linux"
     // libxss1, libasound2, gconf2 - was "error while loading shared libraries: libXss.so.1" on Xubuntu 16.04
     const defaultStagePackages = ["libnotify4", "libappindicator1", "libxtst6", "libnss3", "libxss1", "fontconfig-config", "gconf2", "libasound2", "pulseaudio"]
-    const defaultAfter = ["desktop-glib-only"]
+    const defaultAfter = ["desktop-gtk2"]
     const after = replaceDefault(options.after, defaultAfter)
     snap.parts = {
       app: {

--- a/test/out/linux/__snapshots__/snapTest.js.snap
+++ b/test/out/linux/__snapshots__/snapTest.js.snap
@@ -25,7 +25,7 @@ Object {
   "parts": Object {
     "app": Object {
       "after": Array [
-        "desktop-glib-only",
+        "desktop-gtk2",
       ],
       "plugin": "dump",
       "stage-packages": Array [
@@ -78,7 +78,7 @@ Object {
   "parts": Object {
     "app": Object {
       "after": Array [
-        "desktop-glib-only",
+        "desktop-gtk2",
       ],
       "plugin": "dump",
       "stage-packages": Array [
@@ -132,7 +132,7 @@ Object {
   "parts": Object {
     "app": Object {
       "after": Array [
-        "desktop-glib-only",
+        "desktop-gtk2",
       ],
       "plugin": "dump",
       "stage-packages": Array [
@@ -187,7 +187,7 @@ Object {
   "parts": Object {
     "app": Object {
       "after": Array [
-        "desktop-glib-only",
+        "desktop-gtk2",
       ],
       "plugin": "dump",
       "stage-packages": Array [


### PR DESCRIPTION
I work on the [Snapcraft](https://snapcraft.io) team. This pull request changes the default [desktop helper](https://github.com/Ubuntu/snapcraft-desktop-helpers) for snaps to `desktop-gtk2` which is the preferred default for Electron applications for practically all use cases.