### PR TITLE
fix(nsis): fix cli config error when use Boolean value in -c.nsis config

### DIFF
--- a/packages/electron-builder/src/builder.ts
+++ b/packages/electron-builder/src/builder.ts
@@ -155,8 +155,12 @@ export function normalizeOptions(args: CliOptions): BuildOptions {
       coerceValue(config.mac, "identity")
     }
 
+    // fix Boolean type by coerceTypes
     if (config.nsis != null) {
       coerceTypes(config.nsis);
+    }
+    if (config.nsisWeb != null) {
+      coerceTypes(config.nsisWeb);
     }
   }
 

--- a/packages/electron-builder/src/builder.ts
+++ b/packages/electron-builder/src/builder.ts
@@ -154,6 +154,10 @@ export function normalizeOptions(args: CliOptions): BuildOptions {
     if (config.mac != null) {
       coerceValue(config.mac, "identity")
     }
+
+    if (config.nsis != null) {
+      coerceTypes(config.nsis);
+    }
   }
 
   if ("project" in r && !("projectDir" in result)) {


### PR DESCRIPTION
Currently, when I config in cli like -c.nsis.createDesktopShortcut=true will not work, because it will parsed to String instead of Boolean. 
I just fixed by using coerceTypes.