### PR TITLE
fix(nsis): Windows on ARM support

### DIFF
--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -232,7 +232,7 @@ export default class AppXTarget extends Target {
             return splashScreenTag(userAssets)
 
           case "arch":
-            return arch === Arch.ia32 ? "x86" : "x64"
+            return arch === Arch.ia32 ? "x86" : (arch === Arch.arm64 ? "arm64" : "x64")
 
           case "resourceLanguages":
             return resourceLanguageTag(asArray(options.languages))

--- a/packages/app-builder-lib/src/targets/MsiTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiTarget.ts
@@ -75,7 +75,7 @@ export default class MsiTarget extends Target {
 
     // noinspection SpellCheckingInspection
     const candleArgs = [
-      "-arch", arch === Arch.ia32 ? "x86" : (arch === Arch.armv7l ? "arm" : "x64"),
+      "-arch", arch === Arch.ia32 ? "x86" : (arch === Arch.arm64 ? "arm64" : "x64"),
       `-dappDir=${vm.toVmFile(appOutDir)}`,
     ].concat(this.getCommonWixArgs())
     candleArgs.push("project.wxs")

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -193,7 +193,7 @@ export class NsisTarget extends Target {
     let estimatedSize = 0
     if (this.isPortable && options.useZip) {
       for (const [arch, dir] of this.archs.entries()) {
-        defines[arch === Arch.x64 ? "APP_DIR_64" : "APP_DIR_32"] = dir
+        defines[arch === Arch.x64 ? "APP_DIR_64" : (arch === Arch.arm64 ? "APP_DIR_ARM64" : "APP_DIR_32")] = dir
       }
     }
     else if (USE_NSIS_BUILT_IN_COMPRESSOR && this.archs.size === 1) {
@@ -203,7 +203,7 @@ export class NsisTarget extends Target {
       await BluebirdPromise.map(this.archs.keys(), async arch => {
         const fileInfo = await this.packageHelper.packArch(arch, this)
         const file = fileInfo.path
-        const defineKey = arch === Arch.x64 ? "APP_64" : "APP_32"
+        const defineKey = arch === Arch.x64 ? "APP_64" : (Arch.arm64 ? "APP_ARM64" : "APP_32")
         defines[defineKey] = file
         defines[`${defineKey}_NAME`] = path.basename(file)
         // nsis expect a hexadecimal string

--- a/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -17,7 +17,7 @@ export const NSIS_PATH = new Lazy(() => {
     return Promise.resolve(custom.trim())
   }
   // noinspection SpellCheckingInspection
-  return getBinFromUrl("nsis", "3.0.3.2", "tUrlDPQtbjcooNbTrjUzLupttWlATLDNWqK57TVr+gAt3wkaxFxBS3k80AzEFJbmSeOWrUooO72FFOVGXcoxhA==")
+  return getBinFromUrl("nsis", "3.0.4", "FVF4HClUCsTZ32vYOIC7rTo1qb2pvt2nZwzb86MbKbORukMH0rS3SGBYg/MHmT58PqvRCSlEFai6impEYDYp2Q==")
 })
 
 export class AppPackageHelper {

--- a/packages/app-builder-lib/templates/nsis/common.nsh
+++ b/packages/app-builder-lib/templates/nsis/common.nsh
@@ -23,15 +23,24 @@ Name "${PRODUCT_NAME}"
     Quit
   ${EndIf}
 
-  !ifdef APP_64
+  !ifdef APP_ARM64
     ${If} ${RunningX64}
       SetRegView 64
-    ${Else}
-      !ifndef APP_32
-        MessageBox MB_OK|MB_ICONEXCLAMATION "$(x64WinRequired)"
-        Quit
-      !endif
     ${EndIf}
+    ${If} ${IsNativeARM64}
+      SetRegView 64
+    ${EndIf}
+  !else
+    !ifdef APP_64
+      ${If} ${RunningX64}
+        SetRegView 64
+      ${Else}
+        !ifndef APP_32
+          MessageBox MB_OK|MB_ICONEXCLAMATION "$(x64WinRequired)"
+          Quit
+        !endif
+      ${EndIf}
+    !endif
   !endif
 !macroend
 

--- a/packages/app-builder-lib/templates/nsis/common.nsh
+++ b/packages/app-builder-lib/templates/nsis/common.nsh
@@ -27,7 +27,7 @@ Name "${PRODUCT_NAME}"
     ${If} ${RunningX64}
       SetRegView 64
     ${EndIf}
-    ${If} ${IsNativeARM64} == true
+    ${If} ${IsNativeARM64}
       SetRegView 64
     ${EndIf}
   !else

--- a/packages/app-builder-lib/templates/nsis/common.nsh
+++ b/packages/app-builder-lib/templates/nsis/common.nsh
@@ -27,7 +27,7 @@ Name "${PRODUCT_NAME}"
     ${If} ${RunningX64}
       SetRegView 64
     ${EndIf}
-    ${If} ${IsNativeARM64}
+    ${If} ${IsNativeARM64} == true
       SetRegView 64
     ${EndIf}
   !else

--- a/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
@@ -6,13 +6,19 @@
   Var /GLOBAL packageArch
 
   !ifdef APP_64
+  	!ifdef APP_ARM64
+    StrCpy $packageArch "ARM64"
+	!else
     StrCpy $packageArch "64"
+	!endif
 
     !ifdef APP_32
-      ${if} ${RunningX64}
-        !insertmacro x64_app_files
+      ${if} ${IsNativeARM64}
+    !insertmacro arm64_app_files
+      ${elseif} ${IsNativeAMD64}
+    !insertmacro x64_app_files
       ${else}
-        !insertmacro ia32_app_files
+    !insertmacro ia32_app_files
       ${endIf}
     !else
       !insertmacro x64_app_files
@@ -32,7 +38,11 @@
   !endif
 
   # after decompression
-  ${if} $packageArch == "64"
+  ${if} $packageArch == "ARM64"
+    !ifmacrodef customFiles_arm64
+      !insertmacro customFiles_arm64
+    !endif
+  ${elseif} $packageArch == "64"
     !ifmacrodef customFiles_x64
       !insertmacro customFiles_x64
     !endif
@@ -41,6 +51,10 @@
       !insertmacro customFiles_ia32
     !endif
   ${endIf}
+!macroend
+
+!macro arm64_app_files
+  File /oname=$PLUGINSDIR\app-arm64.${COMPRESSION_METHOD} "${APP_ARM64}"
 !macroend
 
 !macro x64_app_files

--- a/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
@@ -12,19 +12,26 @@
     StrCpy $packageArch "64"
 	!endif
 
-    !ifdef APP_32
-      ${if} ${IsNativeARM64}
-    !insertmacro arm64_app_files
-      ${elseif} ${IsNativeAMD64}
-    !insertmacro x64_app_files
+  !ifdef APP_32
+    !ifdef APP_ARM64
+      ${if} ${IsNativeARM64} == true
+      !insertmacro arm64_app_files
+      ${elseif} ${IsNativeAMD64} == true
+      !insertmacro x64_app_files
       ${else}
-    !insertmacro ia32_app_files
+      !insertmacro ia32_app_files
       ${endIf}
     !else
-      !insertmacro x64_app_files
+      ${if} ${RunningX64} == true
+        !ifdef APP_32
+          !insertmacro x64_app_files
+        !endif
+      ${else}
+        !insertmacro ia32_app_files
+      ${endIf}
     !endif
   !else
-    !insertmacro ia32_app_files
+    !insertmacro x64_app_files
   !endif
 
   !ifdef COMPRESS

--- a/packages/app-builder-lib/templates/nsis/include/installer.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installer.nsh
@@ -18,13 +18,26 @@
       ${if} $packageFile == ""
         !ifdef APP_64_NAME
           !ifdef APP_32_NAME
-            ${if} ${RunningX64}
-              StrCpy $packageFile "${APP_64_NAME}"
-              StrCpy $1 "${APP_64_HASH}"
-            ${else}
-              StrCpy $packageFile "${APP_32_NAME}"
-              StrCpy $1 "${APP_32_HASH}"
-            ${endif}
+		  	!ifdef APP_ARM64_NAME
+				${if} ${IsNativeARM64}
+				  StrCpy $packageFile "${APP_ARM64_NAME}"
+				  StrCpy $1 "${APP_ARM64_HASH}"
+				${elseif} ${IsNativeAMD64}
+				  StrCpy $packageFile "${APP_64_NAME}"
+				  StrCpy $1 "${APP_64_HASH}"
+				${else}
+				  StrCpy $packageFile "${APP_32_NAME}"
+				  StrCpy $1 "${APP_32_HASH}"
+				${endif}
+			!else
+	            ${if} ${RunningX64}
+	              StrCpy $packageFile "${APP_64_NAME}"
+	              StrCpy $1 "${APP_64_HASH}"
+	            ${else}
+	              StrCpy $packageFile "${APP_32_NAME}"
+	              StrCpy $1 "${APP_32_HASH}"
+	            ${endif}
+			!endif
           !else
             StrCpy $packageFile "${APP_64_NAME}"
             StrCpy $1 "${APP_64_HASH}"

--- a/packages/app-builder-lib/templates/nsis/include/installer.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installer.nsh
@@ -18,26 +18,26 @@
       ${if} $packageFile == ""
         !ifdef APP_64_NAME
           !ifdef APP_32_NAME
-		  	!ifdef APP_ARM64_NAME
-				${if} ${IsNativeARM64}
-				  StrCpy $packageFile "${APP_ARM64_NAME}"
-				  StrCpy $1 "${APP_ARM64_HASH}"
-				${elseif} ${IsNativeAMD64}
-				  StrCpy $packageFile "${APP_64_NAME}"
-				  StrCpy $1 "${APP_64_HASH}"
-				${else}
-				  StrCpy $packageFile "${APP_32_NAME}"
-				  StrCpy $1 "${APP_32_HASH}"
-				${endif}
-			!else
-	            ${if} ${RunningX64}
-	              StrCpy $packageFile "${APP_64_NAME}"
-	              StrCpy $1 "${APP_64_HASH}"
-	            ${else}
-	              StrCpy $packageFile "${APP_32_NAME}"
-	              StrCpy $1 "${APP_32_HASH}"
-	            ${endif}
-			!endif
+            !ifdef APP_ARM64_NAME
+              ${if} ${IsNativeARM64} == true
+                StrCpy $packageFile "${APP_ARM64_NAME}"
+                StrCpy $1 "${APP_ARM64_HASH}"
+              ${elseif} ${IsNativeAMD64} == true
+                StrCpy $packageFile "${APP_64_NAME}"
+                StrCpy $1 "${APP_64_HASH}"
+              ${else}
+                StrCpy $packageFile "${APP_32_NAME}"
+                StrCpy $1 "${APP_32_HASH}"
+              ${endif}
+            !else
+              ${if} ${RunningX64}
+                StrCpy $packageFile "${APP_64_NAME}"
+                StrCpy $1 "${APP_64_HASH}"
+              ${else}
+                StrCpy $packageFile "${APP_32_NAME}"
+                StrCpy $1 "${APP_32_HASH}"
+              ${endif}
+            !endif
           !else
             StrCpy $packageFile "${APP_64_NAME}"
             StrCpy $1 "${APP_64_HASH}"
@@ -101,20 +101,20 @@
 !macroend
 
 !macro registryAddInstallInfo
-	WriteRegStr SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}" InstallLocation "$INSTDIR"
-	WriteRegStr SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}" KeepShortcuts "true"
+  WriteRegStr SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}" InstallLocation "$INSTDIR"
+  WriteRegStr SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}" KeepShortcuts "true"
   WriteRegStr SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}" ShortcutName "${SHORTCUT_NAME}"
   !ifdef MENU_FILENAME
     WriteRegStr SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}" MenuDirectory "${MENU_FILENAME}"
   !endif
 
-	${if} $installMode == "all"
-		StrCpy $0 "/allusers"
-		StrCpy $1 ""
-	${else}
-		StrCpy $0 "/currentuser"
-		StrCpy $1 ""
-	${endIf}
+  ${if} $installMode == "all"
+    StrCpy $0 "/allusers"
+    StrCpy $1 ""
+  ${else}
+    StrCpy $0 "/currentuser"
+    StrCpy $1 ""
+  ${endIf}
 
   WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" DisplayName "${UNINSTALL_DISPLAY_NAME}$1"
   # https://github.com/electron-userland/electron-builder/issues/750
@@ -122,18 +122,19 @@
   WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" UninstallString '"$2" $0'
   WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" QuietUninstallString '"$2" $0 /S'
 
-	WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "DisplayVersion" "${VERSION}"
-	!ifdef UNINSTALLER_ICON
-	  WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "DisplayIcon" "$INSTDIR\uninstallerIcon.ico"
-	!else
-	  WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "DisplayIcon" "$appExe,0"
-	!endif
+  WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "DisplayVersion" "${VERSION}"
+  !ifdef UNINSTALLER_ICON
+    WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "DisplayIcon" "$INSTDIR\uninstallerIcon.ico"
+  !else
+    WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "DisplayIcon" "$appExe,0"
+  !endif
 
   !ifdef COMPANY_NAME
-	  WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "Publisher" "${COMPANY_NAME}"
-	!endif
-	WriteRegDWORD SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" NoModify 1
-	WriteRegDWORD SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" NoRepair 1
+    WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "Publisher" "${COMPANY_NAME}"
+  !endif
+
+  WriteRegDWORD SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" NoModify 1
+  WriteRegDWORD SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" NoRepair 1
 
   # allow user to define ESTIMATED_SIZE to avoid GetSize call
   !ifdef ESTIMATED_SIZE
@@ -142,7 +143,8 @@
     ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
     IntFmt $0 "0x%08X" $0
   !endif
-	WriteRegDWORD SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "EstimatedSize" "$0"
+  
+  WriteRegDWORD SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "EstimatedSize" "$0"
 !macroend
 
 !macro cleanupOldMenuDirectory

--- a/packages/app-builder-lib/templates/nsis/include/installer.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installer.nsh
@@ -19,10 +19,10 @@
         !ifdef APP_64_NAME
           !ifdef APP_32_NAME
             !ifdef APP_ARM64_NAME
-              ${if} ${IsNativeARM64} == true
+              ${if} ${IsNativeARM64}
                 StrCpy $packageFile "${APP_ARM64_NAME}"
                 StrCpy $1 "${APP_ARM64_HASH}"
-              ${elseif} ${IsNativeAMD64} == true
+              ${elseif} ${IsNativeAMD64}
                 StrCpy $packageFile "${APP_64_NAME}"
                 StrCpy $1 "${APP_64_HASH}"
               ${else}
@@ -143,7 +143,7 @@
     ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
     IntFmt $0 "0x%08X" $0
   !endif
-  
+
   WriteRegDWORD SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "EstimatedSize" "$0"
 !macroend
 

--- a/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
@@ -8,11 +8,21 @@
   !ifdef APP_PACKAGE_URL_IS_INCOMLETE
     !ifdef APP_64_NAME
       !ifdef APP_32_NAME
-        ${if} ${RunningX64}
-          StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
-        ${else}
-          StrCpy $packageUrl "$packageUrl/${APP_32_NAME}"
-        ${endif}
+	  	!ifdef APP_ARM64_NAME
+			${if} ${IsNativeARM64}
+	          StrCpy $packageUrl "$packageUrl/${APP_ARM64_NAME}"
+	        ${elseif} ${IsNativeAMD64}
+	          StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
+	        ${else}
+	          StrCpy $packageUrl "$packageUrl/${APP_32_NAME}"
+	        ${endif}
+		!else
+	        ${if} ${IsNativeAMD64}
+	          StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
+	        ${else}
+	          StrCpy $packageUrl "$packageUrl/${APP_32_NAME}"
+	        ${endif}
+		!endif
       !else
         StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
       !endif
@@ -21,7 +31,9 @@
     !endif
   !endif
 
-  ${if} ${RunningX64}
+  ${if} ${IsNativeARM64}
+    StrCpy $packageArch "ARM64"
+  ${elseif} ${IsNativeAMD64}
     StrCpy $packageArch "64"
   ${else}
     StrCpy $packageArch "32"

--- a/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
@@ -8,21 +8,21 @@
   !ifdef APP_PACKAGE_URL_IS_INCOMLETE
     !ifdef APP_64_NAME
       !ifdef APP_32_NAME
-	  	!ifdef APP_ARM64_NAME
-			${if} ${IsNativeARM64}
+	    	!ifdef APP_ARM64_NAME
+	  		  ${if} ${IsNativeARM64} == true
 	          StrCpy $packageUrl "$packageUrl/${APP_ARM64_NAME}"
 	        ${elseif} ${IsNativeAMD64}
 	          StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
 	        ${else}
 	          StrCpy $packageUrl "$packageUrl/${APP_32_NAME}"
 	        ${endif}
-		!else
-	        ${if} ${IsNativeAMD64}
+		    !else
+	        ${if} ${IsNativeAMD64} == true
 	          StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
 	        ${else}
 	          StrCpy $packageUrl "$packageUrl/${APP_32_NAME}"
 	        ${endif}
-		!endif
+	     	!endif
       !else
         StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
       !endif
@@ -31,7 +31,7 @@
     !endif
   !endif
 
-  ${if} ${IsNativeARM64}
+  ${if} ${IsNativeARM64} == true
     StrCpy $packageArch "ARM64"
   ${elseif} ${IsNativeAMD64}
     StrCpy $packageArch "64"

--- a/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
@@ -9,7 +9,7 @@
     !ifdef APP_64_NAME
       !ifdef APP_32_NAME
 	    	!ifdef APP_ARM64_NAME
-	  		  ${if} ${IsNativeARM64} == true
+	  		  ${if} ${IsNativeARM64}
 	          StrCpy $packageUrl "$packageUrl/${APP_ARM64_NAME}"
 	        ${elseif} ${IsNativeAMD64}
 	          StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
@@ -31,7 +31,7 @@
     !endif
   !endif
 
-  ${if} ${IsNativeARM64} == true
+  ${if} ${IsNativeARM64} 
     StrCpy $packageArch "ARM64"
   ${elseif} ${IsNativeAMD64}
     StrCpy $packageArch "64"

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -16,17 +16,35 @@ FunctionEnd
 Section
   StrCpy $INSTDIR "$TEMP\${UNPACK_DIR_NAME}"
   RMDir /r $INSTDIR
-	SetOutPath $INSTDIR
+  SetOutPath $INSTDIR
 
-	!ifdef APP_DIR_64
-    !ifdef APP_DIR_32
-      ${if} ${RunningX64}
-        File /r "${APP_DIR_64}\*.*"
-      ${else}
-        File /r "${APP_DIR_32}\*.*"
-      ${endIf}
+  !ifdef APP_DIR_64
+    !ifdef APP_DIR_ARM64
+      !ifdef APP_DIR_32
+        ${if} ${IsNativeARM64}
+          File /r "${APP_DIR_ARM64}\*.*"
+        ${elseif} ${RunningX64}
+          File /r "${APP_DIR_64}\*.*"
+        ${else}
+          File /r "${APP_DIR_32}\*.*"
+        ${endIf}
+      !else
+        ${if} ${IsNativeARM64}
+          File /r "${APP_DIR_ARM64}\*.*"
+        ${else}
+          File /r "${APP_DIR_64}\*.*"
+        {endIf}
+      !endif
     !else
-      File /r "${APP_DIR_64}\*.*"
+      !ifdef APP_DIR_32
+        ${if} ${RunningX64}
+          File /r "${APP_DIR_64}\*.*"
+        ${else}
+          File /r "${APP_DIR_32}\*.*"
+        ${endIf}
+      !else
+        File /r "${APP_DIR_64}\*.*"
+      !endif
     !endif
   !else
     !ifdef APP_DIR_32

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -21,7 +21,7 @@ Section
   !ifdef APP_DIR_64
     !ifdef APP_DIR_ARM64
       !ifdef APP_DIR_32
-        ${if} ${IsNativeARM64} == true
+        ${if} ${IsNativeARM64}
           File /r "${APP_DIR_ARM64}\*.*"
         ${elseif} ${RunningX64}
           File /r "${APP_DIR_64}\*.*"
@@ -29,7 +29,7 @@ Section
           File /r "${APP_DIR_32}\*.*"
         ${endIf}
       !else
-        ${if} ${IsNativeARM64} == true
+        ${if} ${IsNativeARM64}
           File /r "${APP_DIR_ARM64}\*.*"
         ${else}
           File /r "${APP_DIR_64}\*.*"

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -21,7 +21,7 @@ Section
   !ifdef APP_DIR_64
     !ifdef APP_DIR_ARM64
       !ifdef APP_DIR_32
-        ${if} ${IsNativeARM64}
+        ${if} ${IsNativeARM64} == true
           File /r "${APP_DIR_ARM64}\*.*"
         ${elseif} ${RunningX64}
           File /r "${APP_DIR_64}\*.*"
@@ -29,7 +29,7 @@ Section
           File /r "${APP_DIR_32}\*.*"
         ${endIf}
       !else
-        ${if} ${IsNativeARM64}
+        ${if} ${IsNativeARM64} == true
           File /r "${APP_DIR_ARM64}\*.*"
         ${else}
           File /r "${APP_DIR_64}\*.*"

--- a/test/src/helpers/testConfig.ts
+++ b/test/src/helpers/testConfig.ts
@@ -1,7 +1,7 @@
 import * as os from "os"
 import * as path from "path"
 
-export const ELECTRON_VERSION = "6.0.0"
+export const ELECTRON_VERSION = "6.0.8"
 
 export function getElectronCacheDir() {
   if (process.platform === "win32") {

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -15,7 +15,7 @@ test.ifNotCiMac("web installer", app({
 }))
 
 test.ifAll.ifNotCiMac("web installer (default github)", app({
-  targets: Platform.WINDOWS.createTarget(["nsis-web"], Arch.ia32, Arch.x64),
+  targets: Platform.WINDOWS.createTarget(["nsis-web"], Arch.ia32, Arch.x64, Arch.arm64),
   config: {
     publish: {
       provider: "github",


### PR DESCRIPTION
Checklist:

- [ ] (External) Update NSIS in [electron-userland/electron-builder-binaries](https://github.com/electron-userland/electron-builder-binaries) to NSIS 3.0.4, or at least support Native CPU arch detection in x64.nsh (GetNativeMachineArchitecture and related, as shown in https://github.com/kichik/nsis/blob/master/Include/x64.nsh)
**_Done_, pending merge [electron-userland/electron-builder-binaries#27](https://github.com/electron-userland/electron-builder-binaries/pull/27)**

- [ ] Successfully validate updated NSIS scripts
- [x] Update test scripts to target electron 6.0.8 or later
- [ ] Update test scripts to target win/arm64 on windows hosts