### PR TITLE
fix(electron-updater): return correct release notes & name

### DIFF
--- a/packages/electron-updater/src/GitHubProvider.ts
+++ b/packages/electron-updater/src/GitHubProvider.ts
@@ -38,7 +38,7 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
     }, cancellationToken))!
 
     const feed = parseXml(feedXml)
-    const latestRelease = feed.element("entry", false, `No published versions on GitHub`)
+    let latestRelease = feed.element("entry", false, `No published versions on GitHub`)
     let version: string | null
     try {
       if (this.updater.allowPrerelease) {
@@ -47,6 +47,13 @@ export class GitHubProvider extends BaseGitHubProvider<UpdateInfo> {
       }
       else {
         version = await this.getLatestVersionString(cancellationToken)
+        for (const element of feed.getElements("entry")) {
+          if (element.element("link").attribute("href").match(/\/tag\/v?([^\/]+)$/)!![1] === version) {
+            latestRelease = element
+            break
+          }
+        }
+
       }
     }
     catch (e) {

--- a/test/out/updater/__snapshots__/nsisUpdaterTest.js.snap
+++ b/test/out/updater/__snapshots__/nsisUpdaterTest.js.snap
@@ -196,7 +196,7 @@ Object {
       "url": "TestApp-Setup-1.1.0.exe",
     },
   ],
-  "releaseName": "v1.5.2-beta.3",
+  "releaseName": "1.1.0",
   "releaseNotes": "",
   "version": "1.1.0",
 }
@@ -210,7 +210,7 @@ Object {
       "url": "TestApp-Setup-1.1.0.exe",
     },
   ],
-  "releaseName": "v1.5.2-beta.3",
+  "releaseName": "1.1.0",
   "releaseNotes": "",
   "version": "1.1.0",
 }


### PR DESCRIPTION
~Refactors GitHubProvider.ts to fetch release information solely from the~
~GitHub API rather than the atom xml feed, as the atom xml feed doesn't~
~indicate whether or not a release is marked as prerelease, and because~
~the API was being used whenever allowPrerelease was false (likely the~
~vast majority of requests).~

Makes it so that when the most recently published release is a
prerelease build, the GitHubProvider supplies the correct releaseName
and releaseNotes. Prior to this change, releaseName and releaseNotes
were always set to the name and notes from the latest published build,
even if it was prerelease, and even if allowPrerelease was false.

fixes #2742