### PR TITLE
fix(electron-updater): escape quotes instead of throwing an error

### DIFF
--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -27,10 +27,6 @@ export class NsisUpdater extends BaseUpdater {
       downloadUpdateOptions,
       fileInfo,
       task: async (destinationFile, downloadOptions, packageFile, removeTempDirIfAny) => {
-        if (hasQuotes(destinationFile) || (packageFile != null && hasQuotes(packageFile))) {
-          throw newError(`destinationFile or packageFile contains illegal chars`, "ERR_UPDATER_ILLEGAL_FILE_NAME")
-        }
-
         const packageInfo = fileInfo.packageInfo
         const isWebInstaller = packageInfo != null && packageFile != null
         if (isWebInstaller || await this.differentialDownloadInstaller(fileInfo, downloadUpdateOptions, destinationFile, provider)) {
@@ -233,8 +229,4 @@ async function _spawn(exe: string, args: Array<string>): Promise<any> {
       reject(error)
     }
   })
-}
-
-function hasQuotes(name: string): boolean {
-  return name.includes("'") || name.includes('"') || name.includes('`')
 }

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -6,8 +6,30 @@ import { Logger } from "./main"
 // $certificateInfo = (Get-AuthenticodeSignature 'xxx\yyy.exe'
 // | where {$_.Status.Equals([System.Management.Automation.SignatureStatus]::Valid) -and $_.SignerCertificate.Subject.Contains("CN=siemens.com")})
 // | Out-String ; if ($certificateInfo) { exit 0 } else { exit 1 }
-export function verifySignature(publisherNames: Array<string>, tempUpdateFile: string, logger: Logger): Promise<string | null> {
+export function verifySignature(publisherNames: Array<string>, unescapedTempUpdateFile: string, logger: Logger): Promise<string | null> {
   return new Promise<string | null>(resolve => {
+
+    // Escape quotes and backticks in filenames to prevent user from breaking the
+    // arguments and perform a remote command injection.
+    //
+    // Consider example powershell command:
+    // ```powershell
+    // Get-AuthenticodeSignature 'C:\\path\\my-bad-';calc;'filename.exe'
+    // ```
+    // The above would work expected and find the file name, however, it will also execute `;calc;`
+    // command and start the calculator app.
+    //
+    // From Powershell quoting rules:
+    // https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7
+    // * Double quotes `"` are treated literally within single-quoted strings;
+    // * Single quotes can be escaped by doubling them: 'don''t' -> don't;
+    // * Backticks can be escaped by doubling them: 'A backtick (``) character';
+    //
+    // Also note that at this point the file has already been written to the disk, thus we are
+    // guaranteed that the path will not contains any illegal characters like <>:"/\|?*
+    // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    const tempUpdateFile = unescapedTempUpdateFile.replace(/'/g, "''").replace(/`/g, "``");
+
     // https://github.com/electron-userland/electron-builder/issues/2421
     // https://github.com/electron-userland/electron-builder/issues/2535
     execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", `Get-AuthenticodeSignature '${tempUpdateFile}' | ConvertTo-Json -Compress`], {


### PR DESCRIPTION
## Descriptions

This https://github.com/electron-userland/electron-builder/commit/dead150769463adbff38b19e9099df6547db0e24 commit was added as a security measure to avoid command injection when we use downloaded file path that contains quotes when running powershell command.

e.g: `Get-AuthenticodeSignature 'C:\\path\\my-bad-';calc;'filename.exe'` will start a calculator app.

Banning the quotes does stop the command injection, however it also introduce unwanted behavior when performing an update, an example, when the user's path contains a quote, update will never be installed. See: https://github.com/electron-userland/electron-builder/issues/4889

### This PR

Fixes https://github.com/electron-userland/electron-builder/issues/4889 by escaping the quotation as per windows powershell documentation.

e.g. 
```ts
// Unescaped
`Get-AuthenticodeSignature 'C:\\Users\\MyName's\\AppData\\Local\\MyApp.exe'`

// Escaped
`Get-AuthenticodeSignature 'C:\\Users\\MyName''s\\AppData\\Local\\MyApp.exe'`
```

Also when there is a command injection
```ts
// Unescaped
`Get-AuthenticodeSignature 'C:\\Users\\MyName';calc;'s\\AppData\\Local\\MyApp.exe'`

// Escaped
`Get-AuthenticodeSignature 'C:\\Users\\MyName'';calc;''s\\AppData\\Local\\MyApp.exe'`
```

The calculator app will not be opened.