### PR TITLE
feat(snap): ability to specify slot properties

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4341,6 +4341,19 @@
       ],
       "type": "object"
     },
+    "SlotDescriptor": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "typeof": "function"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "type": "object"
+    },
     "SnapOptions": {
       "additionalProperties": false,
       "properties": {
@@ -4608,8 +4621,18 @@
         "slots": {
           "anyOf": [
             {
+              "$ref": "#/definitions/PlugDescriptor"
+            },
+            {
               "items": {
-                "type": "string"
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/SlotDescriptor"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
@@ -4617,7 +4640,7 @@
               "type": "null"
             }
           ],
-          "description": "The list of [slots](https://snapcraft.io/docs/reference/interfaces)."
+          "description": "The list of [slots](https://snapcraft.io/docs/reference/interfaces).\n\nAdditional attributes can be specified using object instead of just name of slot:\n```\n[\n  {\n    \"mpris\": {\n      \"name\": \"chromium\"\n    },\n  }\n]\n\nIn case you want your application to be a compliant MPris player, you will need to definie\nThe mpris slot with \"chromium\" name.\nThis electron has it [hardcoded](https://source.chromium.org/chromium/chromium/src/+/master:components/system_media_controls/linux/system_media_controls_linux.cc;l=51;bpv=0;bpt=1),\nand we need to pass this name so snap [will allow it](https://forum.snapcraft.io/t/unable-to-use-mpris-interface/15360/7) in strict confinement."
         },
         "stagePackages": {
           "anyOf": [

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -71,8 +71,24 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
 
   /**
    * The list of [slots](https://snapcraft.io/docs/reference/interfaces).
+   * 
+   * Additional attributes can be specified using object instead of just name of slot:
+   * ```
+   *[
+   *  {
+   *    "mpris": {
+   *      "name": "chromium"
+   *    },
+   *  }
+   *]
+  *
+   * In case you want your application to be a compliant MPris player, you will need to definie
+   * The mpris slot with "chromium" name.
+   * This electron has it [hardcoded](https://source.chromium.org/chromium/chromium/src/+/master:components/system_media_controls/linux/system_media_controls_linux.cc;l=51;bpv=0;bpt=1),
+   * and we need to pass this name so snap [will allow it](https://forum.snapcraft.io/t/unable-to-use-mpris-interface/15360/7) in strict confinement.
+   * 
    */
-  readonly slots?: Array<string> | null
+  readonly slots?: Array<string | SlotDescriptor> | PlugDescriptor | null
 
   /**
    * Specifies any [parts](https://snapcraft.io/docs/reference/parts) that should be built before this part.
@@ -107,5 +123,9 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
 }
 
 export interface PlugDescriptor {
+  [key: string]: {[key: string]: any} | null
+}
+
+export interface SlotDescriptor {
   [key: string]: {[key: string]: any} | null
 }

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -47,6 +47,9 @@ export default class SnapTarget extends Target {
     const plugs = normalizePlugConfiguration(this.options.plugs)
 
     const plugNames = this.replaceDefault(plugs == null ? null : Object.getOwnPropertyNames(plugs), defaultPlugs)
+
+    const slots = normalizePlugConfiguration(this.options.slots)
+
     const buildPackages = asArray(options.buildPackages)
     const defaultStagePackages = getDefaultStagePackages()
     const stagePackages = this.replaceDefault(options.stagePackages, defaultStagePackages)
@@ -60,10 +63,6 @@ export default class SnapTarget extends Target {
       command: "command.sh",
       plugs: plugNames,
       adapter: "none",
-    }
-
-    if (options.slots != null) {
-      appDescriptor.slots = options.slots
     }
 
     const snap: any = safeLoad(await readFile(path.join(getTemplatePath("snap"), "snapcraft.yaml"), "utf-8"))
@@ -82,6 +81,20 @@ export default class SnapTarget extends Target {
     if (options.layout != null) {
       snap.layout = options.layout
     }
+    if (slots != null) {
+      appDescriptor.slots = Object.getOwnPropertyNames(slots)
+      for (const slotName of appDescriptor.slots) {
+        const slotOptions = slots[slotName]
+        if (slotOptions == null) {
+          continue
+        }
+        if (!snap.slots) {
+          snap.slots = {}
+        }
+        snap.slots[slotName] = slotOptions
+      }
+    }
+    
     deepAssign(snap, {
       name: snapName,
       version: appInfo.version,

--- a/test/snapshots/linux/snapTest.js.snap
+++ b/test/snapshots/linux/snapTest.js.snap
@@ -1637,6 +1637,85 @@ Object {
 }
 `;
 
+exports[`slots option 3`] = `
+Object {
+  "apps": Object {
+    "sep": Object {
+      "command": "command.sh",
+      "environment": Object {
+        "DISABLE_WAYLAND": "1",
+        "LD_LIBRARY_PATH": "$SNAP_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu",
+        "PATH": "$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH",
+        "SNAP_DESKTOP_RUNTIME": "$SNAP/gnome-platform",
+        "TMPDIR": "$XDG_RUNTIME_DIR",
+      },
+      "plugs": Array [
+        "desktop",
+        "desktop-legacy",
+        "home",
+        "x11",
+        "wayland",
+        "unity7",
+        "browser-support",
+        "network",
+        "gsettings",
+        "audio-playback",
+        "pulseaudio",
+        "opengl",
+      ],
+      "slots": Array [
+        "mpris",
+        "another-simple-slot-name",
+      ],
+    },
+  },
+  "architectures": Array [
+    "amd64",
+  ],
+  "base": "core18",
+  "confinement": "strict",
+  "description": "Test Application (test quite “ #378)",
+  "grade": "stable",
+  "name": "sep",
+  "plugs": Object {
+    "gnome-3-28-1804": Object {
+      "default-provider": "gnome-3-28-1804",
+      "interface": "content",
+      "target": "$SNAP/gnome-platform",
+    },
+    "gtk-3-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/themes",
+    },
+    "icon-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/icons",
+    },
+    "sound-themes": Object {
+      "default-provider": "gtk-common-themes",
+      "interface": "content",
+      "target": "$SNAP/data-dir/sounds",
+    },
+  },
+  "slots": Object {
+    "mpris": Object {
+      "interface": "mpris",
+      "name": "chromium",
+    },
+  },
+  "summary": "Sep",
+  "version": "1.1.0",
+}
+`;
+
+exports[`slots option 4`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
 exports[`snap 1`] = `
 Object {
   "linux": Array [

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -132,22 +132,37 @@ test.ifDevOrLinuxCi("plugs option", async () => {
   }
 })
 
-test.ifDevOrLinuxCi("slots option", app({
-  targets: Platform.LINUX.createTarget("snap"),
-  config: {
-    extraMetadata: {
-      name: "sep",
-    },
-    productName: "Sep",
-    snap: {
-      slots: [ "foo", "bar" ],
-    }
-  },
-  effectiveOptionComputed: async ({snap}) => {
-    expect(snap).toMatchSnapshot()
-    return true
-  },
-}))
+test.ifDevOrLinuxCi("slots option", async () => {
+  for (const slots of [
+    [ "foo", "bar" ],
+    [
+      {
+        "mpris": {
+          interface: "mpris",
+          "name": "chromium"
+        },
+      },
+      "another-simple-slot-name",
+    ]
+  ]) {
+    await assertPack("test-app-one", {
+      targets: Platform.LINUX.createTarget("snap"),
+      config: {
+        extraMetadata: {
+          name: "sep",
+        },
+        productName: "Sep",
+        snap: {
+          slots
+        }
+      },
+      effectiveOptionComputed: async ({snap, args}) => {
+        expect(snap).toMatchSnapshot()
+        return true
+      },
+    })
+  }
+})
 
 test.ifDevOrLinuxCi("custom env", app({
   targets: Platform.LINUX.createTarget("snap"),


### PR DESCRIPTION
#### What's in there?

- [x] The ability to specify snap's slot properties (fixes #5339)

This is required to allow snap-packaged app declaring mpris slots.

#### How to test?

Compile source and schema, then `TEST_FILES=snapTest yarn test`.

#### Note to reviewers

I'm currently developing a [portable music player with electron](https://gihub.com/) named `melodie`.
One very basic feature is the usage of [MediaMetadata](https://developer.mozilla.org/en-US/docs/Web/API/MediaMetadata), which makes the operating system aware of which track is currently playing, and gives it a change to pause, and jump to next or previous.

On linux systems, this integrations is use [Media Player Remote Interface Specification](https://www.freedesktop.org/wiki/Specifications/mpris-spec/) (mpris): the application sends DBus commands to interact with the OS.
<img src="https://user-images.githubusercontent.com/186268/94348747-0e6e9580-003f-11eb-8f53-9a6031cca14a.png" width=50%/>

This works perfectly fine with all the packager I've tested, except with snap.

When running the snap in devmode or with classic confinement, Linux can interact with the player controls.
But when using strict confinement, Linux is not aware of it.
The `snappy-debug` tool spot the issue pretty quickly:
```shell
= AppArmor =
Time: Sep 26 20:57:04
Log: apparmor="DENIED" operation="dbus_bind"  bus="session" name="org.mpris.MediaPlayer2.chromium.instance38417" mask="bind" pid=38417 label="snap.melodie.melodie"
DBus access
Suggestion:
* use 'mpris' slot (https://github.com/snapcore/snapd/wiki/Interfaces#mpris)
```

After two days of try-and-fail research and web crawling it appears that:
- the `mpris` slot [needs a `name` attribute](https://snapcraft.io/docs/mpris-interface). When it's not provided, the name is the application name (`melodie` in my case)
- electron use chromium, but chromium does not give control over the named use. [It is hardcoded as `chromium`](https://source.chromium.org/chromium/chromium/src/+/master:components/system_media_controls/linux/system_media_controls_linux.cc;l=51;bpv=0;bpt=1)

I initially though I could hardcode the mpris name as long as someone specifies `mpris` in electron-builder's configuration, but then I changed to something generic: there are other slots [that require parameters](https://snapcraft.io/docs/content-interface).



