### PR TITLE
fix(app-builder-lib): use DigiCert timestamp server as default

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4945,7 +4945,7 @@
                     "description": "The target package type: list of `nsis`, `nsis-web` (Web installer), `portable` ([portable](/configuration/nsis#portable) app without installation), `appx`, `msi`, `squirrel`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`.\nAppX package can be built only on Windows 10.\n\nTo use Squirrel.Windows please install `electron-builder-squirrel-windows` dependency."
                 },
                 "timeStampServer": {
-                    "default": "http://timestamp.verisign.com/scripts/timstamp.dll",
+                    "default": "http://timestamp.digicert.com",
                     "description": "The URL of the time stamp server.",
                     "type": [
                         "null",
@@ -5720,4 +5720,3 @@
     },
     "type": "object"
 }
-

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -199,7 +199,7 @@ function computeSignToolArgs(options: WindowsSignTaskConfiguration, isWin: boole
   const args = isWin ? ["sign"] : ["-in", inputFile, "-out", outputPath]
 
   if (process.env.ELECTRON_BUILDER_OFFLINE !== "true") {
-    const timestampingServiceUrl = options.options.timeStampServer || "http://timestamp.verisign.com/scripts/timstamp.dll"
+    const timestampingServiceUrl = options.options.timeStampServer || "http://timestamp.digicert.com"
     if (isWin) {
       args.push(options.isNest || options.hash === "sha256" ? "/tr" : "/t", options.isNest || options.hash === "sha256" ? (options.options.rfc3161TimeStampServer || "http://timestamp.comodoca.com/rfc3161") : timestampingServiceUrl)
     }

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -61,7 +61,7 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   readonly rfc3161TimeStampServer?: string | null
   /**
    * The URL of the time stamp server.
-   * @default http://timestamp.verisign.com/scripts/timstamp.dll
+   * @default http://timestamp.digicert.com
    */
   readonly timeStampServer?: string | null
 


### PR DESCRIPTION
Switches default timestamp server from `http://timestamp.verisign.com/scripts/timstamp.dll` to `http://timestamp.digicert.com`. After asking DigiCert support if the VeriSign server was down because I was having issues at the time, I was told that it will be deprecated soon. They (and their [docs](https://www.digicert.com/code-signing/signcode-signtool-command-line.htm)) recommend using the new DigiCert server.