### PR TITLE
Fixing downloadPromise not resolving on Mac.

### DIFF
--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -122,14 +122,15 @@ export class MacUpdater extends AppUpdater {
               headers: { "Cache-Control": "no-cache" },
             })
 
-            this.nativeUpdater.once("error", reject)
-
             // The update has been downloaded and is ready to be served to Squirrel
             this.dispatchUpdateDownloaded(event)
 
             if (this.autoInstallOnAppQuit) {
+              this.nativeUpdater.once("error", reject)
               // This will trigger fetching and installing the file on Squirrel side
               this.nativeUpdater.checkForUpdates()
+            } else {
+              resolve([])
             }
           })
         })


### PR DESCRIPTION
Hello,

We are using `autoInstallOnAppQuit=false` (non mandatory updates). After the update, it stopped working for us on Mac. It's because we use `downloadPromise` to wait for the package to be downloaded. The promise never resolves on Mac. The promise never resolves because it depends on `autoInstallOnAppQuit` being `true` and the package being handed to Squirell.

I am not sure whether this is the correct solution to this problem or whether it's just a misunderstanding of the API contract, but I am sure you folks can advise.

Additionally, I am not sure whether we want the HTTP server should be running for `autoInstallOnAppQuit=false` all the time. Perhaps the whole server should only be started when `autoInstallOnAppQuit` is `true` and on `quitAndInstall` call when `autoInstallOnAppQuit` is `false`. I am happy to take the code to that course if deemed suitable.

Thank you for looking into this.