### PR TITLE
feat: add preInstall macro for customise NSIS script

### DIFF
--- a/packages/app-builder-lib/templates/nsis/installSection.nsh
+++ b/packages/app-builder-lib/templates/nsis/installSection.nsh
@@ -57,6 +57,9 @@ SetOutPath $INSTDIR
   File /oname=uninstallerIcon.ico "${UNINSTALLER_ICON}"
 !endif
 
+!ifmacrodef preInstall
+  !insertmacro preInstall
+!endif
 !insertmacro installApplicationFiles
 !insertmacro registryAddInstallInfo
 !insertmacro addStartMenuLink $keepShortcuts


### PR DESCRIPTION
For now, Custom NSIS install Scripts include `customHeader`，`preInit`, `customInit`, `customInstall`.

Some tasks must be executed before install application files.

For example, delete some files those existed in the `$INSTDIR`. ( Sometime the uninstaller doesn't work if between Applications)

```nsis
!macro preInstall
  MessageBox MB_OK "preInstall"
  RMDir /r "$INSTDIR\resources\"
  RMDir /r "$INSTDIR\locales\"
  Delete "$INSTDIR\logo.ico"
  Delete "$INSTDIR\uninst.exe"
!macroend
```

`customInstall` is too late for the clean job. That would be nice if we could provide the `preInstall` macro.