### PR TITLE
fix(electron-updater): Update return type of downloadUpdate from Promise any -> string[]

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -392,9 +392,9 @@ export abstract class AppUpdater extends EventEmitter {
 
   /**
    * Start downloading update manually. You can use this method if `autoDownload` option is set to `false`.
-   * @returns {Promise<string[]>} where the first item in the list is the path to downloaded file.
+   * @returns {Promise<Array<string>>} where the first item in the list is the path to downloaded file.
    */
-  downloadUpdate(cancellationToken: CancellationToken = new CancellationToken()): Promise<string[]> {
+  downloadUpdate(cancellationToken: CancellationToken = new CancellationToken()): Promise<Array<string>> {
     const updateInfoAndProvider = this.updateInfoAndProvider
     if (updateInfoAndProvider == null) {
       const error = new Error("Please check update first")

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -392,9 +392,9 @@ export abstract class AppUpdater extends EventEmitter {
 
   /**
    * Start downloading update manually. You can use this method if `autoDownload` option is set to `false`.
-   * @returns {Promise<string>} Path to downloaded file.
+   * @returns {Promise<string[]>} where the first item in the list is the path to downloaded file.
    */
-  downloadUpdate(cancellationToken: CancellationToken = new CancellationToken()): Promise<any> {
+  downloadUpdate(cancellationToken: CancellationToken = new CancellationToken()): Promise<string[]> {
     const updateInfoAndProvider = this.updateInfoAndProvider
     if (updateInfoAndProvider == null) {
       const error = new Error("Please check update first")


### PR DESCRIPTION
## Descriptions

Noticed that the return type of this function does not align with the documentation. Which says that it resolves to a `Promise<any>` 

https://www.electron.build/auto-update.html#module_electron-updater.AppUpdater+downloadUpdate

#### Picture:
<img width="767" alt="image" src="https://user-images.githubusercontent.com/44967897/76714540-a7ad1d00-677b-11ea-8407-8c268a732ed5.png">

### Review

This PR changes the typing in code to reflect the actual return type `string[]` that will always contain the downloaded file path as the first item in the list, traced in here:
https://github.com/kevinlinv/electron-builder/blob/f2c374974be358b96c896dba417406b4f8106ad2/packages/electron-updater/src/AppUpdater.ts#L588

~~I'll update the docs soon too.~~ See: https://github.com/electron-userland/electron-builder/pull/4787 where the docs update is done.
