### PR TITLE
Revert "fix(appx): App sandbox not enabled (ITMS-90296) (#4244)" (#4390)

### DIFF
--- a/packages/app-builder-lib/templates/entitlements.mac.plist
+++ b/packages/app-builder-lib/templates/entitlements.mac.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <!-- https://github.com/electron-userland/electron-builder/issues/3940 -->


### PR DESCRIPTION
This reverts commit e48681eeee6a48cf68deb6a0a0f1c5c13507d870 which regressed macOS apps (#4390).

@develar @vaibhavtel
