### PR TITLE
add missing %U in desktop file of snap builds

### DIFF
--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -179,7 +179,7 @@ export default class SnapTarget extends Target {
     // snapcraft.yaml inside a snap directory
     const snapMetaDir = path.join(stageDir, this.isUseTemplateApp ? "meta" : "snap")
     const desktopFile = path.join(snapMetaDir, "gui", `${snap.name}.desktop`)
-    await this.helper.writeDesktopEntry(this.options, packager.executableName, desktopFile, {
+    await this.helper.writeDesktopEntry(this.options, packager.executableName + " %U", desktopFile, {
       // tslint:disable:no-invalid-template-strings
       Icon: "${SNAP}/meta/gui/icon.png"
     })


### PR DESCRIPTION
Without this, using protocols in snaps don't work properly as the app is opened by the url isn't passed to the app.