### PR TITLE
fix(mac): remove internet-enable from macOS 10.15 (#4405)

### DIFF
--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -58,7 +58,7 @@ export class DmgTarget extends Target {
       args.push("-imagekey", `zlib-level=${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL || "9"}`)
     }
     await spawn("hdiutil", addLogLevel(args))
-    if (this.options.internetEnabled && parseInt(require("os").split(".")[0]) < 19) {
+    if (this.options.internetEnabled && parseInt(require("os").split(".")[0], 10) < 19) {
       await exec("hdiutil", addLogLevel(["internet-enable"]).concat(artifactPath))
     }
 

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -58,7 +58,7 @@ export class DmgTarget extends Target {
       args.push("-imagekey", `zlib-level=${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL || "9"}`)
     }
     await spawn("hdiutil", addLogLevel(args))
-    if (this.options.internetEnabled) {
+    if (this.options.internetEnabled && parseInt(require("os").split(".")[0]) < 19) {
       await exec("hdiutil", addLogLevel(["internet-enable"]).concat(artifactPath))
     }
 


### PR DESCRIPTION
Prevent the internet-verb from being used with hdiutil on macOS 10.15
"Catalina" or newer, since it was removed

Fixes #4405