### PR TITLE
fix Issue 3054: ELECTRON_BUILDER_NSIS_DIR setting

### DIFF
--- a/packages/electron-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/electron-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -14,7 +14,7 @@ export const nsisTemplatesDir = getTemplatePath("nsis")
 export const NSIS_PATH = new Lazy(() => {
   const custom = process.env.ELECTRON_BUILDER_NSIS_DIR
   if (custom != null && custom.length > 0) {
-    return Promise.resolve(custom)
+    return Promise.resolve(custom.trim())
   }
   // noinspection SpellCheckingInspection
   return getBinFromGithub("nsis", "3.0.3.1", "rYRTO0OqNStw1uFP1RJ4aCGyK+GCz4AIy4uSO3g/sPmuONYDPhp8B0Q6xUx4aTb8hLaFeWyvo7tsp++9nrMoSw==")
@@ -55,7 +55,7 @@ export class AppPackageHelper {
     }
 
     const filesToDelete: Array<string> = []
-    for (const [info, isDelete]  of this.infoToIsDelete.entries()) {
+    for (const [info, isDelete] of this.infoToIsDelete.entries()) {
       if (isDelete) {
         filesToDelete.push(info.path)
       }


### PR DESCRIPTION
Info: https://github.com/electron-userland/electron-builder/issues/3054
space at the end of the path was creating problem while copying a file from src to the destination.