### PR TITLE
fix: Don't force run if not silent

### DIFF
--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -14,7 +14,7 @@ export abstract class BaseUpdater extends AppUpdater {
 
   async quitAndInstall(isSilent: boolean = false, isForceRunAfter: boolean = false): Promise<void> {
     this._logger.info(`Install on explicit quitAndInstall`)
-    const isInstalled = await this.install(isSilent, isSilent ? isForceRunAfter : true)
+    const isInstalled = await this.install(isSilent, isForceRunAfter)
     if (isInstalled) {
       setImmediate(() => {
         if (this.app.quit !== undefined) {


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-builder/issues/2895
Fixes https://github.com/electron-userland/electron-builder/issues/2619

I don't see a reason to force-run if the installer isn't set to silent mode. A quick test on Windows seems to work properly. I've not tested on other platforms. 