### PR TITLE
fix(archive): compute safe artifact name using standard util

### DIFF
--- a/packages/electron-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/electron-builder-lib/src/targets/ArchiveTarget.ts
@@ -25,7 +25,9 @@ export class ArchiveTarget extends Target {
       // tslint:disable-next-line:no-invalid-template-strings
       defaultPattern = "${productName}-${version}" + (arch === Arch.x64 ? "" : "-${arch}") + "-${os}.${ext}"
     }
-    const artifactPath = path.join(this.outDir, packager.expandArtifactNamePattern(this.options, format, arch, defaultPattern, false))
+    const artifactName = packager.expandArtifactNamePattern(this.options, format, arch, defaultPattern, false)
+    const artifactPath = path.join(this.outDir, artifactName)
+
     this.logBuilding(`${isMac ? "macOS " : ""}${format}`, artifactPath, arch)
     if (format.startsWith("tar.")) {
       await tar(packager.compression, format, artifactPath, appOutDir, isMac, packager.info.tempDirManager)
@@ -39,7 +41,7 @@ export class ArchiveTarget extends Target {
 
     packager.info.dispatchArtifactCreated({
       file: artifactPath,
-      safeArtifactName: isMac ? packager.generateName2(format, "mac", true) : packager.generateName(format, arch, true, packager.platform === Platform.WINDOWS ? "win" : null),
+      safeArtifactName: packager.computeSafeArtifactName(artifactName, format, arch, false),
       target: this,
       arch,
       packager,


### PR DESCRIPTION
This ensures the used defined artifact name (`-c.artifactName`) is taken
in consideration when publishing files built with the artifact target.

Without this commit files would always be uploaded as
`${name}-${version}-${arch}.${ext}` for Linux targets with no way to
override it, i.e. to add a `-linux` suffix.