### PR TITLE
fix: nsis update fails for private github repos

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -449,11 +449,9 @@ export function configureRequestOptions(options: RequestOptions, token?: string 
     options.method = method
   }
 
-  let headers = options.headers
-  if (headers == null) {
-    headers = {}
-    options.headers = headers
-  }
+  options.headers = {...options.headers}
+  const headers = options.headers
+
   if (token != null) {
     (headers as any).authorization = token.startsWith("Basic") ? token : `token ${token}`
   }


### PR DESCRIPTION
electron-updater: 4.2.0
electron-builder: 22.2.0

When private github repos:
1. `NsidUpdater` calls `differentialDownloadInstaller` with `token` header
2. This calls `downloadBlockMap`, which then goes to `httpExecutor`
3. Redirects to aws, and `httpExecutor.ts:297` deletes the github token
4. header object never got shallow copied, so `NsidUpdater` higher level argument `downloadOptions` looses its token
5. the fallback passes unauthenticated headers to `httpExecutor`, which now ends up failing trying to fetch metadata from the private repo

Seems like the fix is not mutate. Related to #4544 and #4564