### PR TITLE
fix(nsis): create appdata directory before copying installer

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/installer.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installer.nsh
@@ -84,6 +84,7 @@
       ${if} $installMode == "all"
         SetShellVarContext current
       ${endif}
+      CreateDirectory "$APPDATA\${PRODUCT_FILENAME}"
       CopyFiles /SILENT "$EXEPATH" "$APPDATA\${APP_INSTALLER_STORE_FILE}"
       ${if} $installMode == "all"
         SetShellVarContext all


### PR DESCRIPTION
First update gives error due to __installer.exe missing. 

This is due to it failing to copy over on first install because of no appdata folder yet.