### PR TITLE
fix(electron-publish): Allow GH integration tokens

### DIFF
--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -264,7 +264,7 @@ export function isEmptyOrSpaces(s: string | null | undefined): s is "" | null | 
 }
 
 export function isTokenCharValid(token: string) {
-  return /^[\w\/=+-]+$/.test(token)
+  return /^[.\w\/=+-]+$/.test(token)
 }
 
 export function addValue<K, T>(map: Map<K, Array<T>>, key: K, value: T) {


### PR DESCRIPTION
Fixes #4176

"Integration" tokens, at least those created for GitHub Actions, are formatted as `v1.<40-char token>`, which doesn't pass this regex test and causes the publish to fail.