### PR TITLE
Re-export some of the "builder-util-runtime" types directly from "electron-updater"

### DIFF
--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -5,7 +5,7 @@ import { AppUpdater } from "./AppUpdater"
 import { LoginCallback } from "./electronHttpExecutor"
 
 export { AppUpdater, NoOpLogger } from "./AppUpdater"
-export { UpdateInfo }
+export { CancellationToken, PackageFileInfo, ProgressInfo, UpdateFileInfo, UpdateInfo }
 export { Provider } from "./providers/Provider"
 export { AppImageUpdater } from "./AppImageUpdater"
 export { MacUpdater } from "./MacUpdater"


### PR DESCRIPTION
Export `CancellationToken`, `PackageFileInfo`, `ProgressInfo`, `UpdateFileInfo` directly from `"electron-updater"` as these types are already used in other exported types.

Fixes #5675.