### PR TITLE
feat: send download-progress information when downloading diff packages

### DIFF
--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -3,11 +3,13 @@ import { BlockMap } from "builder-util-runtime/out/blockMapApi"
 import { close, open } from "fs-extra"
 import { createWriteStream } from "fs"
 import { OutgoingHttpHeaders, RequestOptions } from "http"
+import { ProgressInfo, CancellationToken } from "builder-util-runtime"
 import { Logger } from "../main"
 import { copyData } from "./DataSplitter"
 import { URL } from "url"
 import { computeOperations, Operation, OperationKind } from "./downloadPlanBuilder"
 import { checkIsRangesSupported, executeTasksUsingMultipleRangeRequests } from "./multipleRangeDownloader"
+import { ProgressDifferentialDownloadCallbackTransform, ProgressDifferentialDownloadInfo } from "./ProgressDifferentialDownloadCallbackTransform"
 
 export interface DifferentialDownloaderOptions {
   readonly oldFile: string
@@ -18,6 +20,9 @@ export interface DifferentialDownloaderOptions {
   readonly requestHeaders: OutgoingHttpHeaders | null
 
   readonly isUseMultipleRangeRequest?: boolean
+
+  readonly cancellationToken: CancellationToken
+  onProgress?(progress: ProgressInfo): void
 }
 
 export abstract class DifferentialDownloader {
@@ -74,10 +79,10 @@ export abstract class DifferentialDownloader {
 
     logger.info(`Full: ${formatBytes(newSize)}, To download: ${formatBytes(downloadSize)} (${Math.round(downloadSize / (newSize / 100))}%)`)
 
-    return this.downloadFile(operations)
+    return this.downloadFile(operations, downloadSize)
   }
 
-  private downloadFile(tasks: Array<Operation>): Promise<any> {
+  private downloadFile(tasks: Array<Operation>, downloadSize: number): Promise<any> {
     const fdList: Array<OpenedFile> = []
     const closeFiles = (): Promise<Array<void>> => {
       return Promise.all(fdList.map(openedFile => {
@@ -87,7 +92,7 @@ export abstract class DifferentialDownloader {
           })
       }))
     }
-    return this.doDownloadFile(tasks, fdList)
+    return this.doDownloadFile(tasks, fdList, downloadSize)
       .then(closeFiles)
       .catch(e => {
         // then must be after catch here (since then always throws error)
@@ -113,7 +118,7 @@ export abstract class DifferentialDownloader {
       })
   }
 
-  private async doDownloadFile(tasks: Array<Operation>, fdList: Array<OpenedFile>): Promise<any> {
+  private async doDownloadFile(tasks: Array<Operation>, fdList: Array<OpenedFile>, downloadSize: number): Promise<any> {
     const oldFileFd = await open(this.options.oldFile, "r")
     fdList.push({descriptor: oldFileFd, path: this.options.oldFile})
     const newFileFd = await open(this.options.newFile, "w")
@@ -121,6 +126,29 @@ export abstract class DifferentialDownloader {
     const fileOut = createWriteStream(this.options.newFile, {fd: newFileFd})
     await new Promise((resolve, reject) => {
       const streams: Array<any> = []
+
+      // Create our download info transformer if we have one
+      let downloadInfoTransform: ProgressDifferentialDownloadCallbackTransform | undefined = undefined
+      if (!this.options.isUseMultipleRangeRequest && this.options.onProgress) { // TODO: Does not support multiple ranges (someone feel free to PR this!)
+        const expectedByteCounts: Array<number> = []
+        let grandTotalBytes = 0
+
+        for (const task of tasks) {
+          if (task.kind === OperationKind.DOWNLOAD) {
+            expectedByteCounts.push(task.end - task.start)
+            grandTotalBytes += task.end - task.start
+          }
+        }
+
+        const progressDifferentialDownloadInfo: ProgressDifferentialDownloadInfo = {
+          expectedByteCounts: expectedByteCounts,
+          grandTotal: grandTotalBytes
+        }
+
+        downloadInfoTransform = new ProgressDifferentialDownloadCallbackTransform(progressDifferentialDownloadInfo, this.options.cancellationToken, this.options.onProgress)
+        streams.push(downloadInfoTransform)
+      }
+
       const digestTransform = new DigestTransform(this.blockAwareFileInfo.sha512)
       // to simply debug, do manual validation to allow file to be fully written
       digestTransform.isValidateOnEnd = false
@@ -183,6 +211,11 @@ export abstract class DifferentialDownloader {
 
         const operation = tasks[index++]
         if (operation.kind === OperationKind.COPY) {
+          // We are copying, let's not send status updates to the UI
+          if (downloadInfoTransform) {
+            downloadInfoTransform.beginFileCopy()
+          }
+
           copyData(operation, firstStream, oldFileFd, reject, () => w(index))
           return
         }
@@ -195,6 +228,11 @@ export abstract class DifferentialDownloader {
           debug(`download range: ${range}`)
         }
 
+        // We are starting to download
+        if (downloadInfoTransform) {
+          downloadInfoTransform.beginRangeDownload()
+        }
+
         const request = this.httpExecutor.createRequest(requestOptions, response => {
           // Electron net handles redirects automatically, our NodeJS test server doesn't use redirects - so, we don't check 3xx codes.
           if (response.statusCode >= 400) {
@@ -205,6 +243,11 @@ export abstract class DifferentialDownloader {
             end: false
           })
           response.once("end", () => {
+            // Pass on that we are downloading a segment
+            if (downloadInfoTransform) {
+              downloadInfoTransform.endRangeDownload()
+            }
+
             if (++downloadOperationCount === 100) {
               downloadOperationCount = 0
               setTimeout(() => w(index), 1000)

--- a/packages/electron-updater/src/differentialDownloader/ProgressDifferentialDownloadCallbackTransform.ts
+++ b/packages/electron-updater/src/differentialDownloader/ProgressDifferentialDownloadCallbackTransform.ts
@@ -1,0 +1,112 @@
+import { Transform } from "stream"
+import { CancellationToken } from "builder-util-runtime"
+
+enum OperationKind {
+  COPY, DOWNLOAD
+}
+
+export interface ProgressInfo {
+  total: number
+  delta: number
+  transferred: number
+  percent: number
+  bytesPerSecond: number
+}
+
+export interface ProgressDifferentialDownloadInfo {
+  expectedByteCounts: Array<number>,
+  grandTotal: number
+}
+
+export class ProgressDifferentialDownloadCallbackTransform extends Transform {
+  private start = Date.now()
+  private transferred = 0
+  private delta = 0
+  private expectedBytes = 0
+  private index = 0
+  private operationType = OperationKind.COPY
+
+  private nextUpdate = this.start + 1000
+
+  constructor(private readonly progressDifferentialDownloadInfo: ProgressDifferentialDownloadInfo, private readonly cancellationToken: CancellationToken, private readonly onProgress: (info: ProgressInfo) => any) {
+    super()
+  }
+
+  _transform(chunk: any, encoding: string, callback: any) {
+    if (this.cancellationToken.cancelled) {
+      callback(new Error("cancelled"), null)
+      return
+    }
+
+    // Don't send progress update when copying from disk
+    if (this.operationType == OperationKind.COPY) {
+      callback(null, chunk)
+      return
+    }
+
+    this.transferred += chunk.length
+    this.delta += chunk.length
+
+    const now = Date.now()
+    if (now >= this.nextUpdate
+      && this.transferred !== this.expectedBytes /* will be emitted by endRangeDownload() */
+      && this.transferred !== this.progressDifferentialDownloadInfo.grandTotal /* will be emitted on _flush */) {
+      this.nextUpdate = now + 1000
+
+      this.onProgress({
+        total: this.progressDifferentialDownloadInfo.grandTotal,
+        delta: this.delta,
+        transferred: this.transferred,
+        percent: (this.transferred / this.progressDifferentialDownloadInfo.grandTotal) * 100,
+        bytesPerSecond: Math.round(this.transferred / ((now - this.start) / 1000))
+      })
+      this.delta = 0
+    }
+
+    callback(null, chunk)
+  }
+
+  beginFileCopy(): void {
+    this.operationType = OperationKind.COPY
+  }
+
+  beginRangeDownload(): void {
+    this.operationType = OperationKind.DOWNLOAD
+
+    this.expectedBytes += this.progressDifferentialDownloadInfo.expectedByteCounts[this.index++]
+  }
+
+  endRangeDownload(): void {
+    // _flush() will doour final 100%
+    if (this.transferred !== this.progressDifferentialDownloadInfo.grandTotal) {
+      this.onProgress({
+        total: this.progressDifferentialDownloadInfo.grandTotal,
+        delta: this.delta,
+        transferred: this.transferred,
+        percent: (this.transferred / this.progressDifferentialDownloadInfo.grandTotal) * 100,
+        bytesPerSecond: Math.round(this.transferred / ((Date.now() - this.start) / 1000))
+      })
+    }
+  }
+
+  // Called when we are 100% done with the connection/download
+  _flush(callback: any): void {
+    if (this.cancellationToken.cancelled) {
+      callback(new Error("cancelled"))
+      return
+    }
+
+    this.onProgress({
+      total: this.progressDifferentialDownloadInfo.grandTotal,
+      delta: this.delta,
+      transferred: this.transferred,
+      percent: 100,
+      bytesPerSecond: Math.round(this.transferred / ((Date.now() - this.start) / 1000))
+    })
+    this.delta = 0
+    this.transferred = 0
+
+
+    callback(null)
+  }
+}

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -6,7 +6,6 @@ import { LoginCallback } from "./electronHttpExecutor"
 
 export { AppUpdater, NoOpLogger } from "./AppUpdater"
 export { UpdateInfo }
-export { CancellationToken } from "builder-util-runtime"
 export { Provider } from "./providers/Provider"
 export { AppImageUpdater } from "./AppImageUpdater"
 export { MacUpdater } from "./MacUpdater"


### PR DESCRIPTION
Fixes a bunch of issues such as #2521 #4919 #5341...and so many other duplicate tickets

I have tested this with:

- nsis
- nsis-web
- AppImage

I have not gotten to test the AppImage system, but I will test that in the next day or two. Probably works fine though since it is just using the same logic as nsis-web

Some further notes:

1. I have gone ahead and tested this with and without a `onProgress` being supplied, it works for both
2. With these logic changes it will go from 0 -> 100% on the `download-progress` event two times on `nsis-web` (and other similar packaging systems) because it will first download the blockmap, and second download the actual changes. I figured it was better to leave like this, vs change it. This makes it more clear to the user that something is happening (instead of nothing happening which is the current problem/situation).
3. I do not have a way to test `useMultipleRangeRequest`, so I have not implemented this. I left a TODO for someone if they want to make a separate PR for it...doesn't seem too hard, but I did not want to touch the `DataSplitter` stuff, as I did not understand it all.

Overall this is a huge improvement for user experience, but not perfect still. Would love to have someone pick up and finish this and implement the missing functionality into the `executeTasksUsingMultipleRangeRequests` function (and sub-functions).

If you stumble across this PR, and are wondering why you still are not having progress shown, then try using the option `useMultipleRangeRequest` and setting it to `false` in your `package.json` under your `publish` configuration. This option will disable doing all of the downloads in a single HTTP request, and instead will use one HTTP request per download range. This does not work on AWS S3 anyways (which is where my stuff is currently hosted).