### PR TITLE
Re-fetch downloads if cache directory has changed

### DIFF
--- a/packages/app-builder-lib/src/binDownload.ts
+++ b/packages/app-builder-lib/src/binDownload.ts
@@ -36,14 +36,16 @@ export function getBinFromUrl(name: string, version: string, checksum: string): 
 }
 
 export function getBin(name: string, url?: string | null, checksum?: string | null): Promise<string> {
-  let promise = versionToPromise.get(name)
-  // if rejected, we will try to download again
+  // Old cache is ignored if cache environment variable changes
+  const cacheName = process.env.ELECTRON_BUILDER_CACHE + name;
+  let promise = versionToPromise.get(cacheName);// if rejected, we will try to download again
+
   if (promise != null) {
     return promise
   }
 
   promise = doGetBin(name, url, checksum)
-  versionToPromise.set(name, promise)
+  versionToPromise.set(cacheName, promise)
   return promise
 }
 

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -7,7 +7,6 @@ import { statOrNull, walk, exists } from "builder-util/out/fs"
 import { hashFile } from "../../util/hash"
 import _debug from "debug"
 import { readFile, stat, unlink } from "fs-extra"
-import { Lazy } from "lazy-val"
 import * as path from "path"
 import { Target } from "../../core"
 import { DesktopShortcutCreationPolicy, getEffectiveOptions } from "../../options/CommonWindowsInstallerConfiguration"
@@ -31,7 +30,7 @@ const debug = _debug("electron-builder:nsis")
 const ELECTRON_BUILDER_NS_UUID = UUID.parse("50e065bc-3134-11e6-9bab-38c9862bdaf3")
 
 // noinspection SpellCheckingInspection
-const nsisResourcePathPromise = new Lazy(() => getBinFromUrl("nsis-resources", "3.4.1", "Dqd6g+2buwwvoG1Vyf6BHR1b+25QMmPcwZx40atOT57gH27rkjOei1L0JTldxZu4NFoEmW4kJgZ3DlSWVON3+Q=="))
+const nsisResourcePathPromise = () => getBinFromUrl("nsis-resources", "3.4.1", "Dqd6g+2buwwvoG1Vyf6BHR1b+25QMmPcwZx40atOT57gH27rkjOei1L0JTldxZu4NFoEmW4kJgZ3DlSWVON3+Q==")
 
 const USE_NSIS_BUILT_IN_COMPRESSOR = false
 
@@ -548,7 +547,7 @@ export class NsisTarget extends Target {
       this.packager.debugLogger.add("nsis.script", script)
     }
 
-    const nsisPath = await NSIS_PATH.value
+    const nsisPath = await NSIS_PATH()
     const command = path.join(nsisPath, process.platform === "darwin" ? "mac" : (process.platform === "win32" ? "Bin" : "linux"), process.platform === "win32" ? "makensis.exe" : "makensis")
     await spawnAndWrite(command, args, script, {
       // we use NSIS_CONFIG_CONST_DATA_PATH=no to build makensis on Linux, but in any case it doesn't use stubs as MacOS/Windows version, so, we explicitly set NSISDIR
@@ -575,7 +574,7 @@ export class NsisTarget extends Target {
 
     const pluginArch = this.isUnicodeEnabled ? "x86-unicode" : "x86-ansi"
     taskManager.add(async () => {
-      scriptGenerator.addPluginDir(pluginArch, path.join(await nsisResourcePathPromise.value, "plugins", pluginArch))
+      scriptGenerator.addPluginDir(pluginArch, path.join(await nsisResourcePathPromise(), "plugins", pluginArch))
     })
 
     taskManager.add(async () => {

--- a/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -4,7 +4,6 @@ import { PackageFileInfo } from "builder-util-runtime"
 import { getBinFromUrl } from "../../binDownload"
 import { copyFile } from "builder-util/out/fs"
 import { unlink } from "fs-extra"
-import { Lazy } from "lazy-val"
 import * as path from "path"
 import { getTemplatePath } from "../../util/pathManager"
 import { NsisTarget } from "./NsisTarget"
@@ -13,14 +12,14 @@ import zlib from "zlib"
 
 export const nsisTemplatesDir = getTemplatePath("nsis")
 
-export const NSIS_PATH = new Lazy(() => {
+export const NSIS_PATH = () => {
   const custom = process.env.ELECTRON_BUILDER_NSIS_DIR
   if (custom != null && custom.length > 0) {
     return Promise.resolve(custom.trim())
   }
   // noinspection SpellCheckingInspection
   return getBinFromUrl("nsis", "3.0.4.1", "VKMiizYdmNdJOWpRGz4trl4lD++BvYP2irAXpMilheUP0pc93iKlWAoP843Vlraj8YG19CVn0j+dCo/hURz9+Q==")
-})
+}
 
 export class AppPackageHelper {
   private readonly archToFileInfo = new Map<Arch, Promise<PackageFileInfo>>()
@@ -90,7 +89,7 @@ export class CopyElevateHelper {
       return promise
     }
 
-    promise = NSIS_PATH.value
+    promise = NSIS_PATH()
       .then(it => {
         const outFile = path.join(appOutDir, "resources", "elevate.exe")
         const promise = copyFile(path.join(it, "elevate.exe"), outFile, false)


### PR DESCRIPTION
Resolves #4955

Instead of busting the cache as I said in #4955, I use the environment variable content as a cache key prefix because it resolves the issue, there's less code to change, and if someone changes the environment variable back to a directory that was used before, it won't needlessly re-download items.

This promise catch wasn't the only issue. Some functions that called it were in lazy-val calls so they were caching the result. I removed the lazy-val usage making them a function that calls `getBin` / `getBinFromUrl` each time (which itself uses the promise cache anyway so I think it's fine). Maybe some variables could be renamed now but I decided to change the minimum and see what you say.