### PR TITLE
Straighten out statement on index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -70,7 +70,7 @@ A complete solution to package and build a ready for distribution Electron app f
     ```
     Then you can run `yarn dist` (to package in a distributable format (e.g. dmg, windows installer, deb package)) or `yarn pack` (only generates the package directory without really packaging it. This is useful for testing purposes).
 
-    To ensure your native dependencies are always matched electron version, simply add script `"postinstall": "electron-builder install-app-deps"` to your `package.json`.
+    To ensure your native dependencies always matched the electron version, simply add script `"postinstall": "electron-builder install-app-deps"` to your `package.json`.
 
 5. If you have native addons of your own that are part of the application (not as a dependency), set [nodeGypRebuild](/configuration/configuration#Configuration-nodeGypRebuild) to `true`.
    


### PR DESCRIPTION
The following statement in the index.md file needs better tuning:

Before: `To ensure your native dependencies are always matched electron version`

After: `To ensure your native dependencies always matched the electron version`