### PR TITLE
Remove incorrect parsing of electron version

### DIFF
--- a/packages/app-builder-lib/src/electron/electronVersion.ts
+++ b/packages/app-builder-lib/src/electron/electronVersion.ts
@@ -69,7 +69,7 @@ export async function computeElectronVersion(projectDir: string, projectMetadata
     throw new InvalidConfigurationError(`Cannot compute electron version from installed node modules - none of the possible electron modules are installed${versionMessage}.\nSee https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246`)
   }
 
-  return semver.coerce(electronVersionFromMetadata)!!.toString()
+  return String(electronVersionFromMetadata)
 }
 
 function findFromPackageMetadata(packageData: any): string | null {


### PR DESCRIPTION
Semver.coerce removes `-beta.0` part of a version, thus failing to build for those using beta or alpha versions of electron.