### PR TITLE
fix: fix silent uninstallation for running app

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -76,6 +76,8 @@
           ${If} $R0 != 0
             DetailPrint `Waiting for "${PRODUCT_NAME}" to close (taskkill exit code $R0).`
             Sleep 2000
+          ${else}
+            Goto not_running
           ${endIf}
         ${else}
           Goto not_running


### PR DESCRIPTION
MessageBox shouldn't be shown if the app was killed or wasn't running.
Otherwise, it aborts the uninstallation in silent mode as IDCANCEL is the default action.
Introduced by [PR 5902](https://github.com/electron-userland/electron-builder/pull/5902)