### PR TITLE
Feature/do not ignore uninstall errors

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
@@ -170,8 +170,12 @@ Function uninstallOldVersion
     StrCpy $0 "$0 --updated"
   ${endif}
 
-  ExecWait '"$uninstallerFileName" /S /KEEP_APP_DATA $0 _?=$installationDir'
-
+  ExecWait '"$uninstallerFileName" /KEEP_APP_DATA $0 _?=$installationDir' $R0
+  ${if} $R0 != 0
+    DetailPrint `Aborting, uninstall was not successful. Uninstaller errorcode: $R0.`
+    SetErrorLevel 5
+    Abort "Can not uninstall"
+  ${endif}
   Done:
 FunctionEnd
 

--- a/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
@@ -142,7 +142,7 @@ Function uninstallOldVersion
     Goto Done
   ${endif}
 
-  !insertmacro moveFile "$uninstallerFileName" "$PLUGINSDIR\old-uninstaller.exe"
+  !insertmacro copyFile "$uninstallerFileName" "$PLUGINSDIR\old-uninstaller.exe"
   StrCpy $uninstallerFileName "$PLUGINSDIR\old-uninstaller.exe"
 
   ${if} $installMode == "CurrentUser"


### PR DESCRIPTION
- Uninstaller should be copied and not moved:
> The installer should not be moved outside of the directory as this
> kills consistency and makes clean up way harder if something with the uninstaller fails.
- Uninstaller return code should not be ignored
> The current installer does completely ignore if uninstalling failed this mostly will end up in installing fail.
> Checking if an uninstaller is present, its there on update, and expecting a return code of 0
would be sufficient.