### PR TITLE
fix(nsis): Installer not closed when 'runAfterFinish: false'

### DIFF
--- a/packages/electron-builder-lib/templates/nsis/installSection.nsh
+++ b/packages/electron-builder-lib/templates/nsis/installSection.nsh
@@ -88,9 +88,8 @@ ${endIf}
     ${orIf} ${isForceRun}
       !insertmacro doStartApp
     ${endIf}
-
-    !insertmacro quitSuccess
   !endif
+  !insertmacro quitSuccess
 !else
   # for assisted installer run only if silent, because assisted installer has run after finish option
   ${if} ${isForceRun}


### PR DESCRIPTION
Additional fix for #2951