### PR TITLE
Escaping special characters in DMG entries

### DIFF
--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -314,10 +314,11 @@ async function computeDmgEntries(specification: DmgOptions, volumePath: string, 
 
     const entryPath = c.path || `${packager.appInfo.productFilename}.app`
     const entryName = c.name || path.basename(entryPath)
+    const escapedEntryName = entryName.replace(/(['\\])/g, (_, chr) => `\\${chr}`)
     if (result.length !== 0) {
       result += ",\n"
     }
-    result += `'${entryName}': (${c.x}, ${c.y})`
+    result += `'${escapedEntryName}': (${c.x}, ${c.y})`
 
     if (c.type === "link") {
       asyncTaskManager.addTask(exec("ln", ["-s", `/${entryPath.startsWith("/") ? entryPath.substring(1) : entryPath}`, `${volumePath}/${entryName}`]))

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -314,7 +314,7 @@ async function computeDmgEntries(specification: DmgOptions, volumePath: string, 
 
     const entryPath = c.path || `${packager.appInfo.productFilename}.app`
     const entryName = c.name || path.basename(entryPath)
-    const escapedEntryName = entryName.replace(/(['\\])/g, (_, chr) => `\\${chr}`)
+    const escapedEntryName = entryName.replace(/['\\]/g, match => `\\${match}`)
     if (result.length !== 0) {
       result += ",\n"
     }


### PR DESCRIPTION
Fixes an issue when the `productName` contains apostrophes. this is needed because in the python script it creates a literal string but the string is not escaped so an apostrophe terminates the string.

I have also added the backslash to the regex for completeness sake even though I don't think it's needed because it's sanitized out.