### PR TITLE
electron-updater: don't clean temp directory if cached update file doesn't exist

### DIFF
--- a/packages/electron-updater/src/DownloadedUpdateHelper.ts
+++ b/packages/electron-updater/src/DownloadedUpdateHelper.ts
@@ -133,8 +133,7 @@ export class DownloadedUpdateHelper {
 
     const updateFile = path.join(this.cacheDirForPendingUpdate, cachedInfo.fileName)
     if (!(await pathExists(updateFile))) {
-      logger.info("Cached update file doesn't exist, directory for cached update will be cleaned")
-      await this.cleanCacheDirForPendingUpdate()
+      logger.info("Cached update file doesn't exist")
       return null
     }
 


### PR DESCRIPTION
This fixes #5029. I tested using DMG, NSIS, and AppImage.