### PR TITLE
emit appimage-filename-updated event

### DIFF
--- a/packages/app-builder-lib/src/electron/electronMac.ts
+++ b/packages/app-builder-lib/src/electron/electronMac.ts
@@ -121,7 +121,7 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
     helper.CFBundleDisplayName = `${appInfo.productName} Helper ${postfix}`
     helper.CFBundleIdentifier = userProvidedBundleIdentifier
       ? filterCFBundleIdentifier(userProvidedBundleIdentifier)
-      : `${helperBundleIdentifier}.${postfix.replace(/[^a-z0-9]/gim, "")}`
+      : filterCFBundleIdentifier(`${helperBundleIdentifier}.${postfix}`)
     helper.CFBundleVersion = appPlist.CFBundleVersion
   }
 

--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -89,6 +89,9 @@ export class AppImageUpdater extends BaseUpdater {
     }
 
     execFileSync("mv", ["-f", options.installerPath, destination])
+    if(destination !== appImageFile){
+      this.emit('appimage-filename-updated',destination)
+    }
 
     const env: any = {
       ...process.env,

--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -89,8 +89,8 @@ export class AppImageUpdater extends BaseUpdater {
     }
 
     execFileSync("mv", ["-f", options.installerPath, destination])
-    if(destination !== appImageFile){
-      this.emit('appimage-filename-updated',destination)
+    if (destination !== appImageFile) {
+      this.emit('appimage-filename-updated', destination)
     }
 
     const env: any = {


### PR DESCRIPTION
The appimage-filename-updated event is emitted here, so that if the appimage filename is updated, the app will have the opportunity to update the path in the .desktop file