### PR TITLE
docs: Update default stagePackages for Snapcraft

### DIFF
--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -36,7 +36,7 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
 
   /**
    * The list of Ubuntu packages to use that are needed to support the `app` part creation. Like `depends` for `deb`.
-   * Defaults to `["libasound2", "libgconf2-4", "libnotify4", "libnspr4", "libnss3", "libpcre3", "libpulse0", "libxss1", "libxtst6"]`.
+   * Defaults to `["libnspr4", "libnss3", "libxss1", "libappindicator3-1", "libsecret-1-0"]`.
    *
    * If list contains `default`, it will be replaced to default list, so, `["default", "foo"]` can be used to add custom package `foo` in addition to defaults.
    */


### PR DESCRIPTION
The documentation says that the following packages are staged by default:

https://github.com/electron-userland/electron-builder/blob/0b03f106d3215f5f9206776899bdc69ceccfb8d4/packages/app-builder-lib/src/options/SnapOptions.ts#L39

However, `getDefaultStagePackages` returns the following:

https://github.com/electron-userland/electron-builder/blob/0b03f106d3215f5f9206776899bdc69ceccfb8d4/packages/app-builder-lib/src/targets/snap.ts#L306