### PR TITLE
Fixes #2795: Prevent script from hammering time server

### DIFF
--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -170,13 +170,13 @@ async function doSign(configuration: CustomWindowsSignTaskConfiguration, package
   }
   catch (e) {
     if (e.message.includes("The file is being used by another process") || e.message.includes("The specified timestamp server either could not be reached")) {
-      log.warn(`First attempt to code sign failed, another attempt will be made in 2 seconds: ${e.message}`)
+      log.warn(`First attempt to code sign failed, another attempt will be made in 15 seconds: ${e.message}`)
       await new Promise((resolve, reject) => {
         setTimeout(() => {
           vm.exec(tool, args, {timeout, env})
             .then(resolve)
             .catch(reject)
-        }, 2000)
+        }, 15000)
       })
     }
     throw e


### PR DESCRIPTION
The current default time server is timestamp.comodoca.com/rfc3161 and they have the following policy:

> Note: If you are signing several pieces of software with a script, please add a delay of 15 seconds or more between signings so that you're not hammering our servers.

The problem is that electron-builder currently has a retry delay of 2 seconds, which means further calls will fail. This fix simply increases the delay to 15 seconds, which should solve the problem.