### PR TITLE
 feat(nsis): et, vi, ro, el and ka lang

### DIFF
--- a/packages/builder-util/src/langs.ts
+++ b/packages/builder-util/src/langs.ts
@@ -1,4 +1,4 @@
-export const bundledLanguages = ["en_US", "de_DE", "fr_FR", "es_ES", "zh_CN", "zh_TW", "ja_JP", "ko_KR", "it_IT", "nl_NL", "da_DK", "sv_SE", "nb_NO", "fi_FI", "ru_RU", "pt_PT", "pt_BR", "pl_PL", "uk_UA", "cs_CZ", "sk_SK", "hu_HU", "ar_SA", "tr_TR"]
+export const bundledLanguages = ["en_US", "de_DE", "fr_FR", "es_ES", "zh_CN", "zh_TW", "ja_JP", "ko_KR", "it_IT", "nl_NL", "da_DK", "sv_SE", "nb_NO", "fi_FI", "ru_RU", "pt_PT", "pt_BR", "pl_PL", "uk_UA", "cs_CZ", "sk_SK", "hu_HU", "ar_SA", "tr_TR", "vi_VN", "ro_RO", "el_GR", "ka_GE"]
 
 const langToLangWithRegion = new Map<string, string>()
 for (const id of bundledLanguages) {

--- a/packages/builder-util/src/langs.ts
+++ b/packages/builder-util/src/langs.ts
@@ -1,4 +1,4 @@
-export const bundledLanguages = ["en_US", "de_DE", "fr_FR", "es_ES", "zh_CN", "zh_TW", "ja_JP", "ko_KR", "it_IT", "nl_NL", "da_DK", "sv_SE", "nb_NO", "fi_FI", "ru_RU", "pt_PT", "pt_BR", "pl_PL", "uk_UA", "cs_CZ", "sk_SK", "hu_HU", "ar_SA", "tr_TR", "vi_VN", "ro_RO", "el_GR", "ka_GE"]
+export const bundledLanguages = ["en_US", "de_DE", "fr_FR", "es_ES", "zh_CN", "zh_TW", "ja_JP", "ko_KR", "it_IT", "nl_NL", "da_DK", "sv_SE", "nb_NO", "fi_FI", "ru_RU", "pt_PT", "pt_BR", "pl_PL", "uk_UA", "cs_CZ", "sk_SK", "hu_HU", "ar_SA", "tr_TR", "vi_VN", "ro_RO", "el_GR", "et_EE", "ka_GE"]
 
 const langToLangWithRegion = new Map<string, string>()
 for (const id of bundledLanguages) {


### PR DESCRIPTION
With this change, users can add et, vi, ro, el and ka languages to the Installer as a dropdown option, the language files exist already, strings are just missing from bundledLanguages.
