### PR TITLE
fix:(nsis): Fix custom finish page insertion

### DIFF
--- a/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
@@ -5,19 +5,6 @@
 !endif
 
 !ifndef BUILD_UNINSTALLER
-  !ifndef HIDE_RUN_AFTER_FINISH
-    Function StartApp
-      ${if} ${isUpdated}
-        StrCpy $1 "--updated"
-      ${else}
-        StrCpy $1 ""
-      ${endif}
-      ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
-    FunctionEnd
-
-    !define MUI_FINISHPAGE_RUN
-    !define MUI_FINISHPAGE_RUN_FUNCTION "StartApp"
-  !endif
 
   !ifmacrodef customWelcomePage
     !insertmacro customWelcomePage
@@ -62,6 +49,19 @@
   !ifmacrodef customFinishPage
     !insertmacro customFinishPage
   !else
+    !ifndef HIDE_RUN_AFTER_FINISH
+      Function StartApp
+        ${if} ${isUpdated}
+          StrCpy $1 "--updated"
+        ${else}
+          StrCpy $1 ""
+        ${endif}
+        ${StdUtils.ExecShellAsUser} $0 "$launchLink" "open" "$1"
+      FunctionEnd
+
+      !define MUI_FINISHPAGE_RUN
+      !define MUI_FINISHPAGE_RUN_FUNCTION "StartApp"
+    !endif
     !insertmacro MUI_PAGE_FINISH
   !endif
 !else


### PR DESCRIPTION
#5051  Introduced ability to define custom finish page in nsis build.

However, it always throws 
```
install function "StartApp" not referenced
```
warning/error if the user want to alter the way how the app is started.

This PR fixes this error and let the user alter the behavior of finish page completely.