### PR TITLE
Fix transpiled import syntax

### DIFF
--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -4,7 +4,7 @@ import { Fields } from "builder-util/out/log"
 import { httpExecutor } from "builder-util/out/nodeHttpExecutor"
 import { ClientRequest } from "http"
 import { Lazy } from "lazy-val"
-import mime from "mime"
+import * as mime from "mime"
 import { parse as parseUrl, UrlWithStringQuery } from "url"
 import { getCiTag, HttpPublisher, PublishContext, PublishOptions } from "./publisher"
 


### PR DESCRIPTION
For whatever reason, importing the default value of mine started importing the .default object property off of module.exports in mime.   As a result, mime.getType could not be found on undefined. This fixes that.