### PR TITLE
Snap: initialize db and icons for faster startup and remove fonts

### DIFF
--- a/packages/electron-builder-lib/src/targets/snap.ts
+++ b/packages/electron-builder-lib/src/targets/snap.ts
@@ -123,6 +123,10 @@ for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
 done`
       }
 
+      if (appDescriptor.plugs.indexOf("desktop") >= 0 || appDescriptor.plugs.indexOf("desktop-legacy") >= 0) {
+        desktopPartOverride.stage = ["-./usr/share/fonts/**"]
+      }
+
       snap.parts[desktopPart] = desktopPartOverride
     }
 

--- a/packages/electron-builder-lib/src/targets/snap.ts
+++ b/packages/electron-builder-lib/src/targets/snap.ts
@@ -38,6 +38,7 @@ export default class SnapTarget extends Target {
 
     const plugs = normalizePlugConfiguration(options.plugs)
     const plugNames = this.replaceDefault(plugs == null ? null : Object.getOwnPropertyNames(plugs), defaultPlugs)
+    const desktopPart = this.packager.isElectron2 ? "desktop-gtk3" : "desktop-gtk2"
 
     const buildPackages = asArray(options.buildPackages)
     this.isUseTemplateApp = this.options.useTemplateApp !== false && arch === Arch.x64 && buildPackages.length === 0
@@ -74,7 +75,7 @@ export default class SnapTarget extends Target {
         app: {
           plugin: "nil",
           "stage-packages": this.replaceDefault(options.stagePackages, defaultStagePackages),
-          after: this.replaceDefault(options.after, [this.packager.isElectron2 ? "desktop-gtk3" : "desktop-gtk2"]),
+          after: this.replaceDefault(options.after, [desktopPart]),
         }
       },
     }
@@ -104,6 +105,27 @@ export default class SnapTarget extends Target {
     if (options.assumes != null) {
       snap.assumes = asArray(options.assumes)
     }
+
+    if (snap.parts.app.after && snap.parts.app.after.indexOf(desktopPart) >= 0) {
+      const desktopPartOverride: any = {
+        install: `set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done`
+      }
+
+      snap.parts[desktopPart] = desktopPartOverride
+    }
+
     return snap
   }
 

--- a/test/out/linux/__snapshots__/snapTest.js.snap
+++ b/test/out/linux/__snapshots__/snapTest.js.snap
@@ -56,6 +56,21 @@ Object {
         "libxtst6",
       ],
     },
+    "desktop-gtk2": Object {
+      "install": "set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done",
+    },
   },
   "summary": "Sep",
   "version": "1.1.0",
@@ -63,6 +78,69 @@ Object {
 `;
 
 exports[`buildPackages 2`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
+exports[`custom after, no desktop 1`] = `
+Object {
+  "apps": Object {
+    "sep": Object {
+      "adapter": "none",
+      "command": "command.sh",
+      "environment": Object {
+        "LD_LIBRARY_PATH": "$SNAP_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio:$SNAP/usr/lib/x86_64-linux-gnu/mesa-egl:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu",
+        "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
+        "TMPDIR": "$XDG_RUNTIME_DIR",
+      },
+      "plugs": Array [
+        "desktop",
+        "desktop-legacy",
+        "home",
+        "x11",
+        "unity7",
+        "browser-support",
+        "network",
+        "gsettings",
+        "pulseaudio",
+        "opengl",
+      ],
+    },
+  },
+  "architectures": Array [
+    "amd64",
+  ],
+  "confinement": "strict",
+  "description": "Test Application (test quite “ #378)",
+  "grade": "stable",
+  "icon": "snap/gui/icon.png",
+  "name": "sep",
+  "parts": Object {
+    "app": Object {
+      "after": Array [
+        "bar",
+      ],
+      "plugin": "nil",
+      "stage-packages": Array [
+        "libasound2",
+        "libgconf2-4",
+        "libnotify4",
+        "libnspr4",
+        "libnss3",
+        "libpcre3",
+        "libpulse0",
+        "libxss1",
+        "libxtst6",
+      ],
+    },
+  },
+  "summary": "Sep",
+  "version": "1.1.0",
+}
+`;
+
+exports[`custom after, no desktop 2`] = `
 Object {
   "linux": Array [],
 }
@@ -162,6 +240,21 @@ Object {
         "libxtst6",
       ],
     },
+    "desktop-gtk2": Object {
+      "install": "set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done",
+    },
   },
   "summary": "Sep",
   "version": "1.1.0",
@@ -227,6 +320,21 @@ Object {
         "custom",
       ],
     },
+    "desktop-gtk2": Object {
+      "install": "set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done",
+    },
   },
   "summary": "Sep",
   "version": "1.1.0",
@@ -291,6 +399,21 @@ Object {
         "libxss1",
         "libxtst6",
       ],
+    },
+    "desktop-gtk2": Object {
+      "install": "set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done",
     },
   },
   "summary": "Sep",
@@ -359,6 +482,21 @@ Object {
         "foo2",
       ],
     },
+    "desktop-gtk2": Object {
+      "install": "set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done",
+    },
   },
   "summary": "Sep",
   "version": "1.1.0",
@@ -413,6 +551,21 @@ Object {
         "libxss1",
         "libxtst6",
       ],
+    },
+    "desktop-gtk2": Object {
+      "install": "set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done",
     },
   },
   "plugs": Object {
@@ -474,6 +627,21 @@ Object {
         "libxss1",
         "libxtst6",
       ],
+    },
+    "desktop-gtk2": Object {
+      "install": "set -x
+export XDG_DATA_DIRS=$SNAPCRAFT_PART_INSTALL/usr/share
+update-mime-database $SNAPCRAFT_PART_INSTALL/usr/share/mime
+
+for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
+  if [ -f $dir/index.theme ]; then
+    if which gtk-update-icon-cache-3.0 &> /dev/null; then
+      gtk-update-icon-cache-3.0 -q $dir
+    elif which gtk-update-icon-cache &> /dev/null; then
+      gtk-update-icon-cache -q $dir
+    fi
+  fi
+done",
     },
   },
   "plugs": Object {

--- a/test/out/linux/__snapshots__/snapTest.js.snap
+++ b/test/out/linux/__snapshots__/snapTest.js.snap
@@ -70,6 +70,9 @@ for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
     fi
   fi
 done",
+      "stage": Array [
+        "-./usr/share/fonts/**",
+      ],
     },
   },
   "summary": "Sep",
@@ -254,6 +257,9 @@ for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
     fi
   fi
 done",
+      "stage": Array [
+        "-./usr/share/fonts/**",
+      ],
     },
   },
   "summary": "Sep",
@@ -334,6 +340,9 @@ for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
     fi
   fi
 done",
+      "stage": Array [
+        "-./usr/share/fonts/**",
+      ],
     },
   },
   "summary": "Sep",
@@ -414,6 +423,9 @@ for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
     fi
   fi
 done",
+      "stage": Array [
+        "-./usr/share/fonts/**",
+      ],
     },
   },
   "summary": "Sep",
@@ -496,6 +508,9 @@ for dir in $SNAPCRAFT_PART_INSTALL/usr/share/icons/*/; do
     fi
   fi
 done",
+      "stage": Array [
+        "-./usr/share/fonts/**",
+      ],
     },
   },
   "summary": "Sep",
@@ -504,6 +519,40 @@ done",
 `;
 
 exports[`default stagePackages 8`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
+exports[`no desktop plugs 1`] = `
+Object {
+  "apps": Object {
+    "sep": Object {
+      "command": "command.sh",
+      "environment": Object {
+        "LD_LIBRARY_PATH": "$SNAP_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio:$SNAP/usr/lib/x86_64-linux-gnu/mesa-egl:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu",
+        "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
+        "TMPDIR": "$XDG_RUNTIME_DIR",
+      },
+      "plugs": Array [
+        "foo",
+        "bar",
+      ],
+    },
+  },
+  "architectures": Array [
+    "amd64",
+  ],
+  "confinement": "strict",
+  "description": "Test Application (test quite “ #378)",
+  "grade": "stable",
+  "name": "sep",
+  "summary": "Sep",
+  "version": "1.1.0",
+}
+`;
+
+exports[`no desktop plugs 2`] = `
 Object {
   "linux": Array [],
 }

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -166,3 +166,20 @@ test.ifDevOrLinuxCi("custom env", app({
     return true
   },
 }))
+
+test.ifDevOrLinuxCi("custom after, no desktop", app({
+  targets: Platform.LINUX.createTarget("snap"),
+  config: {
+    extraMetadata: {
+      name: "sep",
+    },
+    productName: "Sep",
+    snap: {
+      after: ["bar"],
+    }
+  },
+  effectiveOptionComputed: async ({ snap }) => {
+    expect(snap).toMatchSnapshot()
+    return true
+  },
+}))

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -183,3 +183,20 @@ test.ifDevOrLinuxCi("custom after, no desktop", app({
     return true
   },
 }))
+
+test.ifDevOrLinuxCi("no desktop plugs", app({
+  targets: Platform.LINUX.createTarget("snap"),
+  config: {
+    extraMetadata: {
+      name: "sep",
+    },
+    productName: "Sep",
+    snap: {
+      plugs: ["foo", "bar"]
+    }
+  },
+  effectiveOptionComputed: async ({ snap }) => {
+    expect(snap).toMatchSnapshot()
+    return true
+  },
+}))


### PR DESCRIPTION
In order to improve the startup time for snapped applications we can generate the mime DB and the icon caches at snap build time. In order to do this, we can use snap composition to override the desktop-gtk{2,3} part, adding an install script which does this.
The remote part can't do this by default since it could break legacy applications providing such files but this won't be the case for electron apps.

At the same time, fonts can be removed if a desktop plug is required since `/usr/share/fonts` will be bind-mounted from system.