### PR TITLE
Prevent download notification queueing

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -228,13 +228,19 @@ export abstract class AppUpdater extends EventEmitter {
       return Promise.resolve(null)
     }
 
-    this.signals.updateDownloaded(it => {
-      new Notification({
-        title: "A new update is ready to install",
-        body: `${this.app.getName()} version ${it.version} is downloaded and will be automatically installed on exit`
-      }).show()
+    const checkForUpdatesPromise = this.checkForUpdates()
+    checkForUpdatesPromise.then(it => {
+      if (it.downloadPromise) {
+        it.downloadPromise.then(() => {
+          new Notification({
+            title: "A new update is ready to install",
+            body: `${this.app.getName()} version ${it.updateInfo.version} is downloaded and will be automatically installed on exit`
+          }).show()
+        })
+      }
     })
-    return this.checkForUpdates()
+
+    return checkForUpdatesPromise
   }
 
   private async isStagingMatch(updateInfo: UpdateInfo): Promise<boolean> {


### PR DESCRIPTION
The current implementation using `this.signals.updateDownloaded` is creating an event listener that is never removed. The problem with this is that if you call `checkForUpdatesAndNotify`, no update is found, then call `checkForUpdatesAndNotify` again an hour later and an update *is* found, the notification in this method is actually created twice. This PR updates the method to notify the user when an update is available and the download is successful instead of binding to the `updateDownloaded` event.