### PR TITLE
Adding ‘sign’ dmg option to scheme.json to fix build errors

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -804,7 +804,7 @@
                     "description": "The DMG windows position and size."
                 },
                 "sign": {
-                    "default": true,
+                    "default": false,
                     "description": "Disable signing of the DMG when building. This can help solve issues with Gatekeeper disabling installation of your app.",
                     "type": "boolean"
                 }

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -802,6 +802,11 @@
                 "window": {
                     "$ref": "#/definitions/DmgWindow",
                     "description": "The DMG windows position and size."
+                },
+                "sign": {
+                    "default": true,
+                    "description": "Disable signing of the DMG when building. This can help solve issues with Gatekeeper disabling installation of your app.",
+                    "type": "boolean"
                 }
             },
             "title": "DmgOptions",


### PR DESCRIPTION
This solves a build issue with the 'sign' dmg configuration mentioned in #3870