### PR TITLE
Add ARM64 support for APPX

### DIFF
--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -240,7 +240,7 @@ export default class AppXTarget extends Target {
 
           case "extensions":
             return this.getExtensions(executable, displayName)
-         
+            
           case "minVersion":
             return arch === Arch.arm64 ? "10.0.16299.0" : "10.0.14316.0"
             

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -240,13 +240,13 @@ export default class AppXTarget extends Target {
 
           case "extensions":
             return this.getExtensions(executable, displayName)
-            
+         
           case "minVersion":
             return arch === Arch.arm64 ? "10.0.16299.0" : "10.0.14316.0"
             
           case "maxVersionTested":
             return arch === Arch.arm64 ? "10.0.16299.0" : "10.0.14316.0"
-
+            
           default:
             throw new Error(`Macro ${p1} is not defined`)
         }

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -240,6 +240,12 @@ export default class AppXTarget extends Target {
 
           case "extensions":
             return this.getExtensions(executable, displayName)
+            
+          case "minVersion":
+            return arch === Arch.arm64 ? "10.0.16299.0" : "10.0.14316.0"
+            
+          case "maxVersionTested":
+            return arch === Arch.arm64 ? "10.0.16299.0" : "10.0.14316.0"
 
           default:
             throw new Error(`Macro ${p1} is not defined`)

--- a/packages/app-builder-lib/templates/appx/appxmanifest.xml
+++ b/packages/app-builder-lib/templates/appx/appxmanifest.xml
@@ -20,7 +20,7 @@
     ${resourceLanguages}
   </Resources>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14316.0" MaxVersionTested="10.0.14316.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="${minVersion}" MaxVersionTested="${maxVersionTested}" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust"/>


### PR DESCRIPTION
Microsoft requires the `minVersion` and `maxVersionTested` values for ARM64 builds of APPX to be at least build 10.0.16299.0 (or newer). Updated the manifest builder to apply the appropriate build values depending on the arch.

So for ARM64 builds, the `minVersion` and `maxVersionTested` values will be `10.0.16299.0` and `10.0.14316.0` for everything else. 