### PR TITLE
Change archive names

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -3368,7 +3368,7 @@
           ]
         },
         "archiveName": {
-          "description": "The archive names pattern. Default to `${productName}-${version}.{%target%}.${ext}`",
+          "description": "The archive names pattern. Default to `${sanitizedName}-${version}-${arch}.{%target%}.${ext}`",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -3367,6 +3367,13 @@
             "string"
           ]
         },
+        "archiveName": {
+          "description": "The archive names pattern. Default to `${productName}-${version}.{%target%}.${ext}`",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "createDesktopShortcut": {
           "default": true,
           "description": "Whether to create desktop shortcut. Set to `always` if to recreate also on reinstall (even if removed by user).",

--- a/packages/app-builder-lib/src/core.ts
+++ b/packages/app-builder-lib/src/core.ts
@@ -96,6 +96,11 @@ export interface TargetSpecificOptions {
    */
   readonly artifactName?: string | null
 
+  /**
+   * The arcive file name
+   */
+  readonly archiveName?: string | null
+
   publish?: Publish
 }
 

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -41,6 +41,11 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions {
   readonly artifactName?: string | null
 
   /**
+   * The archive names. Default to `${productName}-${version}.{%target%}.${ext}`
+   */
+  readonly archiveName?: string | null
+
+  /**
    * The compression level. If you want to rapidly test build, `store` can reduce build time significantly. `maximum` doesn't lead to noticeable size difference, but increase build time.
    * @default normal
    */

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -41,7 +41,7 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions {
   readonly artifactName?: string | null
 
   /**
-   * The archive names. Default to `${productName}-${version}.{%target%}.${ext}`
+   * The archive names. Default to `${name}-${version}-${arch}.${ext}`
    */
   readonly archiveName?: string | null
 

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -41,7 +41,7 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions {
   readonly artifactName?: string | null
 
   /**
-   * The archive names. Default to `${name}-${version}-${arch}.${ext}`
+   * The archive names. Default to `${sanitizedName}-${version}-${arch}.{%target%}.${ext}`
    */
   readonly archiveName?: string | null
 

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -480,6 +480,20 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return this.computeArtifactName(pattern, ext, skipArchIfX64 && arch === Arch.x64 ? null : arch)
   }
 
+  expandArchiveNamePattern(targetSpecificOptions: TargetSpecificOptions | null | undefined, ext: string, arch?: Arch | null, defaultPattern?: string): string {
+    let pattern = targetSpecificOptions == null ? null : targetSpecificOptions.archiveName
+    if (pattern == null) {
+      pattern = this.platformSpecificBuildOptions.archiveName || this.config.archiveName
+    }
+
+    if (pattern == null) {
+      // tslint:disable-next-line:no-invalid-template-strings
+      pattern = defaultPattern || "${productName}-${version}-${arch}.${ext}"
+    }
+
+    return this.computeArtifactName(pattern, ext, arch)
+  }
+
   expandArtifactBeautyNamePattern(targetSpecificOptions: TargetSpecificOptions | null | undefined, ext: string, arch?: Arch | null): string {
     // tslint:disable-next-line:no-invalid-template-strings
     return this.expandArtifactNamePattern(targetSpecificOptions, ext, arch, "${productName} ${version} ${arch}.${ext}", true)

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -488,7 +488,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
     if (pattern == null) {
       // tslint:disable-next-line:no-invalid-template-strings
-      pattern = defaultPattern || "${productName}-${version}-${arch}.${ext}"
+      pattern = defaultPattern || "${sanitizedName}-${version}-${arch}.${ext}"
     }
 
     return this.computeArtifactName(pattern, ext, arch)

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -21,7 +21,7 @@ import { appendBlockmap, configureDifferentialAwareArchiveOptions, createBlockma
 import { getWindowsInstallationDirName } from "../targetUtil"
 import { addCustomMessageFileInclude, createAddLangsMacro, LangConfigurator } from "./nsisLang"
 import { computeLicensePage } from "./nsisLicense"
-import { NsisOptions, PortableOptions, NsisWebOptions } from './nsisOptions';
+import { NsisOptions, PortableOptions } from "./nsisOptions";
 import { NsisScriptGenerator } from "./nsisScriptGenerator"
 import { AppPackageHelper, NSIS_PATH, nsisTemplatesDir, UninstallerReader } from "./nsisUtil"
 

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -21,7 +21,7 @@ import { appendBlockmap, configureDifferentialAwareArchiveOptions, createBlockma
 import { getWindowsInstallationDirName } from "../targetUtil"
 import { addCustomMessageFileInclude, createAddLangsMacro, LangConfigurator } from "./nsisLang"
 import { computeLicensePage } from "./nsisLicense"
-import { NsisOptions, PortableOptions } from "./nsisOptions";
+import { NsisOptions, PortableOptions } from "./nsisOptions"
 import { NsisScriptGenerator } from "./nsisScriptGenerator"
 import { AppPackageHelper, NSIS_PATH, nsisTemplatesDir, UninstallerReader } from "./nsisUtil"
 

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -124,20 +124,6 @@ export class NsisTarget extends Target {
     return this.name === "portable"
   }
 
-  private expandArtifactNamePattern(options: NsisWebOptions, format: string) {
-    let pattern = options == null ? null : options.archiveName;
-
-    if (pattern == null) {
-      // tslint:disable-next-line:no-invalid-template-strings
-      pattern = "${productName}-${version}-${arch}.${ext}"
-    }
-    else {
-      // https://github.com/electron-userland/electron-builder/issues/3510
-      // always respect arch in user custom artifact pattern
-      skipArchIfX64 = false
-    }
-  }
-
   private async buildInstaller(): Promise<any> {
     const packager = this.packager
     const appInfo = packager.appInfo

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -81,8 +81,8 @@ export class NsisTarget extends Target {
 
     const isBuildDifferentialAware = this.isBuildDifferentialAware
     const format = !isBuildDifferentialAware && options.useZip ? "zip" : "7z"
-    const archiveFileName = packager.expandArchiveNamePattern(options, format, arch, "${sanitizedName}-${version}-${arch}.nsis.${ext}");
-    const archiveFile = path.join(this.outDir, archiveFileName);
+    const archiveFileName = packager.expandArchiveNamePattern(options, format, arch, "${sanitizedName}-${version}-${arch}.nsis.${ext}")
+    const archiveFile = path.join(this.outDir, archiveFileName)
     const preCompressedFileExtensions = this.getPreCompressedFileExtensions()
     const archiveOptions: ArchiveOptions = {
       withoutDir: true,

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -202,7 +202,7 @@ export interface NsisWebOptions extends NsisOptions {
 
 
   /**
-   * The nsis archive name template. Defaults to `${productName}-{version}-${arch}.nsis.${ext}
+   * The nsis archive name template. Defaults to `${sanitizedName}-{version}-${arch}.nsis.${ext}
    */
   readonly archiveName?: string | null
 }

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -199,4 +199,10 @@ export interface NsisWebOptions extends NsisOptions {
    * The [artifact file name template](/configuration/configuration#artifact-file-name-template). Defaults to `${productName} Web Setup ${version}.${ext}`.
    */
   readonly artifactName?: string | null
+
+
+  /**
+   * The nsis archive name template. Defaults to `${productName}-{version}-${arch}.nsis.${ext}
+   */
+  readonly archiveName?: string | null
 }

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -836,7 +836,7 @@ Object {
               },
             },
             "index.js": Object {
-              "size": 2688,
+              "size": 2644,
             },
             "package.json": Object {
               "size": 548,

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -36,7 +36,7 @@ test.ifAll.ifNotCiMac("web installer, safe name on github", app({
     nsisWeb: {
       //tslint:disable-next-line:no-invalid-template-strings
       artifactName: "${productName}.${ext}",
-      archiveName: "${name}-custom.${ext}"
+      archiveName: "${sanitizedName}-${arch}-custom.${ext}"
     },
   },
 }))

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -36,7 +36,7 @@ test.ifAll.ifNotCiMac("web installer, safe name on github", app({
     nsisWeb: {
       //tslint:disable-next-line:no-invalid-template-strings
       artifactName: "${productName}.${ext}",
-      archiveName: "${productName}-custom.${ext}"
+      archiveName: "${name}-custom.${ext}"
     },
   },
 }))

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -36,6 +36,7 @@ test.ifAll.ifNotCiMac("web installer, safe name on github", app({
     nsisWeb: {
       //tslint:disable-next-line:no-invalid-template-strings
       artifactName: "${productName}.${ext}",
+      archiveName: "${productName}-custom.${ext}"
     },
   },
 }))

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -36,7 +36,7 @@ test.ifAll.ifNotCiMac("web installer, safe name on github", app({
     nsisWeb: {
       //tslint:disable-next-line:no-invalid-template-strings
       artifactName: "${productName}.${ext}",
-      archiveName: "${sanitizedName}-${arch}-custom.${ext}"
+      archiveName: "${sanitizedName}-${version}-${arch}.nsis.${ext}"
     },
   },
 }))


### PR DESCRIPTION
Web installer, should be configured by options "archiveName". That be able to use only one installer for all versions of app. For example if i want to remove version from archive name that prevent web installer from downloading "holded" versions, and each one installation would be latest every time. 