### PR TITLE
feat(electron-updater): follow `autoInstallOnAppQuit = false` on macOS

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -26,8 +26,6 @@ export abstract class AppUpdater extends EventEmitter {
 
   /**
    * Whether to automatically install a downloaded update on app quit (if `quitAndInstall` was not called before).
-   *
-   * Applicable only on Windows and Linux.
    */
   autoInstallOnAppQuit: boolean = true
 


### PR DESCRIPTION
Make `electron-updater` on macOS behave like other OSes regarding the `autoInstallOnAppQuit` flag by cheating a bit around Squirrel.Mac limitation of not being able to *not* apply an update after it has downloaded it.

I tried to make my changes as minimal as possible, and took advantage of the fact that `electron-updater` already downloads the update by itself first and only expose said update to Squirrel in a second time. The trick here is to only trigger Squirrel when we want to apply an update rather than after a successful download.

This PR is basically a rebase of #4308 which never got reviewed and had been automatically closed by the stale bot.

### Context
This feature is required for our app ([Ledger Live](https://github.com/LedgerHQ/ledger-live-desktop)) to be able to do an additional cryptographic check on downloaded files and conditionally abort the update on a failed verification.

At least one other company is relying on this patch, cf #4953