### PR TITLE
fix(docker): fix install of wine

### DIFF
--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -1,6 +1,6 @@
 FROM electronuserland/builder:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && dpkg --add-architecture i386 && curl -L https://dl.winehq.org/wine-builds/winehq.key > winehq.key && apt-key add winehq.key && apt-add-repository https://dl.winehq.org/wine-builds/ubuntu && \
+RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && dpkg --add-architecture i386 && curl -L https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key > winehq.key && apt-key add winehq.key && apt-add-repository 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/ ./' && \
   apt-get update && \
   apt-get -y purge software-properties-common libdbus-glib-1-2 python3-dbus python3-gi python3-pycurl python3-software-properties && \
   apt-get install -y --no-install-recommends winehq-stable && \


### PR DESCRIPTION
I got the following error while building the docker image (what I have to because the public image never gets updated -> please fix that, there are several issues complaining about that) and fixed it with the recommended solution.

https://askubuntu.com/questions/1205550/cant-install-wine-on-ubuntu-actually-lubuntu-18-04