### PR TITLE
Issue 5857 ${arch} causes a build fail

### DIFF
--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -360,7 +360,7 @@ export class NsisTarget extends Target {
     // http://forums.winamp.com/showthread.php?p=3078545
     if (isMacOsCatalina()) {
       try {
-        UninstallerReader.exec(installerPath, uninstallerPath)
+        await UninstallerReader.exec(installerPath, uninstallerPath)
       } catch (error) {
         log.warn(`packager.vm is used: ${error.message}`)
 

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -119,20 +119,7 @@ export class NsisTarget extends Target {
 
   async finishBuild(): Promise<any> {
     try {
-      const { pattern } = this.packager.artifactPatternConfig(this.options, this.installerFilenamePattern)
       const builds = new Set([this.archs])
-      if (pattern.includes("${arch}")) {
-        ;[...this.archs].forEach(([arch, appOutDir]) => {
-          const currArchs = builds.values();
-          let archNotAlreadyIncluded = true;
-          for (let curr of currArchs) {
-              archNotAlreadyIncluded = archNotAlreadyIncluded && !curr.has(arch);
-          }
-          if (archNotAlreadyIncluded) {
-              builds.add(new Map().set(arch, appOutDir))
-          }
-        })
-      }
       await Promise.all([...builds].map(archs => this.buildInstaller(archs)))
     } finally {
       await this.packageHelper.finishBuild()

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -122,7 +122,16 @@ export class NsisTarget extends Target {
       const { pattern } = this.packager.artifactPatternConfig(this.options, this.installerFilenamePattern)
       const builds = new Set([this.archs])
       if (pattern.includes("${arch}")) {
-        ;[...this.archs].forEach(([arch, appOutDir]) => builds.add(new Map<Arch, string>().set(arch, appOutDir)))
+        ;[...this.archs].forEach(([arch, appOutDir]) => {
+          const currArchs = builds.values();
+          let archNotAlreadyIncluded = true;
+          for (let curr of currArchs) {
+              archNotAlreadyIncluded = archNotAlreadyIncluded && !curr.has(arch);
+          }
+          if (archNotAlreadyIncluded) {
+              builds.add(new Map().set(arch, appOutDir))
+          }
+        })
       }
       await Promise.all([...builds].map(archs => this.buildInstaller(archs)))
     } finally {


### PR DESCRIPTION
There are two problems here as reported in Issue #5857 

If you are only using one architecture and you have a ${arch} in the pattern you get the file twice, once from this.archs and once from inside the loop added on line 124. This duplication meant that the builder was trying to output to the same file with two builds and failed. I have added a check to only add individual architectures, if the size of this.archs is greater than 1.

I've also changed each arch to build sequentially. The reason for this is the build was failing because it couldn't access the 7zip files or uninstaller for the build process because it was locked, causing the build to fail.

This *seems* to fix things, though someone else might have a better way of doing it?