### PR TITLE
feat: manually control version strings in installers and uninstallers

### DIFF
--- a/packages/app-builder-lib/src/appInfo.ts
+++ b/packages/app-builder-lib/src/appInfo.ts
@@ -8,6 +8,8 @@ import { expandMacro } from "./util/macroExpander"
 export class AppInfo {
   readonly description = smarten(this.info.metadata.description || "")
   readonly version: string
+  readonly shortVersion: string | undefined
+  readonly shortVersionWindows: string | undefined
 
   readonly buildNumber: string | undefined
   readonly buildVersion: string
@@ -30,6 +32,13 @@ export class AppInfo {
       }
     }
     this.buildVersion = buildVersion
+
+    if (info.metadata.shortVersion) {
+      this.shortVersion = info.metadata.shortVersion
+    }
+    if (info.metadata.shortVersionWindows) {
+      this.shortVersionWindows = info.metadata.shortVersionWindows
+    }
 
     this.productName = info.config.productName || info.metadata.productName || info.metadata.name!!
     this.productFilename = sanitizeFileName(this.productName)
@@ -121,7 +130,7 @@ export class AppInfo {
     }
 
     const info = await this.info.repositoryInfo
-    return info == null || info.type !== "github"  ? null : `https://${info.domain}/${info.user}/${info.project}`
+    return info == null || info.type !== "github" ? null : `https://${info.domain}/${info.user}/${info.project}`
   }
 }
 

--- a/packages/app-builder-lib/src/options/metadata.ts
+++ b/packages/app-builder-lib/src/options/metadata.ts
@@ -41,6 +41,10 @@ export interface Metadata {
   /** @private */
   readonly version?: string
   /** @private */
+  readonly shortVersion?: string | null
+  /** @private */
+  readonly shortVersionWindows?: string | null
+  /** @private */
   readonly productName?: string | null
   /** @private */
   readonly main?: string | null

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -265,8 +265,8 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       "--set-version-string", "FileDescription", appInfo.productName,
       "--set-version-string", "ProductName", appInfo.productName,
       "--set-version-string", "LegalCopyright", appInfo.copyright,
-      "--set-file-version", appInfo.buildVersion,
-      "--set-product-version", appInfo.getVersionInWeirdWindowsForm(),
+      "--set-file-version", appInfo.shortVersion || appInfo.buildVersion,
+      "--set-product-version", appInfo.shortVersionWindows || appInfo.getVersionInWeirdWindowsForm(),
     ]
 
     if (internalName != null) {


### PR DESCRIPTION
Currently, each build has the current version string(s) embedded in various files - namely, the branded Electron executable and (in the case of NSIS) the uninstaller. This causes each installation package to differ considerably from the previous one, as especially compressing of the modified executable may well lead to megabytes of changed data.
With this feature, adding "shortVersion" and (optionally) "shortVersionWindows" in package.json embeds these values instead. Thus a build can be internally tagged as "1.x" or similarly (1.0.0.0 in the Windows format) and have consecutive branded executables or uninstallers identical to the previous ones (as long as the version strings don't change). The result is a significant decrease in update sizes.