### PR TITLE
Set default debian package priority to "optional"

### DIFF
--- a/packages/app-builder-lib/src/targets/fpm.ts
+++ b/packages/app-builder-lib/src/targets/fpm.ts
@@ -149,7 +149,7 @@ export default class FpmTarget extends Target {
     }
 
     if (target === "deb") {
-      use((options as DebOptions).priority, it => args.push("--deb-priority", it!))
+      args.push("--deb-priority", (options as DebOptions).priority ?? "optional")
     } else if (target === "rpm") {
       if (synopsis != null) {
         args.push("--rpm-summary", smarten(synopsis))

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -82,7 +82,7 @@ Object {
   "License": "MIT",
   "Maintainer": "Foo Bar <foo@example.com>",
   "Package": "testapp",
-  "Priority": "extra",
+  "Priority": "optional",
   "Section": "devel",
   "Vendor": "Foo Bar <foo@example.com>",
 }
@@ -157,7 +157,7 @@ Object {
   "License": "MIT",
   "Maintainer": "Foo Bar <foo@example.com>",
   "Package": "testapp",
-  "Priority": "extra",
+  "Priority": "optional",
   "Section": "devel",
   "Vendor": "Foo Bar <foo@example.com>",
 }
@@ -243,7 +243,7 @@ Object {
   "License": "MIT",
   "Maintainer": "Foo Bar <foo@example.com>",
   "Package": "testapp",
-  "Priority": "extra",
+  "Priority": "optional",
   "Section": "devel",
   "Vendor": "Foo Bar <foo@example.com>",
 }
@@ -329,7 +329,7 @@ Object {
   "License": "MIT",
   "Maintainer": "Foo Bar <foo@example.com>",
   "Package": "testapp",
-  "Priority": "extra",
+  "Priority": "optional",
   "Section": "devel",
   "Vendor": "Foo Bar <foo@example.com>",
 }
@@ -418,7 +418,7 @@ Object {
   "License": "MIT",
   "Maintainer": "Foo Bar <foo@example.com>",
   "Package": "testapp",
-  "Priority": "extra",
+  "Priority": "optional",
   "Section": "devel",
   "Vendor": "Foo Bar <foo@example.com>",
 }
@@ -515,7 +515,7 @@ Object {
   "License": "MIT",
   "Maintainer": "Foo Bar <foo@example.com>",
   "Package": "testapp",
-  "Priority": "extra",
+  "Priority": "optional",
   "Section": "devel",
   "Vendor": "Foo Bar <foo@example.com>",
 }
@@ -627,7 +627,7 @@ Object {
   "License": "MIT",
   "Maintainer": "Foo Bar <foo@example.com>",
   "Package": "testapp",
-  "Priority": "extra",
+  "Priority": "optional",
   "Section": "devel",
   "Vendor": "Foo Bar <foo@example.com>",
 }


### PR DESCRIPTION
Set default debian package priority to "optional" since "extra" is deprecated. Updated debian tests. This should fix https://github.com/electron-userland/electron-builder/issues/5930.