### PR TITLE
feat: change to enable auto-updater to pull from prereleases in a Git…

### DIFF
--- a/packages/electron-updater/src/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/PrivateGitHubProvider.ts
@@ -2,6 +2,7 @@ import { CancellationToken, GithubOptions, HttpError, HttpExecutor, newError, Up
 import { OutgoingHttpHeaders, RequestOptions } from "http"
 import { safeLoad } from "js-yaml"
 import * as path from "path"
+import { AppUpdater } from "./AppUpdater"
 import { URL } from "url"
 import { BaseGitHubProvider } from "./GitHubProvider"
 import { getChannelFilename, getDefaultChannelName, newUrlFromBase, ResolvedUpdateFileInfo } from "./main"
@@ -12,7 +13,7 @@ export interface PrivateGitHubUpdateInfo extends UpdateInfo {
 }
 
 export class PrivateGitHubProvider extends BaseGitHubProvider<PrivateGitHubUpdateInfo> {
-  constructor(options: GithubOptions, private readonly token: string, executor: HttpExecutor<any>) {
+  constructor(options: GithubOptions, private readonly updater: AppUpdater, private readonly token: string, executor: HttpExecutor<any>) {
     super(options, "api.github.com", executor)
   }
 
@@ -61,9 +62,21 @@ export class PrivateGitHubProvider extends BaseGitHubProvider<PrivateGitHubUpdat
   }
 
   private async getLatestVersionInfo(cancellationToken: CancellationToken): Promise<ReleaseInfo> {
-    const url = newUrlFromBase(`${this.basePath}/latest`, this.baseUrl)
+    let baseUrl = this.basePath
+    const allowPrerelease = this.updater.allowPrerelease
+
+    if (!allowPrerelease) {
+      baseUrl = `${baseUrl}/latest`
+    }
+
+    const url = newUrlFromBase(`${baseUrl}`, this.baseUrl)
     try {
-      return (JSON.parse((await this.httpRequest(url, this.configureHeaders("application/vnd.github.v3+json"), cancellationToken))!!))
+      let version = (JSON.parse((await this.httpRequest(url, this.configureHeaders("application/vnd.github.v3+json"), cancellationToken))!!))
+      if (allowPrerelease) {
+        version = version.find((v: any) => v.prerelease)
+      }
+
+      return version
     }
     catch (e) {
       throw newError(`Unable to find latest version on GitHub (${url}), please ensure a production release exists: ${e.stack || e.message}`, "ERR_UPDATER_LATEST_VERSION_NOT_FOUND")

--- a/packages/electron-updater/src/providerFactory.ts
+++ b/packages/electron-updater/src/providerFactory.ts
@@ -21,7 +21,7 @@ export function createClient(data: PublishConfiguration | AllPublishOptions, upd
         return new GitHubProvider(githubOptions, updater, httpExecutor)
       }
       else {
-        return new PrivateGitHubProvider(githubOptions, token, httpExecutor)
+        return new PrivateGitHubProvider(githubOptions, updater, token, httpExecutor)
       }
 
     case "s3":


### PR DESCRIPTION
…hub private repository

private Github repositories are now able to auto update from prereleases and releases based on allowPrerelease flag