### PR TITLE
docs(electron-updater): Update docs for downloadUpdate resolved type

### DIFF
--- a/auto-update.md
+++ b/auto-update.md
@@ -245,7 +245,7 @@ Emitted on progress.
 * [.AppUpdater](#AppUpdater) ⇐ <code>[EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter)</code>
     * [`.checkForUpdates()`](#module_electron-updater.AppUpdater+checkForUpdates) ⇒ <code>Promise&lt;[UpdateCheckResult](#UpdateCheckResult)&gt;</code>
     * [`.checkForUpdatesAndNotify()`](#module_electron-updater.AppUpdater+checkForUpdatesAndNotify) ⇒ <code>Promise&lt; \| [UpdateCheckResult](#UpdateCheckResult)&gt;</code>
-    * [`.downloadUpdate(cancellationToken)`](#module_electron-updater.AppUpdater+downloadUpdate) ⇒ <code>Promise&lt;any&gt;</code>
+    * [`.downloadUpdate(cancellationToken)`](#module_electron-updater.AppUpdater+downloadUpdate) ⇒ <code>Promise&lt;Array&lt;string&gt;&gt;</code>
     * [`.getFeedURL()`](#module_electron-updater.AppUpdater+getFeedURL) ⇒ <code>undefined</code> \| <code>null</code> \| <code>String</code>
     * [`.setFeedURL(options)`](#module_electron-updater.AppUpdater+setFeedURL)
     * [`.quitAndInstall(isSilent, isForceRunAfter)`](#module_electron-updater.AppUpdater+quitAndInstall)
@@ -261,11 +261,11 @@ Asks the server whether there is an update.
 Asks the server whether there is an update, download and notify if update available.
 
 <a name="module_electron-updater.AppUpdater+downloadUpdate"></a>
-**`appUpdater.downloadUpdate(cancellationToken)` ⇒ <code>Promise&lt;any&gt;</code>**
+**`appUpdater.downloadUpdate(cancellationToken)` ⇒ <code>Promise&lt;Array&lt;string&gt;&gt;</code>**
 
 Start downloading update manually. You can use this method if `autoDownload` option is set to `false`.
 
-**Returns**: <code>Promise&lt;any&gt;</code> - Path to downloaded file.  
+**Returns**: <code>Promise&lt;Array&lt;string&gt;&gt;</code> - Where the first item in the list is guaranteed to be the path to downloaded file.
 
 - cancellationToken <code>CancellationToken</code>
 


### PR DESCRIPTION
## Descriptions

The typing of `AppUpdater:downloadUpdate` is inaccurate here.

Rather than typing it as `Promise<any>` this should be `Promise<Array<string>>` according to the code: https://github.com/kevinlinv/electron-builder/blob/f2c374974be358b96c896dba417406b4f8106ad2/packages/electron-updater/src/AppUpdater.ts#L588

## Review

This PR is the other pair of the actual code change in https://github.com/electron-userland/electron-builder/pull/4786.

