### PR TITLE
Use the latest command name in the documentation

### DIFF
--- a/configuration/publish.md
+++ b/configuration/publish.md
@@ -67,7 +67,7 @@ But please consider using automatic rules instead of explicitly specifying `publ
  Add to `scripts` in the development `package.json`:
  
  ```json tab="package.json"
- "release": "build"
+ "release": "electron-builder"
  ```
 
  and if you run `yarn release`, a release will be drafted (if doesn't already exist) and artifacts published.


### PR DESCRIPTION
Thanks for sharing your great builder with us! I found one documentation issue, and going to report a fix for it.

Now the command name is not `build` but `electron-builder`, then the command in `"scripts"` should be updated.

refs #4076