### PR TITLE
Fixed splash screen in windows portable

### DIFF
--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -1,15 +1,12 @@
 !include "common.nsh"
 !include "extractAppPackage.nsh"
 
-# https://github.com/electron-userland/electron-builder/issues/3972#issuecomment-505171582
 CRCCheck off
 WindowIcon Off
 AutoCloseWindow True
 RequestExecutionLevel ${REQUEST_EXECUTION_LEVEL}
 
 Function .onInit
-  SetSilent silent
-
   !insertmacro check64BitAndSetRegView
 FunctionEnd
 

--- a/packages/app-builder-lib/templates/nsis/portable.nsi
+++ b/packages/app-builder-lib/templates/nsis/portable.nsi
@@ -7,6 +7,9 @@ AutoCloseWindow True
 RequestExecutionLevel ${REQUEST_EXECUTION_LEVEL}
 
 Function .onInit
+  !ifndef SPLASH_IMAGE
+    SetSilent silent
+  !endif
   !insertmacro check64BitAndSetRegView
 FunctionEnd
 


### PR DESCRIPTION
The splash screen is now working I've tested it with the "electron-webpack-quick-start"
I added a bmp image in a new folder "assets" which is located at the project root.
This is an example on how to configure the build in package.json

```
  "build": {
    "appId": "app.philips-dicom-viewer",
    "portable": {
      "splashImage": "assets\\splash.bmp"
    },
    "win": {
      "target": "portable"
    }
  }
```