### PR TITLE
feat: add custom macro for checking uninstallation results

### DIFF
--- a/packages/app-builder-lib/templates/nsis/installSection.nsh
+++ b/packages/app-builder-lib/templates/nsis/installSection.nsh
@@ -47,8 +47,11 @@ ${if} $isTryToKeepShortcuts == "true"
 ${endif}
 
 !insertmacro uninstallOldVersion SHELL_CONTEXT
+!insertmacro handleUninstallResult SHELL_CONTEXT
+
 ${if} $installMode == "all"
   !insertmacro uninstallOldVersion HKEY_CURRENT_USER
+  !insertmacro handleUninstallResult HKEY_CURRENT_USER
 ${endIf}
 
 SetOutPath $INSTDIR


### PR DESCRIPTION
Due to https://github.com/electron-userland/electron-builder/pull/5292, installers created using the default NSIS script ignore any errors returned by uninstallers, for example if files cannot be replaced, or if the uninstaller has been deleted. This behavior is often unwanted.

The changes here allow users to define `customUnInstallCheck` to handle such cases. In `customUnInstallCheck`, the error flag is set if the uninstaller cannot be executed at all (probably because it is missing). If the error flag is not set, `$R0` contains the return status/error level, which should be set to 0 if the uninstaller exits successfully.