### PR TITLE
Add Apple development as valid development cert

### DIFF
--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -20,6 +20,7 @@ export type CertType =
   | "3rd Party Mac Developer Installer"
   | "Mac Developer"
   | "Apple Development"
+  | "Apple Distribution"
 
 export interface CodeSigningInfo {
   keychainFile?: string | null

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -13,7 +13,13 @@ import { downloadCertificate } from "./codesign"
 
 export const appleCertificatePrefixes = ["Developer ID Application:", "Developer ID Installer:", "3rd Party Mac Developer Application:", "3rd Party Mac Developer Installer:"]
 
-export type CertType = "Developer ID Application" | "Developer ID Installer" | "3rd Party Mac Developer Application" | "3rd Party Mac Developer Installer" | "Mac Developer" | "Apple Development"
+export type CertType =
+  | "Developer ID Application"
+  | "Developer ID Installer"
+  | "3rd Party Mac Developer Application"
+  | "3rd Party Mac Developer Installer"
+  | "Mac Developer"
+  | "Apple Development"
 
 export interface CodeSigningInfo {
   keychainFile?: string | null
@@ -60,7 +66,7 @@ export async function reportError(
   if (qualifier == null) {
     logFields.reason = ""
     if (isAutoDiscoveryCodeSignIdentity()) {
-      logFields.reason += `cannot find valid "${certificateTypes.join(', ')}" identity${isMas ? "" : ` or custom non-Apple code signing certificate`}`
+      logFields.reason += `cannot find valid "${certificateTypes.join(", ")}" identity${isMas ? "" : ` or custom non-Apple code signing certificate`}`
     }
     logFields.reason += ", see https://electron.build/code-signing"
     if (!isAutoDiscoveryCodeSignIdentity()) {

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -13,7 +13,7 @@ import { downloadCertificate } from "./codesign"
 
 export const appleCertificatePrefixes = ["Developer ID Application:", "Developer ID Installer:", "3rd Party Mac Developer Application:", "3rd Party Mac Developer Installer:"]
 
-export type CertType = "Developer ID Application" | "Developer ID Installer" | "3rd Party Mac Developer Application" | "3rd Party Mac Developer Installer" | "Mac Developer"
+export type CertType = "Developer ID Application" | "Developer ID Installer" | "3rd Party Mac Developer Application" | "3rd Party Mac Developer Installer" | "Mac Developer" | "Apple Development"
 
 export interface CodeSigningInfo {
   keychainFile?: string | null
@@ -51,7 +51,7 @@ export function isSignAllowed(isPrintWarn = true): boolean {
 
 export async function reportError(
   isMas: boolean,
-  certificateType: CertType,
+  certificateTypes: CertType[],
   qualifier: string | null | undefined,
   keychainFile: string | null | undefined,
   isForceCodeSigning: boolean
@@ -60,7 +60,7 @@ export async function reportError(
   if (qualifier == null) {
     logFields.reason = ""
     if (isAutoDiscoveryCodeSignIdentity()) {
-      logFields.reason += `cannot find valid "${certificateType}" identity${isMas ? "" : ` or custom non-Apple code signing certificate`}`
+      logFields.reason += `cannot find valid "${certificateTypes.join(', ')}" identity${isMas ? "" : ` or custom non-Apple code signing certificate`}`
     }
     logFields.reason += ", see https://electron.build/code-signing"
     if (!isAutoDiscoveryCodeSignIdentity()) {

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -438,5 +438,5 @@ function getCertificateTypes(isMas: boolean, isDevelopment: boolean): CertType[]
   if (isDevelopment) {
     return ["Mac Developer", "Apple Development"]
   }
-  return isMas ? ["3rd Party Mac Developer Application"] : ["Developer ID Application"]
+  return isMas ? ["3rd Party Mac Developer Application", "Apple Distribution"] : ["Developer ID Application"]
 }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -201,11 +201,11 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     const isDevelopment = type === "development"
     const certificateTypes = getCertificateTypes(isMas, isDevelopment)
 
-    let identity = null;
-    for (let certificateType of certificateTypes) {
-      identity = await findIdentity(certificateType, qualifier, keychainFile);
+    let identity = null
+    for (const certificateType of certificateTypes) {
+      identity = await findIdentity(certificateType, qualifier, keychainFile)
       if (identity != null) {
-        break;
+        break
       }
     }
 


### PR DESCRIPTION
This PR adds support for the newer "Apple Development" certificates, mentioned in the [Xcode 11 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-11-release-notes).

> Xcode 11 supports the new Apple Development and Apple Distribution certificate types. These certificates support building, running, and distributing apps on any Apple platform. Preexisting iOS and macOS development and distribution certificates continue to work, however, new certificates you create in Xcode 11 use the new types. Previous versions of Xcode don’t support these certificates. (45527608)