### PR TITLE
Support differentialPackage for dmg builds

### DIFF
--- a/docs/configuration/dmg.md
+++ b/docs/configuration/dmg.md
@@ -22,6 +22,7 @@ The top-level [dmg](configuration.md#Configuration-dmg) key contains set of opti
   * <code id="DmgWindow-width">width</code> Number - The width. Defaults to background image width or 540.
   * <code id="DmgWindow-height">height</code> Number - The height. Defaults to background image height or 380.
 * <code id="DmgOptions-internetEnabled">internetEnabled</code> = `false` Boolean - Whether to create internet-enabled disk image (when it is downloaded using a browser it will automatically decompress the image, put the application on the desktop, unmount and remove the disk image file).
+* <code id="DmgOptions-differentialPackage">differentialPackage</code> Boolean - Whether to build block map.
 
 Inherited from `TargetSpecificOptions`:
 * <code id="DmgOptions-artifactName">artifactName</code> String - The [artifact file name template](/configuration/configuration.md#artifact-file-name-template).

--- a/docs/generated/NsisOptions.md
+++ b/docs/generated/NsisOptions.md
@@ -29,7 +29,7 @@
   Appropriate license file will be selected by user OS language.
 * <code id="NsisOptions-artifactName">artifactName</code> String - The [artifact file name template](/configuration/configuration.md#artifact-file-name-template). Defaults to `${productName} Setup ${version}.${ext}`.
 * <code id="NsisOptions-deleteAppDataOnUninstall">deleteAppDataOnUninstall</code> = `false` Boolean - *one-click installer only.* Whether to delete app data on uninstall.
-* <code id="NsisOptions-differentialPackage">differentialPackage</code> Boolean - Defaults to `true` for web installer (`nsis-web`)
+* <code id="NsisOptions-differentialPackage">differentialPackage</code> Boolean - Whether to build block map. Defaults to `true` for web installer (`nsis-web`)
 
 ---
 

--- a/packages/electron-builder-lib/src/options/macOptions.ts
+++ b/packages/electron-builder-lib/src/options/macOptions.ts
@@ -233,6 +233,11 @@ export interface DmgOptions extends TargetSpecificOptions {
    * @default false
    */
   readonly internetEnabled?: boolean
+
+  /**
+   * Whether to build block map.
+   */
+  differentialPackage?: boolean
 }
 
 export interface DmgWindow {

--- a/packages/electron-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/electron-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -120,6 +120,7 @@ export interface NsisOptions extends CommonNsisOptions, CommonWindowsInstallerCo
   readonly deleteAppDataOnUninstall?: boolean
 
   /**
+   * Whether to build block map.
    * Defaults to `true` for web installer (`nsis-web`)
    */
   differentialPackage?: boolean

--- a/test/out/mac/__snapshots__/dmgTest.js.snap
+++ b/test/out/mac/__snapshots__/dmgTest.js.snap
@@ -2512,6 +2512,34 @@ Object {
 }
 `;
 
+exports[`no block map 1`] = `
+Object {
+  "mac": Array [],
+}
+`;
+
+exports[`no block map 2`] = `
+Object {
+  "AsarIntegrity": "{\\"checksums\\":{\\"app.asar\\":\\"YYJnZcKYR79+/Un7xZ0fFqTRc7j3NvRfNDY1B1sLXGzBBvOPpir176RAxfQjNYXVwWGHSuXWpSrh5e1lEsamuA==\\",\\"electron.asar\\":\\"ksFqQ3X5rccdlVaj4tOiH6w3EuU2r0+74T+bQ+jo2tynH+7xSMMPv5tfF5ATKsBaDNOQPZtxMsFwjBuUI8XgSw==\\"}}",
+  "CFBundleDisplayName": "NoBlockMap",
+  "CFBundleExecutable": "NoBlockMap",
+  "CFBundleIconFile": "electron.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "NoBlockMap",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.1.0",
+  "DTSDKBuild": "14D125",
+  "DTSDKName": "macosx10.1010.10",
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSMinimumSystemVersion": "10.9.0",
+  "NSHighResolutionCapable": true,
+  "NSMainNibFile": "MainMenu",
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
 exports[`no build directory 1`] = `
 Array [
   Object {

--- a/test/src/mac/dmgTest.ts
+++ b/test/src/mac/dmgTest.ts
@@ -205,6 +205,27 @@ test.ifAll.ifMac("disable dmg icon (light), bundleVersion", () => {
   })
 })
 
+test.ifMac("no block map", app({
+  targets: Platform.MAC.createTarget("dmg"),
+  config: {
+    productName: "NoBlockMap",
+    publish: null,
+    dmg: {
+      differentialPackage: false,
+    }
+  },
+  effectiveOptionComputed: async it => {
+    if (!("specification" in it)) {
+      return false
+    }
+
+    expect(it.specification.differentialPackage).toBe(false)
+    return false
+  },
+}, {
+  projectDirCreated: projectDir => remove(path.join(projectDir, "build")),
+}))
+
 const packagerOptions = {
   targets: Platform.MAC.createTarget("dmg"),
   config: {


### PR DESCRIPTION
Building the block map takes a while. If you don't need it, there is no reason to spend time building it.

This PR adds support for `differentialPackage` for DMG builds.