### PR TITLE
feat(mac): Add option to enable hardened-runtime

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1847,6 +1847,11 @@
                     "description": "Whether a dark mode is supported. If your app does have a dark mode, you can make your app follow the system-wide dark mode setting.",
                     "type": "boolean"
                 },
+                "hardenedRuntime": {
+                    "default": false,
+                    "description": "Whether your app has to be signed with hardened runtime.",
+                    "type": "boolean"
+                },
                 "detectUpdateChannel": {
                     "default": true,
                     "description": "Whether to infer update channel from application version pre-release components. e.g. if version `0.12.1-alpha.1`, channel will be set to `alpha`. Otherwise to `latest`.",
@@ -2330,6 +2335,11 @@
                 "darkModeSupport": {
                     "default": false,
                     "description": "Whether a dark mode is supported. If your app does have a dark mode, you can make your app follow the system-wide dark mode setting.",
+                    "type": "boolean"
+                },
+                "hardenedRuntime": {
+                    "default": false,
+                    "description": "Whether your app has to be signed with hardened runtime.",
                     "type": "boolean"
                 },
                 "detectUpdateChannel": {

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -172,7 +172,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       keychain: keychainName || undefined,
       binaries: (isMas && masOptions != null ? masOptions.binaries : macOptions.binaries) || undefined,
       requirements: isMas || macOptions.requirements == null ? undefined : await this.getResource(macOptions.requirements),
-      "gatekeeper-assess": appleCertificatePrefixes.find(it => identity!.name.startsWith(it)) != null
+      "gatekeeper-assess": appleCertificatePrefixes.find(it => identity!.name.startsWith(it)) != null,
+      "hardened-runtime": macOptions.hardenedRuntime
     }
 
     await this.adjustSignOptions(signOptions, masOptions)

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -110,6 +110,12 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * Extra files to put in archive. Not applicable for `tar.*`.
    */
   readonly extraDistFiles?: Array<string> | string | null
+
+  /**
+   * Whether your app has to be signed with hardened runtime.
+   * @default: false
+   */
+  readonly hardenedRuntime?: boolean
 }
 
 export interface DmgOptions extends TargetSpecificOptions {

--- a/test/out/__snapshots__/BuildTest.js.snap
+++ b/test/out/__snapshots__/BuildTest.js.snap
@@ -1099,7 +1099,7 @@ Object {
               "size": 1069,
             },
             "index.js": Object {
-              "size": 4770,
+              "size": 4826,
             },
             "package.json": Object {
               "size": 524,
@@ -1231,7 +1231,7 @@ Object {
               "size": 1079,
             },
             "rc.js": Object {
-              "size": 2339,
+              "size": 2477,
             },
             "util.js": Object {
               "size": 3034,


### PR DESCRIPTION
This PR adds the option to enable the _hardened runtime_ option during code sign for Mac builds. 
The option is already supported by _electron-osx-sign_, so it's just a matter of passing the flag down. 

Hardened runtime is a requirement for app notarization.