### PR TITLE
Add desktop and desktop-legacy to the default interfaces for snaps

### DIFF
--- a/docs/configuration/snap.md
+++ b/docs/configuration/snap.md
@@ -7,13 +7,13 @@ The top-level [snap](configuration.md#Configuration-snap) key contains set of op
 * <code id="SnapOptions-assumes">assumes</code> Array&lt;String&gt; - The list of features that must be supported by the core in order for this snap to install.
 * <code id="SnapOptions-buildPackages">buildPackages</code> Array&lt;String&gt; - The list of debian packages needs to be installed for building this snap.
 * <code id="SnapOptions-stagePackages">stagePackages</code> Array&lt;String&gt; - The list of Ubuntu packages to use that are needed to support the `app` part creation. Like `depends` for `deb`. Defaults to `["libasound2", "libgconf2-4", "libnotify4", "libnspr4", "libnss3", "libpcre3", "libpulse0", "libxss1", "libxtst6"]`.
-  
+
   If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom package `foo` in addition to defaults.
-* <code id="SnapOptions-plugs">plugs</code> Array&lt;String&gt; - The list of [plugs](https://snapcraft.io/docs/reference/interfaces). Defaults to `["home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"]`.
-  
+* <code id="SnapOptions-plugs">plugs</code> Array&lt;String&gt; - The list of [plugs](https://snapcraft.io/docs/reference/interfaces). Defaults to `["desktop", "desktop-legacy", "home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"]`.
+
   If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom plug `foo` in addition to defaults.
 * <code id="SnapOptions-after">after</code> Array&lt;String&gt; - Specifies any [parts](https://snapcraft.io/docs/reference/parts) that should be built before this part. Defaults to `["desktop-gtk2""]`.
-  
+
   If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom parts `foo` in addition to defaults.
 * <code id="SnapOptions-ubuntuAppPlatformContent">ubuntuAppPlatformContent</code> String - Specify `ubuntu-app-platform1` to use [ubuntu-app-platform](https://insights.ubuntu.com/2016/11/17/how-to-create-snap-packages-on-qt-applications/). Snap size will be greatly reduced, but it is not recommended for now because "the snaps must be connected before running uitk-gallery for the first time".
 

--- a/packages/electron-builder-lib/src/options/SnapOptions.ts
+++ b/packages/electron-builder-lib/src/options/SnapOptions.ts
@@ -39,7 +39,7 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
 
   /**
    * The list of [plugs](https://snapcraft.io/docs/reference/interfaces).
-   * Defaults to `["home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"]`.
+   * Defaults to `["desktop", "desktop-legacy", "home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"]`.
    *
    * If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom plug `foo` in addition to defaults.
    */

--- a/packages/electron-builder-lib/src/targets/snap.ts
+++ b/packages/electron-builder-lib/src/targets/snap.ts
@@ -71,7 +71,7 @@ export default class SnapTarget extends Target {
     snap.apps = {
       [snap.name]: {
         command: `env TMPDIR=$XDG_RUNTIME_DIR desktop-launch $SNAP/${packager.executableName}`,
-        plugs: replaceDefault(options.plugs, ["home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"])
+        plugs: replaceDefault(options.plugs, ["desktop", "desktop-legacy", "home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"])
       }
     }
 

--- a/test/out/linux/__snapshots__/snapTest.js.snap
+++ b/test/out/linux/__snapshots__/snapTest.js.snap
@@ -6,6 +6,8 @@ Object {
     "sep": Object {
       "command": "env TMPDIR=$XDG_RUNTIME_DIR desktop-launch $SNAP/sep",
       "plugs": Array [
+        "desktop",
+        "desktop-legacy",
         "home",
         "x11",
         "unity7",
@@ -58,6 +60,8 @@ Object {
     "sep": Object {
       "command": "env TMPDIR=$XDG_RUNTIME_DIR desktop-launch $SNAP/sep",
       "plugs": Array [
+        "desktop",
+        "desktop-legacy",
         "home",
         "x11",
         "unity7",
@@ -113,6 +117,8 @@ Object {
       "command": "env TMPDIR=$XDG_RUNTIME_DIR desktop-launch $SNAP/sep",
       "plugs": Array [
         "custom",
+        "desktop",
+        "desktop-legacy",
         "home",
         "x11",
         "unity7",
@@ -167,6 +173,8 @@ Object {
       "command": "env TMPDIR=$XDG_RUNTIME_DIR desktop-launch $SNAP/sep",
       "plugs": Array [
         "foo1",
+        "desktop",
+        "desktop-legacy",
         "home",
         "x11",
         "unity7",


### PR DESCRIPTION
This pull request adds the `desktop` and `desktop-legacy` interfaces to the default interfaces used when building snaps. All snap enabled distros are able to support these interfaces now.

  * `desktop`: Can access basic desktop graphical resources, such as fonts and in future will be the interface via which desktop theme integration will be exposed.
  * `desktop-legacy`: Can access desktop legacy methods such as a11y and input methods.

Both interfaces are auto-connected and do not increase the size of the snap.