### PR TITLE
fix(mac): apply app version to helper apps

### DIFF
--- a/packages/electron-builder-lib/src/electron/electronMac.ts
+++ b/packages/electron-builder-lib/src/electron/electronMac.ts
@@ -73,6 +73,10 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
   helperEHPlist.CFBundleIdentifier = `${helperBundleIdentifier}.EH`
   helperNPPlist.CFBundleIdentifier = `${helperBundleIdentifier}.NP`
 
+  helperPlist.CFBundleVersion = appPlist.CFBundleVersion
+  helperEHPlist.CFBundleVersion = appPlist.CFBundleVersion
+  helperNPPlist.CFBundleVersion = appPlist.CFBundleVersion
+
   const protocols = asArray(buildMetadata.protocols).concat(asArray(packager.platformSpecificBuildOptions.protocols))
   if (protocols.length > 0) {
     appPlist.CFBundleURLTypes = protocols.map(protocol => {


### PR DESCRIPTION
Currently the helper apps do not receive version numbers.  This complicates investigation of
crashes in the renderer process, as the version shown in the crash dump is "0".  This patch passes
the version number of the main app to the helper apps as well.

Fixes #2772