### PR TITLE
Add "open" guard for AsarUtil to fix concurrent builds

### DIFF
--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -196,7 +196,6 @@ export class AsarPackager {
           return
         }
 
-        // https://github.com/yarnpkg/yarn/pull/3539
         readFile(file)
           .then(it => {
             writeStream.write(it, () => w(index + 1))

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -209,7 +209,6 @@ export class AsarPackager {
           const readStream = createReadStream(file)
           readStream.on("error", reject)
           readStream.once("end", () => w(index + 1))
-
           readStream.on("open", () => {
             readStream.pipe(writeStream, {
               end: false

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -197,22 +197,12 @@ export class AsarPackager {
         }
 
         // https://github.com/yarnpkg/yarn/pull/3539
-        const stat = metadata.get(file)
-        if (stat != null && stat.size < (2 * 1024 * 1024)) {
-          readFile(file)
-            .then(it => {
-              writeStream.write(it, () => w(index + 1))
-            })
-            .catch(e => reject(`Cannot read file ${file}: ${e.stack || e}`))
-        }
-        else {
-          const readStream = createReadStream(file)
-          readStream.on("error", reject)
-          readStream.once("end", () => w(index + 1))
-          readStream.pipe(writeStream, {
-            end: false
-          })
-        }
+        const readStream = createReadStream(file)
+        readStream.on("error", reject)
+        readStream.once("end", () => w(index + 1))
+        readStream.pipe(writeStream, {
+          end: false
+        })
       }
 
       writeStream.write(headerBuf, () => w(0))

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -197,12 +197,12 @@ export class AsarPackager {
         }
 
         // https://github.com/yarnpkg/yarn/pull/3539
-        const readStream = createReadStream(file)
-        readStream.on("error", reject)
-        readStream.once("end", () => w(index + 1))
-        readStream.pipe(writeStream, {
-          end: false
-        })
+        readFile(file)
+          .then(it => {
+            writeStream.write(it, () => w(index + 1))
+          })
+          .catch(e => reject(`Cannot read file ${file}: ${e.stack || e}`))
+        }
       }
 
       writeStream.write(headerBuf, () => w(0))


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-builder/issues/5565 by adding an `.on("open", () => {})` guard around using the file stream. 

From [the documentation](https://nodejs.org/en/knowledge/advanced/streams/how-to-use-fs-create-read-stream/):

```js
// This will wait until we know the readable stream is actually valid before piping
readStream.on('open', function () {
  // This just pipes the read stream to the response object (which goes to the client)
  readStream.pipe(res);
});
```

The original `createReadStream` call, without a guard, fails on my M1 mac when building multiple architectures with larger files (>7mb). This change makes packaging totally reliable and is best practice for a `readStream`.
