### PR TITLE
fix: write blockmap file for mac zip archives

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,3 +1,7 @@
+<!--
+issue_labeler_regex_version=0
+--!>
+
 <!-- Which version of electron-builder are you using? -->
 <!-- Please always try to use latest version before reporting any issue. -->
 * **Electron-Builder Version**: 

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -11,5 +11,5 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/issue-labeler.yml
-        not-before: 2021-07-01T00:00:00Z
+        enable-versioned-regex: 0
         

--- a/packages/app-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/app-builder-lib/src/targets/ArchiveTarget.ts
@@ -4,7 +4,7 @@ import { Platform, Target, TargetSpecificOptions } from "../core"
 import { copyFiles, getFileMatchers } from "../fileMatcher"
 import { PlatformPackager } from "../platformPackager"
 import { archive, tar } from "./archive"
-import { appendBlockmap } from "./differentialUpdateInfoBuilder"
+import { appendBlockmap, createBlockmap } from "./differentialUpdateInfoBuilder"
 
 export class ArchiveTarget extends Target {
   readonly options: TargetSpecificOptions = (this.packager.config as any)[this.name]
@@ -65,7 +65,11 @@ export class ArchiveTarget extends Target {
       await archive(format, artifactPath, dirToArchive, archiveOptions)
 
       if (this.isWriteUpdateInfo && format === "zip") {
-        updateInfo = await appendBlockmap(artifactPath)
+        if (isMac) {
+          updateInfo = await createBlockmap(artifactPath, this, packager, artifactName)
+        } else {
+          updateInfo = await appendBlockmap(artifactPath)
+        }
       }
     }
 

--- a/test/snapshots/mac/macArchiveTest.js.snap
+++ b/test/snapshots/mac/macArchiveTest.js.snap
@@ -57,7 +57,14 @@ Object {
       "file": "Test App ßW-1.1.0-mac.zip",
       "safeArtifactName": "TestApp-1.1.0-mac.zip",
       "updateInfo": Object {
-        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    Object {
+      "file": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "safeArtifactName": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "updateInfo": Object {
         "sha512": "@sha512",
         "size": "@size",
       },
@@ -104,7 +111,7 @@ Object {
 `;
 
 exports[`invalid target 1`] = `
-"Invalid configuration object. electron-builder 22.10.5 has been initialized using a configuration object that does not match the API schema.
+"Invalid configuration object. electron-builder <appVersion> has been initialized using a configuration object that does not match the API schema.
  - configuration.mac should be one of these:
    object { appId?, artifactName?, asar?, asarUnpack?, binaries?, bundleShortVersion?, bundleVersion?, category?, compression?, cscInstallerKeyPassword?, cscInstallerLink?, cscKeyPassword?, cscLink?, darkModeSupport?, defaultArch?, detectUpdateChannel?, electronLanguages?, electronUpdaterCompatibility?, entitlements?, entitlementsInherit?, entitlementsLoginHelper?, executableName?, extendInfo?, extraDistFiles?, extraFiles?, extraResources?, fileAssociations?, files?, forceCodeSigning?, gatekeeperAssess?, generateUpdatesFilesForAllChannels?, hardenedRuntime?, helperBundleId?, helperEHBundleId?, helperGPUBundleId?, helperNPBundleId?, helperPluginBundleId?, helperRendererBundleId?, icon?, identity?, minimumSystemVersion?, protocols?, provisioningProfile?, publish?, releaseInfo?, requirements?, signIgnore?, strictVerify?, target?, type? } | null
    -> Options related to how build macOS targets.
@@ -132,7 +139,14 @@ Object {
       "file": "Test App ßW-1.1.0-mac.zip",
       "safeArtifactName": "TestApp-1.1.0-mac.zip",
       "updateInfo": Object {
-        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    Object {
+      "file": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "safeArtifactName": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "updateInfo": Object {
         "sha512": "@sha512",
         "size": "@size",
       },


### PR DESCRIPTION
Building a separate blockmap file instead of embedding within zip for mac targets. Embedding the blockmap breaks codesigning.
Fixes: #4299