### PR TITLE
fix: allow $schema property in electron-builder.json

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4964,6 +4964,13 @@
     },
     "description": "Configuration Options",
     "properties": {
+        "$schema": {
+            "description": "JSON Schema for this document.",
+            "type": [
+                "null",
+                "string"
+            ]
+        },
         "afterAllArtifactBuild": {
             "anyOf": [
                 {


### PR DESCRIPTION
It should be allowed to include $schema property in JSON file.

Issue: #3962