### PR TITLE
feat(appx): Add AppX option to show app name on tiles

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -269,6 +269,10 @@
                         "null",
                         "string"
                     ]
+                },
+                "showNameOnTiles": {
+                    "description": "Whether to overlay the app's name on top of tile images on the Start screen. Defaults to `false`. (https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-shownameontiles) in the dependencies.",
+                    "type": "boolean"
                 }
             },
             "title": "AppXOptions",

--- a/packages/app-builder-lib/src/options/AppXOptions.ts
+++ b/packages/app-builder-lib/src/options/AppXOptions.ts
@@ -47,6 +47,12 @@ export interface AppXOptions extends TargetSpecificOptions {
   readonly addAutoLaunchExtension?: boolean
 
   /**
+   * Whether to overlay the app's name on top of tile images on the Start screen. Defaults to `false`. (https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-shownameontiles) in the dependencies.
+   * @default false
+   */
+  readonly showNameOnTiles?: boolean
+
+  /**
    * @private
    * @default false
    */

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -226,7 +226,7 @@ export default class AppXTarget extends Target {
             return lockScreenTag(userAssets)
 
           case "defaultTile":
-            return defaultTileTag(userAssets)
+            return defaultTileTag(userAssets, options.showNameOnTiles || false)
 
           case "splashScreen":
             return splashScreenTag(userAssets)
@@ -303,7 +303,7 @@ function lockScreenTag(userAssets: Array<string>): string {
   }
 }
 
-function defaultTileTag(userAssets: Array<string>): string {
+function defaultTileTag(userAssets: Array<string>, showNameOnTiles: boolean): string {
   const defaultTiles: Array<string> = ["<uap:DefaultTile", 'Wide310x150Logo="assets\\Wide310x150Logo.png"']
 
   if (isDefaultAssetIncluded(userAssets, "LargeTile.png")) {
@@ -313,7 +313,16 @@ function defaultTileTag(userAssets: Array<string>): string {
     defaultTiles.push('Square71x71Logo="assets\\SmallTile.png"')
   }
 
-  defaultTiles.push("/>")
+  if (showNameOnTiles) {
+    defaultTiles.push(">")
+    defaultTiles.push("<uap:ShowNameOnTiles>")
+    defaultTiles.push("<uap:ShowOn", 'Tile="wide310x150Logo"', "/>")
+    defaultTiles.push("<uap:ShowOn", 'Tile="square150x150Logo"', "/>")
+    defaultTiles.push("</uap:ShowNameOnTiles>")
+    defaultTiles.push("</uap:DefaultTile>")
+  } else {
+    defaultTiles.push("/>")
+  }
   return defaultTiles.join(" ")
 }
 

--- a/test/out/__snapshots__/BuildTest.js.snap
+++ b/test/out/__snapshots__/BuildTest.js.snap
@@ -1234,7 +1234,7 @@ Object {
               "size": 2339,
             },
             "util.js": Object {
-              "size": 3007,
+              "size": 3034,
             },
           },
         },
@@ -1416,18 +1416,18 @@ Object {
               "files": Object {
                 "semver": Object {
                   "executable": true,
-                  "size": 4784,
+                  "size": 4418,
                 },
               },
             },
             "package.json": Object {
-              "size": 358,
+              "size": 407,
             },
             "range.bnf": Object {
               "size": 619,
             },
             "semver.js": Object {
-              "size": 37959,
+              "size": 38803,
             },
           },
         },


### PR DESCRIPTION
Adds option to show the app name on the tile images on the start menu. This will display the name on medium (Square150x150Logo) and wide (Wide310x150Logo) tiles.

Verified to be working on a dev build along with an app store submission.