### PR TITLE
fix(nsis): respect --force-run when RUN_AFTER_FINISH is false

### DIFF
--- a/packages/electron-builder-lib/templates/nsis/installSection.nsh
+++ b/packages/electron-builder-lib/templates/nsis/installSection.nsh
@@ -85,7 +85,10 @@ ${endIf}
 !ifdef ONE_CLICK
   !ifdef RUN_AFTER_FINISH
     ${ifNot} ${Silent}
-    ${orIf} ${isForceRun}
+      !insertmacro doStartApp
+    ${endIf}
+  !else
+    ${if} ${isForceRun}
       !insertmacro doStartApp
     ${endIf}
   !endif


### PR DESCRIPTION
This is a follow up for:

https://github.com/electron-userland/electron-builder/issues/2951
https://github.com/electron-userland/electron-builder/pull/2974


```
oneClick: true,
runAfterFinish: false
```
My configuration is now working as expected but the auto update is not starting the app after the update.
Please take a look at it but it should now be ok for all cases.

