### PR TITLE
fix(dmg-builder): fix dmg-license is incompatible with linux and win32

### DIFF
--- a/packages/dmg-builder/package.json
+++ b/packages/dmg-builder/package.json
@@ -15,11 +15,13 @@
   "dependencies": {
     "app-builder-lib": "workspace:*",
     "builder-util": "workspace:*",
-    "dmg-license": "^1.0.8",
     "fs-extra": "^9.0.1",
     "iconv-lite": "^0.6.2",
     "js-yaml": "^3.14.1",
     "sanitize-filename": "^1.6.3"
+  },
+  "optionalDependencies": {
+    "dmg-license": "^1.0.8"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.5",


### PR DESCRIPTION
`dmg-license` `package.json` sets that the module is only compatible with mac. This breaks `yarn install` on `linux` and `win32`. This PR moves `dmg-license` to `optionalDependencies` so `yarn` can ignore the error.

<img width="768" alt="Screen Shot 2020-12-14 at 7 51 38 PM" src="https://user-images.githubusercontent.com/1548835/102083828-c180ab00-3e46-11eb-8793-27bbf29d233f.png">
