### PR TITLE
fix: build fails with `istextorbinary` error stacktrace

### DIFF
--- a/packages/app-builder-lib/electron-osx-sign/util.js
+++ b/packages/app-builder-lib/electron-osx-sign/util.js
@@ -132,7 +132,7 @@ var detectElectronPlatformAsync = module.exports.detectElectronPlatformAsync = f
   })
 }
 
-const isBinaryFile = require("istextorbinary").isBinary;
+const isBinaryFile = require("isbinaryfile").isBinaryFileSync;
 
 /**
  * This function returns a promise resolving the file path if file binary. We check filepath extension first to reduce overhead of reading the file to a buffer for it to scan start/mid/end encoding of the file
@@ -156,7 +156,7 @@ const getFilePathIfBinarySync = module.exports.getFilePathIfBinarySync = functio
   // Still consider the file as binary if extension is empty or seems invalid
   // https://github.com/electron-userland/electron-builder/issues/5465
   if ((ext === '' || ext.indexOf(' ') >= 0) && name[0] !== '.') {
-    return (isBinaryFile(filePath, null) || isBinaryFile(null, fs.readFileSync(filePath))) ? filePath : undefined
+    return isBinaryFile(filePath) ? filePath : undefined
   }
   return undefined
 }

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -58,7 +58,7 @@
     "fs-extra": "^9.1.0",
     "hosted-git-info": "^4.0.0",
     "is-ci": "^3.0.0",
-    "istextorbinary": "^5.12.0",
+    "isbinaryfile": "^4.0.8",
     "js-yaml": "^4.0.0",
     "lazy-val": "^1.0.4",
     "minimatch": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
       fs-extra: 9.1.0
       hosted-git-info: 4.0.0
       is-ci: 3.0.0
-      istextorbinary: 5.12.0
+      isbinaryfile: 4.0.8
       js-yaml: 4.0.0
       lazy-val: 1.0.4
       minimatch: 3.0.4
@@ -135,7 +135,7 @@ importers:
       fs-extra: ^9.1.0
       hosted-git-info: ^4.0.0
       is-ci: ^3.0.0
-      istextorbinary: ^5.12.0
+      isbinaryfile: ^4.0.8
       js-yaml: ^4.0.0
       lazy-val: ^1.0.4
       minimatch: ^3.0.4
@@ -2627,12 +2627,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
-  /binaryextensions/4.15.0:
-    dev: false
-    engines:
-      node: '>=0.8'
-    resolution:
-      integrity: sha512-MkUl3szxXolQ2scI1PM14WOT951KnaTNJ0eMKg7WzOI4kvSxyNo/Cygx4LOBNhwyINhAuSQpJW1rYD9aBSxGaw==
   /bl/4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -3509,15 +3503,6 @@ packages:
       safer-buffer: 2.1.2
     resolution:
       integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
-  /editions/6.1.0:
-    dependencies:
-      errlop: 4.1.0
-      version-range: 1.1.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-h6nWEyIocfgho9J3sTSuhU/WoFOu1hTX75rPBebNrbF38Y9QFDjCDizYXdikHTySW7Y3mSxli8bpDz9RAtc7rA==
   /ejs/3.1.6:
     dependencies:
       jake: 10.8.2
@@ -3565,12 +3550,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
-  /errlop/4.1.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-vul6gGBuVt0M2TPi1/WrcL86+Hb3Q2Tpu3TME3sbVhZrYf7J1ZMHCodI25RQKCVurh56qTfvgM0p3w5cT4reSQ==
   /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -4705,6 +4684,12 @@ packages:
   /isarray/1.0.0:
     resolution:
       integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+  /isbinaryfile/4.0.8:
+    dev: false
+    engines:
+      node: '>= 8.0.0'
+    resolution:
+      integrity: sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==
   /isexe/2.0.0:
     resolution:
       integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
@@ -4764,16 +4749,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
-  /istextorbinary/5.12.0:
-    dependencies:
-      binaryextensions: 4.15.0
-      editions: 6.1.0
-      textextensions: 5.12.0
-    dev: false
-    engines:
-      node: '>=10'
-    resolution:
-      integrity: sha512-wLDRWD7qpNTYubk04+q3en1+XZGS4vYWK0+SxNSXJLaITMMEK+J3o/TlOMyULeH1qozVZ9uUkKcyMA8odyxz8w==
   /jake/10.8.2:
     dependencies:
       async: 0.9.2
@@ -7358,12 +7333,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
-  /textextensions/5.12.0:
-    dev: false
-    engines:
-      node: '>=0.8'
-    resolution:
-      integrity: sha512-IYogUDaP65IXboCiPPC0jTLLBzYlhhw2Y4b0a2trPgbHNGGGEfuHE6tds+yDcCf4mpNDaGISFzwSSezcXt+d6w==
   /throat/5.0.0:
     resolution:
       integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
@@ -7781,20 +7750,6 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
-  /version-compare/1.1.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-zVKtPOJTC9x23lzS4+4D7J+drq80BXVYAmObnr5zqxxFVH7OffJ1lJlAS7LYsQNV56jx/wtbw0UV7XHLrvd6kQ==
-  /version-range/1.1.0:
-    dependencies:
-      version-compare: 1.1.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-R1Ggfg2EXamrnrV3TkZ6yBNgITDbclB3viwSjbZ3+eK0VVNK4ajkYJTnDz5N0bIMYDtK9MUBvXJUnKO5RWWJ6w==
   /w3c-hr-time/1.0.2:
     dependencies:
       browser-process-hrtime: 1.0.0


### PR DESCRIPTION
`istextorbinary` throws some weird errors on various build environments. Reverting back to the previous usage of `isbinaryfile`, but retaining the signing logic flow

Fixes:
#5668
#5762