### PR TITLE
Added support for supplying a value for the ‘ignore’ electron-osx-sign property.

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2183,6 +2183,21 @@
             "string"
           ]
         },
+        "ignore": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null,
+          "description": "Filter to tell electron-osx-sign to filter out certain files."
+        },
         "minimumSystemVersion": {
           "description": "The minimum version of macOS required for the app to run. Corresponds to `LSMinimumSystemVersion`.",
           "type": [
@@ -2729,6 +2744,21 @@
             "null",
             "string"
           ]
+        },
+        "ignore": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null,
+          "description": "Filter to tell electron-osx-sign to filter out certain files."
         },
         "minimumSystemVersion": {
           "description": "The minimum version of macOS required for the app to run. Corresponds to `LSMinimumSystemVersion`.",

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -177,9 +177,24 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       // https://github.com/electron-userland/electron-builder/issues/1699
       // kext are signed by the chipset manufacturers. You need a special certificate (only available on request) from Apple to be able to sign kext.
       ignore: (file: string) => {
-        return file.endsWith(".kext") || file.startsWith("/Contents/PlugIns", appPath.length) ||
-          // https://github.com/electron-userland/electron-builder/issues/2010
-          file.includes("/node_modules/puppeteer/.local-chromium")
+        const filter = options.ignore || false;
+        let matcher, shouldFilter = false;
+        if (filter) {
+            if (Array.isArray(filter)) {
+                for (const item of filter) {
+                  matcher = new RegExp(item);
+                  shouldFilter = matcher.test(file);
+                  if (shouldFilter) {
+                    break;
+                  }
+                }
+            } else {
+              matcher = new RegExp(filter);
+              shouldFilter = matcher.test(file);
+            }
+        }
+        return shouldFilter || file.endsWith(".kext") || file.startsWith("/Contents/PlugIns", appPath.length) || // https://github.com/electron-userland/electron-builder/issues/2010
+        file.includes("/node_modules/puppeteer/.local-chromium");
       },
       identity: identity!,
       type,

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -154,6 +154,12 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * @default false
    */
   readonly gatekeeperAssess?: boolean
+
+  /**
+   * Filter to tell electron-osx-sign to filter out certain files.
+   * @default true
+   */
+  readonly ignore?: Array<string> | string
 }
 
 export interface DmgOptions extends TargetSpecificOptions {


### PR DESCRIPTION
This PR allows users of `electron-builder` to supply additional files to the `electron-osx-sign` utility to ignore during the signing process.

NOTE: This PR follows the `electron-osx-sign` utility's signature for this property. That is, it is either a single RegExp as a JSON String or an Array of JSON Strings of RegExps. It is **NOT** a 'glob' pattern, like many of the other config properties in `electron-builder`. That was more sophistication than I needed.

In any case, you use this patch in your config like this:

```
{
    "appId": "...",
    "mac": {
        ...
        "ignore": ".*\\.app$",
        ...
    }
}
```

**Note the escaping of the backslash there, as you might expect**.

In this case, we are filtering for files/directories ending with `.app` (I had one of those and the `electron-osx-sign` wants to think that they're embedded Mac OS X applications, but this wasn't).

Here's the Array version:

```
{
    "appId": "...",
    "mac": {
        ...
        "ignore": [".*\\.app$", ..., ...]
        ...
    }
}
```

Note that this closes https://github.com/electron-userland/electron-builder/issues/3790.