### PR TITLE
fix(GitHubPublisher): add timeout to GitHub publisher uploads prevent socket hand up due to short timeout default setting fixes #4940

### DIFF
--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -185,6 +185,7 @@ export class GitHubPublisher extends HttpPublisher {
             hostname: parsedUrl.hostname,
             path: parsedUrl.path,
             method: "POST",
+            timeout: 120 * 1000,
             headers: {
               accept: "application/vnd.github.v3+json",
               "Content-Type": mime.getType(fileName) || "application/octet-stream",


### PR DESCRIPTION
fix(GitHubPublisher): add timeout to GitHub publisher uploads

 prevent socket hand up due to short timeout default setting 

fixes #4940