### PR TITLE
fix(multipleRangeDownloader): when response ends nothing more happens

### DIFF
--- a/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
@@ -93,6 +93,13 @@ function doExecuteTasks(differentialDownloader: DifferentialDownloader, options:
     const dicer = new DataSplitter(out, options, partIndexToTaskIndex, m[1] || m[2], partIndexToLength, resolve)
     dicer.on("error", reject)
     response.pipe(dicer)
+	
+	response.on('end', () => {
+	  setTimeout(() => {
+	    request && request.abort()
+	    reject(new Error("Response ends without calling any handlers"))
+	  }, 10000)
+	})
   })
   differentialDownloader.httpExecutor.addErrorAndTimeoutHandlers(request, reject)
   request.end()

--- a/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
@@ -94,12 +94,12 @@ function doExecuteTasks(differentialDownloader: DifferentialDownloader, options:
     dicer.on("error", reject)
     response.pipe(dicer)
 	
-	response.on('end', () => {
-	  setTimeout(() => {
-	    request && request.abort()
-	    reject(new Error("Response ends without calling any handlers"))
-	  }, 10000)
-	})
+    response.on('end', () => {
+      setTimeout(() => {
+        request && request.abort()
+        reject(new Error("Response ends without calling any handlers"))
+      }, 10000)
+    })
   })
   differentialDownloader.httpExecutor.addErrorAndTimeoutHandlers(request, reject)
   request.end()


### PR DESCRIPTION
Nothing more happen when response ends. It leads to issue that no events are pushed outside: e.g. download is successful. In successful cases - I'm not an expert in streams - but as I understand somewhere resolve is called. I didn't find more proper solution, so just wait for 10 seconds and call reject. If resolve was already called previously in success case, this will not lead to any issues.
This PR fixes issue #[4618](https://github.com/electron-userland/electron-builder/issues/4618)
@develar could you please have a look