### PR TITLE
fix:(nsis): Do not delete shortcut if Path is not changed

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/installer.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installer.nsh
@@ -206,7 +206,7 @@
       # The keepShortcuts mechanism IS enabled.
       # The desktop shortcut could exist in an obsolete location (due to name change).
       ${elseif} $oldDesktopLink != $newDesktopLink
-      ${orIf} ${FileExists} "$oldDesktopLink"
+      ${andIf} ${FileExists} "$oldDesktopLink"
         Rename $oldDesktopLink $newDesktopLink
         WinShell::UninstShortcut "$oldDesktopLink"
         WinShell::SetLnkAUMI "$newDesktopLink" "${APP_ID}"


### PR DESCRIPTION
This fixes #2514

**Current behavior:**
Shortcut is recreated if either ```$oldDesktopLink != $newDesktopLink``` **OR** ```$oldDesktopLink exists```.
This mostly happens during update process when ```createDesktopShortcut = true``` and ```allowToChangeInstallationDirectory = false```.

**Proposed behavior:**
Change condition to **AND**. So this will result in following workflow during update.
Shortcut should be recreated ONLY if path changed or old file missing:
```
# The desktop shortcut could exist in an obsolete location (due to name change).
if (links changed AND Old file exists) {
  // recreate lnk
} 
!ifdef RECREATE_DESKTOP_SHORTCUT
  elseIf (links changed OR old file missing) {
    //recreate lnk
  }
!endif
```
If *links haven't changed - nothing recreated*