### PR TITLE
feat(nsis): add possibility to force an install mode programmatically

### DIFF
--- a/packages/app-builder-lib/templates/nsis/multiUserUi.nsh
+++ b/packages/app-builder-lib/templates/nsis/multiUserUi.nsh
@@ -27,6 +27,11 @@ Var RadioButtonLabel1
 
 !macro FUNCTION_INSTALL_MODE_PAGE_FUNCTION PRE LEAVE UNINSTALLER_FUNCPREFIX
 	Function "${UNINSTALLER_FUNCPREFIX}${PRE}"
+		Var /GLOBAL forceMachineInstall
+		Var /GLOBAL forceCurrentInstall
+		StrCpy $forceMachineInstall "0"
+		StrCpy $forceCurrentInstall "0"
+
 		${if} ${UAC_IsInnerInstance}
 		${andIf} ${UAC_IsAdmin}
 		  # inner Process (and Admin) - skip selection, inner process is always used for elevation (machine-wide)
@@ -34,9 +39,16 @@ Var RadioButtonLabel1
 			Abort
 		${endIf}
 
+		!ifmacrodef customInstallmode
+		  # Add this macro to your installer.nsh and set $forceMachineInstall or
+		  # $forceCurrentInstall to enforce one or the other modes.
+		  !insertmacro customInstallMode
+		!endif
+
     ${GetParameters} $R0
     ${GetOptions} $R0 "/allusers" $R1
     ${ifNot} ${Errors}
+    ${OrIf} $forceMachineInstall == "1"
       StrCpy $hasPerMachineInstallation "1"
       StrCpy $hasPerUserInstallation "0"
       ${ifNot} ${UAC_IsAdmin}
@@ -51,6 +63,7 @@ Var RadioButtonLabel1
 
     ${GetOptions} $R0 "/currentuser" $R1
     ${ifNot} ${Errors}
+    ${OrIf} $forceCurrentInstall == "1"
       StrCpy $hasPerMachineInstallation "0"
       StrCpy $hasPerUserInstallation "1"
       !insertmacro setInstallModePerUser


### PR DESCRIPTION
New custom macro in the multiui installer, which
allows to set two variables.
* $forceMachineInstall
* $forceCurrentInstall

Both allow to programmatically set '/currentuser'
or '/allusers'


I was unable to find the files for these docs: https://www.electron.build/configuration/nsis#custom-nsis-script and so the documentations are currently missing for that new custom macro.