### PR TITLE
fix(builder-util): Retry flaky builder operations

### DIFF
--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -317,7 +317,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     const timer = time("wine&sign")
     // rcedit crashed of executed using wine, resourcehacker works
     if (process.platform === "win32" || this.info.framework.name === "electron") {
-      await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)])
+      await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 5 /* retry five times */)
     }
 
     await this.sign(file)

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -372,7 +372,7 @@ export function executeAppBuilder(args: Array<string>, childProcessConsumer?: (c
   return retry(runCommand, maxRetries);
 }
 
-async function retry<T>(
+export async function retry<T>(
   fn: () => Promise<T>,
   retriesLeft = 5,
   interval = 1000


### PR DESCRIPTION
There are various operations that we have found flaky and unreliable on Windows due to AntiVirus issues. 
For example, the RCEdit.exe command to edit the binary information often fails 

```
 ⨯ cannot execute  cause=exit status 1
                    errorOut=Fatal error: Unable to commit changes
```

But will succeed immediately after

This PR adds support to `executeAppBuilder` to retry operations that have failed