### PR TITLE
fix(mac): identifier missing from pkgbuild

### DIFF
--- a/packages/app-builder-lib/src/targets/pkg.ts
+++ b/packages/app-builder-lib/src/targets/pkg.ts
@@ -166,6 +166,7 @@ export class PkgTarget extends Target {
     // now build the package
     const args = [
       "--root", rootPath,
+      "--identifier", this.packager.appInfo.id,
       "--component-plist", propertyListOutputFile,
     ]
 


### PR DESCRIPTION
When building PKG's,  "identifier" is missing from parameter list.

See Issue #4527 