### PR TITLE
Add missing %U in desktop file of appimages

### DIFF
--- a/packages/app-builder-lib/src/targets/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppImageTarget.ts
@@ -19,7 +19,7 @@ export default class AppImageTarget extends Target {
   constructor(ignored: string, private readonly packager: LinuxPackager, private readonly helper: LinuxTargetHelper, readonly outDir: string) {
     super("appImage")
 
-    this.desktopEntry = new Lazy<string>(() => helper.computeDesktopEntry(this.options, "AppRun", {
+    this.desktopEntry = new Lazy<string>(() => helper.computeDesktopEntry(this.options, "AppRun %U", {
       "X-AppImage-Version": `${packager.appInfo.buildVersion}`,
     }))
   }

--- a/test/snapshots/linux/linuxPackagerTest.js.snap
+++ b/test/snapshots/linux/linuxPackagerTest.js.snap
@@ -3,7 +3,7 @@
 exports[`AppImage - default icon, custom executable and custom desktop 1`] = `
 "[Desktop Entry]
 Name=Test App ßW
-Exec=AppRun
+Exec=AppRun %U
 Terminal=true
 Type=Application
 Icon=Foo


### PR DESCRIPTION
this should fix #4035

Add missing %U in .desktop file of appimages, which is missing because the `Exec` var is set, so the code to add it to the other desktop files is not active: 
https://github.com/electron-userland/electron-builder/blob/f938de5aae09cb832a6f7f742e64a0d6c025fb9f/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts#L95-L105