### PR TITLE
Revert "fix(nsis): NSIS Uninstaller registry entry format change (#4069)"

### DIFF
--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -167,7 +167,7 @@ export class NsisTarget extends Target {
       APP_PACKAGE_NAME: appInfo.name
     }
     if (uninstallAppKey !== guid) {
-      defines.UNINSTALL_REGISTRY_KEY_2 = `Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{${guid}}`
+      defines.UNINSTALL_REGISTRY_KEY_2 = `Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${guid}`
     }
 
     const commands: any = {

--- a/packages/app-builder-lib/templates/nsis/multiUser.nsh
+++ b/packages/app-builder-lib/templates/nsis/multiUser.nsh
@@ -6,7 +6,7 @@
 
 # allow user to define own custom
 !define /ifndef INSTALL_REGISTRY_KEY "Software\${APP_GUID}"
-!define /ifndef UNINSTALL_REGISTRY_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\{${UNINSTALL_APP_KEY}}"
+!define /ifndef UNINSTALL_REGISTRY_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${UNINSTALL_APP_KEY}"
 
 # current Install Mode ("all" or "CurrentUser")
 Var installMode


### PR DESCRIPTION
It looks like the change of the registry format has not been well thought through and it causes lots of issues (#4092 and #4126).

The change was made for pure pedantic reasons and didn't consider backwards compatibility with older installer. In our case, we are wrapping the NSIS package with an MSI wrapper that has a bit more functionality than the one provided by electron-builder which no longer works after this change.

My suggestion is to revert the commit all together and leave the registries as they were before.

This reverts commit 7518aee8e1abe0516071b350748e84dc47e35cf7.