### PR TITLE
fix: signing of playwright/playwright-firefox

### DIFF
--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -197,7 +197,12 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
           }
         }
         return file.endsWith(".kext") || file.startsWith("/Contents/PlugIns", appPath.length) ||
-          file.includes("/node_modules/puppeteer/.local-chromium") /* https://github.com/electron-userland/electron-builder/issues/2010 */
+          file.includes("/node_modules/puppeteer/.local-chromium") ||  file.includes("/node_modules/playwright-firefox/.local-browsers") || file.includes("/node_modules/playwright/.local-browsers") 
+          
+          /* Those are browser automating modules, browser (chromium, nightly) cannot be signed
+          https://github.com/electron-userland/electron-builder/issues/2010 
+          https://github.com/electron-userland/electron-builder/issues/5383
+          */
       },
       identity: identity!,
       type,


### PR DESCRIPTION
This PR is based on https://github.com/electron-userland/electron-builder/issues/5383

Now “/node_modules/playwright-firefox/.local-browsers” and “/node_modules/playwright/.local-browsers” also getting ignored like “/node_modules/puppeteer/.local-chromium”.