### PR TITLE
fix(deb): chmod SUID bit on chrome-sandbox for debs

### DIFF
--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -3,5 +3,8 @@
 # Link to the binary
 ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'
 
+# SUID chrome-sandbox for Electron 5+
+chmod 4755 '/opt/${productFilename}/chrome-sandbox' || true
+
 update-mime-database /usr/share/mime || true
 update-desktop-database /usr/share/applications || true


### PR DESCRIPTION
Add SUID bit to packaged `chrome-sandbox` so that it works out of the box on
distros like Debian.

Part of https://github.com/electron-userland/electron-builder/issues/3872