### PR TITLE
fix(AppImage): Linux icon is not set if path is not explicitly defined in config

### DIFF
--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -61,6 +61,11 @@ export class LinuxTargetHelper {
       sources.push(icnsPath)
     }
 
+    // if no explicit sources are defined, default to buildResources directory
+    if (sources.length < 1) {
+      sources.push('./')
+    }
+
     // need to put here and not as default because need to resolve image size
     const result = await packager.resolveIcon(sources, asArray(packager.getDefaultFrameworkIcon()), "set")
     this.maxIconPath = result[result.length - 1].file


### PR DESCRIPTION
If icon path is not explicitly defined in config, `sources` would be an empty array. This leads `resolveIcon` not to send `--path` argument  to `app-builder-bin`. Then `app-builder-bin` fails to create the icon set properly.

I suppose we can set a default `--path` value in `resolveIcon` or `app-builder-bin`, but for safety, I chose to only modify the `LinuxTargetHelper`.

Fix https://github.com/electron-userland/electron-builder/issues/4617
Fix https://github.com/electron-userland/electron-builder/issues/4186
Fix https://github.com/electron-userland/electron-builder/issues/2577
Fix https://github.com/electron-userland/electron-builder/issues/5014