### PR TITLE
Fix bug that generates additional </mime-info> closing tag in mime type xml file

### DIFF
--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -36,8 +36,7 @@ export class LinuxTargetHelper {
   <glob pattern="*.${fileAssociation.ext}"/>
     ${fileAssociation.description ? `<comment>${fileAssociation.description}</comment>` : ""}
   <icon name="x-office-document" />
-  </mime-type>
-</mime-info>`
+  </mime-type>`
       items.push(data)
     }
 


### PR DESCRIPTION
The following error occurs when I try to install a .deb file.

> ```none
> Processing triggers for shared-mime-info (1.9-2) ...
> /usr/share/mime/packages/my-app.xml:9: parser error : Extra content at the end of the document
> </mime-info>
> ^
> Failed to parse '/usr/share/mime/packages/my-app.xml'
> ```

When I look into the generated xml file for the mime type there are multiple </mime-info> closing tags. This PR fixes that issue.