### PR TITLE
fix(appx) Default rfc3161TimeStampServer to http://timestamp.digicert.com

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5255,7 +5255,7 @@
           "description": "The [security level](https://msdn.microsoft.com/en-us/library/6ad1fshk.aspx#Anchor_9) at which the application requests to be executed.\nCannot be specified per target, allowed only in the `win`."
         },
         "rfc3161TimeStampServer": {
-          "default": "http://timestamp.comodoca.com/rfc3161",
+          "default": "http://timestamp.digicert.com",
           "description": "The URL of the RFC 3161 time stamp server.",
           "type": [
             "null",

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -194,7 +194,7 @@ function computeSignToolArgs(options: WindowsSignTaskConfiguration, isWin: boole
   if (process.env.ELECTRON_BUILDER_OFFLINE !== "true") {
     const timestampingServiceUrl = options.options.timeStampServer || "http://timestamp.digicert.com"
     if (isWin) {
-      args.push(options.isNest || options.hash === "sha256" ? "/tr" : "/t", options.isNest || options.hash === "sha256" ? (options.options.rfc3161TimeStampServer || "http://timestamp.comodoca.com/rfc3161") : timestampingServiceUrl)
+      args.push(options.isNest || options.hash === "sha256" ? "/tr" : "/t", options.isNest || options.hash === "sha256" ? (options.options.rfc3161TimeStampServer || "http://timestamp.digicert.com") : timestampingServiceUrl)
     }
     else {
       args.push("-t", timestampingServiceUrl)

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -56,7 +56,7 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   readonly additionalCertificateFile?: string | null
   /**
    * The URL of the RFC 3161 time stamp server.
-   * @default http://timestamp.comodoca.com/rfc3161
+   * @default http://timestamp.digicert.com
    */
   readonly rfc3161TimeStampServer?: string | null
   /**


### PR DESCRIPTION
I was having a codesign error (0x80096005) when using a self signed certificate with the default `rfc3161TimeStampServer` property.

After seeing this issue https://stackoverflow.com/a/62163144 I switched over to `http://timestamp.digicert.com` for `rfc3161TimeStampServer` and it worked again.

I am proposing this should be the default (unless someone can fix the comodo issue!).