### PR TITLE
Fix the npm-scope package cause building error in Windows

### DIFF
--- a/packages/electron-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/electron-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -55,8 +55,10 @@ export class NodeModuleCopyHelper {
     const result: Array<string> = []
     const queue: Array<string> = []
     for (const moduleName of moduleNames) {
-      const depPath = baseDir + path.sep + moduleName
+      const tmpPath = baseDir + path.sep + moduleName
       queue.length = 1
+      // The path should be corrected in Windows that when the moduleName is Scoped packages named.
+      const depPath = path.normalize(tmpPath)
       queue[0] = depPath
 
       // if (dep.link != null) {


### PR DESCRIPTION
Hi, When building our production I got this error in Windows. (We used an npm-scope package) And I fixed it.
```shell
Error: File "" not under the source directory "C:\Users\Administrator\Desktop\splayerx\node_modules"
    at getDestinationPath (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\util\appFileCopier.ts:26:15)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\asar\unpackDetector.ts:71:79
    at Generator.next (<anonymous>)
From previous event:
    at detectUnpackedDirs (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\out\asar\unpackDetector.js:195:17)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\asar\asarUtil.ts:47:13
    at Generator.next (<anonymous>)
From previous event:
    at AsarPackager.createPackageFromFiles (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\asar\asarUtil.ts:39:84)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\asar\asarUtil.ts:34:52
    at Generator.next (<anonymous>)
From previous event:
    at AsarPackager.pack (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\asar\asarUtil.ts:26:79)
    at taskManager.addTask._computeFileSets.then.fileSets (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\platformPackager.ts:281:136)
From previous event:
    at WinPackager.copyAppFiles (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\platformPackager.ts:281:10)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\platformPackager.ts:214:10
    at Generator.next (<anonymous>)
    at runCallback (timers.js:696:18)
    at tryOnImmediate (timers.js:667:5)
    at processImmediate (timers.js:649:5)
From previous event:
    at WinPackager.doPack (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\platformPackager.ts:162:151)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\platformPackager.ts:117:16
    at Generator.next (<anonymous>)
From previous event:
    at WinPackager.pack (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\platformPackager.ts:115:95)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\packager.ts:373:24
    at Generator.next (<anonymous>)
    at xfs.stat (C:\Users\Administrator\Desktop\splayerx\node_modules\fs-extra-p\node_modules\fs-extra\lib\mkdirs\mkdirs.js:56:16)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\graceful-fs\polyfills.js:287:18
    at FSReqWrap.oncomplete (fs.js:150:5)
From previous event:
    at Packager.doBuild (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\packager.ts:341:39)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\packager.ts:317:52
From previous event:
    at Packager._build (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\packager.ts:294:133)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\packager.ts:290:23
    at Generator.next (<anonymous>)
    at runCallback (timers.js:696:18)
    at tryOnImmediate (timers.js:667:5)
    at processImmediate (timers.js:649:5)
From previous event:
    at Packager.build (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\packager.ts:248:14)
    at C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\src\index.ts:51:40
    at Generator.next (<anonymous>)
From previous event:
    at build (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder-lib\out\index.js:220:17)
    at build (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder\src\builder.ts:234:10)
    at then (C:\Users\Administrator\Desktop\splayerx\node_modules\electron-builder\src\cli\cli.ts:46:19)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! splayer@0.0.1 build: `node .electron-vue/build.js && electron-builder`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the splayer@0.0.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Administrator\AppData\Roaming\npm-cache\_logs\2018-06-10T14_17_04_838Z-debug.log
```
