### PR TITLE
fix(dmg): build under Big Sur is not possible if license file is used

### DIFF
--- a/packages/dmg-builder/package.json
+++ b/packages/dmg-builder/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "app-builder-lib": "workspace:*",
     "builder-util": "workspace:*",
+    "dmg-license": "^1.0.8",
     "fs-extra": "^9.0.1",
     "iconv-lite": "^0.6.2",
     "js-yaml": "^3.14.0",

--- a/packages/dmg-builder/src/dmgLicense.ts
+++ b/packages/dmg-builder/src/dmgLicense.ts
@@ -1,14 +1,61 @@
 import { exec, log } from "builder-util"
 import { PlatformPackager } from "app-builder-lib"
 import { getLicenseFiles } from "app-builder-lib/out/util/license"
-import { outputFile, readFile } from "fs-extra"
+import { outputFile, readFile, readJson } from "fs-extra"
 import { serializeString } from "./dmgUtil"
 import { getLicenseButtons, getLicenseButtonsFile } from "./licenseButtons"
+import { dmgLicenseFromJSON } from 'dmg-license'
 
 // DropDMG/dmgbuild a in any case (even if no english, but only ru/de) set to 0 (en_US), well, without docs, just believe that's correct
 const DEFAULT_REGION_CODE = 0
 
-export async function addLicenseToDmg(packager: PlatformPackager<any>, dmgPath: string): Promise<string | null> {
+export async function addLicenseToDmg(packager: PlatformPackager<any>, dmgPath: string): Promise<Object | null> {
+  const licenseFiles = await getLicenseFiles(packager)
+  if (licenseFiles.length === 0) {
+    return null
+  }
+
+  const licenseButtonFiles = await getLicenseButtonsFile(packager)
+  packager.debugLogger.add("dmg.licenseFiles", licenseFiles)
+  packager.debugLogger.add("dmg.licenseButtons", licenseButtonFiles)
+
+  const jsonFile = {
+    '$schema': 'https://github.com/argv-minus-one/dmg-license/raw/master/schema.json',
+    // defaultLang: '',
+    body: [] as any,
+    labels: [] as any
+  }
+
+  for (const file of licenseFiles) {
+    jsonFile.body.push({
+      file: file.file,
+      lang: file.langWithRegion.replace('_', '-')
+    })
+  }
+
+  for (const button of licenseButtonFiles) {
+    let label = await readJson(button.file)
+    if (label.description) {
+      // to support original button file format
+      label.message = label.description
+      delete label.description
+    }
+    jsonFile.labels.push(Object.assign(
+      {
+        lang: button.langWithRegion.replace('_', '-')
+      },
+      label
+    ))
+  }
+
+  await dmgLicenseFromJSON(dmgPath, jsonFile, {
+    onNonFatalError: log.warn.bind(log)
+  })
+
+  return jsonFile
+}
+
+export async function addLicenseToDmgOld(packager: PlatformPackager<any>, dmgPath: string): Promise<string | null> {
   // http://www.owsiak.org/?p=700
   const licenseFiles = await getLicenseFiles(packager)
   if (licenseFiles.length === 0) {


### PR DESCRIPTION
Fixes #5319

In Big Sur the long time deprecated `Rez` and `hdiutil unflatten` tools were removed.
I am  injecting DMG license with [dmg-license](https://github.com/argv-minus-one/dmg-license) package by keeping compatibility with TXT/RTF license and buttons files.

In this first version I keep all the old code.