### PR TITLE
Added missing support for AppX fileAssociations

### DIFF
--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -251,13 +251,16 @@ export default class AppXTarget extends Target {
     const uriSchemes = asArray(this.packager.config.protocols)
       .concat(asArray(this.packager.platformSpecificBuildOptions.protocols))
 
+    const fileAssociations = asArray(this.packager.config.fileAssociations)
+      .concat(asArray(this.packager.platformSpecificBuildOptions.fileAssociations))
+
     let isAddAutoLaunchExtension = this.options.addAutoLaunchExtension
     if (isAddAutoLaunchExtension === undefined) {
       const deps = this.packager.info.metadata.dependencies
       isAddAutoLaunchExtension = deps != null && deps["electron-winstore-auto-launch"] != null
     }
 
-    if (!isAddAutoLaunchExtension && uriSchemes.length === 0) {
+    if (!isAddAutoLaunchExtension && uriSchemes.length === 0 && fileAssociations.length === 0) {
       return ""
     }
 
@@ -277,6 +280,19 @@ export default class AppXTarget extends Target {
             <uap:Protocol Name="${scheme}">
                <uap:DisplayName>${protocol.name}</uap:DisplayName>
              </uap:Protocol>
+          </uap:Extension>`
+      }
+    }
+
+    for (const fileAssociation of fileAssociations) {
+      for (const ext of asArray(fileAssociation.ext)) {
+        extensions += `
+          <uap:Extension Category="windows.fileTypeAssociation">
+            <uap:FileTypeAssociation Name="${ext}">
+              <uap:SupportedFileTypes>
+                <uap:FileType>.${ext}</uap:FileType>
+              </uap:SupportedFileTypes>
+            </uap:FileTypeAssociation>
           </uap:Extension>`
       }
     }


### PR DESCRIPTION
I tested this change using the following `package.json` ElectronBuilder `build` config:
```
    "fileAssociations": [
      {
        "ext": "ext1",
        "role": "Viewer",
        "mimeType": "application/ext1+zip"
      },
      {
        "ext": "ext2",
        "role": "Viewer",
        "mimeType": "application/ext2+zip"
      }
    ],
```

I am running a Windows 10 Pro Virtual Machine (VirtualBox), in "developer mode" so I can install my test `AppX` which is code-signed (via `electron-builder`'s own `certificateFile` config) using a self-signed PFX certificate (generated using `electron-builder create-self-signed-cert -p NAME`) which I added in my "Trusted Root Certification Authorities" (using `mmc.exe` and a "Certificates" snap-in).

Once my test `AppX` is installed (simply by double-clicking on it from the Windows file explorer), I am able to double-click or "open with" from the file explorer the newly-registered `ext1` and `ext2` file extensions.

Once I uninstall the `AppX`, the file extensions are immediately unregistered, as expected.