### PR TITLE
chrore: Add `repository.directory` to packages `package.json`

### DIFF
--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -10,7 +10,11 @@
     "electron-osx-sign",
     "certs/root_certs.keychain"
   ],
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/app-builder-lib"
+  },
   "engines": {
     "node": ">=14.0.0"
   },

--- a/packages/builder-util-runtime/package.json
+++ b/packages/builder-util-runtime/package.json
@@ -4,7 +4,11 @@
   "main": "out/index.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/builder-util-runtime"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -4,7 +4,11 @@
   "main": "out/util.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/builder-util"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/dmg-builder/package.json
+++ b/packages/dmg-builder/package.json
@@ -4,7 +4,11 @@
 	"main": "out/dmgUtil.js",
 	"author": "Vladimir Krivosheev",
 	"license": "MIT",
-	"repository": "electron-userland/electron-builder",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/electron-userland/electron-builder.git",
+		"directory": "packages/dmg-builder"
+	},
 	"bugs": "https://github.com/electron-userland/electron-builder/issues",
 	"homepage": "https://github.com/electron-userland/electron-builder",
 	"files": [

--- a/packages/electron-builder-squirrel-windows/package.json
+++ b/packages/electron-builder-squirrel-windows/package.json
@@ -4,7 +4,11 @@
   "main": "out/SquirrelWindowsTarget.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-builder-squirrel-windows"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-builder/package.json
+++ b/packages/electron-builder/package.json
@@ -10,7 +10,11 @@
     "electron-builder": "./cli.js",
     "install-app-deps": "./install-app-deps.js"
   },
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-builder"
+  },
   "engines": {
     "node": ">=14.0.0"
   },

--- a/packages/electron-forge-maker-appimage/package.json
+++ b/packages/electron-forge-maker-appimage/package.json
@@ -4,7 +4,11 @@
   "main": "main.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-forge-maker-appimage"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-forge-maker-nsis-web/package.json
+++ b/packages/electron-forge-maker-nsis-web/package.json
@@ -4,7 +4,11 @@
   "main": "main.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-forge-maker-nsis-web"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-forge-maker-nsis/package.json
+++ b/packages/electron-forge-maker-nsis/package.json
@@ -4,7 +4,11 @@
   "main": "main.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-forge-maker-nsis"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-forge-maker-snap/package.json
+++ b/packages/electron-forge-maker-snap/package.json
@@ -4,7 +4,11 @@
   "main": "main.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-forge-maker-snap"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-publish/package.json
+++ b/packages/electron-publish/package.json
@@ -4,7 +4,11 @@
   "main": "out/publisher.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-publish"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -5,7 +5,11 @@
   "main": "out/main.js",
   "author": "Vladimir Krivosheev",
   "license": "MIT",
-  "repository": "electron-userland/electron-builder",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/electron-updater"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [


### PR DESCRIPTION
This will allow various bots (as a renovate) to correctly find changelogs in the monorepos.