### PR TITLE
chore: default linux target + ci config

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,5 +65,5 @@ jobs:
       - name: test
         run: node ./test/out/helpers/runTests.js
         env:
-          TEST_FILES: ${{ matrix.TEST_FILES }}
+          TEST_FILES: ${{ matrix.testFiles }}
           FORCE_COLOR: 1

--- a/packages/app-builder-lib/src/linuxPackager.ts
+++ b/packages/app-builder-lib/src/linuxPackager.ts
@@ -23,7 +23,7 @@ export class LinuxPackager extends PlatformPackager<LinuxConfiguration> {
   }
 
   get defaultTarget(): Array<string> {
-    return ["snap", "appimage", "flatpak"]
+    return ["snap", "appimage"]
   }
 
   createTargets(targets: Array<string>, mapper: (name: string, factory: (outDir: string) => Target) => void): void {


### PR DESCRIPTION
- retaining previous default target behavior pre-flatpak merge since it is experimental.
- fixing test.yaml config where it incorrectly referenced an env var matrix