### PR TITLE
fix electron-forge-maker-appimage

### DIFF
--- a/packages/electron-forge-maker-appimage/.gitignore
+++ b/packages/electron-forge-maker-appimage/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/packages/electron-forge-maker-appimage/main.js
+++ b/packages/electron-forge-maker-appimage/main.js
@@ -5,10 +5,10 @@ Object.defineProperty(exports, '__esModule', {
 });
 
 const buildForge = require('app-builder-lib').buildForge;
-const Target = require('app-builder-lib').Target;
+const MakerBase = require('@electron-forge/maker-base').default;
 const platform = require('os').platform;
 
-class MakerAppImage extends Target {
+class MakerAppImage extends MakerBase {
   constructor(configFetcher, providedPlatforms) {
     super(configFetcher, providedPlatforms);
     this.name = 'AppImage';
@@ -19,19 +19,6 @@ class MakerAppImage extends Target {
   }
   make(options) {
     return buildForge(options, { linux: [`appimage:${options.targetArch}`] });
-  }
-
-  get platforms() {
-    if (this.providedPlatforms) return this.providedPlatforms;
-    return this.defaultPlatforms;
-  }
-
-  prepareConfig(targetArch) {
-    if (typeof this.configFetcher === 'function') {
-      this.config = this.configFetcher(targetArch);
-    } else {
-      this.config = this.configFetcher;
-    }
   }
 }
 exports.default = MakerAppImage;

--- a/packages/electron-forge-maker-appimage/main.js
+++ b/packages/electron-forge-maker-appimage/main.js
@@ -1,13 +1,37 @@
-"use strict"
+'use strict';
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-})
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
 
-const buildForge = require("app-builder-lib").buildForge
+const buildForge = require('app-builder-lib').buildForge;
+const Target = require('app-builder-lib').Target;
+const platform = require('os').platform;
 
-exports.isSupportedOnCurrentPlatform = () => Promise.resolve(true)
+class MakerAppImage extends Target {
+  constructor(configFetcher, providedPlatforms) {
+    super(configFetcher, providedPlatforms);
+    this.name = 'AppImage';
+    this.defaultPlatforms = ['linux'];
+  }
+  isSupportedOnCurrentPlatform() {
+    return platform() === 'linux';
+  }
+  make(options) {
+    return buildForge(options, { linux: [`appimage:${options.targetArch}`] });
+  }
 
-exports.default = function (options) {
-  return buildForge(options, {linux: [`appimage:${options.targetArch}`]})
+  get platforms() {
+    if (this.providedPlatforms) return this.providedPlatforms;
+    return this.defaultPlatforms;
+  }
+
+  prepareConfig(targetArch) {
+    if (typeof this.configFetcher === 'function') {
+      this.config = this.configFetcher(targetArch);
+    } else {
+      this.config = this.configFetcher;
+    }
+  }
 }
+exports.default = MakerAppImage;

--- a/packages/electron-forge-maker-appimage/package.json
+++ b/packages/electron-forge-maker-appimage/package.json
@@ -11,6 +11,7 @@
     "*.js"
   ],
   "dependencies": {
+    "@electron-forge/maker-base": "^6.0.0-beta.43",
     "app-builder-lib": "^0.0.0-semantic-release"
   }
 }


### PR DESCRIPTION
AppImage does not seem to work from Electron Forge. issue here:
https://github.com/electron-userland/electron-forge/issues/26

The problem seems to be that the 'electron-forge-maker-appimage' package exports a function, when electron-forge expects a class that implements a specific interface. Details in the issue link above.

I'm not sure if this is the best way to solve this. In the electron-builder repository, all four of the 'electron-forge-maker-* targets are implemented in the same way.

The right solution might be to leave this as-is, and implement this class in the electron-forge repository in this directory:
https://github.com/electron-userland/electron-forge/tree/master/packages/maker

Another possible solution would be to keep this class out of both repositories, and maintain it in a separate repository entirely.

Feedback welcome.