### PR TITLE
Fix: handle dependencies with package 'link' fields

### DIFF
--- a/packages/electron-builder-lib/src/util/packageDependencies.ts
+++ b/packages/electron-builder-lib/src/util/packageDependencies.ts
@@ -208,6 +208,9 @@ class Collector {
     }
     else {
       metadata.parent = parent
+
+      // overwrite if already set by project package.json
+      metadata.link = undefined
     }
 
     metadata.path = rawDir

--- a/test/out/__snapshots__/PublishManagerTest.js.snap
+++ b/test/out/__snapshots__/PublishManagerTest.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dotted s3 bucket 1`] = `
-Object {
-  "linux": Array [
-    Object {
-      "arch": "x64",
-      "file": "TestApp-1.1.0.zip",
-      "safeArtifactName": "TestApp-1.1.0.zip",
-    },
-  ],
-}
-`;
-
 exports[`generic, github and spaces 1`] = `
 Object {
   "mac": Array [

--- a/test/out/__snapshots__/PublishManagerTest.js.snap
+++ b/test/out/__snapshots__/PublishManagerTest.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dotted s3 bucket 1`] = `
+Object {
+  "linux": Array [
+    Object {
+      "arch": "x64",
+      "file": "TestApp-1.1.0.zip",
+      "safeArtifactName": "TestApp-1.1.0.zip",
+    },
+  ],
+}
+`;
+
 exports[`generic, github and spaces 1`] = `
 Object {
   "mac": Array [


### PR DESCRIPTION
Linked bug: #2685 

Some projects, like Mozilla Aframe, set a 'link' property at the root of their package.json file.
This causes problems for our packageDependencies job, which extends that object and adds 'link'
to signify the dependency dir is a symbolic link.

This PR makes sure any existing `link` in package.json is always overwritten with the appropriate value.