### PR TITLE
make "checkForUpdatesAndNotify()" promise actually catchable

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -246,8 +246,7 @@ export abstract class AppUpdater extends EventEmitter {
       return Promise.resolve(null)
     }
 
-    const checkForUpdatesPromise = this.checkForUpdates()
-    checkForUpdatesPromise
+    return this.checkForUpdates()
       .then(it => {
         const downloadPromise = it.downloadPromise
         if (downloadPromise == null) {
@@ -255,7 +254,7 @@ export abstract class AppUpdater extends EventEmitter {
           if (debug != null) {
             debug("checkForUpdatesAndNotify called, downloadPromise is null")
           }
-          return
+          return it
         }
 
         downloadPromise
@@ -265,9 +264,9 @@ export abstract class AppUpdater extends EventEmitter {
               body: `${this.app.name} version ${it.updateInfo.version} has been downloaded and will be automatically installed on exit`
             }).show()
           })
-      })
 
-    return checkForUpdatesPromise
+        return it
+      })
   }
 
   private async isStagingMatch(updateInfo: UpdateInfo): Promise<boolean> {


### PR DESCRIPTION
It makes the promise returned by checkForUpdatesAndNotify() call **actually** catchable.

Without this change possible checkForUpdatesAndNotify() promise rejection becomes `unhandled rejection` and so only global `process.on('unhandledRejection', ...` handler is able to catch the error which is not an acceptable solution.

The simplest way to reproduce the unhandled rejection caused by checkForUpdatesAndNotify() call is to turn off the network and call the checkForUpdatesAndNotify() method. Event if you setup `.catch` handler for this call you will still get unhandled rejection with Error: net::ERR_INTERNET_DISCONNECTED error.