### PR TITLE
fix(nsis): generate uninstaller without elevating (#5575)

### DIFF
--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -375,7 +375,7 @@ export class NsisTarget extends Target {
         }
       }
     } else {
-      await execWine(installerPath)
+      await execWine(installerPath, null, [], { env: { __COMPAT_LAYER: "RunAsInvoker" } })
     }
     await packager.sign(uninstallerPath, "  Signing NSIS uninstaller")
 

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -367,9 +367,9 @@ export function executeAppBuilder(
   function runCommand() {
     return new Promise<string>((resolve, reject) => {
       const childProcess = doSpawn(command, args, {
-        env,
         stdio: ["ignore", "pipe", process.stdout],
         ...extraOptions,
+        env,
       })
       if (childProcessConsumer != null) {
         childProcessConsumer(childProcess)


### PR DESCRIPTION
In order to sign the uninstaller, we generate it by building the installer in a special mode and then run it immediately to get the uninstaller stub which we can then sign.  If the installer is set to require administrative rights to run, this can lead to the build breaking as it would then require administrative rights to generate the (to-be-signed) uninstaller.  We can work around this by setting an environment variable to request Windows to ignore the embedded manifest and always run (the stub installer) as the invoker instead.

Fixes #5575