### PR TITLE
Improve DMG icon coordinates documentation

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -650,9 +650,11 @@
                     "type": "string"
                 },
                 "x": {
+                    "description": "The device-independent pixel offset from the left of the window to the **center** of the icon.",
                     "type": "number"
                 },
                 "y": {
+                    "description": "The device-independent pixel offset from the top of the window to the **center** of the icon.",
                     "type": "number"
                 }
             },
@@ -688,7 +690,7 @@
                     ]
                 },
                 "contents": {
-                    "description": "The content — to customize icon locations.",
+                    "description": "The content — to customize icon locations. The x and y coordinates refer to the position of the **center** of the icon (at 1x scale), and do not take the label into account.",
                     "items": {
                         "$ref": "#/definitions/DmgContent"
                     },


### PR DESCRIPTION
When configuring the coordinates of icons in a DMG, I had a hard time figuring out how the X and Y values actually related to the output I was seeing. I had to do quite a bit of searching to find [this documentation](https://metacpan.org/pod/distribution/Mac-Finder-DSStore/DSStoreFormat.pod) (emphasis mine):

> `'Iloc'`
>
> 16-byte blob, attached to files and directories. The file's icon location. Two 4-byte values **representing the horizontal and vertical positions of the icon's center (not top-left)**. (Then, 6 bytes 0xff and 2 bytes 0?) For the purposes of the center, the **icon only is taken into account, not any label**. The icon's size comes from the icvo blob.

In this PR, I've distilled the information and added it to the DMG configuration schema that drives the relevant documentation.