### PR TITLE
Feat: Add support to pass along a value for the ‘strict verify’ flag …

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2284,6 +2284,11 @@
             "string"
           ]
         },
+        "strictVerify": {
+          "default": true,
+          "description": "Whether to require electron-osx-sign to strictly verify the package to be signed.",
+          "type": "boolean"
+        },
         "target": {
           "anyOf": [
             {
@@ -2830,6 +2835,11 @@
             "null",
             "string"
           ]
+        },
+        "strictVerify": {
+          "default": true,
+          "description": "Whether to require electron-osx-sign to strictly verify the package to be signed.",
+          "type": "boolean"
         },
         "target": {
           "anyOf": [

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -192,6 +192,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       // https://github.com/electron-userland/electron-osx-sign/issues/196
       // will fail on 10.14.5+ because a signed but unnotarized app is also rejected.
       "gatekeeper-assess": options.gatekeeperAssess === true,
+      // https://github.com/electron-userland/electron-builder/issues/1480
+      "strict-verify": options.strictVerify !== false,
       hardenedRuntime: isMas ? masOptions && masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
     }
 

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -154,6 +154,12 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * @default false
    */
   readonly gatekeeperAssess?: boolean
+
+  /**
+   * Whether to let electron-osx-sign verify the contents or not.
+   * @default true
+   */
+  readonly strictVerify?: boolean
 }
 
 export interface DmgOptions extends TargetSpecificOptions {


### PR DESCRIPTION
…to the electron-osx-sign library

This change allows the author to provide a value for ‘strictVerify’ in the ’mac’ configuration. This value is then passed along to the electron-osx-sign library.

This is not a breaking change and it closes #1480