### PR TITLE
fix(nsis): make killing the running app silent

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -48,7 +48,7 @@ Var pid
       DetailPrint `Closing running "${PRODUCT_NAME}"...`
 
       # https://github.com/electron-userland/electron-builder/issues/2516#issuecomment-372009092
-      ExecWait `taskkill /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
+      nsExec::Exec `taskkill /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
       # to ensure that files are not "in-use"
       Sleep 100
 
@@ -57,7 +57,7 @@ Var pid
         # wait to give a chance to exit gracefully
         Sleep 1000
         # do not use /t tree kill - app was killed softly already
-        ExecWait `taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
+        nsExec::Exec `taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
         ${If} $R0 != 0
           DetailPrint `Waiting for "${PRODUCT_NAME}" to close (taskkill exit code $R0).`
           Sleep 2000


### PR DESCRIPTION
Fixes #3484.

`ExecWait` briefly creates a command prompt, possibly causing a visual disruption during updates. [ns:Exec](https://nsis.sourceforge.io/Docs/nsExec/nsExec.txt) is a silent alterntive. 
