### PR TITLE
fix(linux): executable path in Debian postinst script

### DIFF
--- a/packages/app-builder-lib/src/targets/fpm.ts
+++ b/packages/app-builder-lib/src/targets/fpm.ts
@@ -41,6 +41,7 @@ export default class FpmTarget extends Target {
     const templateOptions = {
       // old API compatibility
       executable: packager.executableName,
+      sanitizedProductName: packager.appInfo.sanitizedProductName,
       productFilename: packager.appInfo.productFilename,
       ...packager.platformSpecificBuildOptions,
     }

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Link to the binary
-ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'
+ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 
 # SUID chrome-sandbox for Electron 5+
-chmod 4755 '/opt/${productFilename}/chrome-sandbox' || true
+chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
 
 update-mime-database /usr/share/mime || true
 update-desktop-database /usr/share/applications || true

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -437,6 +437,105 @@ exports[`deb file associations 5`] = `
 </mime-info>"
 `;
 
+exports[`executable path in postinst script 1`] = `
+Object {
+  "linux": Array [
+    Object {
+      "arch": "x64",
+      "file": "TestApp_1.1.0_amd64.deb",
+    },
+  ],
+}
+`;
+
+exports[`executable path in postinst script 2`] = `
+Array [
+  "/",
+  "/opt/",
+  "/usr/",
+  "/opt/foo/",
+  "/opt/foo/Boo",
+  "/opt/foo/chrome-sandbox",
+  "/opt/foo/chrome_100_percent.pak",
+  "/opt/foo/chrome_200_percent.pak",
+  "/opt/foo/icudtl.dat",
+  "/opt/foo/libEGL.so",
+  "/opt/foo/libffmpeg.so",
+  "/opt/foo/libGLESv2.so",
+  "/opt/foo/libvk_swiftshader.so",
+  "/opt/foo/libvulkan.so",
+  "/opt/foo/LICENSE.electron.txt",
+  "/opt/foo/LICENSES.chromium.html",
+  "/opt/foo/resources.pak",
+  "/opt/foo/snapshot_blob.bin",
+  "/opt/foo/v8_context_snapshot.bin",
+  "/opt/foo/vk_swiftshader_icd.json",
+  "/usr/share/",
+  "/opt/foo/resources/",
+  "/opt/foo/resources/app.asar",
+  "/opt/foo/swiftshader/",
+  "/opt/foo/swiftshader/libEGL.so",
+  "/opt/foo/swiftshader/libGLESv2.so",
+  "/usr/share/applications/",
+  "/usr/share/applications/Boo.desktop",
+  "/usr/share/doc/",
+  "/usr/share/icons/",
+  "/usr/share/doc/testapp/",
+  "/usr/share/doc/testapp/changelog.gz",
+  "/usr/share/icons/hicolor/",
+  "/usr/share/icons/hicolor/128x128/",
+  "/usr/share/icons/hicolor/16x16/",
+  "/usr/share/icons/hicolor/256x256/",
+  "/usr/share/icons/hicolor/32x32/",
+  "/usr/share/icons/hicolor/48x48/",
+  "/usr/share/icons/hicolor/512x512/",
+  "/usr/share/icons/hicolor/64x64/",
+  "/usr/share/icons/hicolor/128x128/apps/",
+  "/usr/share/icons/hicolor/128x128/apps/Boo.png",
+  "/usr/share/icons/hicolor/16x16/apps/",
+  "/usr/share/icons/hicolor/16x16/apps/Boo.png",
+  "/usr/share/icons/hicolor/256x256/apps/",
+  "/usr/share/icons/hicolor/256x256/apps/Boo.png",
+  "/usr/share/icons/hicolor/32x32/apps/",
+  "/usr/share/icons/hicolor/32x32/apps/Boo.png",
+  "/usr/share/icons/hicolor/48x48/apps/",
+  "/usr/share/icons/hicolor/48x48/apps/Boo.png",
+  "/usr/share/icons/hicolor/512x512/apps/",
+  "/usr/share/icons/hicolor/512x512/apps/Boo.png",
+  "/usr/share/icons/hicolor/64x64/apps/",
+  "/usr/share/icons/hicolor/64x64/apps/Boo.png",
+]
+`;
+
+exports[`executable path in postinst script 3`] = `
+Object {
+  "Architecture": "amd64",
+  "Depends": "libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libappindicator3-1, libsecret-1-0",
+  "Homepage": "http://foo.example.com",
+  "License": "MIT",
+  "Maintainer": "Foo Bar <foo@example.com>",
+  "Package": "testapp",
+  "Priority": "extra",
+  "Section": "devel",
+  "Vendor": "Foo Bar <foo@example.com>",
+}
+`;
+
+exports[`executable path in postinst script 4`] = `"Test Application (test quite “ #378)"`;
+
+exports[`executable path in postinst script 5`] = `
+"#!/bin/bash
+
+# Link to the binary
+ln -sf '/opt/foo/Boo' '/usr/bin/Boo'
+
+# SUID chrome-sandbox for Electron 5+
+chmod 4755 '/opt/foo/chrome-sandbox' || true
+
+update-mime-database /usr/share/mime || true
+update-desktop-database /usr/share/applications || true"
+`;
+
 exports[`no quotes for safe exec name 1`] = `
 "[Desktop Entry]
 Name=foo

--- a/test/src/linux/debTest.ts
+++ b/test/src/linux/debTest.ts
@@ -45,6 +45,31 @@ test.ifNotWindows(
 )
 
 test.ifNotWindows.ifAll(
+  "executable path in postinst script",
+  app(
+    {
+      targets: Platform.LINUX.createTarget("deb"),
+      config: {
+        productName: "foo",
+        linux: {
+          executableName: "Boo",
+        },
+      },
+    },
+    {
+      packed: async context => {
+        const postinst = (
+          await execShell(`ar p '${context.outDir}/TestApp_1.1.0_amd64.deb' control.tar.gz | ${await getTarExecutable()} zx --to-stdout ./postinst`, {
+            maxBuffer: 10 * 1024 * 1024,
+          })
+        ).stdout
+        expect(postinst.trim()).toMatchSnapshot()
+      },
+    }
+  )
+)
+
+test.ifNotWindows.ifAll(
   "deb file associations",
   app(
     {


### PR DESCRIPTION
Debian .deb packages built when linux.executableName is not the same as the "productName" from package.json don't run properly, because the post-inst script doesn't refer to the binaries at the appropriate path.

Add a test for the correct behavior.

Expose the correct sanitizedProductName value for the after-install.tpl postinst script template.

Still expose the productFilename, too, because users supplying their own templates might still be using it.

Make the associated "executable path in postinst script" test pass.

Closes: #5933