### PR TITLE
feat(docker): update to Ubuntu 20.04 LTS

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic-curl
+FROM buildpack-deps:focal-curl
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -9,9 +9,9 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # git ssh for using as docker image on CircleCI
   # python for node-gyp
   # rpm is required for FPM to build rpm package
-  # libsecret-1-dev and libgnome-keyring-dev are required even for prebuild keytar
-  apt-get -qq install --no-install-recommends qtbase5-dev bsdtar build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip \
-  libsecret-1-dev libgnome-keyring-dev \
+  # libsecret-1-dev is required even for prebuild keytar (https://atom.github.io/node-keytar/)
+  apt-get -qq install --no-install-recommends qtbase5-dev build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip \
+  libsecret-1-dev \
   libopenjp2-tools && \
   # git-lfs
   git lfs install && \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-docker build -t electronuserland/builder:base -t electronuserland/builder:base-06.19 docker/base
+docker build -t electronuserland/builder:base -t electronuserland/builder:base-05.21 docker/base
 
-docker build -t electronuserland/builder:12 -t electronuserland/builder:latest -t electronuserland/builder:12-06.19 docker/node
+docker build -t electronuserland/builder:14 -t electronuserland/builder:latest -t electronuserland/builder:14-05.21 docker/node
 
 docker build -t electronuserland/builder:wine docker/wine
 docker build -t electronuserland/builder:wine-mono docker/wine-mono

--- a/docker/wine-mono/Dockerfile
+++ b/docker/wine-mono/Dockerfile
@@ -3,5 +3,5 @@ FROM electronuserland/builder:wine
 # since mono is required only for deprecated target Squirrel.Windows, extracted to separate docker image to reduce size
 
 RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends mono-devel ca-certificates-mono tzdata && \
+  apt-get install -y --no-install-recommends mono-devel ca-certificates-mono && \
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -1,13 +1,12 @@
 FROM electronuserland/builder:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common && dpkg --add-architecture i386 && \
-  curl -L https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key > winehq.key && apt-key add winehq.key && \
-  apt-add-repository 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/ ./' && \
+RUN dpkg --add-architecture i386 && \
+  curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
+  echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
-  apt-get -y purge software-properties-common libdbus-glib-1-2 python3-dbus python3-gi python3-pycurl python3-software-properties && \
   apt-get install -y --no-install-recommends winehq-stable && \
   # clean
-  apt-get clean && rm -rf /var/lib/apt/lists/* && unlink winehq.key
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN curl -L https://github.com/electron-userland/electron-builder-binaries/releases/download/wine-2.0.3-mac-10.13/wine-home.zip > /tmp/wine-home.zip && unzip /tmp/wine-home.zip -d /root/.wine && unlink /tmp/wine-home.zip
 


### PR DESCRIPTION
While this is not strictly necessary right now (Ubuntu 18.04 is still supported until 2023), this makes it possible to move back to official wine packages (change included) instead of relying on the OBS packages (which seem to be missing a winehq-stable package at the moment, so this would also fix #5579)

Not sure if I can somehow test this change, FWIW my own builds still work with this container image 😄 

(Would also be nice if someone could update the images on Docker Hub afterwards)