### PR TITLE
Expand on Autoupdate error message, minor changes to wording

### DIFF
--- a/packages/electron-updater/README.md
+++ b/packages/electron-updater/README.md
@@ -1,9 +1,9 @@
 # electron-updater
 
-This module allows to automatically update your application. You only need to install this module and write two lines of code!
-To publish your updates you just need a simple file hosting, it does not require a dedicated server.
+This module allows you to automatically update your application. You only need to install this module and write two lines of code!
+To publish your updates you just need simple file hosting, it does not require a dedicated server.
 
-See the [Auto Update](https://electron.build/auto-update) for more information.
+See [Auto Update](https://electron.build/auto-update) for more information.
 
 Supported OS:
  - macOS ([Squirrel.Mac](https://github.com/Squirrel/Squirrel.Mac)).

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -197,7 +197,7 @@ export abstract class AppUpdater extends EventEmitter {
     // https://github.com/electron-userland/electron-builder/issues/1105
     let provider: Provider<any>
     if (typeof options === "string") {
-      provider = new GenericProvider({ provider: "generic", url: options }, this)
+      provider = new GenericProvider({provider: "generic", url: options}, this)
     }
     else {
       provider = createClient(options, this)
@@ -300,7 +300,7 @@ export abstract class AppUpdater extends EventEmitter {
 
     const client = await this.clientPromise
     const stagingUserId = await this.stagingUserIdPromise.value
-    client.setRequestHeaders(this.computeFinalHeaders({ "X-User-Staging-Id": stagingUserId }))
+    client.setRequestHeaders(this.computeFinalHeaders({"X-User-Staging-Id": stagingUserId}))
     return await client.getLatestVersion()
   }
 
@@ -401,7 +401,7 @@ export abstract class AppUpdater extends EventEmitter {
         ...requestHeaders,
       }
     }
-    return this.computeFinalHeaders({ Accept: "*/*" })
+    return this.computeFinalHeaders({Accept: "*/*"})
   }
 
   private async getOrCreateStagingUserId(): Promise<string> {

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -173,7 +173,7 @@ export abstract class AppUpdater extends EventEmitter {
     const currentVersionString = this.app.getVersion()
     const currentVersion = parseVersion(currentVersionString)
     if (currentVersion == null) {
-      throw newError(`App version is not a valid semver version: "${currentVersionString}`, "ERR_UPDATER_INVALID_VERSION")
+      throw newError(`App version is not a valid semver version: "${currentVersionString}"`, "ERR_UPDATER_INVALID_VERSION")
     }
     this.currentVersion = currentVersion
 
@@ -197,7 +197,7 @@ export abstract class AppUpdater extends EventEmitter {
     // https://github.com/electron-userland/electron-builder/issues/1105
     let provider: Provider<any>
     if (typeof options === "string") {
-      provider = new GenericProvider({provider: "generic", url: options}, this)
+      provider = new GenericProvider({ provider: "generic", url: options }, this)
     }
     else {
       provider = createClient(options, this)
@@ -300,7 +300,7 @@ export abstract class AppUpdater extends EventEmitter {
 
     const client = await this.clientPromise
     const stagingUserId = await this.stagingUserIdPromise.value
-    client.setRequestHeaders(this.computeFinalHeaders({"X-User-Staging-Id": stagingUserId}))
+    client.setRequestHeaders(this.computeFinalHeaders({ "X-User-Staging-Id": stagingUserId }))
     return await client.getLatestVersion()
   }
 
@@ -309,7 +309,7 @@ export abstract class AppUpdater extends EventEmitter {
 
     const latestVersion = parseVersion(updateInfo.version)
     if (latestVersion == null) {
-      throw newError(`Latest version (from update server) is not valid semver version: "${latestVersion}`, "ERR_UPDATER_INVALID_VERSION")
+      throw newError(`This file could not be downloaded, or the latest version (from update server) does not have a valid semver version: "${latestVersion}"`, "ERR_UPDATER_INVALID_VERSION")
     }
 
     const isStagingMatch = await this.isStagingMatch(updateInfo)
@@ -401,7 +401,7 @@ export abstract class AppUpdater extends EventEmitter {
         ...requestHeaders,
       }
     }
-    return this.computeFinalHeaders({Accept: "*/*"})
+    return this.computeFinalHeaders({ Accept: "*/*" })
   }
 
   private async getOrCreateStagingUserId(): Promise<string> {


### PR DESCRIPTION
I had an issue where my latest-mac.json was pointing to the wrong server (I had changed the AWS S3 location). In the logs on Mac it just gave this 'semver' error but in reality the app couldn't be downloaded at all. I'm not familiar with how to debug the internals of this project but I wanted to at least improve the error message to help future folks.

I also made some minor updates to the english on the corresponding Readme file