### PR TITLE
Also Look for the Amazon cred header to remove auth header

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -299,8 +299,9 @@ Please double check that your authentication token is correct. Due to security r
     const headers = newOptions.headers
     if (headers != null && headers.authorization != null && (headers.authorization as string).startsWith("token")) {
       const parsedNewUrl = new URL(redirectUrl)
-      if (parsedNewUrl.hostname.endsWith(".amazonaws.com")) {
-        delete headers.authorization
+      if (parsedNewUrl.hostname.endsWith(".amazonaws.com") ||
+        parsedNewUrl.searchParams.has("X-Amz-Credential")) {
+        delete headers.authorization;
       }
     }
     return newOptions


### PR DESCRIPTION
Looks like the amazon dual auth problem is now on other urls than amazonaws.com because github releases is using it now too