### PR TITLE
fix: Windows 7 32 bit crash

### DIFF
--- a/packages/electron-builder-lib/templates/nsis/multiUser.nsh
+++ b/packages/electron-builder-lib/templates/nsis/multiUser.nsh
@@ -27,13 +27,15 @@ Var installMode
       StrCpy $INSTDIR $perUserInstallationFolder
     ${else}
       StrCpy $0 "$LocalAppData\Programs"
+      System::Store S
       # Win7 has a per-user programfiles known folder and this can be a non-default location
-      System::Call 'Shell32::SHGetKnownFolderPath(g "${FOLDERID_UserProgramFiles}",i ${KF_FLAG_CREATE},i0,*i.r2)i.r1'
+      System::Call 'SHELL32::SHGetKnownFolderPath(g "${FOLDERID_UserProgramFiles}", i ${KF_FLAG_CREATE}, p 0, *p .r2)i.r1'
       ${If} $1 == 0
-        System::Call '*$2(&w${NSIS_MAX_STRLEN} .r1)'
+        System::Call '*$2(&w${NSIS_MAX_STRLEN} .s)'
         StrCpy $0 $1
-        System::Call 'Ole32::CoTaskMemFree(ir2)'
+        System::Call 'OLE32::CoTaskMemFree(p r2)'
       ${endif}
+      System::Store L
       StrCpy $INSTDIR "$0\${APP_FILENAME}"
     ${endif}
   !macroend


### PR DESCRIPTION
Made the `setInstallModePerUser` macro look like in this [SO answer](https://stackoverflow.com/a/47164192) and it fixed the issue with win7:32 crash.

fixes #2518