### PR TITLE
fix(win): Relay exit code in portable app

### DIFF
--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -37,7 +37,8 @@ Section
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_FILE", "$EXEPATH").r0'
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_APP_FILENAME", "${APP_FILENAME}").r0'
   ${StdUtils.GetAllParameters} $R0 0
-	ExecWait "$INSTDIR\${APP_EXECUTABLE_FILENAME} $R0"
+	ExecWait "$INSTDIR\${APP_EXECUTABLE_FILENAME} $R0" $0
+  SetErrorlevel $0
 
   SetOutPath $PLUGINSDIR
 	RMDir /r $INSTDIR


### PR DESCRIPTION
<!-- Which version of electron-builder are you using? -->
<!-- Please always try to use latest version before report. -->
* **Version**: 20.19.2

<!-- Which version of electron-updater are you using (if applicable)? -->

<!-- What target are you building for? -->
* **Target**: windows (portable)

<!-- Enter your issue details below this comment. -->
<!-- If you want, you can donate to increase issue priority (https://www.electron.build/donate) -->

When executing a portable build, the exit code would always be 0, even when `process.exit(1)` was used, or an unhandled exception was raised. This is not the case if using an installed version. 
The cause was NSIS not relaying the exit code returned by the child application.