### PR TITLE
feat: macOS default architecture (#5495)

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2389,6 +2389,20 @@
           ],
           "default": "distribution",
           "description": "Whether to sign app for development or for distribution."
+        },
+        "defaultArch": {
+          "anyOf": [
+            {
+              "enum": [
+                "arm64",
+                "universal",
+                "x64"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": "x64",
+          "description": "The default arch to skip in target names."
         }
       },
       "type": "object"

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -99,10 +99,10 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       }
       case Arch.universal: {
         const x64Arch = Arch.x64;
-        const x64AppOutDir = appOutDir + '-' + Arch[x64Arch];
+        const x64AppOutDir = appOutDir + '--' + Arch[x64Arch];
         await super.doPack(outDir, x64AppOutDir, platformName, x64Arch, platformSpecificBuildOptions, targets, false);
         const arm64Arch = Arch.arm64;
-        const arm64AppOutPath = appOutDir + '-' + Arch[arm64Arch];
+        const arm64AppOutPath = appOutDir + '--' + Arch[arm64Arch];
         await super.doPack(outDir, arm64AppOutPath, platformName, arm64Arch, platformSpecificBuildOptions, targets, false);
         const framework = this.info.framework
         log.info({
@@ -278,7 +278,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       const artifactName = this.expandArtifactNamePattern(masOptions, "pkg", arch)
       const artifactPath = path.join(outDir!, artifactName)
       await this.doFlat(appPath, artifactPath, masInstallerIdentity, keychainFile)
-      await this.dispatchArtifactCreated(artifactPath, null, Arch.x64, this.computeSafeArtifactName(artifactName, "pkg", arch))
+      await this.dispatchArtifactCreated(artifactPath, null, Arch.x64, this.computeSafeArtifactName(artifactName, "pkg", arch, true, this.platformSpecificBuildOptions.defaultArch))
     }
   }
 

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -115,6 +115,8 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions {
 
   /** @private */
   cscKeyPassword?: string | null
+
+  readonly defaultArch?: string
 }
 
 export interface ReleaseInfo {

--- a/packages/app-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/app-builder-lib/src/targets/ArchiveTarget.ts
@@ -1,4 +1,4 @@
-import { Arch } from "builder-util"
+import { Arch, defaultArchFromString } from "builder-util"
 import * as path from "path"
 import { Platform, Target, TargetSpecificOptions } from "../core"
 import { copyFiles, getFileMatchers } from "../fileMatcher"
@@ -19,13 +19,14 @@ export class ArchiveTarget extends Target {
     const format = this.name
 
     let defaultPattern: string
+    const defaultArch: Arch = defaultArchFromString(packager.platformSpecificBuildOptions.defaultArch);
     if (packager.platform === Platform.LINUX) {
       // tslint:disable-next-line:no-invalid-template-strings
-      defaultPattern = "${name}-${version}" + (arch === Arch.x64 ? "" : "-${arch}") + ".${ext}"
+      defaultPattern = "${name}-${version}" + (arch === defaultArch ? "" : "-${arch}") + ".${ext}"
     }
     else {
       // tslint:disable-next-line:no-invalid-template-strings
-      defaultPattern = "${productName}-${version}" + (arch === Arch.x64 ? "" : "-${arch}") + "-${os}.${ext}"
+      defaultPattern = "${productName}-${version}" + (arch === defaultArch ? "" : "-${arch}") + "-${os}.${ext}"
     }
 
     const artifactName = packager.expandArtifactNamePattern(this.options, format, arch, defaultPattern, false)
@@ -70,7 +71,7 @@ export class ArchiveTarget extends Target {
       updateInfo,
       file: artifactPath,
       // tslint:disable-next-line:no-invalid-template-strings
-      safeArtifactName: packager.computeSafeArtifactName(artifactName, format, arch, false, defaultPattern.replace("${productName}", "${name}")),
+      safeArtifactName: packager.computeSafeArtifactName(artifactName, format, arch, false, packager.platformSpecificBuildOptions.defaultArch, defaultPattern.replace("${productName}", "${name}")),
       target: this,
       arch,
       packager,

--- a/packages/builder-util/src/arch.ts
+++ b/packages/builder-util/src/arch.ts
@@ -24,8 +24,8 @@ export function getArchCliNames(): Array<string> {
   return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64]]
 }
 
-export function getArchSuffix(arch: Arch): string {
-  return arch === Arch.x64 ? "" : `-${Arch[arch]}`
+export function getArchSuffix(arch: Arch, defaultArch?: string): string {
+  return arch === defaultArchFromString(defaultArch) ? "" : `-${Arch[arch]}`
 }
 
 export function archFromString(name: string): Arch {
@@ -43,6 +43,10 @@ export function archFromString(name: string): Arch {
     default:
       throw new Error(`Unsupported arch ${name}`)
   }
+}
+
+export function defaultArchFromString(name?: string): Arch {
+  return name ? archFromString(name) : Arch.x64;
 }
 
 export function getArtifactArchName(arch: Arch, ext: string): string {

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -17,7 +17,7 @@ if (process.env.JEST_WORKER_ID == null) {
 export { safeStringifyJson } from "builder-util-runtime"
 export { TmpDir } from "temp-file"
 export { log, debug } from "./log"
-export { Arch, getArchCliNames, toLinuxArchString, getArchSuffix, ArchType, archFromString } from "./arch"
+export { Arch, getArchCliNames, toLinuxArchString, getArchSuffix, ArchType, archFromString, defaultArchFromString } from "./arch"
 export { AsyncTaskManager } from "./asyncTaskManager"
 export { DebugLogger } from "./DebugLogger"
 

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -23,7 +23,7 @@ export class DmgTarget extends Target {
   async build(appPath: string, arch: Arch) {
     const packager = this.packager
     // tslint:disable-next-line:no-invalid-template-strings
-    const artifactName = packager.expandArtifactNamePattern(this.options, "dmg", arch, "${productName}-" + (packager.platformSpecificBuildOptions.bundleShortVersion || "${version}") + "-${arch}.${ext}", true)
+    const artifactName = packager.expandArtifactNamePattern(this.options, "dmg", arch, "${productName}-" + (packager.platformSpecificBuildOptions.bundleShortVersion || "${version}") + "-${arch}.${ext}", true, packager.platformSpecificBuildOptions.defaultArch)
     const artifactPath = path.join(this.outDir, artifactName)
     await packager.info.callArtifactBuildStarted({
       targetPresentableName: "DMG",
@@ -118,7 +118,7 @@ export class DmgTarget extends Target {
   computeVolumeName(arch: Arch, custom?: string | null): string {
     const appInfo = this.packager.appInfo
     const shortVersion = this.packager.platformSpecificBuildOptions.bundleShortVersion || appInfo.version
-    const archString = getArchSuffix(arch)
+    const archString = getArchSuffix(arch, this.packager.platformSpecificBuildOptions.defaultArch)
 
     if (custom == null) {
       return `${appInfo.productFilename} ${shortVersion}${archString}`


### PR DESCRIPTION
See #5495.

This adds a `defaultArch` option to `MacConfiguration` to allow switching which 'arch' gets the default target name (skipping the arch extension) for `.zip` and `.dmg` to allow transitioning from `x64` (past/default) to `universal` to `arm64`.

@mmaietta @quanglam2807 @develar