### PR TITLE
fix(mac): make tempFile unique for each call to getProvisioningProfileAsync 

### DIFF
--- a/packages/app-builder-lib/electron-osx-sign/util-provisioning-profiles.js
+++ b/packages/app-builder-lib/electron-osx-sign/util-provisioning-profiles.js
@@ -64,8 +64,13 @@ var getProvisioningProfileAsync = module.exports.getProvisioningProfileAsync = f
     '-i', filePath // Use infile as source of data
   ])
     .then(async function (result) {
+      // make filename unique so it doesn't create issues with parallel method calls
+      const timestamp = process.hrtime.bigint
+        ? process.hrtime.bigint().toString()
+        : process.hrtime().join('')
+
       // todo read directly
-      const tempFile = path.join(os.tmpdir(), `${require('crypto').createHash('sha1').update(filePath).digest("hex")}.plist`)
+      const tempFile = path.join(os.tmpdir(), `${require('crypto').createHash('sha1').update(filePath).update(timestamp).digest('hex')}.plist`)
       await fs.outputFile(tempFile, result)
       const plistContent = await executeAppBuilderAsJson(["decode-plist", "-f", tempFile])
       await fs.unlink(tempFile)


### PR DESCRIPTION
When building multiple targets on macOS, `getProvisioningProfileAsync` (in electron-osx-sign) would create a temporary plist file that was shared between targets. However this method also unlinked the file it created causing the other target, which was running in parallel and still needed the file to crash. 

This fix makes the temporary file name unique for each call to `getProvisioningProfileAsync` by introducing a [high-resolution timer](https://nodejs.org/api/process.html#process_process_hrtime_bigint) as a component of the temporary file name hash, so when the method unlinks the file, it doesn't cause other targets building in parallel to fail as they will have their own copy of the file.

fixes #4204