### PR TITLE
chore: enable NPM_NO_BIN_LINKS for yarn 1.x.x

### DIFF
--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -86,13 +86,13 @@ function installDependencies(appDir: string, options: RebuildOptions): Promise<a
   const npmUserAgent = process.env["npm_config_user_agent"]
   const isYarn2 = npmUserAgent != null && npmUserAgent.startsWith("yarn/2.")
   if (!isYarn2) {
+    if (process.env.NPM_NO_BIN_LINKS === "true") {
+      execArgs.push("--no-bin-links")
+    }
     execArgs.push("--production")
   }
 
   if (!isRunningYarn(execPath)) {
-    if (process.env.NPM_NO_BIN_LINKS === "true") {
-      execArgs.push("--no-bin-links")
-    }
     execArgs.push("--cache-min", "999999999")
   }
 


### PR DESCRIPTION
Enables NPM_NO_BIN_LINKS by pushing `--no-bin-links` parameter to yarn exec args
Since yarn 2 was released `--no-bin-links` parameter was deprecated