### PR TITLE
fix(arm64): fix pacman build, pacman & rpm artifact names

### DIFF
--- a/packages/builder-util/src/arch.ts
+++ b/packages/builder-util/src/arch.ts
@@ -13,7 +13,7 @@ export function toLinuxArchString(arch: Arch, targetName: string): string {
     case Arch.armv7l:
       return targetName === "snap" || targetName === "deb" ? "armhf" : "armv7l"
     case Arch.arm64:
-      return "arm64"
+      return targetName === "pacman" ? "aarch64" : "arm64"
 
     default:
       throw new Error(`Unsupported arch ${arch}`)
@@ -66,6 +66,11 @@ export function getArtifactArchName(arch: Arch, ext: string): string {
   else if (arch === Arch.armv7l) {
     if (ext === "snap") {
       archName = "armhf"
+    }
+  }
+  else if (arch === Arch.arm64) {
+    if (ext === "pacman" || ext === "rpm") {
+      archName = "aarch64"
     }
   }
   return archName


### PR DESCRIPTION
Previous behavior: `pacman` files built for `arm64` could not be installed. Instead, `pacman` would return errors similar to:
```
error: failed to prepare transaction (package architecture is not valid)
:: package yourpackage-arm64 does not have a valid architecture
```

New behavior: `pacman` files built for `arm64` install correctly.

This change corrects the value returned by `toLinuxArchString` when `arch` is `Arch.arm64` and `targetName` is `pacman`. Pacman calls this architecture `aarch64` whereas other targets call it `arm64`. Compare to the existing code for `ia32`, which `pacman` calls `i686` and others call `i386`.

This change also adjusts the value returned by `getArtifactArchName` to better match convention when `arch` is `Arch.arm64`: both `pacman` and `rpm` use `aarch64` in package file names for this architecture. There may be more cases here which need to be corrected, but I'm currently only aware of these two.
