### PR TITLE
fix(nsis): keep injected logger state

### DIFF
--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -222,11 +222,8 @@ export abstract class DifferentialDownloader {
 
         const range = `bytes=${operation.start}-${operation.end - 1}`
         requestOptions.headers!!.range = range
-
-        const debug = this.logger.debug
-        if (debug != null) {
-          debug(`download range: ${range}`)
-        }
+        
+        this.logger?.debug?.(`download range: ${range}`)
 
         // We are starting to download
         if (downloadInfoTransform) {


### PR DESCRIPTION
This change avoids loosing state in the logger in case users inject a logger class instead of an object with functions.