### PR TITLE
fix: cached update validation failing on undefined filename

### DIFF
--- a/packages/electron-updater/src/DownloadedUpdateHelper.ts
+++ b/packages/electron-updater/src/DownloadedUpdateHelper.ts
@@ -106,7 +106,8 @@ export class DownloadedUpdateHelper {
       return null
     }
 
-    if (cachedInfo.fileName == null) {
+    const isCachedInfoFileNameValid = cachedInfo?.fileName !== null ?? false
+    if (isCachedInfoFileNameValid) {
       logger.warn(`Cached update info is corrupted: no fileName, directory for cached update will be cleaned`)
       await this.cleanCacheDirForPendingUpdate()
       return null

--- a/packages/electron-updater/src/DownloadedUpdateHelper.ts
+++ b/packages/electron-updater/src/DownloadedUpdateHelper.ts
@@ -3,7 +3,7 @@ import { createHash } from "crypto"
 import { createReadStream } from "fs"
 import isEqual from "lodash.isequal"
 import { Logger, ResolvedUpdateFileInfo } from "./main"
-import { pathExists, readJson, emptyDir, outputJson, unlink } from "fs-extra"
+import { pathExists, readJson, emptyDir, outputJson, unlink, pathExistsSync } from "fs-extra"
 import * as path from "path"
 
 /** @private **/
@@ -90,24 +90,36 @@ export class DownloadedUpdateHelper {
     }
   }
 
+  /**
+   * Returns "update-info.json" which is created in the update cache directory's "pending" subfolder after the first update is downloaded.  If the update file does not exist then the cache is cleared and recreated.  If the update file exists then its properties are validated.
+   * @param fileInfo
+   * @param logger
+   */
   private async getValidCachedUpdateFile(fileInfo: ResolvedUpdateFileInfo, logger: Logger): Promise<string | null> {
-    let cachedInfo: CachedUpdateInfo
-    const updateInfoFile = this.getUpdateInfoFile()
-    try {
-      cachedInfo = await readJson(updateInfoFile)
+    const updateInfoFilePath: string = this.getUpdateInfoFile()
+
+    const doesUpdateInfoFileExist = await pathExistsSync(updateInfoFilePath);
+    if(!doesUpdateInfoFileExist) {
+      return null;
     }
-    catch (e) {
+
+
+    let cachedInfo: CachedUpdateInfo
+    try {
+      cachedInfo = await readJson(updateInfoFilePath)
+    }
+    catch (error) {
       let message = `No cached update info available`
-      if (e.code !== "ENOENT") {
+      if (error.code !== "ENOENT") {
         await this.cleanCacheDirForPendingUpdate()
-        message += ` (error on read: ${e.message})`
+        message += ` (error on read: ${error.message})`
       }
       logger.info(message)
       return null
     }
 
     const isCachedInfoFileNameValid = cachedInfo?.fileName !== null ?? false
-    if (isCachedInfoFileNameValid) {
+    if (!isCachedInfoFileNameValid) {
       logger.warn(`Cached update info is corrupted: no fileName, directory for cached update will be cleaned`)
       await this.cleanCacheDirForPendingUpdate()
       return null


### PR DESCRIPTION
Closes #4928

In my setup I was encountering a situation where there was never an `update-info.json` file created and the `cachedInfo` object in `DownloadedUpdateHelper.getValidCachedUpdateFile()` was `undefined`.

This effectively meant that an error was thrown and the update never downloaded.

This makes the code a little bit more resilient by using optional chaining and nullish coalescing from typescript to ensure that the cachedInfo object is not undefined and then that the `fileName` is not null.   If it is undefined it will fall back to the `cleanCacheDirForPendingUpdate` function.

I also changed another instance of the `==` operator to `===` as that is generally preferred.

### Update

The root cause of this issue is that the try/catch that is supposed to check if the file exists does not work.  **It does not enter the catch block**.  I discovered this by a large set of console logs and multiple packages and tests.  

What is preferable is an early existence check and early return if the cachedInfo file does not exist.