### PR TITLE
feat(linux): add slots option for snap builds

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4456,6 +4456,24 @@
           ],
           "description": "The list of [plugs](https://snapcraft.io/docs/reference/interfaces).\nDefaults to `[\"desktop\", \"desktop-legacy\", \"home\", \"x11\", \"unity7\", \"browser-support\", \"network\", \"gsettings\", \"audio-playback\", \"pulseaudio\", \"opengl\"]`.\n\nIf list contains `default`, it will be replaced to default list, so, `[\"default\", \"foo\"]` can be used to add custom plug `foo` in addition to defaults.\n\nAdditional attributes can be specified using object instead of just name of plug:\n```\n[\n  {\n    \"browser-sandbox\": {\n      \"interface\": \"browser-support\",\n      \"allow-sandbox\": true\n    },\n  },\n  \"another-simple-plug-name\"\n]\n```"
         },
+        "slots": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The list of [slots](https://snapcraft.io/docs/reference/interfaces)."
+        },
         "publish": {
           "anyOf": [
             {

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -70,6 +70,11 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
   readonly plugs?: Array<string | PlugDescriptor> | PlugDescriptor | null
 
   /**
+   * The list of [slots](https://snapcraft.io/docs/reference/interfaces).
+   */
+  readonly slots?: Array<string> | null
+
+  /**
    * Specifies any [parts](https://snapcraft.io/docs/reference/parts) that should be built before this part.
    * Defaults to `["desktop-gtk2""]`.
    *

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -62,6 +62,10 @@ export default class SnapTarget extends Target {
       adapter: "none",
     }
 
+    if (options.slots != null) {
+      appDescriptor.slots = options.slots
+    }
+
     const snap: any = safeLoad(await readFile(path.join(getTemplatePath("snap"), "snapcraft.yaml"), "utf-8"))
     if (this.isUseTemplateApp) {
       delete appDescriptor.adapter

--- a/test/snapshots/linux/snapTest.js.snap
+++ b/test/snapshots/linux/snapTest.js.snap
@@ -1508,6 +1508,79 @@ Object {
 }
 `;
 
+exports[`slots option 1`] = `
+Object {
+  "apps": Object {
+    "sep": Object {
+      "command": "command.sh",
+      "environment": Object {
+        "DISABLE_WAYLAND": "1",
+        "LD_LIBRARY_PATH": "$SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu",
+        "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
+        "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+        "TMPDIR": "$XDG_RUNTIME_DIR",
+      },
+      "plugs": Array [
+        "desktop",
+        "desktop-legacy",
+        "home",
+        "x11",
+        "wayland",
+        "unity7",
+        "browser-support",
+        "network",
+        "gsettings",
+        "audio-playback",
+        "pulseaudio",
+        "opengl",
+      ],
+      "slots": Array [
+        "foo",
+        "bar",
+      ],
+    },
+  },
+  "architectures": Array [
+    "amd64",
+  ],
+  "base": "core18",
+  "confinement": "strict",
+  "description": "Test Application (test quite “ #378)",
+  "grade": "stable",
+  "name": "sep",
+  "plugs": Object {
+    "gnome-3-28-1804": Object {
+      "default-provider": "gnome-3-28-1804",
+      "interface": "content",
+      "target": "$SNAP/gnome-platform",
+    },
+    "gtk-3-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/themes",
+    },
+    "icon-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/icons",
+    },
+    "sound-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/sounds",
+    },
+  },
+  "summary": "Sep",
+  "version": "1.1.0",
+}
+`;
+
+exports[`slots option 2`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
 exports[`snap 1`] = `
 Object {
   "linux": Array [

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -132,6 +132,23 @@ test.ifDevOrLinuxCi("plugs option", async () => {
   }
 })
 
+test.ifDevOrLinuxCi("slots option", app({
+  targets: Platform.LINUX.createTarget("snap"),
+  config: {
+    extraMetadata: {
+      name: "sep",
+    },
+    productName: "Sep",
+    snap: {
+      slots: [ "foo", "bar" ],
+    }
+  },
+  effectiveOptionComputed: async ({snap}) => {
+    expect(snap).toMatchSnapshot()
+    return true
+  },
+}))
+
 test.ifDevOrLinuxCi("custom env", app({
   targets: Platform.LINUX.createTarget("snap"),
   config: {


### PR DESCRIPTION
Allow applications to expose slots when installed via snap on linux. This is needed for example in applications that want to implement the MPRIS interface to allow external media player control.