### PR TITLE
fix(appx): Invalid code signing tool when building for windows 10 arm64

### DIFF
--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -76,10 +76,11 @@ export default class AppXTarget extends Target {
     await packager.info.callAppxManifestCreated(manifestFile)
     mappingList.push(assetInfo.mappings)
     mappingList.push([`"${vm.toVmFile(manifestFile)}" "AppxManifest.xml"`])
+    const signToolArch = (arch === Arch.arm64 ? "x64" : Arch[arch])
 
     if (isScaledAssetsProvided(userAssets)) {
       const outFile = vm.toVmFile(stageDir.getTempFile("resources.pri"))
-      const makePriPath = vm.toVmFile(path.join(vendorPath, "windows-10", Arch[arch], "makepri.exe"))
+      const makePriPath = vm.toVmFile(path.join(vendorPath, "windows-10", signToolArch, "makepri.exe"))
 
       const assetRoot = stageDir.getTempFile("appx/assets")
       await emptyDir(assetRoot)
@@ -110,7 +111,7 @@ export default class AppXTarget extends Target {
     if (this.options.makeappxArgs != null) {
       makeAppXArgs.push(...this.options.makeappxArgs)
     }
-    await vm.exec(vm.toVmFile(path.join(vendorPath, "windows-10", Arch[arch], "makeappx.exe")), makeAppXArgs)
+    await vm.exec(vm.toVmFile(path.join(vendorPath, "windows-10", signToolArch, "makeappx.exe")), makeAppXArgs)
     await packager.sign(artifactPath)
 
     await stageDir.cleanup()


### PR DESCRIPTION
Fixes an error when generating appx for Windows 10 arm64 due to referencing a non-existent winCodeSign path. When building for arm64, the x64 version of winCodeSign is used.

#### Error log

```
  ⨯ Exit code: ENOENT. spawn C:\Users\shibayan\AppData\Local\electron-builder\Cache\winCodeSign\winCodeSign-2.6.0\windows-10\arm64\makeappx.exe ENOENT  stackTrace=
      Error: Exit code: ENOENT. spawn C:\Users\shibayan\AppData\Local\electron-builder\Cache\winCodeSign\winCodeSign-2.6.0\windows-10\arm64\makeappx.exe ENOENT
          at C:\Users\shibayan\Documents\electron-quick-start\node_modules\builder-util\src\util.ts:125:16
          at exithandler (child_process.js:310:5)
          at ChildProcess.errorhandler (child_process.js:322:5)
          at ChildProcess.emit (events.js:310:20)
          at Process.ChildProcess._handle.onexit (internal/child_process.js:273:12)
          at onErrorNT (internal/child_process.js:469:16)
          at processTicksAndRejections (internal/process/task_queues.js:84:21)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! electron-quick-start@1.0.0 dist: `electron-builder`
npm ERR! Exit status 1
```