### PR TITLE
fix(app-builder-lib): yarn install break on 'electron-builder install-app-deps' when used pnp

### DIFF
--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -12,8 +12,17 @@ export async function installOrRebuild(config: Configuration, appDir: string, op
     buildFromSource: config.buildDependenciesFromSource === true,
     additionalArgs: asArray(config.npmArgs), ...options
   }
+  let isDependenciesInstalled = false
 
-  if (forceInstall || !(await pathExists(path.join(appDir, "node_modules")))) {
+  for (const fileOrDir of ["node_modules", ".pnp.js"]) {
+    if (await pathExists(path.join(appDir, fileOrDir))) {
+      isDependenciesInstalled = true
+
+      break
+    }
+  }
+
+  if (forceInstall || !isDependenciesInstalled) {
     await installDependencies(appDir, effectiveOptions)
   }
   else {


### PR DESCRIPTION
I use yarn with enabled [plug’n’play](https://yarnpkg.com/en/docs/pnp) option, it means that *node_modules* directory doesn't exist instead used *.php.js* file.

https://github.com/electron-userland/electron-builder/blob/ebbd9f796e2d8d5b0720b2b699ba24dc159ee692/packages/app-builder-lib/src/util/yarn.ts#L16-L18

File contains a path resolver and mapping to dependencies paths (include devDependencies). When electron-builder calls **installDependencies** then *.php.js* file will be overwritten (without devDependencies) that break process because builder needs in devDependencies on runtime.
https://github.com/electron-userland/electron-builder/blob/ebbd9f796e2d8d5b0720b2b699ba24dc159ee692/packages/app-builder-lib/src/util/yarn.ts#L75
