### PR TITLE
Update Dockerfile (point to new repo key)

### DIFF
--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -1,11 +1,11 @@
 FROM electronuserland/builder:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && dpkg --add-architecture i386 && curl -L https://dl.winehq.org/wine-builds/Release.key > Release.key && apt-key add Release.key && apt-add-repository https://dl.winehq.org/wine-builds/ubuntu && \
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && dpkg --add-architecture i386 && curl -L https://dl.winehq.org/wine-builds/winehq.key > winehq.key && apt-key add winehq.key && apt-add-repository https://dl.winehq.org/wine-builds/ubuntu && \
   apt-get update && \
   apt-get -y purge software-properties-common libdbus-glib-1-2 python3-dbus python3-gi python3-pycurl python3-software-properties && \
   apt-get install -y --no-install-recommends winehq-stable && \
   # clean
-  apt-get clean && rm -rf /var/lib/apt/lists/* && unlink Release.key
+  apt-get clean && rm -rf /var/lib/apt/lists/* && unlink winehq.key
 
 RUN curl -L https://github.com/electron-userland/electron-builder-binaries/releases/download/wine-2.0.3-mac-10.13/wine-home.zip > /tmp/wine-home.zip && unzip /tmp/wine-home.zip -d /root/.wine && unlink /tmp/wine-home.zip
 


### PR DESCRIPTION
As of Dec 2018, the Wine repo key changed names to winehq.key as per:

https://wiki.winehq.org/Ubuntu 