### PR TITLE
windows nsis: prevent a missing package.7z from nuking the application.

### DIFF
--- a/packages/electron-builder-lib/templates/nsis/include/installer.nsh
+++ b/packages/electron-builder-lib/templates/nsis/include/installer.nsh
@@ -73,6 +73,8 @@
   !else
     !ifdef APP_PACKAGE_URL
       Var /GLOBAL packageFile
+      Var /GLOBAL packageFileExplicitlySpecified
+
       ${StdUtils.GetParameter} $packageFile "package-file" ""
       ${if} $packageFile == ""
         !ifdef APP_64_NAME
@@ -94,10 +96,24 @@
         !endif
         StrCpy $4 "$packageFile"
         StrCpy $packageFile "$EXEDIR/$packageFile"
+        StrCpy $packageFileExplicitlySpecified "false"
+      ${else}
+        StrCpy $packageFileExplicitlySpecified "true"
+      ${endIf}
 
-        ${if} ${FileExists} "$packageFile"
-          # we do not check file hash is specifed explicitly using --package-file because it is clear that user definitly want to use this file and it is user responsibility to check
-          # 1. auto-updater uses --package-file and validates checksum 2. user can user another package file (use case - one installer suitable for any app version (use latest version))
+      # when a user passes `--package-file` and that package exists, we take this to mean that the user definitely
+      # wants to install said package.
+      #
+      # when this is the case, we *do not* check that the file at `--package-path` has checksum `$1` (to be backwards
+      # compatible with previous electron-builder behaviour).
+      #
+      # this means that clients can specify any package file, even if it isn't the one declared at compile time with
+      # `APP_NAME`` and `APP_HASH`. this is deliberate, and was intentionally supported by previous versions of
+      # electron-builder.
+      ${if} ${FileExists} "$packageFile"
+        ${if} $packageFileExplicitlySpecified == "true"
+          Goto fun_extract
+        ${else}
           ${StdUtils.HashFile} $3 "SHA2-512" "$packageFile"
           ${if} $3 == $1
             Goto fun_extract
@@ -105,8 +121,9 @@
             MessageBox MB_OK "Package file $4 found locally, but checksum doesn't match — expected $1, actual $3.$\r$\nLocal file is ignored and package will be downloaded from Internet."
           ${endIf}
         ${endIf}
-        !insertmacro downloadApplicationFiles
       ${endIf}
+
+      !insertmacro downloadApplicationFiles
 
       fun_extract:
         !insertmacro extractUsing7za "$packageFile"


### PR DESCRIPTION
when running setup with `--package-file`, electron-builder's nsis setup may occasionally delete all application files if that package can't be read.

related (but separate) is a bug in `electron-updater` that sometimes deletes the `package.7z`, thereby surfacing this bug. but we shouldn't nuke an app just because `package.7z` is missing in an update - we should fail with a message saying so.

## summary

let's say we have an application called "starcall".

during installation, re-installation, or an upgrade, setup first uninstalls any previous versions of starcall, if any exist.

only once that is done does setup try to access and extract `package.7z` - the package specified in `--package-file`. `electron-update` specifies this, for example.

however, if that package can't be read (for example, because it doesn't exist), the extraction obviously fails, but the installer continues as if everything succeeded. that's a problem because in the previous step we just nuked the entire application off people's computers , so now we've got a "completed" installation with shortcuts that point to an empty application directory.

## the fix

this pull request resolves by far the most common scenario that i've seen in production where people report electron-builder uninstalling their application. (#2859 and #2858 describe the same problem).

after this pull request, nsis will check that `--package-file` exists, and if it doesn't, falls back to installing starcall from the internet. the package url that it uses is version-specific, so `install-v0.0.1.exe` will download the `v0.0.1` package.

the guiding principle behind this change is that we want to keep the application in a working state - when upgrading, if the `--package-file` doesn't exist, our failure case shouldn't be that we nuke the entire application off people's computers (except with dead shortcuts). i'll go into why `package.7z` might not exist later, but tl;dr there is a bug in `electron-updater` that may cause it to occasionally delete the package if it thinks the update installer failed to launch.

## related

there are a few other related bugs that surfaced this bug. i plan to submit a pr to those in the near future, but this one resolves (or works around) the most common issue i've seen in production.