### PR TITLE
feat: add option removePackageKeywords

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6211,6 +6211,11 @@
       "description": "Whether to remove `scripts` field from `package.json` files.",
       "type": "boolean"
     },
+	"removePackageKeywords": {
+	  "default": true,
+	  "description": "Whether to remove `keywords` field from `package.json` files.",
+	  "type": "boolean"
+	},
     "rpm": {
       "anyOf": [
         {

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -232,6 +232,13 @@ export interface Configuration extends PlatformSpecificBuildOptions {
    * @default true
    */
   readonly removePackageScripts?: boolean
+  
+  /**
+   * Whether to remove `keywords` field from `package.json` files.
+   *
+   * @default true
+   */
+  readonly removePackageKeywords?: boolean
 }
 
 export interface AfterPackContext {

--- a/packages/app-builder-lib/src/fileTransformer.ts
+++ b/packages/app-builder-lib/src/fileTransformer.ts
@@ -28,10 +28,11 @@ export function hasDep(name: string, info: Packager) {
 export function createTransformer(srcDir: string, configuration: Configuration, extraMetadata: any, extraTransformer: FileTransformer | null): FileTransformer {
   const mainPackageJson = path.join(srcDir, "package.json")
   const isRemovePackageScripts = configuration.removePackageScripts !== false
+  const isRemovePackageKeywords = configuration.removePackageKeywords !== false
   const packageJson = path.sep + "package.json"
   return file => {
     if (file === mainPackageJson) {
-      return modifyMainPackageJson(file, extraMetadata, isRemovePackageScripts)
+      return modifyMainPackageJson(file, extraMetadata, isRemovePackageScripts, isRemovePackageKeywords)
     }
 
     if (file.endsWith(packageJson) && file.includes(NODE_MODULES_PATTERN)) {
@@ -39,6 +40,7 @@ export function createTransformer(srcDir: string, configuration: Configuration, 
         .then(it => cleanupPackageJson(JSON.parse(it), {
           isMain: false,
           isRemovePackageScripts,
+          isRemovePackageKeywords
         }))
         .catch(e => log.warn(e))
     }
@@ -64,10 +66,11 @@ export function createElectronCompilerHost(projectDir: string, cacheDir: string)
   return require(path.join(electronCompilePath, "config-parser")).createCompilerHostFromProjectRoot(projectDir, cacheDir)
 }
 
-const ignoredPackageMetadataProperties = new Set(["dist", "gitHead", "keywords", "build", "jspm", "ava", "xo", "nyc", "eslintConfig", "contributors", "bundleDependencies", "tags"])
+const ignoredPackageMetadataProperties = new Set(["dist", "gitHead", "build", "jspm", "ava", "xo", "nyc", "eslintConfig", "contributors", "bundleDependencies", "tags"])
 
 interface CleanupPackageFileOptions {
   readonly isRemovePackageScripts: boolean
+  readonly isRemovePackageKeywords: boolean
   readonly isMain: boolean
 }
 
@@ -82,6 +85,7 @@ function cleanupPackageJson(data: any, options: CleanupPackageFileOptions): any 
       if (prop[0] === "_" ||
         ignoredPackageMetadataProperties.has(prop) ||
         (options.isRemovePackageScripts && prop === "scripts") ||
+        (options.isRemovePackageKeywords && prop === "keywords") ||
         (options.isMain && prop === "devDependencies") ||
         (!options.isMain && prop === "bugs") ||
         (isRemoveBabel && prop === "babel")) {
@@ -101,7 +105,7 @@ function cleanupPackageJson(data: any, options: CleanupPackageFileOptions): any 
   return null
 }
 
-async function modifyMainPackageJson(file: string, extraMetadata: any, isRemovePackageScripts: boolean) {
+async function modifyMainPackageJson(file: string, extraMetadata: any, isRemovePackageScripts: boolean, isRemovePackageKeywords: boolean) {
   const mainPackageData = JSON.parse(await readFile(file, "utf-8"))
   if (extraMetadata != null) {
     deepAssign(mainPackageData, extraMetadata)
@@ -111,6 +115,7 @@ async function modifyMainPackageJson(file: string, extraMetadata: any, isRemoveP
   const serializedDataIfChanged = cleanupPackageJson(mainPackageData, {
     isMain: true,
     isRemovePackageScripts,
+    isRemovePackageKeywords
   })
   if (serializedDataIfChanged != null) {
     return serializedDataIfChanged


### PR DESCRIPTION
This will add an option called removePackageKeywords, similar to removePackageScripts, to allow keywords to optionally not be removed from `package.json` files but leaving the current behavior to remove them as default.

The Companion project is intending to switch from including its control modules as git submodules to importing as dependencies in npm.  In this change we noted the keywords were being removed from the packages after building, which we use as an element of search filtering.  With over 250 modules, changing our inclusion method is long overdue, but we'd prefer to not have to change `keywords` to another key name in all those modules, instead continuing with this build option to allow keywords to be included in the package.json files.

This was tested through a local compile and build procedure for our app:
- Leaving the existing compile commands: passed ... no errors, package.json files did not include keywords
- Adding `"removePackageKeywords": false`: passed ... no errors, package.json files included the keywords