### PR TITLE
feat: arm64 support

### DIFF
--- a/packages/builder-util/src/arch.ts
+++ b/packages/builder-util/src/arch.ts
@@ -1,12 +1,14 @@
 export enum Arch {
-  ia32, x64, armv7l
+  ia32, x64, armv7l, arm64
 }
 
 export function toLinuxArchString(arch: Arch) {
-  return arch === Arch.ia32 ? "i386" : (arch === Arch.x64 ? "amd64" : "armv7l")
+  return arch === Arch.ia32 ? "i386" :
+          (arch === Arch.x64 ? "amd64" :
+          (arch === Arch.arm64 ? "arm64" : "armv7l"))
 }
 
-export type ArchType = "x64" | "ia32" | "armv7l"
+export type ArchType = "x64" | "ia32" | "armv7l" | "arm64"
 
 export function getArchSuffix(arch: Arch): string {
   return arch === Arch.x64 ? "" : `-${Arch[arch]}`
@@ -22,6 +24,9 @@ export function archFromString(name: string): Arch {
 
     case "armv7l":
       return Arch.armv7l
+
+    case "arm64":
+      return Arch.arm64
 
     default:
       throw new Error(`Unsupported arch ${name}`)

--- a/packages/electron-builder-lib/src/targets/AppImageTarget.ts
+++ b/packages/electron-builder-lib/src/targets/AppImageTarget.ts
@@ -109,7 +109,7 @@ export default class AppImageTarget extends Target {
         ...process.env,
         PATH: `${vendorToolDir}:${process.env.PATH}`,
         // to avoid detection by appimagetool (see extract_arch_from_text about expected arch names)
-        ARCH: arch === Arch.ia32 ? "i386" : (arch === Arch.x64 ? "x86_64" : "arm"),
+        ARCH: arch === Arch.ia32 ? "i386" : (arch === Arch.x64 ? "x86_64" : (arch === Arch.arm64 ? "arm_aarch64" : "arm")),
       }
     })
 
@@ -177,6 +177,9 @@ function archToRuntimeName(arch: Arch) {
   switch (arch) {
     case Arch.armv7l:
       return "armv7"
+
+    case Arch.arm64:
+      return "arm64"
 
     case Arch.ia32:
       return "i686"

--- a/packages/electron-builder-lib/src/targets/tools.ts
+++ b/packages/electron-builder-lib/src/targets/tools.ts
@@ -82,27 +82,29 @@ export interface ToolDescriptor {
   mac: string
   "linux-ia32"?: string
   "linux-x64"?: string
-  "linux-armV7"?: string
-  "linux-armV8"?: string
+  "linux-armv7"?: string
+  "linux-armv8"?: string
 
   "win-ia32": string
   "win-x64": string
 }
 
 export function getTool(descriptor: ToolDescriptor): Promise<string> {
-  const platform = Platform.current()
-  const checksum = platform === Platform.MAC ? descriptor.mac : (descriptor as any)[`${platform.buildConfigurationKey}-${process.arch}`]
-  if (checksum == null) {
-    throw new Error(`Checksum not specified for ${platform}:${process.arch}`)
+  let arch = process.arch;
+  if (arch === "arm") {
+    arch = "armv7"
+  }
+  else if (arch === "arm64") {
+    arch = "armv8"
   }
 
-  let archQualifier = platform === Platform.MAC ? "" : `-${process.arch}`
-  if (archQualifier === "arm") {
-    archQualifier = "armv7"
+  const platform = Platform.current()
+  const checksum = platform === Platform.MAC ? descriptor.mac : (descriptor as any)[`${platform.buildConfigurationKey}-${arch}`]
+  if (checksum == null) {
+    throw new Error(`Checksum not specified for ${platform}:${arch}`)
   }
-  else if (archQualifier === "arm64") {
-    archQualifier = "armv8"
-  }
+
+  let archQualifier = platform === Platform.MAC ? "" : `-${arch}`
 
   // https://github.com/develar/block-map-builder/releases/download/v0.0.1/block-map-builder-v0.0.1-win-x64.7z
   const version = descriptor.version
@@ -126,8 +128,8 @@ export function getAppBuilderTool() {
     mac: "d27p1TYhPVlWFS+3TO8dh80sHP5imMnZTS04ODvL9xHpCQ7KZEUqFEWYi7zDFXKfzBU6zwBcRGrb8BwQAawvzg==",
     "linux-ia32": "1aLAsDliV/kCYfOQR/NX43pRwO/v4nC7F98Z9ZRO8r8iXEpTLYVJC19FNup81WpD0hvxLBspnbq73YiSE3aX8g==",
     "linux-x64": "6iu/0BzEKTIuCZ/pVPorpLTXjTzqcquTfrlyB9mEyPXQcHPTueK+tBBDQ6SIO7eaGq+W3PDe1oEjgiz2q3Zd4g==",
-    "linux-armV7": "zUxn5fAxeGylF7mqVP+Aaas3vD3ITTS26EBty9VkGz51EYgCVYnQVTacDIQjwB6s1zit6jt8EJy5Jj0Y+6U+7w==",
-    "linux-armV8": "69napXVwaPqQcNp7tozNyo7VJbB90E2RToN0pqGppdfUBzTLJUNnZL5D7H4MoUUPS/WgNRalEswb7GfZOsK4XA==",
+    "linux-armv7": "zUxn5fAxeGylF7mqVP+Aaas3vD3ITTS26EBty9VkGz51EYgCVYnQVTacDIQjwB6s1zit6jt8EJy5Jj0Y+6U+7w==",
+    "linux-armv8": "69napXVwaPqQcNp7tozNyo7VJbB90E2RToN0pqGppdfUBzTLJUNnZL5D7H4MoUUPS/WgNRalEswb7GfZOsK4XA==",
     "win-ia32": "HW+pZS96d0v96iq0y8BX4vg5J97oFMujPaqziatRNZif26EI75lS5S58qCEmooyr9lXDLwbIlNIhrKg7ZzlNhw==",
     "win-x64": "eO8eJq2N/t0/3g3EuRut0LU460WUqzywiRhr+OjEUQH1Gt7GuIdc4gYOfDazYjyeTqlATCfT/OzQMdplaac2wQ==",
   })

--- a/packages/electron-builder-lib/src/targets/tools.ts
+++ b/packages/electron-builder-lib/src/targets/tools.ts
@@ -90,7 +90,7 @@ export interface ToolDescriptor {
 }
 
 export function getTool(descriptor: ToolDescriptor): Promise<string> {
-  let arch = process.arch;
+  let arch = process.arch
   if (arch === "arm") {
     arch = "armv7"
   }
@@ -104,7 +104,7 @@ export function getTool(descriptor: ToolDescriptor): Promise<string> {
     throw new Error(`Checksum not specified for ${platform}:${arch}`)
   }
 
-  let archQualifier = platform === Platform.MAC ? "" : `-${arch}`
+  const archQualifier = platform === Platform.MAC ? "" : `-${arch}`
 
   // https://github.com/develar/block-map-builder/releases/download/v0.0.1/block-map-builder-v0.0.1-win-x64.7z
   const version = descriptor.version


### PR DESCRIPTION
Note, requires arm64 support for binary repo dependancies. 7zip-bin PR has already been sent, but electron-builder-binaries PR (for appimagekit binary) is still to come.