### PR TITLE
Avoid delay due to powershell.exe waiting for input

### DIFF
--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -10,7 +10,8 @@ import { Logger } from "./main"
 export function verifySignature(publisherNames: Array<string>, tempUpdateFile: string, logger: Logger): Promise<string | null> {
   return new BluebirdPromise<string | null>((resolve, reject) => {
     // https://github.com/electron-userland/electron-builder/issues/2421
-    execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", `Get-AuthenticodeSignature '${tempUpdateFile}' | ConvertTo-Json -Compress`], {
+    // https://github.com/electron-userland/electron-builder/issues/2535
+    execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", `Get-AuthenticodeSignature '${tempUpdateFile}' | ConvertTo-Json -Compress`], {
       timeout: 30 * 1000
     }, (error, stdout, stderr) => {
       if (error != null || stderr) {


### PR DESCRIPTION
On Windows 7 we are currently seeing a 30 second delay between the 100% `download-progress` event and `update-downloaded` event. We are not seeing the delay on Windows 10. Investigation reveals that the 30 seconds are spent during the `verifySignature` phase when calling powershell.exe. The process appears to be stuck waiting for input after invoking the command.

Adding `-InputFormat None` fixes the issue on Windows 7 (Powershell v2). Also tested that Windows 10 (Powershell v5) still works. The fix was found on https://serverfault.com/a/639007.