### PR TITLE
fix(nsis): retry closing the app until success

### DIFF
--- a/packages/app-builder-lib/templates/nsis/messages.yml
+++ b/packages/app-builder-lib/templates/nsis/messages.yml
@@ -66,6 +66,8 @@ appRunning:
   fi: "${PRODUCT_NAME} on käynnissä. Napsauta OK sulkeaksesi sen."
   es: "${PRODUCT_NAME} se está ejecutando. Haz clic en Aceptar para cerrarlo."
   da: "${PRODUCT_NAME} er i gang. Klik OK for at lukke."
+appCannotBeClosed:
+  en: "${PRODUCT_NAME} cannot be closed. \nPlease close it manually and click Retry to continue"
 installing:
   en: Installing, please wait...
   de: Installation läuft, bitte warten...


### PR DESCRIPTION
Do not continue installation while the app is running. The running
executable and dlls are locked until the app is closed and the 7z
extraction will result in a partial update. If app cannot be quit
forcibly - ask user to close it manually and retry the app check in
the loop until success.

This situation might happen when the app runs in elevated permissions
mode while the installer is started normally.