### PR TITLE
fix after cancel download,the file haven't remove bug

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -446,6 +446,7 @@ function configurePipes(options: DownloadCallOptions, response: IncomingMessage)
   let lastStream = response
   for (const stream of streams) {
     stream.on("error", (error: Error) => {
+      fileOut.close()
       if (!options.options.cancellationToken.cancelled) {
         options.callback(error)
       }


### PR DESCRIPTION
when I cancel download,  the temp-update-download file is not close, the temp file is occupied . so when next time I try to download again , the last temp-file cant't be removed, when I cancel many times, It will generate many temp-file.