### PR TITLE
feat(mac): pass the provisioning profile path to electron-osx-sign

### DIFF
--- a/packages/electron-builder-lib/src/options/macOptions.ts
+++ b/packages/electron-builder-lib/src/options/macOptions.ts
@@ -44,6 +44,11 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   readonly entitlementsInherit?: string | null
 
   /**
+   * The path to the provisioning profile to use when signing, absolute or relative to the app root.
+   */
+  readonly provisioningProfile?: string | null
+
+  /**
    * The `CFBundleVersion`. Do not use it unless [you need to](https://github.com/electron-userland/electron-builder/issues/565#issuecomment-230678643).
    */
   readonly bundleVersion?: string | null
@@ -101,6 +106,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
 
   /** @private */
   readonly cscInstallerLink?: string | null
+
   /** @private */
   readonly cscInstallerKeyPassword?: string | null
 }
@@ -228,11 +234,6 @@ export interface DmgOptions extends TargetSpecificOptions {
    * @default false
    */
   readonly internetEnabled?: boolean
-
-  /**
-   * The path to the provisioning profile to use when signing, absolute or relative to the app root.
-   */
-  readonly provisioningProfile?: string | null
 }
 
 export interface DmgWindow {

--- a/packages/electron-builder-lib/src/options/macOptions.ts
+++ b/packages/electron-builder-lib/src/options/macOptions.ts
@@ -228,6 +228,11 @@ export interface DmgOptions extends TargetSpecificOptions {
    * @default false
    */
   readonly internetEnabled?: boolean
+
+  /**
+   * The path to the provisioning profile to use when signing, absolute or relative to the app root.
+   */
+  readonly provisioningProfile?: string | null
 }
 
 export interface DmgWindow {
@@ -282,6 +287,11 @@ export interface MasConfiguration extends MacConfiguration {
    * Otherwise [default](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist).
    */
   readonly entitlementsInherit?: string | null
+
+  /**
+   * The path to the provisioning profile to use when signing, absolute or relative to the app root.
+   */
+  readonly provisioningProfile?: string | null
 
   /**
    * Paths of any extra binaries that need to be signed.


### PR DESCRIPTION
Implements #2166.

`provisioningProfile` field can now be passed on the `dmg`, `mas` and `mas-dev` target options;
field should contain a path - absolute or relative to the app root - to the respective provisioning profile.