### PR TITLE
Fix issue where we are unable to manipulate build contents once created

### DIFF
--- a/packages/app-builder-lib/src/targets/differentialUpdateInfoBuilder.ts
+++ b/packages/app-builder-lib/src/targets/differentialUpdateInfoBuilder.ts
@@ -68,7 +68,7 @@ export async function appendBlockmap(file: string): Promise<BlockMapDataHolder> 
   log.info({file: log.filePath(file)}, "building embedded block map")
   const tmpFile = `${file}${TEMPORARY_FILE_SUFFIX}`
   fs.copyFileSync(file, tmpFile)
-  const updateInfo = await executeAppBuilderAsJson<BlockMapDataHolder>(["blockmap", "--input", tmpfile, "--compression", "deflate"])
+  const updateInfo = await executeAppBuilderAsJson<BlockMapDataHolder>(["blockmap", "--input", tmpFile, "--compression", "deflate"])
   fs.unlinkSync(tmpFile)
   return updateInfo
 }
@@ -78,7 +78,7 @@ export async function createBlockmap(file: string, target: Target, packager: Pla
   log.info({blockMapFile: log.filePath(blockMapFile)}, "building block map")
   const tmpFile = `${file}${TEMPORARY_FILE_SUFFIX}`
   fs.copyFileSync(file, tmpFile)
-  const updateInfo = await executeAppBuilderAsJson<BlockMapDataHolder>(["blockmap", "--input", tmpfile, "--output", blockMapFile])
+  const updateInfo = await executeAppBuilderAsJson<BlockMapDataHolder>(["blockmap", "--input", tmpFile, "--output", blockMapFile])
   fs.unlinkSync(tmpFile)
   await packager.info.callArtifactBuildCompleted({
     file: blockMapFile,


### PR DESCRIPTION
Right now, after the build is created we cant manipulate the contents of archive created which we need for our project