### PR TITLE
fix(docker): add missing libgconf-2-4 for chromedriver

### DIFF
--- a/docker/wine-chrome/Dockerfile
+++ b/docker/wine-chrome/Dockerfile
@@ -2,6 +2,6 @@ FROM electronuserland/builder:wine
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
-  apt-get update -y && apt-get install -y --no-install-recommends xvfb google-chrome-stable && \
+  apt-get update -y && apt-get install -y --no-install-recommends xvfb google-chrome-stable libgconf-2-4 && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
chromedriver couldn't start because `libgconf-2-4` was missing.
So Spectron also couldn't start Electron apps for testing.

```
# ./node_modules/.bin/chromedriver
/project/node_modules/electron-chromedriver/bin/chromedriver: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory
```