### PR TITLE
feat: add Electron branding options

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -897,6 +897,18 @@
       },
       "type": "object"
     },
+    "ElectronBrandingOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "projectName": {
+          "type": "string"
+        },
+        "productName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "ElectronDownloadOptions": {
       "additionalProperties": false,
       "properties": {
@@ -5777,6 +5789,10 @@
         }
       ],
       "description": "Returns the path to custom Electron build (e.g. `~/electron/out/R`). Zip files must follow the pattern `electron-v${version}-${platformName}-${arch}.zip`, otherwise it will be assumed to be an unpacked Electron app directory"
+    },
+    "electronBranding": {
+      "$ref": "#/definitions/ElectronBrandingOptions",
+      "description": "The branding used by Electron's distributables. This is needed if a fork has modified Electron's BRANDING.json file."
     },
     "electronDownload": {
       "$ref": "#/definitions/ElectronDownloadOptions",

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -1,6 +1,6 @@
 import { Arch } from "builder-util"
 import { BeforeBuildContext, Target } from "./core"
-import { ElectronDownloadOptions } from "./electron/ElectronFramework"
+import { ElectronBrandingOptions, ElectronDownloadOptions } from "./electron/ElectronFramework"
 import { PrepareApplicationStageDirectoryOptions } from "./Framework"
 import { AppXOptions } from "./options/AppXOptions"
 import { AppImageOptions, DebOptions, LinuxConfiguration, LinuxTargetSpecificOptions } from "./options/linuxOptions"
@@ -138,6 +138,11 @@ export interface Configuration extends PlatformSpecificBuildOptions {
    * The [electron-download](https://github.com/electron-userland/electron-download#usage) options.
    */
   readonly electronDownload?: ElectronDownloadOptions
+
+  /**
+   * The branding used by Electron's distributables. This is needed if a fork has modified Electron's BRANDING.json file.
+   */
+  readonly electronBranding?: ElectronBrandingOptions
 
   /**
    * The version of electron you are packaging for. Defaults to version of `electron`, `electron-prebuilt` or `electron-prebuilt-compile` dependency.

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -23,7 +23,7 @@ export {
 } from "./core"
 export { getArchSuffix, Arch, archFromString } from "builder-util"
 export { Configuration, AfterPackContext, MetadataDirectories } from "./configuration"
-export { ElectronDownloadOptions, ElectronPlatformName } from "./electron/ElectronFramework"
+export { ElectronBrandingOptions, ElectronDownloadOptions, ElectronPlatformName } from "./electron/ElectronFramework"
 export { PlatformSpecificBuildOptions, AsarOptions, FileSet, Protocol, ReleaseInfo } from "./options/PlatformSpecificBuildOptions"
 export { FileAssociation } from "./options/FileAssociation"
 export { MacConfiguration, DmgOptions, MasConfiguration, MacOsTargetName, DmgContent, DmgWindow } from "./options/macOptions"

--- a/packages/electron-builder/src/index.ts
+++ b/packages/electron-builder/src/index.ts
@@ -31,6 +31,7 @@ export {
   MetadataDirectories,
   Protocol,
   ReleaseInfo,
+  ElectronBrandingOptions,
   ElectronDownloadOptions,
   SnapOptions,
   CommonWindowsInstallerConfiguration,


### PR DESCRIPTION
The Electron project contains a [BRANDING.json](https://github.com/electron/electron/blob/665ac6f9c830edbf85596369b49844e1b910c59a/shell/app/BRANDING.json) file which will modify the resulting executable file names. A project I'm working on does exactly this in a fork of Electron.

Exposing these branding options allows Electron forks to build properly if branding has changed.