### PR TITLE
perf(zip): Use default compression level

### DIFF
--- a/packages/electron-builder-lib/src/targets/archive.ts
+++ b/packages/electron-builder-lib/src/targets/archive.ts
@@ -80,20 +80,16 @@ export function compute7zCompressArgs(format: string, options: ArchiveOptions = 
   let storeOnly = options.compression === "store"
   const args = debug7zArgs("a")
 
-  let isLevelSet = false
   if (process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL != null) {
     storeOnly = false
     args.push(`-mx=${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL}`)
-    isLevelSet = true
+  } else if (options.compression === "maximum") {
+    args.push("-mx=9")
   }
 
   if (format === "zip" && options.compression === "maximum") {
     // http://superuser.com/a/742034
     args.push("-mfb=258", "-mpass=15")
-  }
-
-  if (!isLevelSet && !storeOnly) {
-    args.push("-mx=9")
   }
 
   if (options.dictSize != null) {


### PR DESCRIPTION
Building the `zip` target takes a long time, because the file is compressed with level 9, `-mx=9`.

I suggest `-mx=9` is only used when `compression` is set to `maximum`. For `normal` compression, we should use the default level, 5.

In my application, adding `-mx=9` increases the run time by a factor 6, but the size of the compressed file is only reduced with 1.2%. This seems like a bad trade-off.