### PR TITLE
feat(updater): add vertical upgrading for channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ electron-builder-*.d.ts
 /scripts/renderer/out/
 
 __publish.sh
+
+.vscode

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -49,6 +49,13 @@ export abstract class AppUpdater extends EventEmitter {
   allowDowngrade: boolean = false
 
   /**
+   * Whether to always allow downgrading or upgrading for a channel (0.2.0 >
+   * 0.3.0-alpha.234 > 0.2.1-beta.22 > 0.2.0)
+   * @default false
+   */
+  alwaysDownloadLatestForChannel: boolean = false
+
+  /**
    * The current application version.
    */
   readonly currentVersion: string
@@ -317,7 +324,17 @@ export abstract class AppUpdater extends EventEmitter {
     }
 
     const isStagingMatch = await this.isStagingMatch(updateInfo)
-    if (!isStagingMatch || ((this.allowDowngrade && !hasPrereleaseComponents(latestVersion)) ? isVersionsEqual(latestVersion, this.currentVersion) : !isVersionGreaterThan(latestVersion, this.currentVersion))) {
+    const isSameVersion = isVersionsEqual(latestVersion, this.currentVersion)
+    const isLatestVersionNewer = isVersionGreaterThan(latestVersion, this.currentVersion)
+
+    const disallowDowngrade =
+      this.allowDowngrade && !hasPrereleaseComponents(latestVersion)
+        ? isSameVersion
+        : !isLatestVersionNewer
+
+    const forceUpdate = !isSameVersion && this.alwaysDownloadLatestForChannel
+
+    if (!isStagingMatch || (!forceUpdate && disallowDowngrade)) {
       this.updateAvailable = false
       this._logger.info(`Update for version ${this.currentVersion} is not available (latest version: ${updateInfo.version}, downgrade is ${this.allowDowngrade ? "allowed" : "disallowed"}).`)
       this.emit("update-not-available", updateInfo)


### PR DESCRIPTION
Hi, 

in one of the projects I'm working on I have to adhere to gitflow for our git branching model, we have enhanced it with gitversion to automatically tag our releases with a semver that makes sense across branches. 

from the following example graphs, take note that I only build electron apps from develop branches (alpha channel), master branches (latest channel), hotfix and release branches (beta channel) as per 
http://gitversion.readthedocs.io/en/latest/git-branching-strategies/gitflow-examples/

the current alpha/beta/latest setup doesn't allow for switching between release channels in such a way that it always takes the latest from that channel.

the option `generateUpdatesFilesForAllChannels` set to `true` doesn't work for us for the following reason: I release `alpha` versions far more frequently than beta releases and in turn I release `beta` versions far more frequently than `latest` ones, setting `generateUpdatesFilesForAllChannels` to true would result in a tiny window where my `alpha` channel and `beta` channel have a non-alpha and a non-beta release assigned to it. 

I want to avoid this

I tried a combination of `allowPrerelease` and `allowDowngrade` and made sure to understand the codebase before making this change. 

I added a flag as a non-breaking change in the `AppUpdater` class: `alwaysDownloadLatestForChannel` that would allow downgrading or upgrading to a newer or older version on a particular channel. 

the use case is that currently I cannot switch between a `latest` 2.0.0 and a beta `2.0.0-beta.123` if I wanted to switch back to the `beta` channel and update to that version. I am aware that this sounds somewhat strange, but for QA this is a must have. In the current setup what has to be done is the following: 

I am on `latest` 2.0.0, I have an `alpha` 3.0.0-alpha.34 and a `beta` 2.0.0-beta.23. When `allowDowngrade` and `allowPrerelease` are set I can `upgrade` from 2.0.0 to 3.0.0-alpha.34 but I can not `downgrade` to 2.0.0-beta.23. Only after upgrading to 3.0.0-alpha.34 can i downgrade to 2.0.0-beta.23 and then back to 2.0.0. 

adding the `alwaysDownloadLatestForChannel` option just ensures that when I switch to a channel, I download the version stated in that channel, unless if it's the version I am currently on. 