### PR TITLE
Add support for PKG background images in dark mode

### DIFF
--- a/packages/app-builder-lib/src/targets/pkg.ts
+++ b/packages/app-builder-lib/src/targets/pkg.ts
@@ -101,6 +101,7 @@ export class PkgTarget extends Target {
         // noinspection SpellCheckingInspection
         const scaling = options.background.scaling || "tofit"
         distInfo = distInfo.substring(0, insertIndex) + `    <background file="${background}" alignment="${alignment}" scaling="${scaling}"/>\n` + distInfo.substring(insertIndex)
+        distInfo = distInfo.substring(0, insertIndex) + `    <background-darkAqua file="${background}" alignment="${alignment}" scaling="${scaling}"/>\n` + distInfo.substring(insertIndex)
       }
     }
 


### PR DESCRIPTION
When specifying the `background` option for the `pkg` target, it only appears when the installer is launched in light mode.

This patch adds the `background-darkAqua` line to the generated distribution XML file so that the background image also works in dark mode.