### PR TITLE
Pass URL argument %U in desktop file of snap and appimage builds

### DIFF
--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -101,8 +101,9 @@ export class LinuxTargetHelper {
         exec += " "
         exec += executableArgs.join(" ")
       }
-      exec += " %U"
     }
+
+    exec += " %U"
 
     const desktopMeta: any = {
       Name: appInfo.productName,

--- a/test/snapshots/linux/linuxPackagerTest.js.snap
+++ b/test/snapshots/linux/linuxPackagerTest.js.snap
@@ -3,7 +3,7 @@
 exports[`AppImage - default icon, custom executable and custom desktop 1`] = `
 "[Desktop Entry]
 Name=Test App ßW
-Exec=AppRun
+Exec=AppRun %U
 Terminal=true
 Type=Application
 Icon=Foo


### PR DESCRIPTION
Currently the URL argument `%U` is not passed to the executable in the desktop files for snaps and appimages.
As a result the app does not receive the URL when custom protocol handlers are used. This PR passes the ad `%U` to the executable of both appimages and snaps.

Related PRs:
- #5001 (fix for snap)
- #4909 (fix for appimage)

Realted issues:
- #4035 
- #5024 