### PR TITLE
corrected path for binary in package

### DIFF
--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Link to the binary
-ln -sf '/opt/${productFilename}/${executable}' '/usr/local/bin/${executable}'
+ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'

--- a/packages/app-builder-lib/templates/linux/after-remove.tpl
+++ b/packages/app-builder-lib/templates/linux/after-remove.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Delete the link to the binary
-rm -f '/usr/local/bin/${executable}'
+rm -f '/usr/bin/${executable}'


### PR DESCRIPTION
Debian packages should place binaries in /usr/bin rather than /usr/local/bin see [this](https://www.debian.org/doc/manuals/maint-guide/modify.en.html#destdir) for details