### PR TITLE
Add user agent check for yarn

### DIFF
--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -71,7 +71,7 @@ function installDependencies(appDir: string, options: RebuildOptions): Promise<a
   let execPath = process.env.npm_execpath || process.env.NPM_CLI_JS
   const execArgs = ["install", "--production"]
 
-  if (!isYarnPath(execPath)) {
+  if (!isRunningYarn(execPath)) {
     if (process.env.NPM_NO_BIN_LINKS === "true") {
       execArgs.push("--no-bin-links")
     }
@@ -104,8 +104,11 @@ function getPackageToolPath() {
   }
 }
 
-function isYarnPath(execPath: string | null | undefined) {
-  return process.env.FORCE_YARN === "true" || (execPath != null && path.basename(execPath).startsWith("yarn"))
+function isRunningYarn(execPath: string | null | undefined) {
+  const userAgent = process.env.npm_config_user_agent
+  return process.env.FORCE_YARN === "true" ||
+    (execPath != null && path.basename(execPath).startsWith("yarn")) ||
+    (userAgent != null && /\byarn\b/.test(userAgent))
 }
 
 export interface RebuildOptions {
@@ -135,7 +138,7 @@ export async function rebuild(appDir: string, options: RebuildOptions) {
   log.info({platform, arch}, "rebuilding native production dependencies")
 
   let execPath = process.env.npm_execpath || process.env.NPM_CLI_JS
-  const isYarn = isYarnPath(execPath)
+  const isYarn = isRunningYarn(execPath)
   const execArgs: Array<string> = []
   if (execPath == null) {
     execPath = getPackageToolPath()


### PR DESCRIPTION
There is inconsistency in what `yarn` reports via `process.env.npm_execpath` when running `yarn` from `package.json` script in a __workspace configuration__ and when running directly from shell.


#### When running `package.json` script

```bash
$ yarn run whoami
/usr/local/Cellar/yarn/1.7.0/libexec/lib/cli.js # CULPRIT
```

You can reproduce this with the following `package.json`:

```json
{
  "scripts": {
    "whoami": "yarn run env | grep npm_execpath"
  }
}
```

#### When running directly from shell

```bash
$ yarn run env | grep npm_execpath
"npm_execpath": "/usr/local/Cellar/yarn/1.7.0/libexec/bin/yarn.js" # THAT WORKS
```

The former path fails all existing checks in `electron-builder`, and tricks it into thinking that the script is being executed by `npm`. 

This assumption causes crash in my case due to unavailable `rebuild` command that `electron-builder install-app-deps` attempt to run.

The fix itself adds additional check for `npm_config_user_agent` which seems to be always set, i.e:

```
yarn/1.7.0 npm/? node/v8.11.2 darwin x64
```

We could always rely on `npm_config_user_agent` instead of path but I felt that it was a fragile assumption and it could be that older versions of `yarn` didn't set this properly.

Closes #3181

Related issue on yarn's repo https://github.com/yarnpkg/yarn/issues/6163