### PR TITLE
Fix pre-gyp for darwin targets if build on Linux or in Docker

### DIFF
--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -56,7 +56,7 @@ export function getGypEnv(frameworkInfo: DesktopFrameworkInfo, platform: NodeJS.
   if (platform !== process.platform) {
     common.npm_config_force = "true"
   }
-  if (platform === "win32") {
+  if (platform === "win32" || platform === "darwin") {
     common.npm_config_target_libc = "unknown"
   }
 


### PR DESCRIPTION
Same issue as https://github.com/electron-userland/electron-builder/issues/3049 but for 'darwin' target.

node-libcurl fails to download precompiled binaries for darwin target:
> 2020-08-01 05:53:38  |    node-pre-gyp verb cli [
2020-08-01 05:53:38  |    node-pre-gyp verb cli   '/usr/local/bin/node',
2020-08-01 05:53:38  |    node-pre-gyp verb cli   '/project/node_modules/node-libcurl/node_modules/.bin/node-pre-gyp',
2020-08-01 05:53:38  |    node-pre-gyp verb cli   'install',
2020-08-01 05:53:38  |    node-pre-gyp verb cli   '--fallback-to-build'
2020-08-01 05:53:38  |    node-pre-gyp verb cli ]
2020-08-01 05:53:38  |    node-pre-gyp info using node-pre-gyp@0.15.0
2020-08-01 05:53:38  |    node-pre-gyp info using node@12.16.1 | linux | x64
2020-08-01 05:53:38  |    node-pre-gyp verb command install []
2020-08-01 05:53:38  |    node-pre-gyp WARN Using request for node-pre-gyp https download 
2020-08-01 05:53:38  |    node-pre-gyp http GET https://github.com/JCMais/node-libcurl/releases/download/v2.2.0/node_libcurl-v2.2.0-electron-v8.1-darwin-x64-glibc.tar.gz
2020-08-01 05:53:38  |    node-pre-gyp http 404 https://github.com/JCMais/node-libcurl/releases/download/v2.2.0/node_libcurl-v2.2.0-electron-v8.1-darwin-x64-glibc.tar.gz
2020-08-01 05:53:38  |    node-pre-gyp WARN Tried to download(404): https://github.com/JCMais/node-libcurl/releases/download/v2.2.0/node_libcurl-v2.2.0-electron-v8.1-darwin-x64-glibc.tar.gz 
2020-08-01 05:53:38  |    node-pre-gyp WARN Pre-built binaries not found for node-libcurl@2.2.0 and electron@8.1.1 (electron-v8.1 ABI, glibc) (falling back to source compile with node-gyp) 
2020-08-01 05:53:38  |    node-pre-gyp http 404 status code downloading tarball https://github.com/JCMais/node-libcurl/releases/download/v2.2.0/node_libcurl-v2.2.0-electron-v8.1-darwin-x64-glibc.tar.gz

For windows it is ok:
> 2020-08-01 05:51:26  |    node-pre-gyp info it worked if it ends with ok
2020-08-01 05:51:26  |    node-pre-gyp verb cli [
2020-08-01 05:51:26  |    node-pre-gyp verb cli   '/usr/local/bin/node',
2020-08-01 05:51:26  |    node-pre-gyp verb cli   '/project/node_modules/node-libcurl/node_modules/.bin/node-pre-gyp',
2020-08-01 05:51:26  |    node-pre-gyp verb cli   'install',
2020-08-01 05:51:26  |    node-pre-gyp verb cli   '--fallback-to-build'
2020-08-01 05:51:26  |    node-pre-gyp verb cli ]
2020-08-01 05:51:26  |    node-pre-gyp info using node-pre-gyp@0.15.0
2020-08-01 05:51:26  |    node-pre-gyp info using node@12.16.1 | linux | x64
2020-08-01 05:51:26  |    node-pre-gyp verb command install []
2020-08-01 05:51:26  |    node-pre-gyp WARN Using request for node-pre-gyp https download 
2020-08-01 05:51:26  |    node-pre-gyp http GET https://github.com/JCMais/node-libcurl/releases/download/v2.2.0/node_libcurl-v2.2.0-electron-v8.1-win32-x64-unknown.tar.gz
2020-08-01 05:51:26  |    node-pre-gyp http 200 https://github.com/JCMais/node-libcurl/releases/download/v2.2.0/node_libcurl-v2.2.0-electron-v8.1-win32-x64-unknown.tar.gz