### PR TITLE
Do not remove GitHub's releaseType attribute from the publish configuration

### DIFF
--- a/packages/electron-builder-lib/src/publish/updateInfoBuilder.ts
+++ b/packages/electron-builder-lib/src/publish/updateInfoBuilder.ts
@@ -92,11 +92,6 @@ export async function createUpdateInfoTasks(event: ArtifactCreated, _publishConf
   const tasks: Array<UpdateInfoFileTask> = []
   const electronUpdaterCompatibility = (packager.platformSpecificBuildOptions as any).electronUpdaterCompatibility
   for (let publishConfiguration of publishConfigs) {
-    if (publishConfiguration.provider === "github" && "releaseType" in publishConfiguration) {
-      publishConfiguration = {...publishConfiguration!!}
-      delete (publishConfiguration as GithubOptions).releaseType
-    }
-
     const isBintray = publishConfiguration.provider === "bintray"
     let dir = outDir
     // Bintray uses different variant of channel file info, better to generate it to a separate dir by always

--- a/packages/electron-builder-lib/src/publish/updateInfoBuilder.ts
+++ b/packages/electron-builder-lib/src/publish/updateInfoBuilder.ts
@@ -1,6 +1,6 @@
 import BluebirdPromise from "bluebird-lst"
 import { Arch, hashFile, log, safeStringifyJson, serializeToYaml } from "builder-util"
-import { GenericServerOptions, GithubOptions, PublishConfiguration, UpdateInfo, WindowsUpdateInfo } from "builder-util-runtime"
+import { GenericServerOptions, PublishConfiguration, UpdateInfo, WindowsUpdateInfo } from "builder-util-runtime"
 import { outputFile, outputJson, readFile } from "fs-extra-p"
 import { Lazy } from "lazy-val"
 import * as path from "path"

--- a/packages/electron-builder-lib/src/publish/updateInfoBuilder.ts
+++ b/packages/electron-builder-lib/src/publish/updateInfoBuilder.ts
@@ -91,7 +91,7 @@ export async function createUpdateInfoTasks(event: ArtifactCreated, _publishConf
   const sharedInfo = await createUpdateInfo(version, event, await getReleaseInfo(packager))
   const tasks: Array<UpdateInfoFileTask> = []
   const electronUpdaterCompatibility = (packager.platformSpecificBuildOptions as any).electronUpdaterCompatibility
-  for (let publishConfiguration of publishConfigs) {
+  for (const publishConfiguration of publishConfigs) {
     const isBintray = publishConfiguration.provider === "bintray"
     let dir = outDir
     // Bintray uses different variant of channel file info, better to generate it to a separate dir by always


### PR DESCRIPTION
These lines cause an issue when publishing a build to GitHub with a `releaseType` of `prerelease` or `release`. When the `latest*.yml` files are published, the GitHub publisher fails to upload these files without the `releaseType` option, as the `releaseType` defaults to `draft`, which does not match the `releaseType` of the release and its executables.

I realize that these may be here for a good reason, so this pull request should definitely be reviewed by someone that is more familiar with the publishing system (@develar). 


Closes #2971.