### PR TITLE
Update deprecated env var for CircleCI

### DIFF
--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -316,7 +316,7 @@ export function isPullRequest() {
     return value && value !== "false"
   }
 
-  return isSet(process.env.TRAVIS_PULL_REQUEST) || isSet(process.env.CI_PULL_REQUEST) || isSet(process.env.CI_PULL_REQUESTS) || isSet(process.env.BITRISE_PULL_REQUEST) || isSet(process.env.APPVEYOR_PULL_REQUEST_NUMBER)
+  return isSet(process.env.TRAVIS_PULL_REQUEST) || isSet(process.env.CIRCLE_PULL_REQUEST) || isSet(process.env.BITRISE_PULL_REQUEST) || isSet(process.env.APPVEYOR_PULL_REQUEST_NUMBER)
 }
 
 export function isEnvTrue(value: string | null | undefined) {


### PR DESCRIPTION
As mentioned [here](https://circleci.com/docs/2.0/env-vars/?gclid=Cj0KCQiAq97uBRCwARIsADTziyYsyJYon6xicbXgtFgEEIaqhWwaw9Rub_IRdQsH9yuDtE3jdnfAJ68aAlLeEALw_wcB#built-in-environment-variables), `CI_PULL_REQUEST` and `CI_PULL_REQUESTS` are deprecated, and `CIRCLE_PULL_REQUEST` and `CIRCLE_PULL_REQUESTS` should be used instead.

If there's multiple PRs, `CIRCLE_PULL_REQUEST` will have one url at random, so checking that should be sufficient for CircleCI

In general, it might be worth looking into this, to support other CI tools as well: https://github.com/watson/ci-info#ciispr