### PR TITLE
tests: update size in snapshot

### DIFF
--- a/test/out/__snapshots__/BuildTest.js.snap
+++ b/test/out/__snapshots__/BuildTest.js.snap
@@ -1099,7 +1099,7 @@ Object {
               "size": 1069,
             },
             "index.js": Object {
-              "size": 4626,
+              "size": 4691,
             },
             "package.json": Object {
               "size": 524,


### PR DESCRIPTION
This should get the unit tests green again.