### PR TITLE
fix: replace deprecated interface

### DIFF
--- a/packages/electron-builder/src/cli/install-app-deps.ts
+++ b/packages/electron-builder/src/cli/install-app-deps.ts
@@ -67,7 +67,7 @@ function main() {
   return installAppDeps(configureInstallAppDepsCommand(yargs).argv)
 }
 
-if (process.mainModule === module) {
+if (require.main === module) {
   log.warn("please use as subcommand: electron-builder install-app-deps")
   main()
     .catch(printErrorAndExit)


### PR DESCRIPTION
Change process.mainModule to require.main as process.mainModule is deprecated since nodejs v14

Should not break as require.main has been around since v0.1.17