### PR TITLE
Updated messageTransformer to return string

### DIFF
--- a/packages/builder-util/src/log.ts
+++ b/packages/builder-util/src/log.ts
@@ -22,7 +22,7 @@ export class Logger {
   constructor(protected readonly stream: WritableStream) {
   }
 
-  messageTransformer: ((message: string, level: LogLevel) => string) = it => it
+  messageTransformer: ((message: string, level: LogLevel) => string) = it => it.toString()
 
   filePath(file: string) {
     const cwd = process.cwd()


### PR DESCRIPTION
Using `toString()` to ensure the message is always a string as expected.
Fixes #2469.