### PR TITLE
fix(builder-util-runtime): temp-update file is not closed correctly when update is cancelled 

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -431,6 +431,7 @@ function configurePipes(options: DownloadCallOptions, response: IncomingMessage)
   let lastStream = response
   for (const stream of streams) {
     stream.on("error", (error: Error) => {
+      fileOut.close()
       if (!options.options.cancellationToken.cancelled) {
         options.callback(error)
       }
@@ -439,7 +440,7 @@ function configurePipes(options: DownloadCallOptions, response: IncomingMessage)
   }
 
   fileOut.on("finish", () => {
-    (fileOut.close as any)(options.callback)
+    fileOut.close()
   })
 }
 


### PR DESCRIPTION
temp-update file is not closed correctly when update is cancelled or an error has hanpened which makes this temp-update cannot be removed during the update process and causes `EPERM: operation not permitted ` error
#3681
