### PR TITLE
icons.md: Refer to buildResources

### DIFF
--- a/icons.md
+++ b/icons.md
@@ -8,20 +8,20 @@ Files
 * *Optional* `background.png` (macOS DMG background).
 * *Optional* `background@2x.png` (macOS DMG Retina background).
 
-need to be placed in the [build](configuration/configuration.md#MetadataDirectories-buildResources) directory. All files are optional — but it is important to provide `icon.icns` (or `icon.png`), otherwise default Electron icon will be used.
+need to be placed in the [buildResources](configuration/configuration.md#MetadataDirectories-buildResources) directory. All files are optional — but it is important to provide `icon.icns` (or `icon.png`), as otherwise the default Electron icon will be used.
 
 ## Windows (NSIS)
 
 * *Optional* `icon.ico` (Windows app icon) or `icon.png`. Icon size should be at least 256x256.
 
-need to be placed in the [build](configuration/configuration.md#MetadataDirectories-buildResources) directory. It is important to provide `icon.ico` (or `icon.png`), otherwise default Electron icon will be used.
+needs to be placed in the [buildResources](configuration/configuration.md#MetadataDirectories-buildResources) directory. It is important to provide `icon.ico` (or `icon.png`), as otherwise the default Electron icon will be used.
 
 ## Linux
 
 Linux icon set will be generated automatically based on the macOS `icns` file or common `icon.png`.
 
 Or you can put them into the `build/icons` directory if you want to specify them yourself.
-The filename must contain the size (e.g. `32x32.png`) of the icon). Recommended sizes: 16, 24, 32, 48, 64, 96, 128, 256. (or just 512).
+The filename must contain the size (e.g. `32x32.png`) of the icon). Recommended sizes: 16, 24, 32, 48, 64, 96, 128, 256 (or just 512).
 
 ## AppX
 

--- a/icons.md
+++ b/icons.md
@@ -8,13 +8,13 @@ Files
 * *Optional* `background.png` (macOS DMG background).
 * *Optional* `background@2x.png` (macOS DMG Retina background).
 
-need to be placed in the [buildResources](configuration/configuration.md#MetadataDirectories-buildResources) directory. All files are optional — but it is important to provide `icon.icns` (or `icon.png`), as otherwise the default Electron icon will be used.
+need to be placed in the [`buildResources`](configuration/configuration.md#MetadataDirectories-buildResources) directory (by default: build/). All files are optional — but it is important to provide `icon.icns` (or `icon.png`), as otherwise the default Electron icon will be used.
 
 ## Windows (NSIS)
 
 * *Optional* `icon.ico` (Windows app icon) or `icon.png`. Icon size should be at least 256x256.
 
-needs to be placed in the [buildResources](configuration/configuration.md#MetadataDirectories-buildResources) directory. It is important to provide `icon.ico` (or `icon.png`), as otherwise the default Electron icon will be used.
+needs to be placed in the [`buildResources`](configuration/configuration.md#MetadataDirectories-buildResources) directory (by default: build/). It is important to provide `icon.ico` (or `icon.png`), as otherwise the default Electron icon will be used.
 
 ## Linux
 


### PR DESCRIPTION
Be explicit about the `buildResources` directory instead of referring to its default value ("build").