### PR TITLE
feat(electron-updater): allow custom update providers (#3656)

### DIFF
--- a/packages/builder-util-runtime/src/index.ts
+++ b/packages/builder-util-runtime/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from "./httpExecutor"
 export {
   BintrayOptions,
+  CustomPublishOptions,
   GenericServerOptions,
   GithubOptions,
   PublishConfiguration,

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -41,6 +41,17 @@ export interface PublishConfiguration {
 
 // https://github.com/electron-userland/electron-builder/issues/3261
 export interface CustomPublishOptions extends PublishConfiguration {
+  /**
+   * The provider. Must be `custom`.
+   */
+  readonly provider: "custom"
+
+  /**
+   * The Provider to provide UpdateInfo regarding available updates.  Required
+   * to use custom providers with electron-updater.
+   */
+  updateProvider?: new (options: CustomPublishOptions, updater: any, runtimeOptions: any) => any
+
   [index: string]: any
 }
 

--- a/packages/electron-updater/src/providerFactory.ts
+++ b/packages/electron-updater/src/providerFactory.ts
@@ -2,6 +2,7 @@ import {
   AllPublishOptions,
   BaseS3Options,
   BintrayOptions,
+  CustomPublishOptions,
   GenericServerOptions,
   getS3LikeProviderBaseUrl,
   GithubOptions,
@@ -63,6 +64,15 @@ export function createClient(data: PublishConfiguration | AllPublishOptions, upd
 
     case "bintray":
       return new BintrayProvider(data as BintrayOptions, runtimeOptions)
+
+    case "custom": {
+      const options = data as CustomPublishOptions
+      const constructor = options.updateProvider
+      if (!constructor) {
+        throw newError("Custom provider not specified", "ERR_UPDATER_INVALID_PROVIDER_CONFIGURATION")
+      }
+      return new constructor(options, updater, runtimeOptions)
+    }
 
     default:
       throw newError(`Unsupported provider: ${provider}`, "ERR_UPDATER_UNSUPPORTED_PROVIDER")


### PR DESCRIPTION
Currently, the custom publisher can't be used in combination with `electron-updater`: there is a hard-coded list of update providers, and an exception is thrown if the publisher isn't one of the known ones.

This adds the ability to use a custom provider; however, the caller must pass in a custom `options` object where one of the fields contains a constructor function.

This doesn't seem to affect the tests (that is, they still pass fine).