### PR TITLE
feat(snap): add Snap `title` option

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4647,6 +4647,13 @@
             "string"
           ]
         },
+        "title": {
+          "description": "An optional title for the snap, may contain uppercase letters and spaces. Defaults to `productName`. See [snap format documentation](https://snapcraft.io/docs/snap-format).",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "useTemplateApp": {
           "description": "Whether to use template snap. Defaults to `true` if `stagePackages` not specified.",
           "type": "boolean"

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -104,6 +104,11 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
    * The defaults can be found in [snap.ts](https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/templates/snap/snapcraft.yaml#L29).
    */
   readonly appPartStage?: Array<string> | null
+
+  /**
+   * An optional title for the snap, may contain uppercase letters and spaces. Defaults to `productName`. See [snap format documentation](https://snapcraft.io/docs/snap-format).
+   */
+  readonly title?: string | null
 }
 
 export interface PlugDescriptor {

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -85,6 +85,7 @@ export default class SnapTarget extends Target {
     deepAssign(snap, {
       name: snapName,
       version: appInfo.version,
+      title: options.title || appInfo.productName,
       summary: options.summary || appInfo.productName,
       description: this.helper.getDescription(options),
       architectures: [toLinuxArchString(arch, "snap")],


### PR DESCRIPTION
### Description

This pull request adds the `title` option for the `Snap` format.

### Implementation

The option defaults to `productName`.

### Background

The `title` attribute (see [Snap format](https://snapcraft.io/docs/snap-format)) describes:
_"An optional title for the snap, may contain uppercase letters and spaces"_

### Documentation

A pull request containing the supplemental documentation was created separately:
[docs(snap): add documentation for Snap `title` option (for #5350)](https://github.com/electron-userland/electron-builder/pull/5351)