### PR TITLE
feat: Custom electronDist callback

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5711,8 +5711,15 @@
       "type": "boolean"
     },
     "electronDist": {
-      "description": "The path to custom Electron build (e.g. `~/electron/out/R`).",
-      "type": "string"
+      "description": "Returns the path to custom Electron build (e.g. `~/electron/out/R`). Zip files must follow the pattern `electron-v${version}-${platformName}-${arch}.zip`, otherwise it will be assumed to be an unpacked Electron app directory",
+      "anyOf": [
+        {
+          "typeof": "function"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "electronDownload": {
       "$ref": "#/definitions/ElectronDownloadOptions",

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -1,6 +1,7 @@
 import { Arch } from "builder-util"
 import { BeforeBuildContext, Target } from "./core"
 import { ElectronDownloadOptions } from "./electron/ElectronFramework"
+import { PrepareApplicationStageDirectoryOptions } from "./Framework"
 import { AppXOptions } from "./options/AppXOptions"
 import { AppImageOptions, DebOptions, LinuxConfiguration, LinuxTargetSpecificOptions } from "./options/linuxOptions"
 import { DmgOptions, MacConfiguration, MasConfiguration } from "./options/macOptions"
@@ -129,9 +130,9 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   readonly electronCompile?: boolean
 
   /**
-   * The path to custom Electron build (e.g. `~/electron/out/R`).
+   * Returns the path to custom Electron build (e.g. `~/electron/out/R`). Zip files must follow the pattern `electron-v${version}-${platformName}-${arch}.zip`, otherwise it will be assumed to be an unpacked Electron app directory
    */
-  readonly electronDist?: string
+  readonly electronDist?: string | ((options: PrepareApplicationStageDirectoryOptions) => string)
 
   /**
    * The [electron-download](https://github.com/electron-userland/electron-download#usage) options.

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -143,14 +143,15 @@ export async function createElectronFrameworkSupport(configuration: Configuratio
 }
 
 async function unpack(prepareOptions: PrepareApplicationStageDirectoryOptions, options: ElectronDownloadOptions, distMacOsAppName: string) {
-  const packager = prepareOptions.packager
-  const out = prepareOptions.appOutDir
+  const { packager, appOutDir, platformName } = prepareOptions
 
-  let dist: string | null | undefined = packager.config.electronDist
+  const electronDist = packager.config.electronDist
+  let dist: string | undefined | null = (typeof electronDist === 'function') ? electronDist(prepareOptions) : electronDist
   if (dist != null) {
-    const zipFile = `electron-v${options.version}-${prepareOptions.platformName}-${options.arch}.zip`
+    const zipFile = `electron-v${options.version}-${platformName}-${options.arch}.zip`
     const resolvedDist = path.resolve(packager.projectDir, dist)
     if ((await statOrNull(path.join(resolvedDist, zipFile))) != null) {
+      log.debug({ resolvedDist, zipFile }, "Resolved electronDist")
       options.cache = resolvedDist
       dist = null
     }
@@ -161,15 +162,15 @@ async function unpack(prepareOptions: PrepareApplicationStageDirectoryOptions, o
     if (isSafeToUnpackElectronOnRemoteBuildServer(packager)) {
       return
     }
-
-    await executeAppBuilder(["unpack-electron", "--configuration", JSON.stringify([options]), "--output", out, "--distMacOsAppName", distMacOsAppName])
+    log.info({ zipPath: options.cache }, "Unpacking electron zip")
+    await executeAppBuilder(["unpack-electron", "--configuration", JSON.stringify([options]), "--output", appOutDir, "--distMacOsAppName", distMacOsAppName])
   }
   else {
     isFullCleanup = true
     const source = packager.getElectronSrcDir(dist)
-    const destination = packager.getElectronDestinationDir(out)
+    const destination = packager.getElectronDestinationDir(appOutDir)
     log.info({source, destination}, "copying Electron")
-    await emptyDir(out)
+    await emptyDir(appOutDir)
     await copyDir(source, destination, {
       isUseHardLink: DO_NOT_USE_HARD_LINKS,
     })

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -149,7 +149,7 @@ async function unpack(prepareOptions: PrepareApplicationStageDirectoryOptions, o
   let dist: string | undefined | null = (typeof electronDist === 'function') ? electronDist(prepareOptions) : electronDist
   if (dist != null) {
     const zipFile = `electron-v${options.version}-${platformName}-${options.arch}.zip`
-    const resolvedDist = path.resolve(packager.projectDir, dist)
+    const resolvedDist = path.isAbsolute(dist) ? dist : path.resolve(packager.projectDir, dist)
     if ((await statOrNull(path.join(resolvedDist, zipFile))) != null) {
       log.debug({ resolvedDist, zipFile }, "Resolved electronDist")
       options.cache = resolvedDist


### PR DESCRIPTION
Follow up from discussion with @lutzroeder and @quanglam2807 
https://github.com/electron-userland/electron-builder/pull/5481#issuecomment-749752069

- Enabling `electronDist` to be a function that returns the path to the electron dist directory. 
- Updated documentation for the expected options (string path vs function)

This is necessary for universal builds where an `electronDist` must be specified per-architecture and there are multiple Arch-Targets provided. This applies to Windows (ia32+x64) and Mac (x64+arm64)
```
const archs = platform === builder.Platform.MAC ? [builder.Arch.universal] : [builder.Arch.x64, builder.Arch.ia32]
const targets = platform.createTarget(null, ...archs)
```
Used in electron-builder config as::
```
electronDist: (options: PrepareApplicationStageDirectoryOptions) => {
    // console.log("PrepareApplicationStageDirectoryOptions", options)
    return prepareRebrandedElectronDist(options);
},
```

Note: this does not change the functionality of what electron-builder _searches for_ at that path: search for properly-named zip OR assume it as unpacked app directory. This only allows an alternative way of specifying where those files are located.