### PR TITLE
chore: improving log readability

### DIFF
--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -151,7 +151,7 @@ async function unpack(prepareOptions: PrepareApplicationStageDirectoryOptions, o
     const zipFile = `electron-v${options.version}-${platformName}-${options.arch}.zip`
     const resolvedDist = path.isAbsolute(dist) ? dist : path.resolve(packager.projectDir, dist)
     if ((await statOrNull(path.join(resolvedDist, zipFile))) != null) {
-      log.debug({ resolvedDist, zipFile }, "Resolved electronDist")
+      log.info({ resolvedDist, zipFile }, "Resolved electronDist")
       options.cache = resolvedDist
       dist = null
     }
@@ -162,7 +162,6 @@ async function unpack(prepareOptions: PrepareApplicationStageDirectoryOptions, o
     if (isSafeToUnpackElectronOnRemoteBuildServer(packager)) {
       return
     }
-    log.info({ zipPath: options.cache }, "Unpacking electron zip")
     await executeAppBuilder(["unpack-electron", "--configuration", JSON.stringify([options]), "--output", appOutDir, "--distMacOsAppName", distMacOsAppName])
   }
   else {

--- a/packages/builder-util/src/log.ts
+++ b/packages/builder-util/src/log.ts
@@ -92,7 +92,7 @@ export class Logger {
       // Remove unnecessary line breaks
       if (fieldValue != null && typeof fieldValue === "string" && fieldValue.includes("\n")) {
         valuePadding = " ".repeat(messagePadding + message.length + fieldPadding.length + 2)
-        fieldValue = "\n" + valuePadding + fieldValue.replace(/\n\s*\n/g, `\n${valuePadding}`)
+        fieldValue = fieldValue.replace(/\n\s*\n/g, `\n${valuePadding}`)
       }
       else if (Array.isArray(fieldValue)) {
         fieldValue = JSON.stringify(fieldValue)

--- a/packages/builder-util/src/log.ts
+++ b/packages/builder-util/src/log.ts
@@ -89,9 +89,10 @@ export class Logger {
     for (const name of fieldNames) {
       let fieldValue = fields[name]
       let valuePadding: string | null = null
+      // Remove unnecessary line breaks
       if (fieldValue != null && typeof fieldValue === "string" && fieldValue.includes("\n")) {
         valuePadding = " ".repeat(messagePadding + message.length + fieldPadding.length + 2)
-        fieldValue = "\n" + valuePadding + fieldValue.replace(/\n/g, `\n${valuePadding}`)
+        fieldValue = "\n" + valuePadding + fieldValue.replace(/\n\s*\n/g, `\n${valuePadding}`)
       }
       else if (Array.isArray(fieldValue)) {
         fieldValue = JSON.stringify(fieldValue)

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -240,7 +240,7 @@ function handleProcess(event: string, childProcess: ChildProcess, command: strin
       }
     }
     else {
-      reject(new ExecError(command, code, formatOut(out, "Output"), formatOut(errorOut, "Error output")))
+      reject(new ExecError(command, code, out, errorOut))
     }
   })
 }

--- a/packages/electron-builder/src/cli/cli.ts
+++ b/packages/electron-builder/src/cli/cli.ts
@@ -52,7 +52,7 @@ function wrap(task: (args: any) => Promise<any>) {
           log.error(null, error.message)
         }
         else if (!(error instanceof ExecError) || !error.alreadyLogged) {
-          log.error({stackTrace: error.stack}, error.message)
+          log.error({ culprit: task.name }, error.message)
         }
       })
   }

--- a/packages/electron-builder/src/cli/cli.ts
+++ b/packages/electron-builder/src/cli/cli.ts
@@ -52,7 +52,7 @@ function wrap(task: (args: any) => Promise<any>) {
           log.error(null, error.message)
         }
         else if (!(error instanceof ExecError) || !error.alreadyLogged) {
-          log.error({ culprit: task.name }, error.message)
+          log.error( { failedTask: task.name, stackTrace: error.stack }, error.message)
         }
       })
   }

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -1138,7 +1138,7 @@ Object {
               "size": 1069,
             },
             "abi_registry.json": Object {
-              "size": 1620,
+              "size": 1742,
             },
             "index.js": Object {
               "size": 6099,

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -200,17 +200,17 @@ Object {
           Object {
             "sha512": "@sha512",
             "size": "@size",
+            "url": "TestApp-1.1.0-mac.dmg",
+          },
+          Object {
+            "sha512": "@sha512",
+            "size": "@size",
             "url": "TestApp-1.1.0-mac-arm64.dmg",
           },
           Object {
             "sha512": "@sha512",
             "size": "@size",
             "url": "TestApp-1.1.0-mac-universal.dmg",
-          },
-          Object {
-            "sha512": "@sha512",
-            "size": "@size",
-            "url": "TestApp-1.1.0-mac.dmg",
           },
         ],
         "path": "TestApp-1.1.0-mac.zip",

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -200,17 +200,17 @@ Object {
           Object {
             "sha512": "@sha512",
             "size": "@size",
-            "url": "TestApp-1.1.0-mac.dmg",
-          },
-          Object {
-            "sha512": "@sha512",
-            "size": "@size",
             "url": "TestApp-1.1.0-mac-arm64.dmg",
           },
           Object {
             "sha512": "@sha512",
             "size": "@size",
             "url": "TestApp-1.1.0-mac-universal.dmg",
+          },
+          Object {
+            "sha512": "@sha512",
+            "size": "@size",
+            "url": "TestApp-1.1.0-mac.dmg",
           },
         ],
         "path": "TestApp-1.1.0-mac.zip",
@@ -335,6 +335,53 @@ Object {
 `;
 
 exports[`two-package 5`] = `
+Array [
+  "TestApp.icns",
+  "app-update.yml",
+  "app.asar",
+  "bn.lproj",
+  "en.lproj",
+]
+`;
+
+exports[`two-package 6`] = `
+Object {
+  "CFBundleDisplayName": "TestApp",
+  "CFBundleExecutable": "TestApp",
+  "CFBundleIconFile": "TestApp.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "TestApp",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.1.0",
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSRequiresNativeExecution": true,
+  "NSAppTransportSecurity": Object {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": Object {
+      "127.0.0.1": Object {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": Object {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSHighResolutionCapable": true,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
+exports[`two-package 7`] = `
 Array [
   "TestApp.icns",
   "app-update.yml",

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -191,7 +191,7 @@ async function packAndCheck(packagerOptions: PackagerOptions, checkOptions: Asse
 
   const objectToCompare: any = {}
   for (const platform of packagerOptions.targets!!.keys()) {
-    objectToCompare[platform.buildConfigurationKey] = await Promise.all((artifacts.get(platform) || []).sort((a, b) => sortKey(a).localeCompare(sortKey(b))).map(async it => {
+    objectToCompare[platform.buildConfigurationKey] = await Promise.all((artifacts.get(platform) || []).sort((a, b) => sortKey(a).localeCompare(sortKey(b), 'en')).map(async it => {
       const result: any = {...it}
       const file = result.file
       if (file != null) {


### PR DESCRIPTION
Providing an alternative approach to #5664

Fixes double wrapping of an error message (duplicated `formatOut`)
Significantly improves logging readability for debugging issues. Also adds `task.name` to the cli logging in order to more easily identify where a function is throwing