### PR TITLE
Changed the Quick Setup Guide to include the target platform in the exemple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ See documentation on [electron.build](https://www.electron.build).
     ```json
     "scripts": {
       "pack": "electron-builder --dir",
-      "dist": "electron-builder"
+      "dist": "electron-builder -m" 
     }
     ```
+    Change the `-m` to select the [Target](https://www.electron.build/cli#target) platform. If you supress the target, it will build for your current OS.
+
     Then you can run `yarn dist` (to package in a distributable format (e.g. dmg, windows installer, deb package)) or `yarn pack` (only generates the package directory without really packaging it. This is useful for testing purposes).
 
     To ensure your native dependencies are always matched electron version, simply add script `"postinstall": "electron-builder install-app-deps"` to your `package.json`.


### PR DESCRIPTION
Fixes #4180 