### PR TITLE
chore: ignoring node-abi in test snapshot to achieve consistent unit test results

### DIFF
--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -1156,46 +1156,6 @@ Object {
             },
           },
         },
-        "node-abi": Object {
-          "files": Object {
-            ".github": Object {
-              "files": Object {
-                "workflows": Object {
-                  "files": Object {
-                    "update-abi.yml": Object {
-                      "size": 1309,
-                    },
-                  },
-                },
-              },
-            },
-            "CODE_OF_CONDUCT.md": Object {
-              "size": 3194,
-            },
-            "CONTRIBUTING.md": Object {
-              "size": 1646,
-            },
-            "LICENSE": Object {
-              "size": 1069,
-            },
-            "abi_registry.json": Object {
-              "size": 1885,
-            },
-            "index.js": Object {
-              "size": 6391,
-            },
-            "package.json": Object {
-              "size": 547,
-            },
-            "scripts": Object {
-              "files": Object {
-                "update-abi-registry.js": Object {
-                  "size": 3105,
-                },
-              },
-            },
-          },
-        },
         "noop-logger": Object {
           "files": Object {
             "History.md": Object {

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -354,7 +354,7 @@ async function verifySmartUnpack(resourceDir: string) {
 }
 
 // https://github.com/electron-userland/electron-builder/issues/1738
-test.ifAll.ifDevOrLinuxCi(
+test.ifDevOrLinuxCi(
   "posix smart unpack",
   app(
     {
@@ -367,8 +367,11 @@ test.ifAll.ifDevOrLinuxCi(
         files: [
           // test ignore pattern for node_modules defined as file set filter
           {
-            filter: "!node_modules/napi-build-utils/napi-build-utils-1.0.0.tgz",
-          },
+            filter: [
+              "!node_modules/napi-build-utils/napi-build-utils-1.0.0.tgz",
+              "!node_modules/node-abi/*"
+            ]
+          }
         ],
       },
     },


### PR DESCRIPTION
chore: Tests break due to node-abi dependency `abi_registry.json` periodically changing file size.
- Removing node-abi from snapshot as its creating test instability even when `master` branch was already stable.
- Adding BuildTest posix unpack tests to default to running.