### PR TITLE
Add support for recursive mixin-like extends

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5804,11 +5804,21 @@
       ]
     },
     "extends": {
-      "description": "The name of a built-in configuration preset or path to config file (relative to project dir). Currently, only `react-cra` is supported.\n\nIf `react-scripts` in the app dependencies, `react-cra` will be set automatically. Set to `null` to disable automatic detection.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      ],
+      "description": "The name of a built-in configuration preset (currently, only `react-cra` is supported) or any number of paths to config files (relative to project dir).\n\nThe latter allows to mixin a config from multiple other configs, as if you `Object.assign` them, but properly combine `files` glob patterns.\n\nIf `react-scripts` in the app dependencies, `react-cra` will be set automatically. Set to `null` to disable automatic detection."
     },
     "extraFiles": {
       "anyOf": [

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -145,11 +145,13 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   electronVersion?: string | null
 
   /**
-   * The name of a built-in configuration preset or path to config file (relative to project dir). Currently, only `react-cra` is supported.
+   * The name of a built-in configuration preset (currently, only `react-cra` is supported) or any number of paths to config files (relative to project dir).
+   *
+   * The latter allows to mixin a config from multiple other configs, as if you `Object.assign` them, but properly combine `files` glob patterns.
    *
    * If `react-scripts` in the app dependencies, `react-cra` will be set automatically. Set to `null` to disable automatic detection.
    */
-  extends?: string | null
+  extends?: Array<string> | string | null
 
   /**
    * Inject properties to `package.json`.

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -293,7 +293,7 @@ export class Packager {
       // it is a path to config file
       configPath = configFromOptions
       configFromOptions = null
-    } else if (configFromOptions != null && configFromOptions.extends != null && configFromOptions.extends.includes(".")) {
+    } else if (configFromOptions != null && typeof configFromOptions.extends === "string" && configFromOptions.extends.includes(".")) {
       configPath = configFromOptions.extends
       delete configFromOptions.extends
     }

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -141,15 +141,14 @@ function normalizeFiles(configuration: Configuration, name: "files" | "extraFile
   configuration[name] = value.filter(it => it != null)
 }
 
-function mergeFiles(configuration: Configuration, parentConfiguration: Configuration, mergedConfiguration: Configuration, name: "files" | "extraFiles" | "extraResources") {
+function mergeFiles(configuration: Configuration, parentConfiguration: Configuration, name: "files" | "extraFiles" | "extraResources"): FileSet[] {
   const list = configuration[name] as Array<FileSet> | null
   const parentList = parentConfiguration[name] as Array<FileSet> | null
   if (list == null || parentList == null) {
-    return
+    return []
   }
 
   const result = list.slice()
-  mergedConfiguration[name] = result
 
   itemLoop: for (const item of parentList) {
     for (const existingItem of list) {
@@ -169,6 +168,8 @@ function mergeFiles(configuration: Configuration, parentConfiguration: Configura
     // existing item not found, simply add
     result.push(item)
   }
+
+  return result
 }
 
 export function doMergeConfigs(configuration: Configuration, parentConfiguration: Configuration | null) {
@@ -185,7 +186,7 @@ export function doMergeConfigs(configuration: Configuration, parentConfiguration
   normalizeFiles(parentConfiguration, "extraResources")
 
   const result = deepAssign(getDefaultConfig(), parentConfiguration, configuration)
-  mergeFiles(configuration, parentConfiguration, result, "files")
+  result.files = mergeFiles(configuration, parentConfiguration, "files")
   return result
 }
 

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -141,13 +141,7 @@ function normalizeFiles(configuration: Configuration, name: "files" | "extraFile
   configuration[name] = value.filter(it => it != null)
 }
 
-function mergeFiles(configuration: Configuration, parentConfiguration: Configuration, name: "files" | "extraFiles" | "extraResources"): FileSet[] {
-  const list = configuration[name] as Array<FileSet> | null
-  const parentList = parentConfiguration[name] as Array<FileSet> | null
-  if (list == null || parentList == null) {
-    return []
-  }
-
+function mergeFileSets(list: FileSet[], parentList: FileSet[]): FileSet[] {
   const result = list.slice()
 
   itemLoop: for (const item of parentList) {
@@ -186,7 +180,7 @@ export function doMergeConfigs(configuration: Configuration, parentConfiguration
   normalizeFiles(parentConfiguration, "extraResources")
 
   const result = deepAssign(getDefaultConfig(), parentConfiguration, configuration)
-  result.files = mergeFiles(configuration, parentConfiguration, "files")
+  result.files = mergeFileSets((configuration.files ?? []) as FileSet[], (parentConfiguration.files ?? []) as FileSet[])
   return result
 }
 

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -155,15 +155,17 @@ function mergeFilters(value: Filter, other: Filter): string[] {
   return normalizeFilter(value).concat(normalizeFilter(other))
 }
 
-function mergeFileSets(list: FileSet[], parentList: FileSet[]): FileSet[] {
-  const result = list.slice()
+function mergeFileSets(lists: FileSet[][]): FileSet[] {
+  const result = []
 
-  for (const item of parentList) {
-    const existingItem = list.find(i => isSimilarFileSet(i, item))
-    if (existingItem) {
-      existingItem.filter = mergeFilters(item.filter, existingItem.filter)
-    } else {
-      result.push(item)
+  for (const list of lists) {
+    for (const item of list) {
+      const existingItem = result.find(i => isSimilarFileSet(i, item))
+      if (existingItem) {
+        existingItem.filter = mergeFilters(item.filter, existingItem.filter)
+      } else {
+        result.push(item)
+      }
     }
   }
 
@@ -184,7 +186,7 @@ export function doMergeConfigs(configuration: Configuration, parentConfiguration
   normalizeFiles(parentConfiguration, "extraResources")
 
   const result = deepAssign(getDefaultConfig(), parentConfiguration, configuration)
-  result.files = mergeFileSets((configuration.files ?? []) as FileSet[], (parentConfiguration.files ?? []) as FileSet[])
+  result.files = mergeFileSets([(configuration.files ?? []) as FileSet[], (parentConfiguration.files ?? []) as FileSet[]])
   return result
 }
 

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -151,7 +151,7 @@ function mergeFiles(configuration: Configuration, parentConfiguration: Configura
   const result = list.slice()
   mergedConfiguration[name] = result
 
-  itemLoop: for (const item of parentConfiguration.files as Array<FileSet>) {
+  itemLoop: for (const item of parentList) {
     for (const existingItem of list) {
       if (existingItem.from === item.from && existingItem.to === item.to) {
         if (item.filter != null) {

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -141,12 +141,16 @@ function normalizeFiles(configuration: Configuration, name: "files" | "extraFile
   configuration[name] = value.filter(it => it != null)
 }
 
+function isSimilarFileSet(value: FileSet, other: FileSet): boolean {
+  return value.from === other.from && value.to === other.to
+}
+
 function mergeFileSets(list: FileSet[], parentList: FileSet[]): FileSet[] {
   const result = list.slice()
 
   itemLoop: for (const item of parentList) {
     for (const existingItem of list) {
-      if (existingItem.from === item.from && existingItem.to === item.to) {
+      if (isSimilarFileSet(existingItem, item)) {
         if (item.filter != null) {
           if (existingItem.filter == null) {
             existingItem.filter = item.filter.slice()

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -145,20 +145,23 @@ function isSimilarFileSet(value: FileSet, other: FileSet): boolean {
   return value.from === other.from && value.to === other.to
 }
 
+type Filter = FileSet["filter"]
+
+function normalizeFilter(filter: Filter): string[] {
+  return Array.isArray(filter) ? filter : typeof filter === "string" ? [filter] : []
+}
+
+function mergeFilters(value: Filter, other: Filter): string[] {
+  return normalizeFilter(value).concat(normalizeFilter(other))
+}
+
 function mergeFileSets(list: FileSet[], parentList: FileSet[]): FileSet[] {
   const result = list.slice()
 
   itemLoop: for (const item of parentList) {
     for (const existingItem of list) {
       if (isSimilarFileSet(existingItem, item)) {
-        if (item.filter != null) {
-          if (existingItem.filter == null) {
-            existingItem.filter = item.filter.slice()
-          } else {
-            existingItem.filter = (item.filter as Array<string>).concat(existingItem.filter)
-          }
-        }
-
+        existingItem.filter = mergeFilters(item.filter, existingItem.filter)
         continue itemLoop
       }
     }

--- a/packages/app-builder-lib/src/util/config.ts
+++ b/packages/app-builder-lib/src/util/config.ts
@@ -158,16 +158,13 @@ function mergeFilters(value: Filter, other: Filter): string[] {
 function mergeFileSets(list: FileSet[], parentList: FileSet[]): FileSet[] {
   const result = list.slice()
 
-  itemLoop: for (const item of parentList) {
-    for (const existingItem of list) {
-      if (isSimilarFileSet(existingItem, item)) {
-        existingItem.filter = mergeFilters(item.filter, existingItem.filter)
-        continue itemLoop
-      }
+  for (const item of parentList) {
+    const existingItem = list.find(i => isSimilarFileSet(i, item))
+    if (existingItem) {
+      existingItem.filter = mergeFilters(item.filter, existingItem.filter)
+    } else {
+      result.push(item)
     }
-
-    // existing item not found, simply add
-    result.push(item)
   }
 
   return result

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -51,9 +51,16 @@ test("cli", async () => {
 })
 
 test("merge configurations", () => {
-  const result = doMergeConfigs(
+  const result = doMergeConfigs([
     {
-      files: ["**/*", "!webpack", "!.*", "!config/jsdoc.json", "!package.*", "!docs", "!private"],
+      files: [
+        {
+          from: "dist/renderer",
+        },
+        {
+          from: "dist/renderer-dll",
+        },
+      ],
     },
     {
       files: [
@@ -64,15 +71,23 @@ test("merge configurations", () => {
         {
           from: "dist/main",
         },
+      ],
+    },
+    {
+      files: ["**/*", "!webpack", "!.*", "!config/jsdoc.json", "!package.*"],
+    },
+    {
+      files: [
         {
-          from: "dist/renderer",
-        },
-        {
-          from: "dist/renderer-dll",
+          from: ".",
+          filter: ["!docs"],
         },
       ],
-    }
-  )
+    },
+    {
+      files: ["!private"],
+    },
+  ])
 
   // console.log("data: " + JSON.stringify(result, null, 2))
   expect(result).toMatchObject({


### PR DESCRIPTION
This allows to mixin a config from multiple other configs, as if you `Object.assign` them, but properly combine `files` glob patterns.