### PR TITLE
fix(mac): adding arch suffix to pkg target to enable non-universal pkg builds

### DIFF
--- a/packages/app-builder-lib/src/targets/pkg.ts
+++ b/packages/app-builder-lib/src/targets/pkg.ts
@@ -34,7 +34,7 @@ export class PkgTarget extends Target {
     const appInfo = packager.appInfo
 
     // pkg doesn't like not ASCII symbols (Could not open package to list files: /Volumes/test/t-gIjdGK/test-project-0/dist/Test App ßW-1.1.0.pkg)
-    const artifactName = packager.expandArtifactNamePattern(options, "pkg")
+    const artifactName = packager.expandArtifactNamePattern(options, "pkg", arch)
     const artifactPath = path.join(this.outDir, artifactName)
 
     await packager.info.callArtifactBuildStarted({


### PR DESCRIPTION
Enabling arm64 builds for pkg distributions. Requires `arch` to be specified for build name, otherwise it'll try to build x64 and arm64 with the same name 
Fixes: #5847