### PR TITLE
Fix NSIS web build

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
@@ -17,7 +17,7 @@
 	          StrCpy $packageUrl "$packageUrl/${APP_32_NAME}"
 	        ${endif}
 		    !else
-	        ${if} ${IsNativeAMD64} == true
+	        ${if} ${IsNativeAMD64}
 	          StrCpy $packageUrl "$packageUrl/${APP_64_NAME}"
 	        ${else}
 	          StrCpy $packageUrl "$packageUrl/${APP_32_NAME}"
@@ -31,7 +31,7 @@
     !endif
   !endif
 
-  ${if} ${IsNativeARM64} 
+  ${if} ${IsNativeARM64}
     StrCpy $packageArch "ARM64"
   ${elseif} ${IsNativeAMD64}
     StrCpy $packageArch "64"


### PR DESCRIPTION
This fixes #4402. More specifically error `
!insertmacro: macro "_If" requires 4 parameter(s), passed 6!
` during build of nsis-web target