### PR TITLE
snap: do not set environment for classic

### DIFF
--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -15,7 +15,7 @@ const defaultStagePackages = ["libasound2", "libgconf2-4", "libnotify4", "libnsp
 const defaultPlugs = ["desktop", "desktop-legacy", "home", "x11", "unity7", "browser-support", "network", "gsettings", "pulseaudio", "opengl"]
 
 export default class SnapTarget extends Target {
-  readonly options: SnapOptions = {...this.packager.platformSpecificBuildOptions, ...(this.packager.config as any)[this.name]}
+  readonly options: SnapOptions = { ...this.packager.platformSpecificBuildOptions, ...(this.packager.config as any)[this.name] }
 
   public isUseTemplateApp = false
 
@@ -50,19 +50,6 @@ export default class SnapTarget extends Target {
 
     const appDescriptor: any = {
       command: `command.sh`,
-      environment: {
-        TMPDIR: "$XDG_RUNTIME_DIR",
-        PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
-        LD_LIBRARY_PATH: [
-          "$SNAP_LIBRARY_PATH",
-          "$SNAP/usr/lib/" + linuxArchName + "-linux-gnu:$SNAP/usr/lib/" + linuxArchName + "-linux-gnu/pulseaudio",
-          "$SNAP/usr/lib/" + linuxArchName + "-linux-gnu/mesa-egl",
-          "$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/" + linuxArchName + "-linux-gnu:$SNAP/usr/lib/" + linuxArchName + "-linux-gnu",
-          "$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib",
-          "$SNAP/lib/" + linuxArchName + "-linux-gnu:$SNAP/usr/lib/" + linuxArchName + "-linux-gnu"
-        ].join(":"),
-        ...options.environment,
-      },
       plugs: plugNames,
     }
     const snap: any = {
@@ -83,6 +70,22 @@ export default class SnapTarget extends Target {
           after: this.replaceDefault(options.after, [desktopPart]),
         }
       },
+    }
+
+    if (options.confinement !== "classic") {
+      appDescriptor.environment = {
+        TMPDIR: "$XDG_RUNTIME_DIR",
+        PATH: "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
+        LD_LIBRARY_PATH: [
+          "$SNAP_LIBRARY_PATH",
+          "$SNAP/usr/lib/" + linuxArchName + "-linux-gnu:$SNAP/usr/lib/" + linuxArchName + "-linux-gnu/pulseaudio",
+          "$SNAP/usr/lib/" + linuxArchName + "-linux-gnu/mesa-egl",
+          "$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/" + linuxArchName + "-linux-gnu:$SNAP/usr/lib/" + linuxArchName + "-linux-gnu",
+          "$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib",
+          "$SNAP/lib/" + linuxArchName + "-linux-gnu:$SNAP/usr/lib/" + linuxArchName + "-linux-gnu"
+        ].join(":"),
+        ...options.environment,
+      }
     }
 
     if (!this.isUseTemplateApp) {
@@ -181,7 +184,7 @@ done`
       Icon: "${SNAP}/meta/gui/icon.png"
     })
 
-    if (packager.packagerOptions.effectiveOptionComputed != null && await packager.packagerOptions.effectiveOptionComputed({snap, desktopFile})) {
+    if (packager.packagerOptions.effectiveOptionComputed != null && await packager.packagerOptions.effectiveOptionComputed({ snap, desktopFile })) {
       return
     }
 


### PR DESCRIPTION
When setting an environment for classically confined snaps,
process that are spawned from within this environment will
contaminate the loading of the spawned applications on the
system causing symbol mismatches, for this reason it is
disabled, making library discovery rely on each binaries
RPATH.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>

--
I am not really much of a javascript developer, running `yarn test` produces this error which seems unrelated:
      ⨯ part download request failed with status code 403
