### PR TITLE
Fix a verb tense typo

### DIFF
--- a/configuration/configuration.md
+++ b/configuration/configuration.md
@@ -126,7 +126,7 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 * <code id="Configuration-afterSign">afterSign</code> - The function (or path to file or module id) to be [run after pack and sign](#aftersign) (but before pack into distributable format).
 * <code id="Configuration-artifactBuildStarted">artifactBuildStarted</code> module:app-builder-lib/out/configuration.__type | String - The function (or path to file or module id) to be run on artifact build start.
 * <code id="Configuration-artifactBuildCompleted">artifactBuildCompleted</code> module:app-builder-lib/out/configuration.__type | String - The function (or path to file or module id) to be run on artifact build completed.
-* <code id="Configuration-afterAllArtifactBuild">afterAllArtifactBuild</code> - The function (or path to file or module id) to be [run after all artifacts are build](#afterAllArtifactBuild).
+* <code id="Configuration-afterAllArtifactBuild">afterAllArtifactBuild</code> - The function (or path to file or module id) to be [run after all artifacts are built](#afterAllArtifactBuild).
 * <code id="Configuration-onNodeModuleFile">onNodeModuleFile</code> - The function (or path to file or module id) to be [run on each node module](#onnodemodulefile) file.
 * <code id="Configuration-beforeBuild">beforeBuild</code> (context: BeforeBuildContext) => Promise | null - The function (or path to file or module id) to be run before dependencies are installed or rebuilt. Works when `npmRebuild` is set to `true`. Resolving to `false` will skip dependencies install or rebuild.
     

--- a/includes/hooks.md
+++ b/includes/hooks.md
@@ -49,7 +49,7 @@ Configuration in the same way as `afterPack` (see above).
 
 ### afterAllArtifactBuild
 
-The function (or path to file or module id) to be run after all artifacts are build.
+The function (or path to file or module id) to be run after all artifacts are built.
 
 ```typescript
 (buildResult: BuildResult): Promise<Array<string>> | Array<string>


### PR DESCRIPTION
* Fixes a typo in the docs. The wrong tense was used in the documentation.