### PR TITLE
Add loginhelper entitlement option

### DIFF
--- a/packages/app-builder-lib/electron-osx-sign/index.d.ts
+++ b/packages/app-builder-lib/electron-osx-sign/index.d.ts
@@ -9,6 +9,7 @@ interface SignOptions extends BaseSignOptions {
   binaries?: string[];
   entitlements?: string;
   'entitlements-inherit'?: string;
+  'entitlements-loginhelper'?: string;
   'gatekeeper-assess'?: boolean;
   hardenedRuntime?: boolean;
   'identity-validation'?: boolean;

--- a/packages/app-builder-lib/electron-osx-sign/sign.js
+++ b/packages/app-builder-lib/electron-osx-sign/sign.js
@@ -211,7 +211,7 @@ function signApplicationAsync (opts) {
             entitlementsFile = opts['entitlements-loginhelper']
           }
 
-          return execFileAsync('codesign', args.concat('--entitlements', entitlementsFile, filePath))
+          await execFileAsync('codesign', args.concat('--entitlements', entitlementsFile, filePath))
         }
         debuglog('Signing... ' + opts.app)
         await execFileAsync('codesign', args.concat('--entitlements', opts.entitlements, opts.app))

--- a/packages/app-builder-lib/electron-osx-sign/sign.js
+++ b/packages/app-builder-lib/electron-osx-sign/sign.js
@@ -206,7 +206,12 @@ function signApplicationAsync (opts) {
             continue
           }
           debuglog('Signing... ' + filePath)
-          await execFileAsync('codesign', args.concat('--entitlements', opts['entitlements-inherit'], filePath))
+          let entitlementsFile = opts['entitlements-inherit']
+          if (filePath.includes('Library/LoginItems')) {
+            entitlementsFile = opts['entitlements-loginhelper']
+          }
+
+          return execFileAsync('codesign', args.concat('--entitlements', entitlementsFile, filePath))
         }
         debuglog('Signing... ' + opts.app)
         await execFileAsync('codesign', args.concat('--entitlements', opts.entitlements, opts.app))
@@ -334,6 +339,12 @@ const signAsync = module.exports.signAsync = function (opts) {
             opts['entitlements-inherit'] = filePath
           }
         }
+      }
+      if (!opts['entitlements-loginhelper']) {
+        filePath = opts.entitlements
+        debugwarn('No `entitlements-loginhelper` passed in arguments:', '\n',
+          '* Sandbox entitlements file for login helper is default to:', filePath)
+        opts['entitlements-loginhelper'] = filePath
       }
     })
     .then(async function () {

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1982,6 +1982,13 @@
             "string"
           ]
         },
+        "entitlementsLoginHelper": {
+          "desciption": "Path to login helper entitlement file. When using App Sandbox, the the `com.apple.security.inherit` key that is normally in the inheritted entitlements cannot be inherited since the login helper is a standalone executable. Defaults to the value provided for `entitlements`.\n\nThis option only applies when signing with `entitlements` provided.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "extendInfo": {
           "description": "The extra entries for `Info.plist`."
         },
@@ -2517,6 +2524,13 @@
         },
         "entitlementsInherit": {
           "description": "The path to child entitlements which inherit the security settings for signing frameworks and bundles of a distribution. `build/entitlements.mas.inherit.plist` will be used if exists (it is a recommended way to set).\nOtherwise [default](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist).",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "entitlementsLoginHelper": {
+          "desciption": "Path to login helper entitlement file. When using App Sandbox, the the `com.apple.security.inherit` key that is normally in the inheritted entitlements cannot be inherited since the login helper is a standalone executable. Defaults to the value provided for `entitlements`.\n\nThis option only applies when signing with `entitlements` provided.",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -252,6 +252,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     if (customSignOptions.provisioningProfile != null) {
       signOptions["provisioning-profile"] = customSignOptions.provisioningProfile
     }
+    signOptions['entitlements-loginhelper'] = customSignOptions.entitlementsLoginHelper
   }
 
   //noinspection JSMethodCanBeStatic

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -43,6 +43,8 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    */
   readonly entitlementsInherit?: string | null
 
+  readonly entitlementsLoginHelper?: string | null
+
   /**
    * The path to the provisioning profile to use when signing, absolute or relative to the app root.
    */


### PR DESCRIPTION
Addresses https://github.com/electron-userland/electron-builder/issues/3302 and https://github.com/electron-userland/electron-builder/issues/2035. See [this PR](https://github.com/electron/electron-osx-sign/pull/210) for the main issue: `electron-osx-sign` right now has options only for entitlements used to sign every `.app` in the bundle. This is an issue for Mac App Store builds that want to use a login helper, because `.app` files aside from the login helper need to be signed with entitlements that look like:

```
<dict>
    <key>com.apple.security.app-sandbox</key>
    <true/>
    <key>com.apple.security.inherit</key>
    <true/>
</dict>
```

while the login helper must be signed with entitlements that look like:
```
<dict>
    <key>com.apple.security.app-sandbox</key>
    <true/>
</dict>
```

Changes to `sign.js` are lifted from that PR, and the rest of the changes are exposing that option from `electron-builder` and piping into `electron-osx-sign`.
