### PR TITLE
fixed unhandled error

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -193,7 +193,7 @@ export abstract class AppUpdater extends EventEmitter {
     // https://github.com/electron-userland/electron-builder/issues/1105
     let provider: Provider<any>
     if (typeof options === "string") {
-      provider = new GenericProvider({provider: "generic", url: options}, this, {
+      provider = new GenericProvider({ provider: "generic", url: options }, this, {
         ...runtimeOptions,
         isUseMultipleRangeRequest: isUrlProbablySupportMultiRangeRequests(options),
       })
@@ -266,12 +266,9 @@ export abstract class AppUpdater extends EventEmitter {
           })
         return it
       })
-      checkAndNotifyPromise.catch(e=>{
-        const debug = this._logger.debug
-        if (debug != null) {
-          debug("checkForUpdatesAndNotify() Catched an Error")
-        }
-      })
+    checkAndNotifyPromise.catch(e => {
+      this._logger.error("suppress checking update error")
+    })
     return checkAndNotifyPromise
   }
 
@@ -347,7 +344,7 @@ export abstract class AppUpdater extends EventEmitter {
 
     const client = await this.clientPromise
     const stagingUserId = await this.stagingUserIdPromise.value
-    client.setRequestHeaders(this.computeFinalHeaders({"x-user-staging-id": stagingUserId}))
+    client.setRequestHeaders(this.computeFinalHeaders({ "x-user-staging-id": stagingUserId }))
     return {
       info: await client.getLatestVersion(),
       provider: client,
@@ -474,7 +471,7 @@ export abstract class AppUpdater extends EventEmitter {
         ...requestHeaders,
       }
     }
-    return this.computeFinalHeaders({accept: "*/*"})
+    return this.computeFinalHeaders({ accept: "*/*" })
   }
 
   private async getOrCreateStagingUserId(): Promise<string> {

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -246,7 +246,7 @@ export abstract class AppUpdater extends EventEmitter {
       return Promise.resolve(null)
     }
 
-    return this.checkForUpdates()
+    const checkAndNotifyPromise = this.checkForUpdates()
       .then(it => {
         const downloadPromise = it.downloadPromise
         if (downloadPromise == null) {
@@ -264,9 +264,15 @@ export abstract class AppUpdater extends EventEmitter {
               body: `${this.app.name} version ${it.updateInfo.version} has been downloaded and will be automatically installed on exit`
             }).show()
           })
-
         return it
       })
+      checkAndNotifyPromise.catch(e=>{
+        const debug = this._logger.debug
+        if (debug != null) {
+          debug("checkForUpdatesAndNotify() Catched an Error")
+        }
+      })
+    return checkAndNotifyPromise
   }
 
   private async isStagingMatch(updateInfo: UpdateInfo): Promise<boolean> {

--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -24,7 +24,7 @@ export abstract class DifferentialDownloader {
 
   private readonly logger: Logger
 
-  // noinspection TypeScriptAbstractClassConstructorCanBeMadeProtected
+  // noinspection TypeScriptAb`stractClassConstructorCanBeMadeProtected
   constructor(protected readonly blockAwareFileInfo: BlockMapDataHolder, readonly httpExecutor: HttpExecutor<any>, readonly options: DifferentialDownloaderOptions) {
     this.logger = options.logger
   }


### PR DESCRIPTION
fix: Add a catch to due with the Error thrown in the method<checkAndNotifyPromise> of AppUpdater when the network is down(offline)

We don't want our users disturbed by an  unhandled error which showing up with the system-dialog. <checkAndNotifyPromise> is just a daily checking job.It should always hide in the background.
