### PR TITLE
fix: Spawn yarn.cmd on windows

### DIFF
--- a/test/src/helpers/setVersions.ts
+++ b/test/src/helpers/setVersions.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
 
 function getLatestVersions(packageData: Array<any>) {
   return BluebirdPromise.map(packageData, packageInfo => {
-    return exec("yarn", ["info", "--json", packageInfo.name, "dist-tags"])
+    return exec(/^win/.test(process.platform) ? 'yarn.cmd' : 'yarn', ["info", "--json", packageInfo.name, "dist-tags"])
       .then((it: string) => {
         if (it === "") {
           // {"type":"error","data":"Received invalid response from npm."}


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-builder/issues/2789
You cannot build locally on Windows without this.