### PR TITLE
fix(docker): Squirrel.Windows requires tzdata package

### DIFF
--- a/docker/wine-mono/Dockerfile
+++ b/docker/wine-mono/Dockerfile
@@ -3,5 +3,5 @@ FROM electronuserland/builder:wine
 # since mono is required only for deprecated target Squirrel.Windows, extracted to separate docker image to reduce size
 
 RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends mono-devel ca-certificates-mono && \
+  apt-get install -y --no-install-recommends mono-devel ca-certificates-mono tzdata && \
   apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Without tzdata Update-Mono.exe throws the exception: `System.IO.FileNotFoundException: Could not find file "/etc/localtime"` ([#3143](https://github.com/electron-userland/electron-builder/issues/3143), [#232](https://github.com/electron/windows-installer/issues/232))