### PR TITLE
fix(builder-util): Add debug types to dependencies

### DIFF
--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -11,6 +11,7 @@
     "out"
   ],
   "dependencies": {
+    "@types/debug": "^4.1.1",
     "app-builder-bin": "2.6.6",
     "temp-file": "^3.3.2",
     "fs-extra-p": "^7.0.1",


### PR DESCRIPTION
When using `electron-builder` with TypeScript and not having `@types/debug` locally installed, I get the following error when building:

```
./../node_modules/builder-util/out/util.d.ts:3:20 - error TS7016: Could not find a declaration file for module 'debug'.
'<omitted>/node_modules/builder-util/node_modules/debug/src/index.js' implicitly has an 'any' type.
  Try `npm install @types/debug` if it exists or add a new declaration (.d.ts) file containing `declare module 'debug';`
```