### PR TITLE
fix: Nsis custom uninstall page extension point

### DIFF
--- a/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
@@ -70,6 +70,9 @@
     !insertmacro PAGE_INSTALL_MODE
   !endif
   !insertmacro MUI_UNPAGE_INSTFILES
+  !ifmacrodef customUninstallPage
+    !insertmacro customUninstallPage
+  !endif
   !insertmacro MUI_UNPAGE_FINISH
 !endif
 


### PR DESCRIPTION
Ability to add macros to uninstaller BEFORE the finish page