### PR TITLE
 Electron builder yaml is now discovered through JS file

### DIFF
--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -53,7 +53,7 @@ export async function getConfig(projectDir: string, configPath: string | null, c
       config.extends = extendsSpec
     }
     else if (devDependencies != null && "electron-webpack" in devDependencies) {
-      const electronWebpack = require("electron-webpack/packages/electron-webpack")
+      const electronWebpack = require("electron-webpack")
       deepAssign(config, await electronWebpack.electronBuilderConfig())
     }
   }

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -54,7 +54,12 @@ export async function getConfig(projectDir: string, configPath: string | null, c
     }
     else if (devDependencies != null && "electron-webpack" in devDependencies) {
       const electronWebpack = require("electron-webpack")
-      deepAssign(config, await electronWebpack.electronBuilderConfig())
+      if (electronWebpack.electronBuilderConfig != null) {
+        deepAssign(config, await electronWebpack.electronBuilderConfig())
+      } else {
+        extendsSpec = "electron-webpack/electron-builder.yml"
+        config.extends = extendsSpec
+      }
     }
   }
 

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -1,6 +1,6 @@
 import { asArray, DebugLogger, InvalidConfigurationError, log, deepAssign } from "builder-util"
 import { statOrNull } from "builder-util/out/fs"
-import { readJson } from "fs-extra-p"
+import { readJson, pathExists } from "fs-extra-p"
 import { Lazy } from "lazy-val"
 import * as path from "path"
 import { getConfig as _getConfig, loadParentConfig, orNullIfFileNotExist, ReadConfigRequest, validateConfig as _validateConfig } from "read-config-file"
@@ -53,13 +53,9 @@ export async function getConfig(projectDir: string, configPath: string | null, c
       config.extends = extendsSpec
     }
     else if (devDependencies != null && "electron-webpack" in devDependencies) {
-      const electronWebpack = require("electron-webpack")
-      if (electronWebpack.electronBuilderConfig != null) {
-        deepAssign(config, await electronWebpack.electronBuilderConfig())
-      } else {
-        extendsSpec = "electron-webpack/electron-builder.yml"
-        config.extends = extendsSpec
-      }
+      const electronBuilderJs = "electron-webpack/out/electron-builder.js"
+      const extendsSpec = await pathExists(electronBuilderJs) ? electronBuilderJs : "electron-webpack/electron-builder.yml"
+      config.extends = extendsSpec
     }
   }
 

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -53,8 +53,8 @@ export async function getConfig(projectDir: string, configPath: string | null, c
       config.extends = extendsSpec
     }
     else if (devDependencies != null && "electron-webpack" in devDependencies) {
-      extendsSpec = "electron-webpack/electron-builder.yml"
-      config.extends = extendsSpec
+      const electronWebpack = require('electron-webpack/packages/electron-webpack')
+      deepAssign(config, await electronWebpack.electronBuilderConfig())
     }
   }
 

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -54,7 +54,7 @@ export async function getConfig(projectDir: string, configPath: string | null, c
     }
     else if (devDependencies != null && "electron-webpack" in devDependencies) {
       const electronBuilderJs = "electron-webpack/out/electron-builder.js"
-      const extendsSpec = await pathExists(electronBuilderJs) ? electronBuilderJs : "electron-webpack/electron-builder.yml"
+      extendsSpec = await pathExists(electronBuilderJs) ? electronBuilderJs : "electron-webpack/electron-builder.yml"
       config.extends = extendsSpec
     }
   }

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -53,7 +53,7 @@ export async function getConfig(projectDir: string, configPath: string | null, c
       config.extends = extendsSpec
     }
     else if (devDependencies != null && "electron-webpack" in devDependencies) {
-      const electronWebpack = require('electron-webpack/packages/electron-webpack')
+      const electronWebpack = require("electron-webpack/packages/electron-webpack")
       deepAssign(config, await electronWebpack.electronBuilderConfig())
     }
   }


### PR DESCRIPTION
Depends on https://github.com/electron-userland/electron-webpack/pull/221

Electron webpack does not respect the dist directory specified in `directories.output` so this PR allows the config to be passed through correctly.