### PR TITLE
fix(electron-updater): remove error callback param event

### DIFF
--- a/docs/encapsulated manual update via menu.js
+++ b/docs/encapsulated manual update via menu.js
@@ -13,7 +13,7 @@ const { autoUpdater } = require('electron-updater')
 let updater
 autoUpdater.autoDownload = false
 
-autoUpdater.on('error', (event, error) => {
+autoUpdater.on('error', (error) => {
   dialog.showErrorBox('Error: ', error == null ? "unknown" : (error.stack || error).toString())
 })
 


### PR DESCRIPTION
```
// class AppUpdater
this.on("error", error => {
    this._logger.error(`Error: ${error.stack || error.message}`);
});
```