### PR TITLE
fix(electron-updater): recurrent 404 Errors on GitHub Enterprise

### DIFF
--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -14,7 +14,8 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
     super(executor, false /* because GitHib uses S3 */)
 
     this.baseUrl = newBaseUrl(githubUrl(options, defaultHost))
-    this.baseApiUrl = newBaseUrl(githubUrl(options, defaultHost || "api.github.com"))
+    const apiHost = defaultHost === "github.com" ? "api.github.com" || defaultHost
+    this.baseApiUrl = newBaseUrl(githubUrl(options, apiHost))
   }
 
   protected computeGithubBasePath(result: string) {

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -14,7 +14,7 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
     super(executor, false /* because GitHib uses S3 */)
 
     this.baseUrl = newBaseUrl(githubUrl(options, defaultHost))
-    this.baseApiUrl = newBaseUrl(this.options.host || "api.github.com")
+    this.baseApiUrl = newBaseUrl(githubUrl(options, defaultHost || "api.github.com"))
   }
 
   protected computeGithubBasePath(result: string) {

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -15,7 +15,7 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
     this.baseUrl = newBaseUrl(githubUrl(options, defaultHost))
   }
 
-  protected computeGithubBasePath(result: string) {
+  protected computeGithubApiBasePath(result: string) {
     // https://github.com/electron-userland/electron-builder/issues/1903#issuecomment-320881211
     const host = this.options.host
     return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -15,7 +15,7 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
     this.baseUrl = newBaseUrl(githubUrl(options, defaultHost))
   }
 
-  protected computeGithubApiBasePath(result: string) {
+  protected computeGithubBasePath(result: string) {
     // https://github.com/electron-userland/electron-builder/issues/1903#issuecomment-320881211
     const host = this.options.host
     return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result
@@ -108,7 +108,7 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
   }
 
   private get apiBasePath() {
-    return this.computeGithubApiBasePath(`/repos/${this.options.owner}/${this.options.repo}/releases`)
+    return this.computeGithubBasePath(`/repos/${this.options.owner}/${this.options.repo}/releases`)
   }
 
   resolveFiles(updateInfo: UpdateInfo): Array<ResolvedUpdateFileInfo> {

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -115,8 +115,7 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
 
   resolveFiles(updateInfo: UpdateInfo): Array<ResolvedUpdateFileInfo> {
     // still replace space to - due to backward compatibility
-    return resolveFiles(updateInfo, this.
-, p => this.getBaseDownloadPath(updateInfo.version, p.replace(/ /g, "-")))
+    return resolveFiles(updateInfo, this.baseUrl, p => this.getBaseDownloadPath(updateInfo.version, p.replace(/ /g, "-")))
   }
 
   private getBaseDownloadPath(version: string, fileName: string) {

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -8,12 +8,13 @@ import { parseUpdateInfo, resolveFiles } from "./Provider"
 export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<T> {
   // so, we don't need to parse port (because node http doesn't support host as url does)
   protected readonly baseUrl: URL
+  protected readonly baseApiUrl: URL
 
   protected constructor(protected readonly options: GithubOptions, defaultHost: string, executor: HttpExecutor<any>) {
     super(executor, false /* because GitHib uses S3 */)
 
     this.baseUrl = newBaseUrl(githubUrl(options, defaultHost))
-    this.baseApiUrl = this.options.host || "api.github.com"
+    this.baseApiUrl = newBaseUrl(this.options.host || "api.github.com")
   }
 
   protected computeGithubBasePath(result: string) {

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -14,7 +14,7 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
     super(executor, false /* because GitHib uses S3 */)
 
     this.baseUrl = newBaseUrl(githubUrl(options, defaultHost))
-    const apiHost = defaultHost === "github.com" ? "api.github.com" || defaultHost
+    const apiHost = defaultHost === "github.com" ? "api.github.com" : defaultHost
     this.baseApiUrl = newBaseUrl(githubUrl(options, apiHost))
   }
 

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -29,6 +29,8 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
 
   async getLatestVersion(): Promise<UpdateInfo> {
     const basePath = this.basePath
+    const apiBasePath = this.apiBasePath
+
     const cancellationToken = new CancellationToken()
 
     const feedXml: string = (await this.httpRequest(newUrlFromBase(`${basePath}.atom`, this.baseUrl), {
@@ -44,7 +46,7 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
         version = latestRelease.element("link").attribute("href").match(/\/tag\/v?([^\/]+)$/)!![1]
       }
       else {
-        version = await this.getLatestVersionString(basePath, cancellationToken)
+        version = await this.getLatestVersionString(apiBasePath, cancellationToken)
       }
     }
     catch (e) {
@@ -102,7 +104,11 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
   }
 
   private get basePath() {
-    return this.computeGithubBasePath(`/${this.options.owner}/${this.options.repo}/releases`)
+    return `/${this.options.owner}/${this.options.repo}/releases`
+  }
+
+  private get apiBasePath() {
+    return this.computeGithubApiBasePath(`/repos/${this.options.owner}/${this.options.repo}/releases`)
   }
 
   resolveFiles(updateInfo: UpdateInfo): Array<ResolvedUpdateFileInfo> {

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -17,8 +17,8 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
 
   protected computeGithubBasePath(result: string) {
     // https://github.com/electron-userland/electron-builder/issues/1903#issuecomment-320881211
-    const host = this.options.host
-    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result
+    const {host} = this.options
+    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : "api.github.com"
   }
 }
 

--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -13,12 +13,13 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
     super(executor, false /* because GitHib uses S3 */)
 
     this.baseUrl = newBaseUrl(githubUrl(options, defaultHost))
+    this.baseApiUrl = this.options.host || "api.github.com"
   }
 
   protected computeGithubBasePath(result: string) {
     // https://github.com/electron-userland/electron-builder/issues/1903#issuecomment-320881211
     const {host} = this.options
-    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : "api.github.com"
+    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result
   }
 }
 
@@ -87,7 +88,7 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
   }
 
   private async getLatestVersionString(basePath: string, cancellationToken: CancellationToken): Promise<string | null> {
-    const url = newUrlFromBase(`${basePath}/latest`, this.baseUrl)
+    const url = newUrlFromBase(`${basePath}/latest`, this.baseApiUrl)
     try {
       // do not use API to avoid limit
       const rawData = await this.httpRequest(url, {Accept: "application/json"}, cancellationToken)
@@ -113,7 +114,8 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
 
   resolveFiles(updateInfo: UpdateInfo): Array<ResolvedUpdateFileInfo> {
     // still replace space to - due to backward compatibility
-    return resolveFiles(updateInfo, this.baseUrl, p => this.getBaseDownloadPath(updateInfo.version, p.replace(/ /g, "-")))
+    return resolveFiles(updateInfo, this.
+, p => this.getBaseDownloadPath(updateInfo.version, p.replace(/ /g, "-")))
   }
 
   private getBaseDownloadPath(version: string, fileName: string) {


### PR DESCRIPTION
Following #2038

I have many 404 Errors on urls like "https://supagithub.com/api/v3/awesome-team/awesome-project/releases.atom" on GitHub Enterprise that makes the auto-update always fail :(
Looking at the running code outside GitHub Enterprise, it seems like the same happens as : "https://api.github.com/electron-userland/electron-builder/releases.atom" end with 404 too. 
I'm fixing this by decoupling the GitHub url and the GitHub Api url.
The expected url is "https://github.com/electron-userland/electron-builder/releases.atom"
as for GitHub Enterprise: "https://supagithub.com/awesome-team/awesome-project/releases.atom"