### PR TITLE
feat(nsis): implement file associations per user

### DIFF
--- a/packages/electron-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/electron-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -554,10 +554,6 @@ export class NsisTarget extends Target {
 
     const fileAssociations = packager.fileAssociations
     if (fileAssociations.length !== 0) {
-      if (options.perMachine !== true && options.oneClick !== false) {
-        // https://github.com/electron-userland/electron-builder/issues/772
-        throw new InvalidConfigurationError(`Please set perMachine to true — file associations works on Windows only if installed for all users`)
-      }
 
       scriptGenerator.include(path.join(path.join(nsisTemplatesDir, "include"), "FileAssociation.nsh"))
       if (isInstaller) {

--- a/test/out/windows/__snapshots__/oneClickInstallerTest.js.snap
+++ b/test/out/windows/__snapshots__/oneClickInstallerTest.js.snap
@@ -84,8 +84,6 @@ Object {
 }
 `;
 
-exports[`file associations only perMachine 1`] = `"ERR_ELECTRON_BUILDER_INVALID_CONFIGURATION"`;
-
 exports[`html license 1`] = `
 Object {
   "win": Array [

--- a/test/src/windows/oneClickInstallerTest.ts
+++ b/test/src/windows/oneClickInstallerTest.ts
@@ -2,7 +2,7 @@ import { Arch, Platform } from "electron-builder"
 import { copy, writeFile } from "fs-extra-p"
 import * as path from "path"
 import { assertThat } from "../helpers/fileAssert"
-import { app, appThrows, assertPack, copyTestAsset, modifyPackageJson } from "../helpers/packTester"
+import { app, assertPack, copyTestAsset, modifyPackageJson } from "../helpers/packTester"
 import { checkHelpers, doTest, expectUpdateMetadata } from "../helpers/winHelper"
 
 const nsisTarget = Platform.WINDOWS.createTarget(["nsis"])
@@ -209,7 +209,8 @@ test.ifNotCiMac("string menuCategory", app({
   }
 }))
 
-test.ifDevOrLinuxCi("file associations only perMachine", appThrows({
+
+test.ifDevOrLinuxCi("file associations per user", app({
   targets: Platform.WINDOWS.createTarget(["nsis"], Arch.ia32),
   config: {
     publish: null,
@@ -218,6 +219,10 @@ test.ifDevOrLinuxCi("file associations only perMachine", appThrows({
         ext: "foo",
         name: "Test Foo",
       }
-    ],
+    ]
+  },
+}, {
+  packed: async context => {
+    return doTest(context.outDir, true)
   },
 }))


### PR DESCRIPTION
By writing the relevant entries either to

    HKEY_LOCAL_MACHINE\Software\Classes

or to

    HKEY_CURRENT_USER\Software\Classes

we're able to support file associations on user installations, too.

Closes https://github.com/electron-userland/electron-builder/issues/2860.