### PR TITLE
feat(app-builder-lib): the pkg interface adds the must-close attribute (#4380)

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -3831,6 +3831,20 @@
             "null",
             "string"
           ]
+        },
+        "mustClose": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Identifies applications that must be closed before the package is installed.\n\nCorresponds to [must-close](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html#//apple_ref/doc/uid/TP40005370-CH100-SW77)"
         }
       },
       "type": "object"

--- a/packages/app-builder-lib/src/options/pkgOptions.ts
+++ b/packages/app-builder-lib/src/options/pkgOptions.ts
@@ -78,6 +78,11 @@ export interface PkgOptions extends TargetSpecificOptions {
   readonly welcome?: string | null
 
   /**
+   * Identifies applications that must be closed before the package is installed.\n\nCorresponds to [must-close](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html#//apple_ref/doc/uid/TP40005370-CH100-SW77)
+   */
+  readonly mustClose?: Array<string> | null
+
+  /**
    * The path to the conclusion file. This may be used to customize the text on the final "Summary" page of the installer.
    */
   readonly conclusion?: string | null

--- a/packages/app-builder-lib/src/targets/pkg.ts
+++ b/packages/app-builder-lib/src/targets/pkg.ts
@@ -80,6 +80,17 @@ export class PkgTarget extends Target {
 
     const options = this.options
     let distInfo = await readFile(distInfoFile, "utf-8")
+
+    if (options.mustClose != null && options.mustClose.length !== 0) {
+      const startContent = `    <pkg-ref id="${this.packager.appInfo.id}">\n        <must-close>\n`
+      const endContent = "        </must-close>\n    </pkg-ref>\n</installer-gui-script>"
+      let mustCloseContent = ""
+      options.mustClose.forEach(appId => {
+        mustCloseContent += `            <app id="${appId}"/>\n`
+      })
+      distInfo = distInfo.replace("</installer-gui-script>", `${startContent}${mustCloseContent}${endContent}`)
+    }
+
     const insertIndex = distInfo.lastIndexOf("</installer-gui-script>")
     distInfo = distInfo.substring(0, insertIndex) + `    <domains enable_anywhere="${options.allowAnywhere}" enable_currentUserHome="${options.allowCurrentUserHome}" enable_localSystem="${options.allowRootDirectory}" />\n` + distInfo.substring(insertIndex)
 


### PR DESCRIPTION
Add mustClsoe key in pkg
Identifies applications that must be closed before the package is installed.
must-close: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html#//apple_ref/doc/uid/TP40005370-CH100-SW77

issues: https://github.com/electron-userland/electron-builder/issues/4380