### PR TITLE
Log the raw version string when AppUpdater fails to parse semver of latest version

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -305,7 +305,7 @@ export abstract class AppUpdater extends EventEmitter {
   private async isUpdateAvailable(updateInfo: UpdateInfo): Promise<boolean> {
     const latestVersion = parseVersion(updateInfo.version)
     if (latestVersion == null) {
-      throw newError(`This file could not be downloaded, or the latest version (from update server) does not have a valid semver version: "${latestVersion}"`, "ERR_UPDATER_INVALID_VERSION")
+      throw newError(`This file could not be downloaded, or the latest version (from update server) does not have a valid semver version: "${updateInfo.version}"`, "ERR_UPDATER_INVALID_VERSION")
     }
 
     const currentVersion = this.currentVersion


### PR DESCRIPTION
When the app updater fails because the version string can't be parsed, we are putting `latestVersion` into the logs, which we know is `null`. That's not too helpful, but putting the raw string from `updateInfo.version` is helpful because you might be able to see what's gone wrong with parsing it.