### PR TITLE
fix(app-builder-lib): remove lock to devDependencies

### DIFF
--- a/packages/app-builder-lib/src/util/packageMetadata.ts
+++ b/packages/app-builder-lib/src/util/packageMetadata.ts
@@ -109,15 +109,4 @@ function checkDependencies(dependencies: { [key: string]: string } | null | unde
   if (swVersion != null && !versionSatisfies(swVersion, ">=20.32.0")) {
     errors.push(`At least electron-builder-squirrel-windows 20.32.0 is required by current electron-builder version. Please set electron-builder-squirrel-windows to "^20.32.0"`)
   }
-
-  const deps = ["electron", "electron-prebuilt", "electron-rebuild"]
-  if (process.env.ALLOW_ELECTRON_BUILDER_AS_PRODUCTION_DEPENDENCY !== "true") {
-    deps.push("electron-builder")
-  }
-  for (const name of deps) {
-    if (name in dependencies) {
-      errors.push(`Package "${name}" is only allowed in "devDependencies". `
-        + `Please remove it from the "dependencies" section in your package.json.`)
-    }
-  }
 }


### PR DESCRIPTION
This code was blocking the installation in a CI pipeline without installing all devDependecies which is against the official documentation of npm.

https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file

- **"dependencies"**: Packages required by your application in production.
- **"devDependencies"**: Packages that are only needed for local development and testing.

Electron, electron-builder etc. are all required to build the production version and not just for local development or testing. So they should be normal dependencies inside the package.json.

Related issues:
#2330
#2481
#3335
Fixes #4563