### PR TITLE
Always run code signing with /debug

### DIFF
--- a/packages/electron-builder-lib/src/windowsCodeSign.ts
+++ b/packages/electron-builder-lib/src/windowsCodeSign.ts
@@ -247,6 +247,7 @@ function computeSignToolArgs(options: WindowsSignTaskConfiguration, isWin: boole
   }
 
   if (isWin) {
+    args.push('/debug')
     // must be last argument
     args.push(inputFile)
   }


### PR DESCRIPTION
When there's a problem with codesigning, it would be nice if the /debug output were available.  As the output to this command doesn't seem to be displayed unless there's a problem, always running with /debug output seems reasonable.