### PR TITLE
fix: nsis installer /D installation path override

### DIFF
--- a/packages/electron-builder-lib/templates/nsis/multiUser.nsh
+++ b/packages/electron-builder-lib/templates/nsis/multiUser.nsh
@@ -39,12 +39,11 @@ Var installMode
       StrCpy $INSTDIR "$0\${APP_FILENAME}"
     ${endif}
         
-    # Allow /D switch to override installation path https://github.com/electron-userland/electron-builder/issues/1551
-    ${GetParameters} $R0
-    ${GetOptions} $R0 "/D=" $R1
-    ${IfNot} ${Errors}  
-      StrCpy $INSTDIR $R1
-    ${EndIf}
+    # allow /D switch to override installation path https://github.com/electron-userland/electron-builder/issues/1551
+    ${StdUtils.GetParameter} $R0 "D" ""
+    ${If} $R0 != ""
+      StrCpy $INSTDIR $R0
+    ${endif}
 
   !macroend
 !endif
@@ -83,12 +82,11 @@ Var installMode
       StrCpy $INSTDIR "$0\${APP_FILENAME}"
     ${endif}
   
-    # Allow /D switch to override installation path https://github.com/electron-userland/electron-builder/issues/1551
-    ${GetParameters} $R0
-    ${GetOptions} $R0 "/D=" $R1
-    ${IfNot} ${Errors}  
-      StrCpy $INSTDIR $R1
-    ${EndIf}
-
+    # allow /D switch to override installation path https://github.com/electron-userland/electron-builder/issues/1551
+    ${StdUtils.GetParameter} $R0 "D" ""
+    ${If} $R0 != ""
+      StrCpy $INSTDIR $R0
+    ${endif}
+      
   !macroend
 !endif

--- a/packages/electron-builder-lib/templates/nsis/multiUser.nsh
+++ b/packages/electron-builder-lib/templates/nsis/multiUser.nsh
@@ -38,6 +38,14 @@ Var installMode
       System::Store L
       StrCpy $INSTDIR "$0\${APP_FILENAME}"
     ${endif}
+        
+    # Allow /D switch to override installation path https://github.com/electron-userland/electron-builder/issues/1551
+    ${GetParameters} $R0
+    ${GetOptions} $R0 "/D=" $R1
+    ${IfNot} ${Errors}  
+      StrCpy $INSTDIR $R1
+    ${EndIf}
+
   !macroend
 !endif
 
@@ -74,5 +82,13 @@ Var installMode
 
       StrCpy $INSTDIR "$0\${APP_FILENAME}"
     ${endif}
+  
+    # Allow /D switch to override installation path https://github.com/electron-userland/electron-builder/issues/1551
+    ${GetParameters} $R0
+    ${GetOptions} $R0 "/D=" $R1
+    ${IfNot} ${Errors}  
+      StrCpy $INSTDIR $R1
+    ${EndIf}
+
   !macroend
 !endif


### PR DESCRIPTION
The default /D parameter behavior (change installation path for silent install/software distribution) was not present in the NSIS installer. Default NSIS behavior translates /D path into an initial $INSTDIR value. 

The NSIS restriction that /D has to be the last parameter still exists, however due to use of StdUtils.GetParameter quotes are now supported.

Issue: #1551 
