### PR TITLE
fix: typo in `fileMatcher`'s default patterns

### DIFF
--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -177,7 +177,7 @@ export function getMainFileMatchers(
   }
   patterns.splice(insertIndex, 0, ...customFirstPatterns)
 
-  patterns.push(`!**/*.{${excludedExts}${packager.config.includePdb === true ? "" : ",pdb"}`)
+  patterns.push(`!**/*.{${excludedExts}${packager.config.includePdb === true ? "" : ",pdb"}}`)
   patterns.push("!**/._*")
   patterns.push("!**/electron-builder.{yaml,yml,json,json5,toml}")
   patterns.push(`!**/{${excludedNames}}`)


### PR DESCRIPTION
There is a single `}`, but it is a part of the expansion pattern `${}` not the glob pattern.