### PR TITLE
fix: respect signDlls flag on Windows in asar.unpacked

### DIFF
--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -370,7 +370,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
 
     const outResourcesDir = path.join(packContext.appOutDir, "resources", "app.asar.unpacked")
     // noinspection JSUnusedLocalSymbols
-    const fileToSign = await walk(outResourcesDir, (file, stat) => stat.isDirectory() || file.endsWith(".exe") || file.endsWith(".dll"))
+    const fileToSign = await walk(outResourcesDir, (file, stat) => stat.isDirectory() || file.endsWith(".exe") || (this.isSignDlls() && file.endsWith(".dll")))
     await BluebirdPromise.map(fileToSign, file => this.sign(file), {concurrency: 4})
   }
 }


### PR DESCRIPTION
Although the flag was checked against in signing DLLs in the extra files and resources, the files in the asar unpacked directory were
not using the same check.

Closes #4728 