### PR TITLE
Check File existence before running NSIS Updater

### DIFF
--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -9,6 +9,7 @@ import { GenericDifferentialDownloader } from "./differentialDownloader/GenericD
 import { newUrlFromBase, ResolvedUpdateFileInfo } from "./main"
 import { findFile, Provider } from "./Provider"
 import { unlink } from "fs-extra-p"
+import * as fs from "fs-extra"
 import { verifySignature } from "./windowsExecutableCodeSignatureVerifier"
 
 export class NsisUpdater extends BaseUpdater {
@@ -104,7 +105,7 @@ export class NsisUpdater extends BaseUpdater {
     }
 
     const packagePath = this.downloadedUpdateHelper.packageFile
-    if (packagePath != null) {
+    if (packagePath != null && fs.existsSync(packagePath)) {
       // only = form is supported
       args.push(`--package-file="${packagePath}"`)
     }


### PR DESCRIPTION
Fixes a bug where a user can have their app uninstall on an update.

Right now it's possible for the package path to not exist, but be passed in anyway. One way to set up application as "assistedInstaller: true, perMachine: true". Then upon the elevate.exe being called on the first attempt at updating, to press "No". Then restart the application and press "Yes" on the next elevate when updating. **This only happens in production - I was unable to reproduce this bug in development**

If you check the path of the package, there isn't a package, so the installer tries to run on an empty file, but fails causing an uninstall for the user (since that part of the NSIS code will run). 

There may be a more elegant solution, and since there are steps to reproduce it isn't too bad.