### PR TITLE
fix:(appx): invalid CA publisher syntax from app-builder (#3501, #4931)

### DIFF
--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -161,7 +161,7 @@ export default class AppXTarget extends Target {
     }
 
     const certInfo = await this.packager.lazyCertInfo.value
-    const publisher = certInfo == null ? null : certInfo.bloodyMicrosoftSubjectDn
+    const publisher = this.options.publisher || (certInfo == null ? null : certInfo.bloodyMicrosoftSubjectDn)
     if (publisher == null) {
       throw new Error("Internal error: cannot compute subject using certificate info")
     }


### PR DESCRIPTION
honor publisher in `package.json`, for example:
```JSON
"build": {
    "appx": {
        "publisher": "CN=\"Bob Doe\", O=\"Bob Doe\", STREET=123 Fake St., L=London, S=London, PostalCode=A1042, C=GB",
    }
}
```