### PR TITLE
feat(portable): adding splash image to portable nsis package

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -3928,6 +3928,13 @@
             }
           ]
         },
+        "splashImage": {
+          "describe": "An image to show while the portable executable is extracting. This image must be a bitmap (`.bmp`) image.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "requestExecutionLevel": {
           "default": "user",
           "description": "The [requested execution level](http://nsis.sourceforge.net/Reference/RequestExecutionLevel) for Windows.",

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -231,6 +231,7 @@ export class NsisTarget extends Target {
       const portableOptions = options as PortableOptions
       defines.REQUEST_EXECUTION_LEVEL = portableOptions.requestExecutionLevel || "user"
       defines.UNPACK_DIR_NAME = portableOptions.unpackDirName || (await executeAppBuilder(["ksuid"]))
+      defines.SPLASH_IMAGE = portableOptions.splashImage || null
     }
     else {
       await this.configureDefines(oneClick, defines)

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -231,7 +231,10 @@ export class NsisTarget extends Target {
       const portableOptions = options as PortableOptions
       defines.REQUEST_EXECUTION_LEVEL = portableOptions.requestExecutionLevel || "user"
       defines.UNPACK_DIR_NAME = portableOptions.unpackDirName || (await executeAppBuilder(["ksuid"]))
-      defines.SPLASH_IMAGE = portableOptions.splashImage || null
+
+      if (portableOptions.splashImage) {
+        defines.SPLASH_IMAGE = portableOptions.splashImage
+      }
     }
     else {
       await this.configureDefines(oneClick, defines)

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -178,7 +178,7 @@ export interface PortableOptions extends TargetSpecificOptions, CommonNsisOption
   /**
    * An image to show while the portable executable is extracting. This image must be a bitmap (`.bmp`) image.
    */
-   readonly splashImage?: string | null
+  readonly splashImage?: string | null
 }
 
 /**

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -174,6 +174,11 @@ export interface PortableOptions extends TargetSpecificOptions, CommonNsisOption
    * Defaults to [uuid](https://github.com/segmentio/ksuid) of build (changed on each build of portable executable).
    */
   readonly unpackDirName?: string
+
+  /**
+   * An image to show while the portable executable is extracting. This image must be a bitmap (`.bmp`) image.
+   */
+   readonly splashImage?: string | null
 }
 
 /**

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -8,17 +8,22 @@ AutoCloseWindow True
 RequestExecutionLevel ${REQUEST_EXECUTION_LEVEL}
 
 Function .onInit
-  # TODO set to silent if no splash image was defined
-  # SetSilent silent
+  ${IfNot} ${FileExists} "${SPLASH_IMAGE}"
+    SetSilent silent
+  ${EndIf}
+
   !insertmacro check64BitAndSetRegView
 FunctionEnd
 
 Function .onGUIInit
   InitPluginsDir
-  # TODO figure out how to pass in a variable for the image
-  File /oname=$PLUGINSDIR\splash.bmp "C:\image.bmp"
-  BgImage::SetBg $PLUGINSDIR\splash.bmp
-  BgImage::Redraw
+
+  File /NONFATAL "${SPLASH_IMAGE}"
+  ${If} ${FileExists} "${SPLASH_IMAGE}"
+    File /oname=$PLUGINSDIR\splash.bmp "C:\image.bmp"
+    BgImage::SetBg $PLUGINSDIR\splash.bmp
+    BgImage::Redraw
+  ${EndIf}
 FunctionEnd
 
 Section
@@ -64,7 +69,9 @@ Section
     !endif
   !endif
 
-  BgImage::Destroy
+  ${If} ${FileExists} "${SPLASH_IMAGE}"
+    BgImage::Destroy
+  ${EndIf}
 
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_DIR", "$EXEDIR").r0'
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_FILE", "$EXEPATH").r0'

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -7,13 +7,23 @@ WindowIcon Off
 AutoCloseWindow True
 RequestExecutionLevel ${REQUEST_EXECUTION_LEVEL}
 
-SilentInstall silent
-
 Function .onInit
+  # TODO set to silent if no splash image was defined
+  # SetSilent silent
   !insertmacro check64BitAndSetRegView
 FunctionEnd
 
+Function .onGUIInit
+  InitPluginsDir
+  # TODO figure out how to pass in a variable for the image
+  File /oname=$PLUGINSDIR\splash.bmp "C:\image.bmp"
+  BgImage::SetBg $PLUGINSDIR\splash.bmp
+  BgImage::Redraw
+FunctionEnd
+
 Section
+  HideWindow
+
   StrCpy $INSTDIR "$TEMP\${UNPACK_DIR_NAME}"
   RMDir /r $INSTDIR
   SetOutPath $INSTDIR
@@ -53,6 +63,8 @@ Section
       !insertmacro extractEmbeddedAppPackage
     !endif
   !endif
+
+  BgImage::Destroy
 
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_DIR", "$EXEDIR").r0'
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_FILE", "$EXEPATH").r0'

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -20,7 +20,7 @@ Function .onGUIInit
 
   File /NONFATAL "${SPLASH_IMAGE}"
   ${If} ${FileExists} "${SPLASH_IMAGE}"
-    File /oname=$PLUGINSDIR\splash.bmp "C:\image.bmp"
+    File /oname=$PLUGINSDIR\splash.bmp "${SPLASH_IMAGE}"
     BgImage::SetBg $PLUGINSDIR\splash.bmp
     BgImage::Redraw
   ${EndIf}

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -8,9 +8,9 @@ AutoCloseWindow True
 RequestExecutionLevel ${REQUEST_EXECUTION_LEVEL}
 
 Function .onInit
-  ${IfNot} ${FileExists} "${SPLASH_IMAGE}"
+  !ifndef SPLASH_IMAGE
     SetSilent silent
-  ${EndIf}
+  !endif
 
   !insertmacro check64BitAndSetRegView
 FunctionEnd
@@ -18,12 +18,11 @@ FunctionEnd
 Function .onGUIInit
   InitPluginsDir
 
-  File /NONFATAL "${SPLASH_IMAGE}"
-  ${If} ${FileExists} "${SPLASH_IMAGE}"
-    File /oname=$PLUGINSDIR\splash.bmp "${SPLASH_IMAGE}"
+  !ifdef SPLASH_IMAGE
+    File /NONFATAL /oname=$PLUGINSDIR\splash.bmp "${SPLASH_IMAGE}"
     BgImage::SetBg $PLUGINSDIR\splash.bmp
     BgImage::Redraw
-  ${EndIf}
+  !endif
 FunctionEnd
 
 Section
@@ -69,9 +68,9 @@ Section
     !endif
   !endif
 
-  ${If} ${FileExists} "${SPLASH_IMAGE}"
+  !ifdef SPLASH_IMAGE
     BgImage::Destroy
-  ${EndIf}
+  !endif
 
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_DIR", "$EXEDIR").r0'
   System::Call 'Kernel32::SetEnvironmentVariable(t, t)i ("PORTABLE_EXECUTABLE_FILE", "$EXEPATH").r0'

--- a/test/out/windows/__snapshots__/portableTest.js.snap
+++ b/test/out/windows/__snapshots__/portableTest.js.snap
@@ -12,6 +12,18 @@ Object {
 }
 `;
 
+exports[`portable - splashImage 1`] = `
+Object {
+  "win": Array [
+    Object {
+      "arch": "x64",
+      "file": "Test App ßWPortable.1.1.0.exe",
+      "safeArtifactName": "TestApp-1.1.0.exe",
+    },
+  ],
+}
+`;
+
 exports[`portable 1`] = `
 Object {
   "win": Array [

--- a/test/src/windows/portableTest.ts
+++ b/test/src/windows/portableTest.ts
@@ -1,6 +1,6 @@
 import { Platform, Arch } from "electron-builder"
 import * as path from "path"
-import { app, copyTestAsset } from "../helpers/packTester"
+import { app, copyTestAsset, getFixtureDir } from "../helpers/packTester"
 
 // build in parallel - https://github.com/electron-userland/electron-builder/issues/1340#issuecomment-286061789
 test.ifAll.ifNotCiMac("portable", app({
@@ -53,5 +53,17 @@ test.ifNotCiMac("portable - artifactName and request execution level", app({
 }, {
   projectDirCreated: projectDir => {
     return copyTestAsset("headerIcon.ico", path.join(projectDir, "build", "foo test space.ico"))
+  },
+}))
+
+test.ifNotCiMac("portable - splashImage", app({
+  targets: Platform.WINDOWS.createTarget(["portable"]),
+  config: {
+    publish: null,
+    portable: {
+      //tslint:disable-next-line:no-invalid-template-strings
+      artifactName: "${productName}Portable.${version}.${ext}",
+      splashImage: path.resolve(getFixtureDir(), "installerHeader.bmp"),
+    },
   },
 }))


### PR DESCRIPTION
This PR is meant to address #2548 and #3972 by allowing a developer to add a splash image that is displayed while the portable Windows executable is extracting files. This lets the user know that the application is doing work and will soon open.