### PR TITLE
fix(mas): set hardenedRuntime to false by default for mas and mas-dev

### DIFF
--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -193,7 +193,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       // https://github.com/electron-userland/electron-osx-sign/issues/196
       // will fail on 10.14.5+ because a signed but unnotarized app is also rejected.
       "gatekeeper-assess": options.gatekeeperAssess === true,
-      hardenedRuntime: isMas ? masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
+      hardenedRuntime: isMas ? masOptions && masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
     }
 
     await this.adjustSignOptions(signOptions, masOptions)

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -193,7 +193,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       // https://github.com/electron-userland/electron-osx-sign/issues/196
       // will fail on 10.14.5+ because a signed but unnotarized app is also rejected.
       "gatekeeper-assess": options.gatekeeperAssess === true,
-      hardenedRuntime: options.hardenedRuntime !== false,
+      hardenedRuntime: isMas ? masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
     }
 
     await this.adjustSignOptions(signOptions, masOptions)


### PR DESCRIPTION
`hardenedRuntime` causes:
- `mas-dev` build to crash with `EXC_BAD_ACCESS (Code Signature Invalid) `. Fixes: https://github.com/electron-userland/electron-builder/issues/4074.
- `mas` build to show a blank white window (screenshot taken by Mac App Store Review Team):
<img width="804" alt="attachment-9419197367202469221Screenshot-1219-174003" src="https://user-images.githubusercontent.com/1548835/71229896-fd714680-22ac-11ea-8c3c-81206c36dfcd.png">

`hardenedRuntime` can be explicitly set to `true` if needed for `mas` build in `masOptions`. 