### PR TITLE
Fix electron-updater: Url parameters are ignore

### DIFF
--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -157,11 +157,9 @@ export function newBaseUrl(url: string) {
 // so, it makes sense only for Generic Provider for channel files
 export function newUrlFromBase(pathname: string, baseUrl: URL, addRandomQueryToAvoidCaching: boolean = false): URL {
   const result = new URL(pathname, baseUrl)
-  let hasSearch = result.search != null && result.search.length !== 0
-  // search is not propagated (search is an empty string if not specified)
-  if (!hasSearch && baseUrl.search) {
-    result.search = baseUrl.search
-    hasSearch = true
+  const hasSearch = baseUrl.search != null && baseUrl.search.length !== 0; // search is not propagated (search is an empty string if not specified)
+  if (hasSearch) {
+    result.search = baseUrl.search;
   }
   if (addRandomQueryToAvoidCaching && !hasSearch) {
     result.search = `noCache=${Date.now().toString(32)}`


### PR DESCRIPTION
Currently add parameters in URL is not working,
( ex: https:google.com/index.php?key=value  is considered as https:google.com/index.php).

Main reasons:  
- search object is inside baseUrl.
- pathname just contains the full path without parameters.