### PR TITLE
feat(build-util): add param "logName" in log as log key and fix bad log display when win sign error 

### DIFF
--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -250,6 +250,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
           log.warn({error: message, attempt: i + 1}, `cannot sign`)
           continue
         }
+        e.logName = 'sign error'
         throw e
       }
     }

--- a/packages/electron-builder/src/cli/cli.ts
+++ b/packages/electron-builder/src/cli/cli.ts
@@ -50,9 +50,10 @@ function wrap(task: (args: any) => Promise<any>) {
         process.on("exit", () => process.exitCode = 1)
         if (error instanceof InvalidConfigurationError) {
           log.error(null, error.message)
-        }
-        else if (!(error instanceof ExecError) || !error.alreadyLogged) {
+        } else if (error instanceof ExecError && !error.alreadyLogged) {
           log.error({stackTrace: error.stack}, error.message)
+        } else {
+          log.error({stackTrace: error.stack}, error.message, error.logName)
         }
       })
   }


### PR DESCRIPTION
log.ts use error.message as log display name, like below, when message is long, it will hard read

![Xnip2021-03-01_13-12-37_mosaic](https://user-images.githubusercontent.com/16059383/109454910-50898080-7a90-11eb-9f11-969cfdc7bcfb.png)

I just add param "logName" in log as log key and display 'sign error' as log name when winPackager.ts throw a error like below

![Xnip2021-03-01_13-05-55_mosaic](https://user-images.githubusercontent.com/16059383/109455207-140a5480-7a91-11eb-9db9-0761de792ba7.png)

change is  compatible 