### PR TITLE
fix: implement signApp function for macPackager

### DIFF
--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -1,9 +1,11 @@
+import BluebirdPromise from "bluebird-lst"
 import { deepAssign, Arch, AsyncTaskManager, exec, InvalidConfigurationError, log, use } from "builder-util"
 import { signAsync, SignOptions } from "electron-osx-sign"
 import { ensureDir } from "fs-extra-p"
 import { Lazy } from "lazy-val"
 import * as path from "path"
 import { copyFile, unlinkIfExists } from "builder-util/out/fs"
+import { orIfFileNotExist } from "builder-util/out/promise"
 import { AppInfo } from "./appInfo"
 import { appleCertificatePrefixes, CertType, CodeSigningInfo, createKeychain, findIdentity, Identity, isSignAllowed, reportError } from "./codeSign/macCodeSign"
 import { DIR_TARGET, Platform, Target } from "./core"
@@ -86,7 +88,6 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     if (!hasMas || targets.length > 1) {
       const appPath = prepackaged == null ? path.join(this.computeAppOutDir(outDir, arch), `${this.appInfo.productFilename}.app`) : prepackaged
       nonMasPromise = (prepackaged ? Promise.resolve() : this.doPack(outDir, path.dirname(appPath), this.platform.nodeName as ElectronPlatformName, arch, this.platformSpecificBuildOptions, targets))
-        .then(() => this.sign(appPath, null, null))
         .then(() => this.packageInDistributableFormat(appPath, Arch.x64, targets, taskManager))
     }
 
@@ -304,6 +305,34 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     if (extendInfo != null) {
       Object.assign(appPlist, extendInfo)
     }
+  }
+  
+  protected async signApp(packContext: AfterPackContext, isAsar: boolean): Promise<any> {
+    const appFileName = `${this.appInfo.productFilename}.app`
+    if (this.platformSpecificBuildOptions.signAndEditExecutable === false) {
+      return
+    }
+
+    await BluebirdPromise.map(readdir(packContext.appOutDir), (file: string): any => {
+      if (file === appFileName) {
+        return this.sign(path.join(packContext.appOutDir, file))
+      }
+      return null
+    })
+
+    if (!isAsar) {
+      return
+    }
+
+    const outResourcesDir = path.join(packContext.appOutDir, "resources", "app.asar.unpacked")
+    await BluebirdPromise.map(orIfFileNotExist(readdir(outResourcesDir), []), (file: string): any => {
+      if (file.endsWith(".app")) {
+        return this.sign(path.join(outResourcesDir, file))
+      }
+      else {
+        return null
+      }
+    })
   }
 }
 


### PR DESCRIPTION
As per #3504, afterSign was called before the sign function was called on mac. I tracked this down to a logic error where signApp wasn't implemented for macPackager and thus immediately resolved. Mac then called the sign function directly, leading to the incorrect behaviour.

I was able to successfully build with this, and have the afterSign function called at the right time, with the changes below. I'm however not familiar with typescript (or electron-builders code standards) so likely I'll need to make some changes. This can serve as a first setup.