### PR TITLE
fix/dockerfile-libxtst6 (#5907)

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -10,9 +10,11 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # python for node-gyp
   # rpm is required for FPM to build rpm package
   # libsecret-1-dev is required even for prebuild keytar (https://atom.github.io/node-keytar/)
-  apt-get -qq install --no-install-recommends qtbase5-dev build-essential autoconf libssl-dev gcc-multilib g++-multilib lzip rpm python libcurl4 git git-lfs ssh unzip libarchive-tools \
-  libsecret-1-dev \
-  libopenjp2-tools && \
+  apt-get -qq install --no-install-recommends \
+        qtbase5-dev build-essential autoconf libssl-dev gcc-multilib g++-multilib \
+        lzip rpm python libcurl4 git git-lfs ssh unzip libarchive-tools \
+        libxtst6 libsecret-1-dev libopenjp2-tools \
+  && \
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*

--- a/docker/base/test.sh
+++ b/docker/base/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-yarn
-yarn test
+pnpm i
+pnpm run test

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -1179,10 +1179,10 @@ Object {
               "size": 1069,
             },
             "abi_registry.json": Object {
-              "size": 1884,
+              "size": 1885,
             },
             "index.js": Object {
-              "size": 6099,
+              "size": 6391,
             },
             "package.json": Object {
               "size": 547,


### PR DESCRIPTION
The dockerfile upgrade to ubuntu 20 removed libxtst6 from the image. Adding it explicitly to install 
Fixes: #5907