### PR TITLE
fix(nsis): don't kill ourselves when upgrading

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -58,7 +58,7 @@
       DetailPrint `Closing running "${PRODUCT_NAME}"...`
 
       # https://github.com/electron-userland/electron-builder/issues/2516#issuecomment-372009092
-      nsExec::Exec `taskkill /t /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
+      nsExec::Exec `taskkill /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
       # to ensure that files are not "in-use"
       Sleep 300
 
@@ -66,7 +66,7 @@
       ${if} $R0 == 0
         # wait to give a chance to exit gracefully
         Sleep 1000
-        nsExec::Exec `taskkill /f /t /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
+        nsExec::Exec `taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
         ${If} $R0 != 0
           DetailPrint `Waiting for "${PRODUCT_NAME}" to close (taskkill exit code $R0).`
           Sleep 2000


### PR DESCRIPTION
Windows `taskkill.exe` will kill the actual installer when using the `/t` option it appears after some vigorous testing.

```
C:\Windows\system32>taskkill /t /im "Badlion Client.exe" /fi "PID ne 62548"
ERROR: The process with PID 65300 (child process of PID 57508) could not be terminated.
Reason: This process can only be terminated forcefully (with /F option).
ERROR: The process with PID 43552 (child process of PID 57508) could not be terminated.
Reason: This process can only be terminated forcefully (with /F option).
ERROR: The process with PID 59664 (child process of PID 57508) could not be terminated.
Reason: This process can only be terminated forcefully (with /F option).
SUCCESS: Sent termination signal to process with PID 62548, child of PID 57508.
ERROR: The process with PID 57508 (child process of PID 7964) could not be terminated.
Reason: One or more child processes of this process were still running.

C:\Windows\system32>taskkill /t /f /im "Badlion Client.exe" /fi "PID ne 62548"
SUCCESS: The process with PID 65300 (child process of PID 57508) has been terminated.
SUCCESS: The process with PID 43552 (child process of PID 57508) has been terminated.
SUCCESS: The process with PID 59664 (child process of PID 57508) has been terminated.
SUCCESS: The process with PID 62548 (child process of PID 57508) has been terminated.
SUCCESS: The process with PID 57508 (child process of PID 7964) has been terminated.

C:\Windows\system32>taskkill /f /im "Badlion Client.exe" /fi "PID ne 39848"
SUCCESS: The process "Badlion Client.exe" with PID 65496 has been terminated.
SUCCESS: The process "Badlion Client.exe" with PID 65756 has been terminated.
SUCCESS: The process "Badlion Client.exe" with PID 65472 has been terminated.
SUCCESS: The process "Badlion Client.exe" with PID 63528 has been terminated.
```

The first attempt the nsis installer's PID was 62548, and the second was 39848. Notice that with the `/t` flag it tries to kill itself, and does not listen to the `/fi` filter option which should ignore itself. The `/t` flag seems to take precedence here. 

I know that this was originally done due to this issue: https://github.com/electron-userland/electron-builder/issues/2894 but the reality here is that the user application should be responsible to clean up any spawned children before running the updating software.

I actually currently have a bug myself that is preventing proper shut down which I will fix, but this second layer bug of the installer killing itself is also a problem that should be resolved.