### PR TITLE
Fix-[#4068]:NSIS Uninstaller registry entry format change

### DIFF
--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -167,7 +167,7 @@ export class NsisTarget extends Target {
       APP_PACKAGE_NAME: appInfo.name
     }
     if (uninstallAppKey !== guid) {
-      defines.UNINSTALL_REGISTRY_KEY_2 = `Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${guid}`
+      defines.UNINSTALL_REGISTRY_KEY_2 = `Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{${guid}}`
     }
 
     const commands: any = {

--- a/packages/app-builder-lib/templates/nsis/multiUser.nsh
+++ b/packages/app-builder-lib/templates/nsis/multiUser.nsh
@@ -6,7 +6,7 @@
 
 # allow user to define own custom
 !define /ifndef INSTALL_REGISTRY_KEY "Software\${APP_GUID}"
-!define /ifndef UNINSTALL_REGISTRY_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${UNINSTALL_APP_KEY}"
+!define /ifndef UNINSTALL_REGISTRY_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\{${UNINSTALL_APP_KEY}}"
 
 # current Install Mode ("all" or "CurrentUser")
 Var installMode


### PR DESCRIPTION
1) In windows Registry entry for uninstaller is located at this path 
`Software\Microsoft\Windows\CurrentVersion\Uninstall\` with just the guid as Example: `\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\ddd366r9-367b-5d51-b552-9754365` but the convention to store the key with id in registry is `\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\\{ddd366r9-367b-5d51-b552-9754365}`.

