### PR TITLE
fix(mac): fix "Contents/Info.plist" don't have identical SHAs when creating a universal build

### DIFF
--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -100,10 +100,10 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       case Arch.universal: {
         const x64Arch = Arch.x64;
         const x64AppOutDir = appOutDir + '--' + Arch[x64Arch];
-        await super.doPack(outDir, x64AppOutDir, platformName, x64Arch, platformSpecificBuildOptions, targets, false);
+        await super.doPack(outDir, x64AppOutDir, platformName, x64Arch, platformSpecificBuildOptions, targets, false, true);
         const arm64Arch = Arch.arm64;
         const arm64AppOutPath = appOutDir + '--' + Arch[arm64Arch];
-        await super.doPack(outDir, arm64AppOutPath, platformName, arm64Arch, platformSpecificBuildOptions, targets, false);
+        await super.doPack(outDir, arm64AppOutPath, platformName, arm64Arch, platformSpecificBuildOptions, targets, false, true);
         const framework = this.info.framework
         log.info({
           platform: platformName,

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -158,7 +158,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
   }
 
-  protected async doPack(outDir: string, appOutDir: string, platformName: ElectronPlatformName, arch: Arch, platformSpecificBuildOptions: DC, targets: Array<Target>, sign: boolean = true) {
+  protected async doPack(outDir: string, appOutDir: string, platformName: ElectronPlatformName, arch: Arch, platformSpecificBuildOptions: DC, targets: Array<Target>, sign: boolean = true, disableAsarIntegrity: boolean = false) {
     if (this.packagerOptions.prepackaged != null) {
       return
     }
@@ -226,7 +226,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       await framework.beforeCopyExtraFiles({
         packager: this,
         appOutDir,
-        asarIntegrity: asarOptions == null ? null : await computeData(resourcesPath, asarOptions.externalAllowed ? {externalAllowed: true} : null),
+        asarIntegrity: asarOptions == null || disableAsarIntegrity ? null : await computeData(resourcesPath, asarOptions.externalAllowed ? {externalAllowed: true} : null),
         platformName,
       })
     }


### PR DESCRIPTION
Resolve https://github.com/electron-userland/electron-builder/issues/5547

`@electron/universal` requires that `Contents/Info.plist` of `arm64` and `x64` build to be identical. But `asarIntegrity` of each build is different so when it is added to `Info.plist`:
```
<key>AsarIntegrity</key>
<string>xxx</string>
```
It causes `Contents/Info.plist` to become mismatched. `@electron/universal` returns `Error: Expected all non-binary files to have identical SHAs when creating a universal build but "Contents/Info.plist" did not`, causing the build process to fail.

This PR disables `asarIntegrity` for universal build.