### PR TITLE
fix(nsis): fix spawnAndWrite reject in util

### DIFF
--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -186,7 +186,7 @@ export function spawnAndWrite(command: string, args: Array<string>, data: string
         clearTimeout(timeout)
       }
       finally {
-        reject(error.stack || error.toString())
+        reject(error)
       }
     })
 


### PR DESCRIPTION
When nsis script error, spawnAndWrite reject(error.stack || error.toString()) will cause a bad error message "[object Object]" because error log handle in  expect a error object.
I just fix it. 