### PR TITLE
Extend http file limit

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -218,8 +218,8 @@ Please double check that your authentication token is correct. Due to security r
             if (contentLength != null) {
               const size = parseInt(contentLength, 10)
               if (size > 0) {
-                if (size > 52428800) {
-                  callback(new Error("Maximum allowed size is 50 MB"))
+                if (size > 524288000) {
+                  callback(new Error("Maximum allowed size is 500 MB"))
                   return
                 }
 
@@ -234,8 +234,8 @@ Please double check that your authentication token is correct. Due to security r
               } else if (result == null) {
                 result = chunk
               } else {
-                if (result.length > 52428800) {
-                  callback(new Error("Maximum allowed size is 50 MB"))
+                if (result.length > 524288000) {
+                  callback(new Error("Maximum allowed size is 500 MB"))
                   return
                 }
                 result = Buffer.concat([result, chunk])


### PR DESCRIPTION
Related to #4676 and propably some more

As an electron app takes up more than 50 MB pretty easily the updater stops working due to the very low chunk size limit of currently 50 MB.