### PR TITLE
Add electron version on issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,10 +1,14 @@
 <!-- Which version of electron-builder are you using? -->
-<!-- Please always try to use latest version before report. -->
+<!-- Please always try to use latest version before reporting any issue. -->
 * **Version**: 
 
+<!-- Which version of electron are you using? -->
+<!-- Please verify if the error is electron related before reporting any issues. -->
+* **Electron Version**:
+* **Electron Type (current, beta, nightly)**:
 <!-- Which version of electron-updater are you using (if applicable)? -->
 
-<!-- What target are you building for? -->
+<!-- For which target are you building for? -->
 * **Target**: 
 
 <!-- Enter your issue details below this comment. -->


### PR DESCRIPTION
Adding the electron version might give us a better troubleshooting, since some errors people might encounter can be electron-related and updater/builder only needs a simple change to make that work.