### PR TITLE
fix: make autoInstallOnAppQuit behave as expected

### DIFF
--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -82,6 +82,11 @@ export abstract class BaseUpdater extends AppUpdater {
         return
       }
 
+      if (!this.autoInstallOnAppQuit) {
+        this._logger.info("Update will not be installed on quit because autoInstallOnAppQuit is set to false.")
+        return
+      }
+
       if (exitCode !== 0) {
         this._logger.info(`Update will be not installed on quit because application is quitting with exit code ${exitCode}`)
         return


### PR DESCRIPTION
In my application I wish to set `autoInstallOnAppQuit` to false, so that electron-updater doesn't install the update when the application quits. However it turns out that when you set `autoInstallOnAppQuit` after you have called `checkForUpdates`, the quitHandler will already be added. And there is no further check in place to prevent the app from installing the update. So even if `autoInstallOnAppQuit` is set to false it will still install the update on quit.

I have added a check to prevent the above from happening. And thus making `autoInstallOnAppQuit` behave as expected.