### PR TITLE
Add support for snap autostart option

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4325,6 +4325,10 @@
         "useTemplateApp": {
           "description": "Whether to use template snap. Defaults to `true` if `stagePackages` not specified.",
           "type": "boolean"
+        },
+        "autoStart": {
+          "description": "Whether or not the snap should automatically start on login.",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -81,6 +81,12 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
    * Whether to use template snap. Defaults to `true` if `stagePackages` not specified.
    */
   readonly useTemplateApp?: boolean
+
+  /**
+   * Whether or not the snap should automatically start on login.
+   * @default false
+   */
+  readonly autoStart?: boolean
 }
 
 export interface PlugDescriptor {

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -88,6 +88,10 @@ export default class SnapTarget extends Target {
       },
     })
 
+    if (options.autoStart) {
+      appDescriptor.autostart = `${snap.name}.desktop`
+    }
+
     if (options.confinement === "classic") {
       delete appDescriptor.plugs
       delete snap.plugs
@@ -191,6 +195,7 @@ export default class SnapTarget extends Target {
       return
     }
 
+    console.log(JSON.stringify(snap, null, 2))
     await outputFile(path.join(snapMetaDir, this.isUseTemplateApp ? "snap.yaml" : "snapcraft.yaml"), serializeToYaml(snap))
 
     const hooksDir = await packager.getResource(options.hooks, "snap-hooks")

--- a/test/out/linux/__snapshots__/snapTest.js.snap
+++ b/test/out/linux/__snapshots__/snapTest.js.snap
@@ -11,6 +11,75 @@ Object {
 }
 `;
 
+exports[`auto start 1`] = `
+Object {
+  "apps": Object {
+    "sep": Object {
+      "autostart": "sep.desktop",
+      "command": "command.sh",
+      "environment": Object {
+        "DISABLE_WAYLAND": "1",
+        "LD_LIBRARY_PATH": "$SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu",
+        "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
+        "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+        "TMPDIR": "$XDG_RUNTIME_DIR",
+      },
+      "plugs": Array [
+        "desktop",
+        "desktop-legacy",
+        "home",
+        "x11",
+        "wayland",
+        "unity7",
+        "browser-support",
+        "network",
+        "gsettings",
+        "pulseaudio",
+        "opengl",
+      ],
+    },
+  },
+  "architectures": Array [
+    "amd64",
+  ],
+  "base": "core18",
+  "confinement": "strict",
+  "description": "Test Application (test quite “ #378)",
+  "grade": "stable",
+  "name": "sep",
+  "plugs": Object {
+    "gnome-3-28-1804": Object {
+      "default-provider": "gnome-3-28-1804",
+      "interface": "content",
+      "target": "$SNAP/gnome-platform",
+    },
+    "gtk-3-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/themes",
+    },
+    "icon-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/icons",
+    },
+    "sound-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/sounds",
+    },
+  },
+  "summary": "Sep",
+  "version": "1.1.0",
+}
+`;
+
+exports[`auto start 2`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
 exports[`buildPackages 1`] = `
 Object {
   "apps": Object {

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -185,3 +185,21 @@ test.ifDevOrLinuxCi("no desktop plugs", app({
     return true
   },
 }))
+
+test.ifAll.ifDevOrLinuxCi("auto start", app({
+  targets: snapTarget,
+  config: {
+    extraMetadata: {
+      name: "sep",
+    },
+    productName: "Sep",
+    snap: {
+      autoStart: true
+    }
+  },
+  effectiveOptionComputed: async ({ snap, args }) => {
+    expect(snap).toMatchSnapshot()
+    expect(snap.apps.sep.autostart).toEqual("sep.desktop")
+    return true
+  },
+}))


### PR DESCRIPTION
Add support for `autostart` snap option. This allows snaps to define that they should be launched upon login.

See https://snapcraft.io/docs/snap-format:

>      # Name of the desktop file placed by the application in 
>      # $SNAP_USER_DATA/.config/autostart to indicate that application 
>      # should be started with the user's desktop session. The application
>      # is started using the app's command wrapper (<name>.<app>) plus
>      # any arguments  present in the Exec=.. line inside the autostart
>      # desktop file.
>      # (snapd 2.32.4+)
>      autostart: <command line>

Basically, this just needs to set the value of `autostart` to the name of the `.desktop` file that is created in `$SNAP_USER_DATA/.config/autostart`. E.g. an "myapp" with `snap/myapp/current/.config/autostart/myapp.desktop` should have an `autostart` of `myapp.desktop`. The snap autostart helper will then pick this up and launch the app on login.

For other package formats on linux I can simply use https://github.com/Teamwork/node-auto-launch, however this does not work for snaps. Hardcoding the value into the snap config itself is not ideal given autolaunch then can't be turned off, but at least this way you can turn it on at all if required.

I have tested this with my application and it is working perfectly.