### PR TITLE
fix: quit on decompression errors in NSIS

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
@@ -80,6 +80,10 @@
 !macro decompress
   !ifdef ZIP_COMPRESSION
     nsisunz::Unzip "$PLUGINSDIR\app-$packageArch.zip" "$INSTDIR"
+    Pop $R0
+    StrCmp $R0 "success" +3
+      MessageBox MB_OK|MB_ICONEXCLAMATION "$(decompressionFailed)$\n$R0"
+      Quit
   !else
     !insertmacro extractUsing7za "$PLUGINSDIR\app-$packageArch.7z"
   !endif

--- a/packages/app-builder-lib/templates/nsis/messages.yml
+++ b/packages/app-builder-lib/templates/nsis/messages.yml
@@ -110,3 +110,5 @@ areYouSureToUninstall:
   fi: Oletko varma, että haluat poistaa ${PRODUCT_NAME} asennuksen?
   es: ¿Seguro que quieres desinstalar ${PRODUCT_NAME}?
   da: Er du sikker på, at du vil afinstallere ${PRODUCT_NAME}?
+decompressionFailed:
+  en: Failed to decompress files. Please try running the installer again.


### PR DESCRIPTION
Unlike 7zip, zip decompression pushes a return value on stack. If it not
`success` installer should fail and display the error to the user
instead of assuming that installation was successful.

One of the causes of decompression errors might be a lingering child
process that still uses dlls and node.js bindings so that they cannot be
overwritten. In such case, prior to this patch nsis installer would
update some of the non-locked files and start the app as if it had been
fully updated.