### PR TITLE
NSIS: Install with File Associations and with selection "Per-machine" / "Per-user"

### DIFF
--- a/packages/electron-builder/src/targets/nsis/nsis.ts
+++ b/packages/electron-builder/src/targets/nsis/nsis.ts
@@ -508,11 +508,6 @@ export class NsisTarget extends Target {
 
     const fileAssociations = packager.fileAssociations
     if (fileAssociations.length !== 0) {
-      if (options.perMachine !== true) {
-        // https://github.com/electron-userland/electron-builder/issues/772
-        throw new Error(`Please set perMachine to true — file associations works on Windows only if installed for all users`)
-      }
-
       scriptGenerator.include(path.join(path.join(nsisTemplatesDir, "include"), "FileAssociation.nsh"))
       if (isInstaller) {
         const registerFileAssociationsScript = new NsisScriptGenerator()


### PR DESCRIPTION
Remove exception about `fileAssociations` without `perMachine`, cause we want to install file associations on Windows if User has an Admin grants, but we still want to let a common User install it without any problems (and without file associations). This fix is not broke anything, but it let to build NSIS installer completely.

Also, created an issue in the original repository:
https://github.com/electron-userland/electron-builder/issues/2496

I hope someday it will be fixed and we could switch to the original repository.