### PR TITLE
Updater: note about dev-app-update.yml

### DIFF
--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -50,6 +50,8 @@ autoUpdater.logger = require("electron-log")
 autoUpdater.logger.transports.file.level = "info"
 ```
 
+Note that in order to develop/test UI/UX of updating without packaging the application you need to have a file named `dev-app-update.yml` in the root of your project, which matches your `publish` setting from electron-builder config (but in YML format).
+
 ## Staged Rollouts
 
 Staged rollouts allow you to distribute the latest version of your app to a subset of users that you can increase over time, similar to rollouts on platforms like Google Play.

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -50,7 +50,7 @@ autoUpdater.logger = require("electron-log")
 autoUpdater.logger.transports.file.level = "info"
 ```
 
-Note that in order to develop/test UI/UX of updating without packaging the application you need to have a file named `dev-app-update.yml` in the root of your project, which matches your `publish` setting from electron-builder config (but in YML format).
+Note that in order to develop/test UI/UX of updating without packaging the application you need to have a file named `dev-app-update.yml` in the root of your project, which matches your `publish` setting from electron-builder config (but in [YAML](https://www.json2yaml.com) format).
 
 ## Staged Rollouts
 


### PR DESCRIPTION
Adds a note about `dev-app-update.yml` file that is required for working against user triggered update flow without packaging.