### PR TITLE
Feature/export updaters for configurability

### DIFF
--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -1,3 +1,5 @@
+import { OutgoingHttpHeaders } from "http"
+
 export type PublishProvider = "github" | "bintray" | "s3" | "spaces" | "generic" | "custom" | "snapStore"
 
 // typescript-json-schema generates only PublishConfiguration if it is specified in the list, so, it is not added here
@@ -30,6 +32,11 @@ export interface PublishConfiguration {
    * @default true
    */
   readonly publishAutoUpdate?: boolean
+
+  /**
+   * Any custom request headers
+   */
+  readonly requestHeaders?: OutgoingHttpHeaders
 }
 
 // https://github.com/electron-userland/electron-builder/issues/3261

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -175,6 +175,10 @@ export abstract class AppUpdater extends EventEmitter {
 
     if (options != null) {
       this.setFeedURL(options)
+
+      if (typeof options !== 'string' && options.requestHeaders) {
+        this.requestHeaders = options.requestHeaders
+      }
     }
   }
 

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -8,6 +8,9 @@ export { AppUpdater, NoOpLogger } from "./AppUpdater"
 export { UpdateInfo }
 export { CancellationToken } from "builder-util-runtime"
 export { Provider } from "./providers/Provider"
+export { AppImageUpdater } from "./AppImageUpdater"
+export { MacUpdater } from "./MacUpdater"
+export { NsisUpdater } from "./NsisUpdater"
 
 // autoUpdater to mimic electron bundled autoUpdater
 let _autoUpdater: any


### PR DESCRIPTION
Expose Updaters downstream so configs (especially requestHeaders) can be passed in.

Custom request header supports was added in issue #1175 / commit dd1320d but those are _not_ exposed to callers.
This PR exposes those by:
1. Making the updaters available directly (0330632)
2. Setting the value `requestHeaders` in the `AppUpdater` constructor (bcae4e8)