### PR TITLE
Allow --package-file arg to escape spaces in filenames

### DIFF
--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -106,7 +106,7 @@ export class NsisUpdater extends BaseUpdater {
     const packagePath = this.downloadedUpdateHelper.packageFile
     if (packagePath != null) {
       // only = form is supported
-      args.push(`--package-file=${packagePath}`)
+      args.push(`--package-file="${packagePath}"`)
     }
 
     const spawnOptions = {


### PR DESCRIPTION
Right now package file doesn't escape spaces in the filename, which causes a bug where the package file passed to the nsis installer to be incorrect. This means that when the installer runs, it will fail on folders such as 

`C:\Users\first last\appdata\roaming\package-version.7z`

This issue only seems to occur upon a failed Differential update (due to perMachine) followed by a full download to the users' appdata folder.

This fixes it by forcing the whole file path to be a single arg. I believe this also fixes the following issue

#2640 

I'm unsure if #2363 is the same issue, but I see similar symptoms