### PR TITLE
fix issue #4639: require().split is not a function

### DIFF
--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -58,7 +58,7 @@ export class DmgTarget extends Target {
       args.push("-imagekey", `zlib-level=${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL || "9"}`)
     }
     await spawn("hdiutil", addLogLevel(args))
-    if (this.options.internetEnabled && parseInt(require("os").split(".")[0], 10) < 19) {
+    if (this.options.internetEnabled && parseInt(require("os").release().split(".")[0], 10) < 19) {
       await exec("hdiutil", addLogLevel(["internet-enable"]).concat(artifactPath))
     }
 


### PR DESCRIPTION
Prior commit did not properly reference the desired os.release() function and caused dmg build to fail.