### PR TITLE
fix(mac): Allow arm64 macs to update to x64 version if no arm64 version available

### DIFF
--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -33,9 +33,9 @@ export class MacUpdater extends AppUpdater {
 
     let files = downloadUpdateOptions.updateInfoAndProvider.provider.resolveFiles(downloadUpdateOptions.updateInfoAndProvider.info);
 
+    // Allow arm64 macs to install universal or rosetta2(x64) - https://github.com/electron-userland/electron-builder/pull/5524
     const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64")
     if (files.some(isArm64)) {
-      // Allow arm64 macs to install universal or rosetta2(x64) - https://github.com/electron-userland/electron-builder/pull/5524
       files = files.filter(file => (process.arch === "arm64") === isArm64(file));
     }
 

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -35,7 +35,7 @@ export class MacUpdater extends AppUpdater {
 
     const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64")
     if (files.some(isArm64)) {
-      files = files.filter(file => process.arch == "arm64" === isArm64(file));
+      files = files.filter(file => (process.arch === "arm64") === isArm64(file));
     }
 
     const zipFileInfo = findFile(files, "zip", ["pkg", "dmg"])

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -35,6 +35,7 @@ export class MacUpdater extends AppUpdater {
 
     const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64")
     if (files.some(isArm64)) {
+      // Allow arm64 macs to install universal or rosetta2(x64) - https://github.com/electron-userland/electron-builder/pull/5524
       files = files.filter(file => (process.arch === "arm64") === isArm64(file));
     }
 

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -35,7 +35,7 @@ export class MacUpdater extends AppUpdater {
 
     const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64")
     if (files.some(isArm64)) {
-      files.filter(file => process.arch == "arm64" === isArm64(file));
+      files = files.filter(file => process.arch == "arm64" === isArm64(file));
     }
 
     const zipFileInfo = findFile(files, "zip", ["pkg", "dmg"])

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -5,7 +5,7 @@ import { createServer, IncomingMessage, ServerResponse } from "http"
 import { AddressInfo } from "net"
 import { AppAdapter } from "./AppAdapter"
 import { AppUpdater, DownloadUpdateOptions } from "./AppUpdater"
-import { UpdateDownloadedEvent } from "./main"
+import { ResolvedUpdateFileInfo, UpdateDownloadedEvent } from "./main"
 import { findFile } from "./providers/Provider"
 import AutoUpdater = Electron.AutoUpdater
 
@@ -31,8 +31,13 @@ export class MacUpdater extends AppUpdater {
   protected doDownloadUpdate(downloadUpdateOptions: DownloadUpdateOptions): Promise<Array<string>> {
     this.updateInfoForPendingUpdateDownloadedEvent = null
 
-    const files = downloadUpdateOptions.updateInfoAndProvider.provider.resolveFiles(downloadUpdateOptions.updateInfoAndProvider.info)
-      .filter(file => (process.arch == 'arm64') === (file.url.pathname.includes('arm64')));
+    let files = downloadUpdateOptions.updateInfoAndProvider.provider.resolveFiles(downloadUpdateOptions.updateInfoAndProvider.info);
+
+    const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64")
+    if (files.some(isArm64)) {
+      files.filter(file => process.arch == "arm64" === isArm64(file));
+    }
+
     const zipFileInfo = findFile(files, "zip", ["pkg", "dmg"])
     if (zipFileInfo == null) {
       throw newError(`ZIP file not provided: ${safeStringifyJson(files)}`, "ERR_UPDATER_ZIP_FILE_NOT_FOUND")


### PR DESCRIPTION
If an arm64 mac is running an intel version of an app (through Rosetta) and there are no arm64 versions of the app to update to then we should update to the intel version anyway.

Without this code change then an arm64 mac would be stuck on the current version until an arm64 version is released.