### PR TITLE
Properly filter files that exist outside of the app directory (like hoisted modules) (fixes #2942)

### DIFF
--- a/packages/electron-builder-lib/src/util/filter.ts
+++ b/packages/electron-builder-lib/src/util/filter.ts
@@ -28,25 +28,25 @@ function findCommonPath(path1: string, path2: string) {
   // If one of the paths *is* the full prefix, optimize for that
   if (
     longerPath.slice(0, shorterPath.length) === shorterPath &&
-    longerPath[shorterPath.length] === '/'
+    longerPath[shorterPath.length] === path.sep
   ) {
     return shorterPath + '/';
   }
 
-  const path1Parts = path1.split('/');
-  const path2Parts = path2.split('/');
+  const path1Parts = path1.split(path.sep);
+  const path2Parts = path2.split(path.sep);
 
-  let path = '';
+  let result = '';
 
   for (let i = 0; i < path1Parts.length; i++) {
     if (path1Parts[i] === path2Parts[i]) {
-      path += path2Parts[i] + '/';
+      result += path2Parts[i] + path.sep;
     } else {
       break;
     }
   }
 
-  return path;
+  return result;
 }
 
 /** @internal */

--- a/packages/electron-builder-lib/src/util/filter.ts
+++ b/packages/electron-builder-lib/src/util/filter.ts
@@ -20,7 +20,8 @@ export function hasMagic(pattern: Minimatch) {
   return false
 }
 
-function findCommonPath(path1, path2) {
+/** @internal */
+function findCommonPath(path1: string, path2: string) {
   const longerPath = path1.length >= path2.length ? path1 : path2;
   const shorterPath = path1.length < path2.length ? path1 : path2;
 


### PR DESCRIPTION
I figured out the problem in #2942.

This isn't a Windows-specific issue like I first thought; I just hadn't tested my new build pipeline on macOS yet.

electron-builder supports yarn workspaces, where modules have been hoisted into a root repo. The electron app exists in a subpackage like `packages/desktop-electron`, while almost all dependencies have been hoisted up into a top-level `node_modules`.

The problem is this piece of code in `createFilter`:

```js
let relative = it.substring(srcWithEndSlash.length)
```

The problem is it assumes `it`, which is a path, exists below `srcWithEndSlash`. This may not be the case with hoisted modules. `it` may be `~/project/node_modules/lib/foo.js` while `srcWithEndSlash` is `~/project/packages/desktop-electron/`. The result is that `it` will be erroneously cut off, since it will slice off the full length of `srcWithEndSlash`.

The result is you end up with partial paths, which then might falsely match filters. In my case, a dependency had a `dist` folder, and the `node_modules/lib/dist/file.js` path happened to get sliced into `dist/file.js` which matches the `!dist{,/**/*}` filter which makes it *not* include that file. (That filter is attempting to not include the `dist` folder generated by electron-builder). The result is the `dist` folder of an internal dependency is missing.

This is probably not the right solution. I also haven't written TS before, but this is the code that works if I patch electron-builder in `node_modules` manually. I'm happy to help improve this and get some kind of fix in.