### PR TITLE
Proton: use babel only when installed

### DIFF
--- a/packages/electron-builder-lib/src/ProtonFramework.ts
+++ b/packages/electron-builder-lib/src/ProtonFramework.ts
@@ -48,37 +48,30 @@ class ProtonFramework implements Framework {
     else {
       try {
         babel = require("babel-core")
-      } catch (e) {
+      }
+      catch (e) {
         // babel isn't installed
+        log.debug(null, "don't transpile source code using Babel")
+        return null
       }
     }
 
-    if (babel) {
-      log.info({options: safeStringifyJson(babelOptions, new Set<string>(["presets"]))}, "transpile source code using Babel")
-    } else {
-      log.info("don't transpile source code using Babel")
-    }
-
+    log.info({options: safeStringifyJson(babelOptions, new Set<string>(["presets"]))}, "transpile source code using Babel")
     return file => {
       if (!(file.endsWith(".js") || file.endsWith(".jsx")) || file.includes(NODE_MODULES_PATTERN)) {
         return null
       }
 
-      if (babel) {
-        return new Promise((resolve, reject) => {
-          return babel.transformFile(file, babelOptions, (error: Error, result: any) => {
-            if (error == null) {
-              resolve(result.code)
-            }
-            else {
-              reject(error)
-            }
-          })
+      return new Promise((resolve, reject) => {
+        return babel.transformFile(file, babelOptions, (error: Error, result: any) => {
+          if (error == null) {
+            resolve(result.code)
+          }
+          else {
+            reject(error)
+          }
         })
-      }
-      else {
-        return readFile(file, "utf8")
-      }
+      })
     }
   }
 

--- a/packages/electron-builder-lib/src/ProtonFramework.ts
+++ b/packages/electron-builder-lib/src/ProtonFramework.ts
@@ -1,4 +1,4 @@
-import { chmod, emptyDir, ensureDir, writeFile, readFile } from "fs-extra-p"
+import { chmod, emptyDir, ensureDir, writeFile } from "fs-extra-p"
 import { getBin } from "builder-util/out/binDownload"
 import { FileTransformer, copyFile } from "builder-util/out/fs"
 import { log } from "builder-util"


### PR DESCRIPTION
babel isn't strictly required for proton-native. More importantly, this allows libui-node to use the existing infrastructure for proton-native.

Fixes #2903
Fixes https://github.com/parro-it/libui-node/issues/108