### PR TITLE
Added support for overriding ‘strict-verify’ electron-osx-sign property.

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2284,6 +2284,23 @@
             "string"
           ]
         },
+        "strictVerify": {
+          "default": true,
+          "description": "Whether to let electron-osx-sign verify the contents or not.",
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+        },
         "target": {
           "anyOf": [
             {
@@ -2830,6 +2847,23 @@
             "null",
             "string"
           ]
+        },
+        "strictVerify": {
+          "default": true,
+          "description": "Whether to let electron-osx-sign verify the contents or not.",
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
         },
         "target": {
           "anyOf": [

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2285,8 +2285,6 @@
           ]
         },
         "strictVerify": {
-          "default": true,
-          "description": "Whether to let electron-osx-sign verify the contents or not.",
           "anyOf": [
             {
               "items": {
@@ -2295,11 +2293,14 @@
               "type": "array"
             },
             {
-              "type": "string"
-            },
-            {
-              "type": "boolean"
+              "type": [
+                "string",
+                "boolean"
+              ]
             }
+          ],
+          "default": true,
+          "description": "Whether to let electron-osx-sign verify the contents or not."
         },
         "target": {
           "anyOf": [
@@ -2849,8 +2850,6 @@
           ]
         },
         "strictVerify": {
-          "default": true,
-          "description": "Whether to let electron-osx-sign verify the contents or not.",
           "anyOf": [
             {
               "items": {
@@ -2859,11 +2858,14 @@
               "type": "array"
             },
             {
-              "type": "string"
-            },
-            {
-              "type": "boolean"
+              "type": [
+                "string",
+                "boolean"
+              ]
             }
+          ],
+          "default": true,
+          "description": "Whether to let electron-osx-sign verify the contents or not."
         },
         "target": {
           "anyOf": [

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -193,7 +193,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       // will fail on 10.14.5+ because a signed but unnotarized app is also rejected.
       "gatekeeper-assess": options.gatekeeperAssess === true,
       // https://github.com/electron-userland/electron-builder/issues/1480
-      "strict-verify": options.strictVerify || true,
+      "strict-verify": options.strictVerify,
       hardenedRuntime: isMas ? masOptions && masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
     }
 

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -192,6 +192,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       // https://github.com/electron-userland/electron-osx-sign/issues/196
       // will fail on 10.14.5+ because a signed but unnotarized app is also rejected.
       "gatekeeper-assess": options.gatekeeperAssess === true,
+      // https://github.com/electron-userland/electron-builder/issues/1480
+      "strict-verify": options.strictVerify || true,
       hardenedRuntime: isMas ? masOptions && masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
     }
 

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -154,6 +154,12 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * @default false
    */
   readonly gatekeeperAssess?: boolean
+
+  /**
+   * Whether to let electron-osx-sign verify the contents or not.
+   * @default true
+   */
+  readonly strictVerify?: Array<string> | string | boolean
 }
 
 export interface DmgOptions extends TargetSpecificOptions {


### PR DESCRIPTION
This provides support for overriding the electron-osx-sign `strict-verify` property and supersedes a prior PR that only supported boolean values here.