### PR TITLE
Add executableArgs and " %U" to executableName before calling writeDesktopEntry

### DIFF
--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -189,7 +189,16 @@ export default class SnapTarget extends Target {
     // snapcraft.yaml inside a snap directory
     const snapMetaDir = path.join(stageDir, this.isUseTemplateApp ? "meta" : "snap")
     const desktopFile = path.join(snapMetaDir, "gui", `${snap.name}.desktop`)
-    await this.helper.writeDesktopEntry(this.options, packager.executableName, desktopFile, {
+    
+    let exec = packager.executableName
+    const executableArgs = this.options.executableArgs
+    if (executableArgs) {
+      exec += " "
+      exec += executableArgs.join(" ")
+    }
+    exec += " %U"    
+    
+    await this.helper.writeDesktopEntry(this.options, exec, desktopFile, {
       // tslint:disable:no-invalid-template-strings
       Icon: "${SNAP}/meta/gui/icon.png"
     })


### PR DESCRIPTION
Add executableArgs and " %U" to packager.executableName before passing it writeDesktopEntry, since writeDesktopEntry() only adds executableArgs and " %U" if no exec string is passed. This fix works with the existing functions in LinuxTargetHelper.ts so it won't affect any other Linux targets.