### PR TITLE
fix: Escape version in NSIS Updater during replace

### DIFF
--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -17,12 +17,14 @@
     "fs-extra": "^9.1.0",
     "js-yaml": "^4.0.0",
     "lazy-val": "^1.0.4",
+    "lodash.escaperegexp": "^4.1.2",
     "lodash.isequal": "^4.5.0",
     "semver": "^7.3.4"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.7",
     "@types/js-yaml": "^4.0.0",
+    "@types/lodash.escaperegexp": "^4.1.6",
     "@types/lodash.isequal": "^4.5.5"
   },
   "typings": "./out/main.d.ts",

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -14,6 +14,7 @@ import { newUrlFromBase } from "./util"
 import { verifySignature } from "./windowsExecutableCodeSignatureVerifier"
 import { URL } from "url"
 import { gunzipSync } from "zlib"
+import escapeRegExp from "lodash.escaperegexp"
 
 export class NsisUpdater extends BaseUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -7,14 +7,12 @@ import { BaseUpdater, InstallOptions } from "./BaseUpdater"
 import { DifferentialDownloaderOptions } from "./differentialDownloader/DifferentialDownloader"
 import { FileWithEmbeddedBlockMapDifferentialDownloader } from "./differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader"
 import { GenericDifferentialDownloader } from "./differentialDownloader/GenericDifferentialDownloader"
-import { DOWNLOAD_PROGRESS, ResolvedUpdateFileInfo } from "./main"
+import { DOWNLOAD_PROGRESS, ResolvedUpdateFileInfo, blockmapFiles } from "./main"
 import { findFile, Provider } from "./providers/Provider"
 import { unlink } from "fs-extra"
-import { newUrlFromBase } from "./util"
 import { verifySignature } from "./windowsExecutableCodeSignatureVerifier"
 import { URL } from "url"
 import { gunzipSync } from "zlib"
-import escapeRegExp from "lodash.escaperegexp"
 
 export class NsisUpdater extends BaseUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -139,13 +137,8 @@ export class NsisUpdater extends BaseUpdater {
       if (this._testOnlyOptions != null && !this._testOnlyOptions.isUseDifferentialDownload) {
         return true
       }
-
-      const newBlockMapUrl = newUrlFromBase(`${fileInfo.url.pathname}.blockmap`, fileInfo.url)
-      const oldBlockMapUrl = newUrlFromBase(
-        `${fileInfo.url.pathname.replace(new RegExp(downloadUpdateOptions.updateInfoAndProvider.info.version, "g"), this.app.version)}.blockmap`,
-        fileInfo.url
-      )
-      this._logger.info(`Download block maps (old: "${oldBlockMapUrl.href}", new: ${newBlockMapUrl.href})`)
+      const blockmapFileUrls = blockmapFiles(fileInfo, downloadUpdateOptions.updateInfoAndProvider.info, this.app);
+      this._logger.info(`Download block maps (old: "${blockmapFileUrls[0]}", new: ${blockmapFileUrls[1]})`)
 
       const downloadBlockMap = async (url: URL): Promise<BlockMap> => {
         const data = await this.httpExecutor.downloadToBuffer(url, {
@@ -178,8 +171,9 @@ export class NsisUpdater extends BaseUpdater {
         downloadOptions.onProgress = it => this.emit(DOWNLOAD_PROGRESS, it)
       }
 
-      const blockMapDataList = await Promise.all([downloadBlockMap(oldBlockMapUrl), downloadBlockMap(newBlockMapUrl)])
-      await new GenericDifferentialDownloader(fileInfo.info, this.httpExecutor, downloadOptions).download(blockMapDataList[0], blockMapDataList[1])
+      const blockMapDataList = await Promise.all(blockmapFileUrls.map(u => downloadBlockMap(u)));
+      await new GenericDifferentialDownloader(fileInfo.info, this.httpExecutor, downloadOptions)
+        .download(blockMapDataList[0], blockMapDataList[1])
       return false
     } catch (e) {
       this._logger.error(`Cannot download differentially, fallback to full download: ${e.stack || e}`)

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -1,10 +1,8 @@
-import { AppAdapter } from "./AppAdapter"
 import { CancellationToken, PackageFileInfo, ProgressInfo, UpdateFileInfo, UpdateInfo } from "builder-util-runtime"
 import { EventEmitter } from "events"
 import { URL } from "url"
 import { AppUpdater } from "./AppUpdater"
 import { LoginCallback } from "./electronHttpExecutor"
-import escapeRegExp from "lodash.escaperegexp"
 
 export { AppUpdater, NoOpLogger } from "./AppUpdater"
 export { UpdateInfo }
@@ -112,37 +110,3 @@ export interface Logger {
 
   debug?(message: string): void
 }
-<<<<<<< HEAD
-=======
-
-// if baseUrl path doesn't ends with /, this path will be not prepended to passed pathname for new URL(input, base)
-/** @internal */
-export function newBaseUrl(url: string): URL {
-  const result = new URL(url)
-  if (!result.pathname.endsWith("/")) {
-    result.pathname += "/"
-  }
-  return result
-}
-
-// addRandomQueryToAvoidCaching is false by default because in most cases URL already contains version number,
-// so, it makes sense only for Generic Provider for channel files
-export function newUrlFromBase(pathname: string, baseUrl: URL, addRandomQueryToAvoidCaching = false): URL {
-  const result = new URL(pathname, baseUrl)
-  // search is not propagated (search is an empty string if not specified)
-  const search = baseUrl.search
-  if (search != null && search.length !== 0) {
-    result.search = search
-  }
-  else if (addRandomQueryToAvoidCaching) {
-    result.search = `noCache=${Date.now().toString(32)}`
-  }
-  return result
-}
-
-export function blockmapFiles(fileInfo: ResolvedUpdateFileInfo, updateInfo: UpdateInfo, app: AppAdapter): URL[] {
-  const newBlockMapUrl = newUrlFromBase(`${fileInfo.url.pathname}.blockmap`, fileInfo.url)
-  const oldBlockMapUrl = newUrlFromBase(`${fileInfo.url.pathname.replace(new RegExp(escapeRegExp(updateInfo.version), "g"), app.version)}.blockmap`, fileInfo.url)
-  return [oldBlockMapUrl, newBlockMapUrl];
-}
->>>>>>> 5d147ceb (Refactored and added test case)

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -1,8 +1,10 @@
+import { AppAdapter } from "./AppAdapter"
 import { CancellationToken, PackageFileInfo, ProgressInfo, UpdateFileInfo, UpdateInfo } from "builder-util-runtime"
 import { EventEmitter } from "events"
 import { URL } from "url"
 import { AppUpdater } from "./AppUpdater"
 import { LoginCallback } from "./electronHttpExecutor"
+import escapeRegExp from "lodash.escaperegexp"
 
 export { AppUpdater, NoOpLogger } from "./AppUpdater"
 export { UpdateInfo }
@@ -110,3 +112,37 @@ export interface Logger {
 
   debug?(message: string): void
 }
+<<<<<<< HEAD
+=======
+
+// if baseUrl path doesn't ends with /, this path will be not prepended to passed pathname for new URL(input, base)
+/** @internal */
+export function newBaseUrl(url: string): URL {
+  const result = new URL(url)
+  if (!result.pathname.endsWith("/")) {
+    result.pathname += "/"
+  }
+  return result
+}
+
+// addRandomQueryToAvoidCaching is false by default because in most cases URL already contains version number,
+// so, it makes sense only for Generic Provider for channel files
+export function newUrlFromBase(pathname: string, baseUrl: URL, addRandomQueryToAvoidCaching = false): URL {
+  const result = new URL(pathname, baseUrl)
+  // search is not propagated (search is an empty string if not specified)
+  const search = baseUrl.search
+  if (search != null && search.length !== 0) {
+    result.search = search
+  }
+  else if (addRandomQueryToAvoidCaching) {
+    result.search = `noCache=${Date.now().toString(32)}`
+  }
+  return result
+}
+
+export function blockmapFiles(fileInfo: ResolvedUpdateFileInfo, updateInfo: UpdateInfo, app: AppAdapter): URL[] {
+  const newBlockMapUrl = newUrlFromBase(`${fileInfo.url.pathname}.blockmap`, fileInfo.url)
+  const oldBlockMapUrl = newUrlFromBase(`${fileInfo.url.pathname.replace(new RegExp(escapeRegExp(updateInfo.version), "g"), app.version)}.blockmap`, fileInfo.url)
+  return [oldBlockMapUrl, newBlockMapUrl];
+}
+>>>>>>> 5d147ceb (Refactored and added test case)

--- a/packages/electron-updater/src/util.ts
+++ b/packages/electron-updater/src/util.ts
@@ -1,5 +1,7 @@
 // if baseUrl path doesn't ends with /, this path will be not prepended to passed pathname for new URL(input, base)
 import { URL } from "url"
+// @ts-ignore
+import * as escapeRegExp from "lodash.escaperegexp"
 
 /** @internal */
 export function newBaseUrl(url: string): URL {
@@ -26,4 +28,10 @@ export function newUrlFromBase(pathname: string, baseUrl: URL, addRandomQueryToA
 
 export function getChannelFilename(channel: string): string {
   return `${channel}.yml`
+}
+
+export function blockmapFiles(baseUrl: URL, oldVersion: string, newVersion: string): URL[] {
+  const newBlockMapUrl = newUrlFromBase(`${baseUrl.pathname}.blockmap`, baseUrl)
+  const oldBlockMapUrl = newUrlFromBase(`${baseUrl.pathname.replace(new RegExp(escapeRegExp(newVersion), "g"), oldVersion)}.blockmap`, baseUrl)
+  return [oldBlockMapUrl, newBlockMapUrl]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,21 +309,25 @@ importers:
       fs-extra: 9.1.0
       js-yaml: 4.0.0
       lazy-val: 1.0.4
+      lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
       semver: 7.3.4
     devDependencies:
       '@types/fs-extra': 9.0.8
       '@types/js-yaml': 4.0.0
+      '@types/lodash.escaperegexp': 4.1.6
       '@types/lodash.isequal': 4.5.5
     specifiers:
       '@types/fs-extra': ^9.0.7
       '@types/js-yaml': ^4.0.0
+      '@types/lodash.escaperegexp': ^4.1.6
       '@types/lodash.isequal': ^4.5.5
       '@types/semver': ^7.3.4
       builder-util-runtime: workspace:*
       fs-extra: ^9.1.0
       js-yaml: ^4.0.0
       lazy-val: ^1.0.4
+      lodash.escaperegexp: ^4.1.2
       lodash.isequal: ^4.5.0
       semver: ^7.3.4
   test:
@@ -1903,6 +1907,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+  /@types/lodash.escaperegexp/4.1.6:
+    dependencies:
+      '@types/lodash': 4.14.168
+    dev: true
+    resolution:
+      integrity: sha512-uENiqxLlqh6RzeE1cC6Z2gHqakToN9vKlTVCFkSVjAfeMeh2fY0916tHwJHeeKs28qB/hGYvKuampGYH5QDVCw==
   /@types/lodash.isequal/4.5.5:
     dependencies:
       '@types/lodash': 4.14.168
@@ -5536,6 +5546,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+  /lodash.escaperegexp/4.1.2:
+    dev: false
+    resolution:
+      integrity: sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
   /lodash.flatten/4.4.0:
     dev: false
     resolution:

--- a/test/src/urlUtilTest.ts
+++ b/test/src/urlUtilTest.ts
@@ -1,6 +1,5 @@
 import { URL } from "url"
-import { newUrlFromBase, blockmapFiles } from "electron-updater"
-import { TestAppAdapter } from "./helpers/TestAppAdapter"
+import { newUrlFromBase, blockmapFiles } from "electron-updater/out/util"
 
 test("newUrlFromBase", () => {
   const fileUrl = new URL("https://AWS_S3_HOST/bucket-yashraj/electron%20Setup%2011.0.3.exe")
@@ -20,17 +19,7 @@ test("create blockmap urls", () => {
   const baseUrlString = `https://gitlab.com/artifacts/master/raw/electron%20Setup%20${newVersion}.exe`
   const baseUrl = new URL(baseUrlString)
 
-  const fileInfo = {url: baseUrl, info: {url: baseUrlString, sha512: ''}};
-  const updateInfo = {
-    version: newVersion,
-    files: [fileInfo.info],
-    path: baseUrlString,
-    sha512: '',
-    releaseDate: 'Today',
-  }
-  const app = new TestAppAdapter(oldVersion, '')
-
-  const blockMapUrls = blockmapFiles(fileInfo, updateInfo, app);
+  const blockMapUrls = blockmapFiles(baseUrl, oldVersion, newVersion)
 
   expect(blockMapUrls[0].href).toBe('https://gitlab.com/artifacts/master/raw/electron%20Setup%201.1.9-2+ed8ccd.exe.blockmap');
   expect(blockMapUrls[1].href).toBe('https://gitlab.com/artifacts/master/raw/electron%20Setup%201.1.9-3+be4a1f.exe.blockmap');

--- a/test/src/urlUtilTest.ts
+++ b/test/src/urlUtilTest.ts
@@ -1,5 +1,6 @@
 import { URL } from "url"
-import { newUrlFromBase } from "electron-updater/out/util"
+import { newUrlFromBase, blockmapFiles } from "electron-updater"
+import { TestAppAdapter } from "./helpers/TestAppAdapter"
 
 test("newUrlFromBase", () => {
   const fileUrl = new URL("https://AWS_S3_HOST/bucket-yashraj/electron%20Setup%2011.0.3.exe")
@@ -11,4 +12,26 @@ test("add no cache", () => {
   const baseUrl = new URL("https://gitlab.com/artifacts/master/raw/dist?job=build_electron_win")
   const newBlockMapUrl = newUrlFromBase("latest.yml", baseUrl, true)
   expect(newBlockMapUrl.href).toBe("https://gitlab.com/artifacts/master/raw/latest.yml?job=build_electron_win")
+})
+
+test("create blockmap urls", () => {
+  const oldVersion = "1.1.9-2+ed8ccd"
+  const newVersion = "1.1.9-3+be4a1f"
+  const baseUrlString = `https://gitlab.com/artifacts/master/raw/electron%20Setup%20${newVersion}.exe`
+  const baseUrl = new URL(baseUrlString)
+
+  const fileInfo = {url: baseUrl, info: {url: baseUrlString, sha512: ''}};
+  const updateInfo = {
+    version: newVersion,
+    files: [fileInfo.info],
+    path: baseUrlString,
+    sha512: '',
+    releaseDate: 'Today',
+  }
+  const app = new TestAppAdapter(oldVersion, '')
+
+  const blockMapUrls = blockmapFiles(fileInfo, updateInfo, app);
+
+  expect(blockMapUrls[0].href).toBe('https://gitlab.com/artifacts/master/raw/electron%20Setup%201.1.9-2+ed8ccd.exe.blockmap');
+  expect(blockMapUrls[1].href).toBe('https://gitlab.com/artifacts/master/raw/electron%20Setup%201.1.9-3+be4a1f.exe.blockmap');
 })


### PR DESCRIPTION
The updater derives the path to the old blockmap file by using the url of the new blockmap file and changing the version. The code uses a RegEx with the replace function in order to replace all occurrences of the version number.

The problem is that the version number is a string like '0.1.9-2+273e2eb' and contains characters like '.' and '+' that get interpreted as regex characters. This works in most cases since a simple version string like '0.1.9' will accidentally match a typical filename. However it would aggressively match a filename like 'My-Application0A1B9-Setup-0.1.9.exe', and will fail with versions containing plus signs. 
 
I initially tried using String.ReplaceAll but it was only recently added in Chrome 85. Some sort of escaping needs to happen, so I used lodash.escapeRegExp since the project already seems to be using lodash. If there's a problem with the dependency, we can use simpler escaping since I think the '.' and '+' are the only valid semver characters that cause regex problems.