### PR TITLE
feat(electron-updater): extensible sources

### DIFF
--- a/packages/electron-updater/src/providerFactory.ts
+++ b/packages/electron-updater/src/providerFactory.ts
@@ -1,45 +1,77 @@
 import { AllPublishOptions, BaseS3Options, BintrayOptions, GenericServerOptions, getS3LikeProviderBaseUrl, GithubOptions, newError, PublishConfiguration } from "builder-util-runtime"
+import { Provider } from "./main"
 import { AppUpdater } from "./AppUpdater"
 import { BintrayProvider } from "./BintrayProvider"
 import { GenericProvider } from "./GenericProvider"
 import { GitHubProvider } from "./GitHubProvider"
 import { PrivateGitHubProvider } from "./PrivateGitHubProvider"
 
-export function createClient(data: PublishConfiguration | AllPublishOptions, updater: AppUpdater) {
+export type ProviderFactoryFunction = (data: PublishConfiguration | AllPublishOptions, updater: AppUpdater) => Provider<any>
+
+interface ProviderFactoryList {
+  [key: string]: ProviderFactoryFunction
+}
+
+const providerList: ProviderFactoryList = {
+  github: createGitHubProvider,
+  spaces: createSpacesOrS3Provider,
+  s3: createSpacesOrS3Provider,
+  generic: createGenericProvider,
+  bintray: createBinTrayProvider
+}
+
+export function createClient(data: PublishConfiguration | AllPublishOptions, updater: AppUpdater): Provider<any> {
   // noinspection SuspiciousTypeOfGuard
   if (typeof data === "string") {
     throw newError("Please pass PublishConfiguration object", "ERR_UPDATER_INVALID_PROVIDER_CONFIGURATION")
   }
 
-  const httpExecutor = updater.httpExecutor
-  const provider = data.provider
-  switch (provider) {
-    case "github":
-      const githubOptions = data as GithubOptions
-      const token = (githubOptions.private ? process.env.GH_TOKEN || process.env.GITHUB_TOKEN : null) || githubOptions.token
-      if (token == null) {
-        return new GitHubProvider(githubOptions, updater, httpExecutor)
-      }
-      else {
-        return new PrivateGitHubProvider(githubOptions, token, httpExecutor)
-      }
-
-    case "s3":
-    case "spaces":
-      return new GenericProvider({
-        provider: "generic",
-        url: getS3LikeProviderBaseUrl(data),
-        channel: (data as BaseS3Options).channel || null
-      }, updater, provider === "spaces" /* https://github.com/minio/minio/issues/5285#issuecomment-350428955 */)
-
-    case "generic":
-      const options = data as GenericServerOptions
-      return new GenericProvider(options, updater, options.useMultipleRangeRequest !== false && !options.url.includes("s3.amazonaws.com"))
-
-    case "bintray":
-      return new BintrayProvider(data as BintrayOptions, httpExecutor)
-
-    default:
-      throw newError(`Unsupported provider: ${provider}`, "ERR_UPDATER_UNSUPPORTED_PROVIDER")
+  const providerFactoryFunction = providerList[data.provider]
+  if (!providerFactoryFunction) {
+    throw newError(`Unsupported provider: ${data.provider}`, "ERR_UPDATER_UNSUPPORTED_PROVIDER")
   }
+  return providerFactoryFunction(data, updater)
+}
+
+export function registerProviderType(name: string, factoryMethod: ProviderFactoryFunction) {
+  if (!providerList[name]) {
+    throw newError(`Provider name ${name} is already registered`, "ERR_PROVIDER_NAME_COLLISION")
+  }
+  providerList[name] = factoryMethod
+}
+
+export function unregisterProviderType(name: string) {
+  delete providerList[name]
+}
+
+function createGitHubProvider(data: PublishConfiguration | AllPublishOptions, updater: AppUpdater) {
+  const githubOptions = data as GithubOptions
+  const token = (githubOptions.private ? process.env.GH_TOKEN || process.env.GITHUB_TOKEN : null) || githubOptions.token
+  if (token == null) {
+    return new GitHubProvider(githubOptions, updater, updater.httpExecutor)
+  }
+  else {
+    return new PrivateGitHubProvider(githubOptions, token, updater.httpExecutor)
+  }
+}
+
+function createSpacesOrS3Provider(data: PublishConfiguration | AllPublishOptions, updater: AppUpdater) {
+  if (typeof data === "string") {
+    throw newError("Please pass PublishConfiguration object", "ERR_UPDATER_INVALID_PROVIDER_CONFIGURATION")
+  }
+
+  return new GenericProvider({
+    provider: "generic",
+    url: getS3LikeProviderBaseUrl(data),
+    channel: (data as BaseS3Options).channel || null
+  }, updater, data.provider === "spaces" /* https://github.com/minio/minio/issues/5285#issuecomment-350428955 */)
+}
+
+function createGenericProvider(data: PublishConfiguration | AllPublishOptions, updater: AppUpdater) {
+  const options = data as GenericServerOptions
+  return new GenericProvider(options, updater, options.useMultipleRangeRequest !== false && !options.url.includes("s3.amazonaws.com"))
+}
+
+function createBinTrayProvider(data: PublishConfiguration | AllPublishOptions, updater: AppUpdater) {
+  return new BintrayProvider(data as BintrayOptions, updater.httpExecutor)
 }


### PR DESCRIPTION
With this change, users can register their own provider factory
functions. This allows users to write their own auto update providers,
or to extend the ones provided by this library. To do this, a user calls
`providerFactory.registerProviderType` passing a name for the provider
type as a string, and a function which accepts a `data` argument of type
`PublishConfiguration | AllPublishOptions` and an instance of
`AppUpdater`, and returns an instance of `Provider<any>`.