### PR TITLE
fix:(electron-updater) not rejecting with error when response stream gets an error

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -155,6 +155,7 @@ Please double check that your authentication token is correct. Due to security r
     response.setEncoding("utf8")
 
     let data = ""
+    response.on("error", reject)
     response.on("data", (chunk: string) => data += chunk)
     response.on("end", () => {
       try {
@@ -248,6 +249,10 @@ Please double check that your authentication token is correct. Due to security r
         options.callback(new Error(`Cannot download "${requestOptions.protocol || "https:"}//${requestOptions.hostname}${requestOptions.path}", status ${response.statusCode}: ${response.statusMessage}`))
         return
       }
+
+      // It is possible for the response stream to fail, e.g. when a network is lost while
+      // response stream is in progress. Stop waiting and reject so consumer can catch the error.
+      response.on("error", options.callback)
 
       // this code not relevant for Electron (redirect event instead handled)
       const redirectUrl = safeGetHeader(response, "location")


### PR DESCRIPTION
# Intent

Fix a bug where network error thrown when invoking `updater.downloadUpdate()` is not catchable.

Related issue: https://github.com/electron-userland/electron-builder/issues/2451

## Review

#### Problem

Network error such as `net::ERR_NETWORK_CHANGED`, etc could happen when a `response` stream is in progress. We do not seem to handle any cases related to this, which resulted in the error being thrown globally and the original `updater.downloadUpdate()` not resolving.

#### How to reproduce

```ts
// assumes that we have a new version ready to be downloaded
// on a cold cache
try {
  await autoUpdater.downloadUpdate() // When the download is in progress, disconnect
                                     // from the internet, this will not reject
                                     // and never settles. Additionally, a `net::ERR_...` 
                                     // depending on the network error will be thrown
                                     // and not caught causing an `uncaughtException`.
} catch (e) {
  console.error(e)
}

```

#### Solution

This PR is attaching `response.on("error", handler)` where appropriate to make sure we reject with the error so the consumer can catch and react to the error without attaching a global `uncaughtException` handler manually.


