### PR TITLE
fix(electron-updater): update from prerelease to prerelease crash

### DIFF
--- a/packages/electron-updater/src/providers/PrivateGitHubProvider.ts
+++ b/packages/electron-updater/src/providers/PrivateGitHubProvider.ts
@@ -73,7 +73,7 @@ export class PrivateGitHubProvider extends BaseGitHubProvider<PrivateGitHubUpdat
     try {
       let version = (JSON.parse((await this.httpRequest(url, this.configureHeaders("application/vnd.github.v3+json"), cancellationToken))!!))
       if (allowPrerelease) {
-        version = version.find((v: any) => v.prerelease)
+        version = version.find((v: any) => v.prerelease) || version[0]
       }
       return version
     }


### PR DESCRIPTION
Updater is checking current app version, and if it contains alfa or beta etc., allowPrerelease became true.
If no one update contains prerelease github flag – app crashes.
If next release (sorted by semver) contains prerelease flag – then if will be installed, but I can't see how to exit from prerelease circle using current implementation.

closes: https://github.com/electron-userland/electron-builder/issues/3163