### PR TITLE
feat: allow python path to be configurable

### DIFF
--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -298,7 +298,7 @@ async function customizeDmg(volumePath: string, specification: DmgOptions, packa
   env.iconLocations = await computeDmgEntries(specification, volumePath, packager, asyncTaskManager)
   await asyncTaskManager.awaitTasks()
 
-  await exec("/usr/bin/python", [path.join(getDmgVendorPath(), "dmgbuild/core.py")], {
+  await exec(process.env.PYTHON_PATH || "/usr/bin/python", [path.join(getDmgVendorPath(), "dmgbuild/core.py")], {
     cwd: getDmgVendorPath(),
     env,
   })


### PR DESCRIPTION
Enables `dmg-builder` to use a custom python path. This is a necessary option to provide as `/usr/bin/python` may be python 3 and `dmg-builder` depends on python 2.7.

Closes #5889