### PR TITLE
afterSign hook

### DIFF
--- a/docs/api/electron-builder.md
+++ b/docs/api/electron-builder.md
@@ -17,6 +17,7 @@ Developer API only. See [Configuration](/configuration/configuration.md) for use
     * [.Packager](#Packager)
         * [`.addAfterPackHandler(handler)`](#module_electron-builder.Packager+addAfterPackHandler)
         * [`.afterPack(context)`](#module_electron-builder.Packager+afterPack) ⇒ <code>Promise&lt;any&gt;</code>
+        * [`.afterSign(context)`](#module_electron-builder.Packager+afterSign) ⇒ <code>Promise&lt;any&gt;</code>
         * [`.artifactCreated(handler)`](#module_electron-builder.Packager+artifactCreated) ⇒ <code>[Packager](#Packager)</code>
         * [`.build()`](#module_electron-builder.Packager+build) ⇒ <code>Promise&lt;[BuildResult](#BuildResult)&gt;</code>
         * [`.dispatchArtifactCreated(event)`](#module_electron-builder.Packager+dispatchArtifactCreated)
@@ -139,7 +140,9 @@ Developer API only. See [Configuration](/configuration/configuration.md) for use
 **Methods**
 * [.Packager](#Packager)
     * [`.addAfterPackHandler(handler)`](#module_electron-builder.Packager+addAfterPackHandler)
+    * [`.addAfterSignHandler(handler)`](#module_electron-builder.Packager+addAfterSignHandler)
     * [`.afterPack(context)`](#module_electron-builder.Packager+afterPack) ⇒ <code>Promise&lt;any&gt;</code>
+    * [`.afterSign(context)`](#module_electron-builder.Packager+afterSign) ⇒ <code>Promise&lt;any&gt;</code>
     * [`.artifactCreated(handler)`](#module_electron-builder.Packager+artifactCreated) ⇒ <code>[Packager](#Packager)</code>
     * [`.build()`](#module_electron-builder.Packager+build) ⇒ <code>Promise&lt;[BuildResult](#BuildResult)&gt;</code>
     * [`.dispatchArtifactCreated(event)`](#module_electron-builder.Packager+dispatchArtifactCreated)
@@ -151,8 +154,22 @@ Developer API only. See [Configuration](/configuration/configuration.md) for use
 | --- | --- |
 | handler | <code>callback</code> | 
 
+<a name="module_electron-builder.Packager+addAfterSignHandler"></a>
+### `packager.addAfterSignHandler(handler)`
+
+| Param | Type |
+| --- | --- |
+| handler | <code>callback</code> | 
+
 <a name="module_electron-builder.Packager+afterPack"></a>
 ### `packager.afterPack(context)` ⇒ <code>Promise&lt;any&gt;</code>
+
+| Param | Type |
+| --- | --- |
+| context | <code>[AfterPackContext](#AfterPackContext)</code> | 
+
+<a name="module_electron-builder.Packager+afterSign"></a>
+### `packager.afterSign(context)` ⇒ <code>Promise&lt;any&gt;</code>
 
 | Param | Type |
 | --- | --- |

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -113,6 +113,7 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 ---
 
 * <code id="Configuration-afterPack">afterPack</code> (context: AfterPackContext) => Promise | null - The function (or path to file or module id) to be run after pack (but before pack into distributable format and sign).
+* <code id="Configuration-afterSign">afterSign</code> (context: AfterPackContext) => Promise | null - The function (or path to file or module id) to be run after pack and sign (but before pack into distributable format).
 * <code id="Configuration-beforeBuild">beforeBuild</code> (context: BeforeBuildContext) => Promise | null - The function (or path to file or module id) to be run before dependencies are installed or rebuilt. Works when `npmRebuild` is set to `true`. Resolving to `false` will skip dependencies install or rebuild.
 <!-- end of generated block -->
 

--- a/packages/electron-builder-lib/src/configuration.ts
+++ b/packages/electron-builder-lib/src/configuration.ts
@@ -166,6 +166,12 @@ export interface Configuration extends PlatformSpecificBuildOptions {
    * The function (or path to file or module id) to be run after pack (but before pack into distributable format and sign).
    */
   readonly afterPack?: ((context: AfterPackContext) => Promise<any>) | string | null
+
+  /**
+   * The function (or path to file or module id) to be run after pack and sign (but before pack into distributable format).
+   */
+  readonly afterSign?: ((context: AfterPackContext) => Promise<any>) | string | null
+
   /**
    * The function (or path to file or module id) to be run before dependencies are installed or rebuilt. Works when `npmRebuild` is set to `true`. Resolving to `false` will skip dependencies install or rebuild.
    */

--- a/packages/electron-builder-lib/src/packager.ts
+++ b/packages/electron-builder-lib/src/packager.ts
@@ -74,6 +74,8 @@ export class Packager {
 
   private readonly afterPackHandlers: Array<(context: AfterPackContext) => Promise<any> | null> = []
 
+  private readonly afterSignHandlers: Array<(context: AfterPackContext) => Promise<any> | null> = []
+
   readonly options: PackagerOptions
 
   readonly debugLogger = new DebugLogger(log.isDebugEnabled)
@@ -205,6 +207,10 @@ export class Packager {
 
   addAfterPackHandler(handler: (context: AfterPackContext) => Promise<any> | null) {
     this.afterPackHandlers.push(handler)
+  }
+
+  addAfterSignHandler(handler: (context: AfterPackContext) => Promise<any> | null) {
+    this.afterSignHandlers.push(handler)
   }
 
   artifactCreated(handler: (event: ArtifactCreated) => void): Packager {
@@ -445,6 +451,16 @@ export class Packager {
     if (afterPack != null) {
       // user handler should be last
       handlers.push(afterPack)
+    }
+    return BluebirdPromise.each(handlers, it => it(context))
+  }
+
+  afterSign(context: AfterPackContext): Promise<any> {
+    const afterSign = resolveFunction(this.config.afterSign)
+    const handlers = this.afterSignHandlers.slice()
+    if (afterSign != null) {
+      // user handler should be last
+      handlers.push(afterSign)
     }
     return BluebirdPromise.each(handlers, it => it(context))
   }

--- a/packages/electron-builder-lib/src/platformPackager.ts
+++ b/packages/electron-builder-lib/src/platformPackager.ts
@@ -213,6 +213,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     await this.info.afterPack(packContext)
     await this.sanityCheckPackage(appOutDir, asarOptions != null)
     await this.signApp(packContext)
+    await this.info.afterSign(packContext)
   }
 
   private copyAppFiles(taskManager: AsyncTaskManager, asarOptions: AsarOptions | null, resourcePath: string, outDir: string, platformSpecificBuildOptions: DC, excludePatterns: Array<Minimatch>, macroExpander: ((it: string) => string)) {

--- a/scripts/jsdoc2md.js
+++ b/scripts/jsdoc2md.js
@@ -64,7 +64,7 @@ async function render2(files, jsdoc2MdOptions) {
   const renderer = new Renderer(dataMap)
 
   const blockedPropertyName = new Set([
-    "fileAssociations", "directories", "buildVersion", "mac", "linux", "win", "buildDependenciesFromSource", "afterPack",
+    "fileAssociations", "directories", "buildVersion", "mac", "linux", "win", "buildDependenciesFromSource", "afterPack", "afterSign",
     "installerIcon", "include", "createDesktopShortcut", "displayLanguageSelector", "signingHashAlgorithms", "publisherName",
     "forceCodeSigning",
   ])
@@ -124,6 +124,9 @@ async function render2(files, jsdoc2MdOptions) {
       }
       if (context.object.name === "Configuration") {
         if (context.property.name === "afterPack") {
+          return "(context: AfterPackContext) => Promise | null"
+        }
+        if (context.property.name === "afterSign") {
           return "(context: AfterPackContext) => Promise | null"
         }
         if (context.property.name === "beforeBuild") {

--- a/test/out/__snapshots__/BuildTest.js.snap
+++ b/test/out/__snapshots__/BuildTest.js.snap
@@ -7,6 +7,13 @@ Object {
 }
 `;
 
+exports[`afterSign 1`] = `
+Object {
+  "linux": Array [],
+  "mac": Array [],
+}
+`;
+
 exports[`beforeBuild 1`] = `
 Object {
   "linux": Array [],

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -149,6 +149,23 @@ test.ifLinuxOrDevMac("afterPack", () => {
   })
 })
 
+test.ifLinuxOrDevMac("afterSign", () => {
+  let called = 0
+  return assertPack("test-app-one", {
+    targets: createTargets([Platform.LINUX, Platform.MAC], DIR_TARGET),
+    config: {
+      afterSign: () => {
+        called++
+        return BluebirdPromise.resolve()
+      }
+    }
+  }, {
+    packed: async () => {
+      expect(called).toEqual(2)
+    }
+  })
+})
+
 test.ifLinuxOrDevMac("beforeBuild", () => {
   let called = 0
   return assertPack("test-app-one", {


### PR DESCRIPTION
Hi

In documentation there is 2 hooks available : afterPack and beforeBuild.
I propose to add another hook : afterSign.
If defined, the callback function is called after code-signing ( but before pack into distributable format).

Regards
Jeremie 