### PR TITLE
[Electron Builder] Fix for Signing error on docker with WSL 2 engine …

### DIFF
--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -326,7 +326,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     if (process.platform === "win32" || process.platform === "darwin") {
       await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry three times */)
     }
-    else if (process.platform !== "darwin" && this.info.framework.name === "electron") {
+    else if (this.info.framework.name === "electron") {
       const vendorPath = await getSignVendorPath()
       await execWine(path.join(vendorPath, "rcedit-ia32.exe"), path.join(vendorPath, "rcedit-x64.exe"), args)
    }

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -323,7 +323,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
 
     const timer = time("wine&sign")
     // rcedit crashed of executed using wine, resourcehacker works
-    if (process.platform === "win32" ||  process.platform === "darwin") {
+    if (process.platform === "win32" || process.platform === "darwin") {
       await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry three times */)
     }
     else if (this.info.framework.name === "electron") {

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -323,7 +323,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
 
     const timer = time("wine&sign")
     // rcedit crashed of executed using wine, resourcehacker works
-    if (process.platform === "win32" || process.platform === "darwin") {
+    if (process.platform === "win32" ||  process.platform === "darwin") {
       await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry three times */)
     }
     else if (this.info.framework.name === "electron") {

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -8,7 +8,7 @@ import isCI from "is-ci"
 import { Lazy } from "lazy-val"
 import * as path from "path"
 import { downloadCertificate } from "./codeSign/codesign"
-import { CertificateFromStoreInfo, CertificateInfo, FileCodeSigningInfo, getCertificateFromStoreInfo, getCertInfo, sign, WindowsSignOptions } from "./codeSign/windowsCodeSign"
+import { CertificateFromStoreInfo, CertificateInfo, FileCodeSigningInfo, getCertificateFromStoreInfo, getCertInfo, getSignVendorPath, sign, WindowsSignOptions } from "./codeSign/windowsCodeSign"
 import { AfterPackContext } from "./configuration"
 import { DIR_TARGET, Platform, Target } from "./core"
 import { RequestedExecutionLevel, WindowsConfiguration } from "./options/winOptions"
@@ -23,6 +23,7 @@ import { BuildCacheManager, digest } from "./util/cacheManager"
 import { isBuildCacheEnabled } from "./util/flags"
 import { time } from "./util/timer"
 import { getWindowsVm, VmManager } from "./vm/vm"
+import { execWine } from "./wine"
 
 export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   readonly cscInfo = new Lazy<FileCodeSigningInfo | CertificateFromStoreInfo | null>(() => {
@@ -322,9 +323,13 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
 
     const timer = time("wine&sign")
     // rcedit crashed of executed using wine, resourcehacker works
-    if (process.platform === "win32" || this.info.framework.name === "electron") {
-      await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry five times */)
+    if (process.platform === "win32") {
+      await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry three times */)
     }
+    else if (this.info.framework.name === "electron") {
+      const vendorPath = await getSignVendorPath()
+      await execWine(path.join(vendorPath, "rcedit-ia32.exe"), path.join(vendorPath, "rcedit-x64.exe"), args)
+   }
 
     await this.sign(file)
     timer.end()

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -323,7 +323,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
 
     const timer = time("wine&sign")
     // rcedit crashed of executed using wine, resourcehacker works
-    if (process.platform === "win32") {
+    if (process.platform === "win32" || process.platform === "darwin") {
       await executeAppBuilder(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry three times */)
     }
     else if (this.info.framework.name === "electron") {


### PR DESCRIPTION
…#5185

Description: As expected, the rcedit-x64.exe executable can't be called natively and  this would be necessary for all uses of electron-builder from non-Windows (linux & mac) environments.