### PR TITLE
fix: correctly encode Unicode characters in DMG licenses

### DIFF
--- a/packages/dmg-builder/src/dmgLicense.ts
+++ b/packages/dmg-builder/src/dmgLicense.ts
@@ -94,7 +94,7 @@ function getRtfUnicodeEscapedString(text: string) {
       result += text[i]
     }
     else {
-      result += `\\u${text.codePointAt(i)}`
+      result += `\\u${text.codePointAt(i)}?`
     }
   }
   return result


### PR DESCRIPTION
Fixes a bug where licenses containing characters that are outside the standard ASCII 7-bit character set would not contain the correct content when added to macOS DMGs. The RTF escape sequence used to encode these characters was missing the "placeholder" character that should be present after the code point data. This commit adds a ? (question mark) character as the placeholder.

See https://www.zopatista.com/python/2012/06/06/rtf-and-unicode/#so-does-rtf-handle-unicode