### PR TITLE
Added missing `event-update-not-available` in UpdaterEvents

### DIFF
--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -54,7 +54,7 @@ export interface UpdateCheckResult {
   readonly versionInfo: UpdateInfo
 }
 
-export type UpdaterEvents = "login" | "checking-for-update" | "update-available" | "update-cancelled" | "download-progress" | "update-downloaded" | "error"
+export type UpdaterEvents = "login" | "checking-for-update" | "update-available" | "update-not-available" | "update-cancelled" | "download-progress" | "update-downloaded" | "error"
 
 export const DOWNLOAD_PROGRESS: UpdaterEvents = "download-progress"
 export const UPDATE_DOWNLOADED: UpdaterEvents = "update-downloaded"


### PR DESCRIPTION
[Document](https://www.electronjs.org/docs/api/auto-updater#event-update-not-available)