### PR TITLE
always include a secure timestamp with your code-signing signature

### DIFF
--- a/packages/app-builder-lib/electron-osx-sign/sign.js
+++ b/packages/app-builder-lib/electron-osx-sign/sign.js
@@ -141,6 +141,7 @@ function signApplicationAsync (opts) {
 
       const args = [
         '--sign', opts.identity.hash || opts.identity.name,
+        '--deep',
         '--force'
       ]
       if (opts.keychain) {
@@ -151,6 +152,8 @@ function signApplicationAsync (opts) {
       }
       if (opts.timestamp) {
         args.push('--timestamp=' + opts.timestamp)
+      } else {
+        args.push('--timestamp')
       }
       if (opts.hardenedRuntime || opts['hardened-runtime']) {
         // 17.7.0 === 10.13.6


### PR DESCRIPTION

> Include a secure timestamp with your code-signing signature. (The Xcode distribution workflow includes a secure timestamp by default. For custom workflows, include the --timestamp option when running the codesign tool.)

https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution?language=objc