### PR TITLE
Added electron 3(Node 10) support to nisis updater

### DIFF
--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -74,7 +74,7 @@ export class AppImageUpdater extends BaseUpdater {
     })
   }
 
-  protected doInstall(installerPath: string, isSilent: boolean, isRunAfter: boolean): boolean {
+  protected async doInstall(installerPath: string, isSilent: boolean, isRunAfter: boolean): Promise<boolean> {
     const appImageFile = process.env.APPIMAGE!!
     if (appImageFile == null) {
       throw newError("APPIMAGE env is not defined", "ERR_UPDATER_OLD_FILE_NOT_FOUND")

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -33,7 +33,7 @@ export abstract class BaseUpdater extends AppUpdater {
     })
   }
 
-  protected abstract doInstall(installerPath: string, isSilent: boolean, isRunAfter: boolean): boolean
+  protected abstract doInstall(installerPath: string, isSilent: boolean, isRunAfter: boolean): Promise<boolean>
 
   protected async install(isSilent: boolean, isRunAfter: boolean): Promise<boolean> {
     if (this.quitAndInstallCalled) {
@@ -54,7 +54,7 @@ export abstract class BaseUpdater extends AppUpdater {
 
     try {
       this._logger.info(`Install: isSilent: ${isSilent}, isRunAfter: ${isRunAfter}`)
-      return this.doInstall(installerPath, isSilent, isRunAfter)
+      return await this.doInstall(installerPath, isSilent, isRunAfter)
     }
     catch (e) {
       this.dispatchError(e)

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -136,23 +136,23 @@ export class NsisUpdater extends BaseUpdater {
    *   - node 8: Throws the error
    *   - node 10: Emit the error(Need to listen with on)
    */
-  private async _spawn(exe: string, args: string[], options: any) {
+  private async _spawn(exe: string, args: Array<string>, options: any) {
     return new Promise((resolve, reject) => {
 
       try {
         const process = spawn(exe, args, options)
-        process.on("error", (error) => {
-          reject(error);
-        });
-        process.unref();
+        process.on("error", error => {
+          reject(error)
+        })
+        process.unref()
 
         if (process.pid !== undefined) {
-          resolve(true);
+          resolve(true)
         }
       } catch (error) {
-        reject(error);
+        reject(error)
       }
-    });
+    })
 
   }
 

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -131,6 +131,11 @@ export class NsisUpdater extends BaseUpdater {
     return true
   }
 
+  /**
+   * This handles both node 8 and node 10 way of emitting error when spawing a process
+   *   - node 8: Throws the error
+   *   - node 10: Emit the error(Need to listen with on)
+   */
   private async _spawn(exe: string, args: string[], options: any) {
     return new Promise((resolve, reject) => {
 
@@ -162,7 +167,7 @@ export class NsisUpdater extends BaseUpdater {
       this._logger.info(`Download block maps (old: "${oldBlockMapUrl.href}", new: ${newBlockMapUrl.href})`)
 
       const downloadBlockMap = async (url: URL): Promise<BlockMap> => {
-        const requestOptions = configureRequestOptionsFromUrl(url, { headers: downloadUpdateOptions.requestHeaders });
+        const requestOptions = configureRequestOptionsFromUrl(url, {headers: downloadUpdateOptions.requestHeaders});
         (requestOptions as any).gzip = true
         const data = await this.httpExecutor.request(requestOptions, downloadUpdateOptions.cancellationToken)
         if (data == null) {


### PR DESCRIPTION
fix #3367 

Looks like that in node 10 (Electron 3 use node 10) `spawn` is not throwing errors when the process fail to execute. This means the updater doesn't catch the `EACCES` error emitted when installer need admin permissions.

The fix will try to catch error both from node 8 and node 10 by listening to the error event for node 10 and using try catch for node 8. This should keep support for electron 2 while enabling electron 3.

