### PR TITLE
fix(electron-builder): Configuring yargs through package.json is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@types/semver": "^6.0.0",
     "@types/source-map-support": "^0.5.0",
     "@types/stat-mode": "^0.2.0",
-    "@types/yargs": "^12.0.11",
+    "@types/yargs": "^13.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-preset-ts-node6-bluebird": "^3.0.2",
     "convert-source-map": "^1.6.0",

--- a/packages/electron-builder/package.json
+++ b/packages/electron-builder/package.json
@@ -63,8 +63,5 @@
   "typings": "./out/index.d.ts",
   "publishConfig": {
     "tag": "next"
-  },
-  "yargs": {
-    "camel-case-expansion": false
   }
 }

--- a/packages/electron-builder/src/builder.ts
+++ b/packages/electron-builder/src/builder.ts
@@ -235,7 +235,7 @@ export function build(rawOptions?: CliOptions): Promise<Array<string>> {
 export function configureBuildCommand(yargs: yargs.Argv): yargs.Argv {
   const publishGroup = "Publishing:"
   const buildGroup = "Building:"
-  const deprecated = "Deprecated:";
+  const deprecated = "Deprecated:"
 
   return yargs
     .option("mac", {

--- a/packages/electron-builder/src/builder.ts
+++ b/packages/electron-builder/src/builder.ts
@@ -237,10 +237,6 @@ export function configureBuildCommand(yargs: yargs.Argv): yargs.Argv {
   const buildGroup = "Building:"
   const deprecated = "Deprecated:";
 
-  (yargs as any).parserConfiguration({
-    "camel-case-expansion": false,
-  })
-
   return yargs
     .option("mac", {
       group: buildGroup,

--- a/packages/electron-builder/src/cli/cli.ts
+++ b/packages/electron-builder/src/cli/cli.ts
@@ -17,6 +17,9 @@ import { start } from "./start"
 
 // tslint:disable:no-unused-expression
 yargs
+  .parserConfiguration({
+    "camel-case-expansion": false,
+  })
   .command(["build", "*"], "Build", configureBuildCommand, wrap(build))
   .command("install-app-deps", "Install app deps", configureInstallAppDepsCommand, wrap(installAppDeps))
   .command("node-gyp-rebuild", "Rebuild own native code", configureInstallAppDepsCommand /* yes, args the same as for install app deps */, wrap(rebuildAppNativeCode))

--- a/packages/electron-builder/src/cli/install-app-deps.ts
+++ b/packages/electron-builder/src/cli/install-app-deps.ts
@@ -19,6 +19,9 @@ export function configureInstallAppDepsCommand(yargs: yargs.Argv): yargs.Argv {
   // https://github.com/yargs/yargs/issues/760
   // demandOption is required to be set
   return yargs
+    .parserConfiguration({
+      "camel-case-expansion": false,
+    })
     .option("platform", {
       choices: ["linux", "darwin", "win32"],
       default: process.platform,

--- a/test/out/__snapshots__/BuildTest.js.snap
+++ b/test/out/__snapshots__/BuildTest.js.snap
@@ -1231,7 +1231,7 @@ Object {
               "size": 1079,
             },
             "rc.js": Object {
-              "size": 2339,
+              "size": 2477,
             },
             "util.js": Object {
               "size": 3034,

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -12,6 +12,7 @@ test("cli", async () => {
   // because these methods are internal
   const { configureBuildCommand, normalizeOptions } = require("electron-builder/out/builder")
   const yargs = require("yargs")
+  yargs.parserConfiguration({"camel-case-expansion": false})
   configureBuildCommand(yargs)
 
   function parse(input: string): any {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,10 +1212,22 @@
   resolved "https://registry.yarnpkg.com/@types/stat-mode/-/stat-mode-0.2.0.tgz#e16dd655f08d097865288eb8162654675b6510a9"
   integrity sha512-ievkTyQfkfckk+Bc4x4gk/WgEZYjGqwPrcgvwLGkEKLov626dnzoRm6SMMqZj9bM78vPrsg84QTzSGL2dCbp7Q==
 
-"@types/yargs@^12.0.11", "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
+"@types/yargs-parser@*":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
+  integrity sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==
+
+"@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.11"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.11.tgz#a090d88e1f40a910e6443c95493c1c035c76ebdc"
   integrity sha512-IsU1TD+8cQCyG76ZqxP0cVFnofvfzT8p/wO8ENT4jbN/KKN3grsHFgHNl/U+08s33ayX4LwI85cEhYXCOlOkMw==
+
+"@types/yargs@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.0.tgz#d2acb3bec0047d8f648ebacdab6b928a900c42c4"
+  integrity sha512-hY0o+kcz9M6kH32NUeb6VURghqMuCVkiUx+8Btsqhj4Hhov/hVGUx9DmBJeIkzlp1uAQK4wngQBCjqWdUUkFyA==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 abab@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Issue: #3751

1. remove `yargs` field from `package.json`.
2. upgrade `@types/yargs` for better type definitions.
3. move `parserConfiguration` to the entry point for every "cli".