### PR TITLE
Adding msi project created hook.

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5902,6 +5902,20 @@
         }
       ]
     },
+    "msiProjectCreated": {
+      "anyOf": [
+        {
+          "typeof": "function"
+        },
+        {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      ],
+      "description": "MSI project created on disk - not packed into .msi package yet."
+    },
     "nodeGypRebuild": {
       "default": false,
       "description": "Whether to execute `node-gyp rebuild` before starting to package the app.\n\nDon't [use](https://github.com/electron-userland/electron-builder/issues/683#issuecomment-241214075) [npm](http://electron.atom.io/docs/tutorial/using-native-node-modules/#using-npm) (neither `.npmrc`) for configuring electron headers. Use `electron-builder node-gyp-rebuild` instead.",

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -199,11 +199,11 @@ export interface Configuration extends PlatformSpecificBuildOptions {
    */
   readonly afterAllArtifactBuild?: ((context: BuildResult) => Promise<Array<string>> | Array<string>) | string | null
   /**
-   * Appx manifest created on disk - not packed into .appx package yet.
+   * MSI project created on disk - not packed into .msi package yet.
    */
   readonly msiProjectCreated?: ((path: string) => Promise<any> | any) | string | null
   /**
-   * MSI project created on disk - not packed into .msi package yet.
+   * Appx manifest created on disk - not packed into .appx package yet.
    */
   readonly appxManifestCreated?: ((path: string) => Promise<any> | any) | string | null
   /**

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -201,6 +201,10 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   /**
    * Appx manifest created on disk - not packed into .appx package yet.
    */
+  readonly msiProjectCreated?: ((path: string) => Promise<any> | any) | string | null
+  /**
+   * MSI project created on disk - not packed into .msi package yet.
+   */
   readonly appxManifestCreated?: ((path: string) => Promise<any> | any) | string | null
   /**
    * The function (or path to file or module id) to be [run on each node module](#onnodemodulefile) file.

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -291,6 +291,13 @@ export class Packager {
     }
   }
 
+  async callMsiProjectCreated(path: string): Promise<void> {
+    const handler = resolveFunction(this.config.msiProjectCreated, "msiProjectCreated")
+    if (handler != null) {
+      await Promise.resolve(handler(path))
+    }
+  }
+
   async build(): Promise<BuildResult> {
     let configPath: string | null = null
     let configFromOptions = this.options.config

--- a/packages/app-builder-lib/src/targets/MsiTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiTarget.ts
@@ -70,6 +70,8 @@ export default class MsiTarget extends Target {
       objectFiles.push(ASSISTED_UI_FILE_NAME.replace(".wxs", ".wixobj"))
     }
 
+    await packager.info.callMsiProjectCreated(projectFile)
+
     // noinspection SpellCheckingInspection
     const vendorPath = await getBinFromUrl("wix", "4.0.0.5512.2", "/X5poahdCc3199Vt6AP7gluTlT1nxi9cbbHhZhCMEu+ngyP1LiBMn+oZX7QAZVaKeBMc2SjVp7fJqNLqsUnPNQ==")
 


### PR DESCRIPTION
Add a hook to allow modification of `project.wxs` before packaging.

Same idea as #4613 but for MSIs.