### PR TITLE
Fixed Squirrel Windows Description Error

### DIFF
--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -114,7 +114,7 @@ export default class SquirrelWindowsTarget extends Target {
     if (!options.description) {
       throw new InvalidConfigurationError("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.")
     }
-    
+
     if (options.remoteToken == null) {
       options.remoteToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
     }

--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -114,7 +114,7 @@ export default class SquirrelWindowsTarget extends Target {
     if (!options.description) {
       throw new InvalidConfigurationError("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.")
     }
-
+    
     if (options.remoteToken == null) {
       options.remoteToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
     }

--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -111,6 +111,10 @@ export default class SquirrelWindowsTarget extends Target {
       ...this.options as any,
     }
 
+    if (!options.description) {
+      throw new InvalidConfigurationError("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.");
+    }
+
     if (options.remoteToken == null) {
       options.remoteToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
     }

--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -112,7 +112,7 @@ export default class SquirrelWindowsTarget extends Target {
     }
 
     if (!options.description) {
-      throw new InvalidConfigurationError("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.");
+      throw new InvalidConfigurationError("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.")
     }
 
     if (options.remoteToken == null) {

--- a/packages/electron-builder-squirrel-windows/src/squirrelPack.ts
+++ b/packages/electron-builder-squirrel-windows/src/squirrelPack.ts
@@ -71,7 +71,7 @@ export class SquirrelBuilder {
     ])
 
     if (!options.description) {
-      throw new Error("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.");
+      throw new Error("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.")
     }
 
     if (options.remoteReleases) {

--- a/packages/electron-builder-squirrel-windows/src/squirrelPack.ts
+++ b/packages/electron-builder-squirrel-windows/src/squirrelPack.ts
@@ -70,6 +70,10 @@ export class SquirrelBuilder {
         .then(() => ensureDir(outputDirectory))
     ])
 
+    if (!options.description) {
+      throw new Error("Description is required, go to package.json and create a description in order to successfully build a windows installer with squirrel.");
+    }
+
     if (options.remoteReleases) {
       await syncReleases(outputDirectory, options)
     }


### PR DESCRIPTION
A Description in package.json is required if you want to successfully build a windows installer with squirrel.
I've added simple checks for that to alert the developer the error, instead of a 30 line mono error.