### PR TITLE
fix(electron-updater): Make updater work again when using aws s3 private buckets

### DIFF
--- a/packages/electron-updater/src/electronHttpExecutor.ts
+++ b/packages/electron-updater/src/electronHttpExecutor.ts
@@ -46,6 +46,15 @@ export class ElectronHttpExecutor extends HttpExecutor<Electron.ClientRequest> {
   }
 
   createRequest(options: any, callback: (response: any) => void): any {
+
+    // fix (node 7+) for making electron updater work when using AWS private buckets, check if headers contain Host property
+    if (options.headers && options.headers.Host){
+      // set host value from headers.Host
+      options.host = options.headers.Host
+      // remove header property 'Host', if not removed causes net::ERR_INVALID_ARGUMENT exception
+      delete options.headers.Host;
+    }
+
     // differential downloader can call this method very often, so, better to cache session
     if (this.cachedSession == null) {
       this.cachedSession = getNetSession()


### PR DESCRIPTION
See 
https://github.com/electron-userland/electron-builder/issues/4454
and 
https://github.com/electron-userland/electron-builder/issues/4758