### PR TITLE
fix: support Yarn 2/PNP projects

### DIFF
--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -98,5 +98,6 @@
     "electron-builder-squirrel-windows": "workspace:*"
   },
   "//": "electron-builder-squirrel-windows and dmg-builder added as dev dep for tests (as otherwise `require` doesn't work using Yarn 2)",
-  "typings": "./out/index.d.ts"
+  "typings": "./out/index.d.ts",
+  "preferUnplugged": true
 }

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -94,7 +94,7 @@
     "@types/js-yaml": "^3.12.6",
     "@types/normalize-package-data": "^2.4.0",
     "@types/semver": "^7.3.4",
-    "dmg-builder": "workspace:*",
+    "dmg-builder": "../dmg-builder",
     "electron-builder-squirrel-windows": "workspace:*"
   },
   "//": "electron-builder-squirrel-windows and dmg-builder added as dev dep for tests (as otherwise `require` doesn't work using Yarn 2)",

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -51,7 +51,9 @@
     "builder-util-runtime": "workspace:*",
     "chromium-pickle-js": "^0.2.0",
     "debug": "^4.3.2",
+    "dmg-builder": "workspace:*",
     "ejs": "^3.1.5",
+    "electron-builder-squirrel-windows": "workspace:*",
     "electron-publish": "workspace:*",
     "fs-extra": "^9.0.1",
     "hosted-git-info": "^3.0.7",
@@ -93,11 +95,9 @@
     "@types/is-ci": "^2.0.0",
     "@types/js-yaml": "^3.12.6",
     "@types/normalize-package-data": "^2.4.0",
-    "@types/semver": "^7.3.4",
-    "dmg-builder": "../dmg-builder",
-    "electron-builder-squirrel-windows": "workspace:*"
+    "@types/semver": "^7.3.4"
   },
-  "//": "electron-builder-squirrel-windows and dmg-builder added as dev dep for tests (as otherwise `require` doesn't work using Yarn 2)",
+  "//": "electron-builder-squirrel-windows and dmg-builder added as deps (as otherwise `require` doesn't work using Yarn 2)",
   "typings": "./out/index.d.ts",
   "preferUnplugged": true
 }

--- a/packages/dmg-builder/package.json
+++ b/packages/dmg-builder/package.json
@@ -28,5 +28,6 @@
     "@types/js-yaml": "^3.12.6",
     "temp-file": "^3.3.7"
   },
-  "typings": "./out/dmg.d.ts"
+  "typings": "./out/dmg.d.ts",
+  "preferUnplugged": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2775,7 +2775,7 @@ __metadata:
     builder-util-runtime: "workspace:*"
     chromium-pickle-js: ^0.2.0
     debug: ^4.3.2
-    dmg-builder: ../dmg-builder
+    dmg-builder: "workspace:*"
     ejs: ^3.1.5
     electron-builder-squirrel-windows: "workspace:*"
     electron-publish: "workspace:*"
@@ -4443,24 +4443,6 @@ __metadata:
     test-value: ^3.0.0
     walk-back: ^4.0.0
   checksum: a02b9ef16eabbee439f84a3e43d8d85719c51f1a2ba7314f855a69b9d02619b60c6908c3fdaa25400bee50e6c554fcc9659cec92cb7134cff92b57be6c75ca0c
-  languageName: node
-  linkType: hard
-
-"dmg-builder@file:../dmg-builder::locator=app-builder-lib%40workspace%3Apackages%2Fapp-builder-lib":
-  version: 22.10.3
-  resolution: "dmg-builder@file:../dmg-builder#../dmg-builder::hash=952416&locator=app-builder-lib%40workspace%3Apackages%2Fapp-builder-lib"
-  dependencies:
-    app-builder-lib: "workspace:*"
-    builder-util: "workspace:*"
-    dmg-license: ^1.0.8
-    fs-extra: ^9.0.1
-    iconv-lite: ^0.6.2
-    js-yaml: ^3.14.1
-    sanitize-filename: ^1.6.3
-  dependenciesMeta:
-    dmg-license:
-      optional: true
-  checksum: e622405d21fcd582576047b614eea8a20388f24e49ca806a538d2a5d1b423629c3001e7a3f2388673bc33b3df782e1c5782d317dd81b0e98358bc57eced4a60a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2775,7 +2775,7 @@ __metadata:
     builder-util-runtime: "workspace:*"
     chromium-pickle-js: ^0.2.0
     debug: ^4.3.2
-    dmg-builder: "workspace:*"
+    dmg-builder: ../dmg-builder
     ejs: ^3.1.5
     electron-builder-squirrel-windows: "workspace:*"
     electron-publish: "workspace:*"
@@ -4443,6 +4443,24 @@ __metadata:
     test-value: ^3.0.0
     walk-back: ^4.0.0
   checksum: a02b9ef16eabbee439f84a3e43d8d85719c51f1a2ba7314f855a69b9d02619b60c6908c3fdaa25400bee50e6c554fcc9659cec92cb7134cff92b57be6c75ca0c
+  languageName: node
+  linkType: hard
+
+"dmg-builder@file:../dmg-builder::locator=app-builder-lib%40workspace%3Apackages%2Fapp-builder-lib":
+  version: 22.10.3
+  resolution: "dmg-builder@file:../dmg-builder#../dmg-builder::hash=952416&locator=app-builder-lib%40workspace%3Apackages%2Fapp-builder-lib"
+  dependencies:
+    app-builder-lib: "workspace:*"
+    builder-util: "workspace:*"
+    dmg-license: ^1.0.8
+    fs-extra: ^9.0.1
+    iconv-lite: ^0.6.2
+    js-yaml: ^3.14.1
+    sanitize-filename: ^1.6.3
+  dependenciesMeta:
+    dmg-license:
+      optional: true
+  checksum: e622405d21fcd582576047b614eea8a20388f24e49ca806a538d2a5d1b423629c3001e7a3f2388673bc33b3df782e1c5782d317dd81b0e98358bc57eced4a60a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Some build steps (e.g. `app-builder icon`) do not work with Yarn 2/PNP, causing electron-builder to fail. Unplugging the affected packages allows build to complete without rewriting all dependencies to be PNP-aware.

Some app-builder dev dependencies also needed to be declared as full dependencies since Yarn 2 sees that they are required at runtime and fails with an ambiguity error in strict mode.