### PR TITLE
Adding 10% on size for temporary dmg used in hdiutil 

### DIFF
--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -38,7 +38,7 @@ export class DmgTarget extends Target {
     // https://github.com/electron-userland/electron-builder/issues/2115
     const backgroundFile = specification.background == null ? null : await transformBackgroundFileIfNeed(specification.background, packager.info.tempDirManager)
     const finalSize = await computeAssetSize(packager.info.cancellationToken, tempDmg, specification, backgroundFile)
-    const expandingFinalSize = (finalSize * 0.1) + finalSize;
+    const expandingFinalSize = (finalSize * 0.1) + finalSize
     await exec("hdiutil", ["resize", "-size", expandingFinalSize.toString(), tempDmg])
 
     const volumePath = path.join("/Volumes", volumeName)

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -38,7 +38,8 @@ export class DmgTarget extends Target {
     // https://github.com/electron-userland/electron-builder/issues/2115
     const backgroundFile = specification.background == null ? null : await transformBackgroundFileIfNeed(specification.background, packager.info.tempDirManager)
     const finalSize = await computeAssetSize(packager.info.cancellationToken, tempDmg, specification, backgroundFile)
-    await exec("hdiutil", ["resize", "-size", finalSize.toString(), tempDmg])
+    const expandingFinalSize = (finalSize * 0.1) + finalSize;
+    await exec("hdiutil", ["resize", "-size", expandingFinalSize.toString(), tempDmg])
 
     const volumePath = path.join("/Volumes", volumeName)
     if (await exists(volumePath)) {


### PR DESCRIPTION
Upon signing and notarization electron-builder is expanding application more than allocated size in method `computeAssetSize` which is located under: 

```
packages/dmg-builder/src/dmg.ts
```

This fix is adding 10% of additional size on temporary dmg. This fix closes #3301 among other tasks which 'no space left on device'.

