### PR TITLE
Update URL to linux configuration documentation

### DIFF
--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -110,7 +110,7 @@ export class LinuxTargetHelper {
         }
         log.warn({
           reason: "linux.category is not set and cannot map from macOS",
-          docs: "https://electron.build/configuration/configuration#LinuxBuildOptions-category",
+          docs: "https://www.electron.build/configuration/linux",
         }, "application Linux category is set to default \"Utility\"")
         category = "Utility"
       }


### PR DESCRIPTION
Since configuration document was moved to separate page, the URL was no longer correct.