### PR TITLE
Remove unnecessary volume binding

### DIFF
--- a/docs/multi-platform-build.md
+++ b/docs/multi-platform-build.md
@@ -96,7 +96,6 @@ See example Docker usage on a CI server in the [sample .travis.yml](https://gith
      --env ELECTRON_CACHE="/root/.cache/electron" \
      --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
      -v ${PWD}:/project \
-     -v ${PWD##*/}-node-modules:/project/node_modules \
      -v ~/.cache/electron:/root/.cache/electron \
      -v ~/.cache/electron-builder:/root/.cache/electron-builder \
      electronuserland/builder:wine


### PR DESCRIPTION
PWD is already bound to /project which includes node_modules.