### PR TITLE
feat(appx): add support for modifying .appx manifest

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5331,6 +5331,20 @@
       ],
       "description": "The function (or path to file or module id) to be run on artifact build start."
     },
+    "appxManifestCreated": {
+      "anyOf": [
+        {
+          "typeof": "function"
+        },
+        {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      ],
+      "description": "The function (or path to file or module id) to be run when appx manifest is created but before it is packed into the installer bundle."
+    },
     "artifactName": {
       "description": "The [artifact file name template](/configuration/configuration#artifact-file-name-template). Defaults to `${productName}-${version}.${ext}` (some target can have other defaults, see corresponding options).",
       "type": [

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -198,7 +198,10 @@ export interface Configuration extends PlatformSpecificBuildOptions {
    * The function (or path to file or module id) to be [run after all artifacts are build](#afterAllArtifactBuild).
    */
   readonly afterAllArtifactBuild?: ((context: BuildResult) => Promise<Array<string>> | Array<string>) | string | null
-
+  /**
+   * Appx manifest created on disk - not packed into .appx package yet.
+   */
+  readonly appxManifestCreated?: ((path: string) => Promise<any> | any) | string | null
   /**
    * The function (or path to file or module id) to be [run on each node module](#onnodemodulefile) file.
    */

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -284,6 +284,13 @@ export class Packager {
     }
   }
 
+  async callAppxManifestCreated(path: string): Promise<void> {
+    const handler = resolveFunction(this.config.appxManifestCreated, "appxManifestCreated")
+    if (handler != null) {
+      await Promise.resolve(handler(path))
+    }
+  }
+
   async build(): Promise<BuildResult> {
     let configPath: string | null = null
     let configFromOptions = this.options.config

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -73,7 +73,7 @@ export default class AppXTarget extends Target {
 
     const manifestFile = stageDir.getTempFile("AppxManifest.xml")
     await this.writeManifest(manifestFile, arch, await this.computePublisherName(), userAssets)
-    await packager.info.callAppxManifestCreated(manifestFile);
+    await packager.info.callAppxManifestCreated(manifestFile)
     mappingList.push(assetInfo.mappings)
     mappingList.push([`"${vm.toVmFile(manifestFile)}" "AppxManifest.xml"`])
 

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -73,6 +73,7 @@ export default class AppXTarget extends Target {
 
     const manifestFile = stageDir.getTempFile("AppxManifest.xml")
     await this.writeManifest(manifestFile, arch, await this.computePublisherName(), userAssets)
+    await packager.info.callAppxManifestCreated(manifestFile);
     mappingList.push(assetInfo.mappings)
     mappingList.push([`"${vm.toVmFile(manifestFile)}" "AppxManifest.xml"`])
 


### PR DESCRIPTION
This PR adds a new hook, appxManifestCreated(path: string), that allows modifying the appx manifest before it is packed into the .appx installer. 