### PR TITLE
fix(builder-util-runtime): set timeout when request is closed

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -285,11 +285,16 @@ Please double check that your authentication token is correct. Due to security r
   }
 
   private addTimeOutHandler(request: any, callback: (error: Error) => void) {
+    const timeoutCb = () => {
+      request.abort()
+      callback(new Error("Request timed out"))
+    }
+
     request.on("socket", (socket: Socket) => {
-      socket.setTimeout(60 * 1000, () => {
-        request.abort()
-        callback(new Error("Request timed out"))
-      })
+      socket.setTimeout(60 * 1000, timeoutCb)
+    })
+    request.on("close", () => {
+      setTimeout(timeoutCb, 30 * 1000)
     })
   }
 


### PR DESCRIPTION
"Socket" event is not fired if Electron "net" version of request is used. It lead to issue that request will never be timed out if something went wrong. I didn't find how to set timeout request in Electron net module. I'm open to proposals of more clear approach.
This PR fixes issue https://github.com/electron-userland/electron-builder/issues/4618