### PR TITLE
docs: fix misused command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See documentation on [electron.build](https://www.electron.build).
       "dist": "electron-builder"
     }
     ```
-    Then you can run `yarn dist` (to package in a distributable format (e.g. dmg, windows installer, deb package)) or `yarn pack` (only generates the package directory without really packaging it. This is useful for testing purposes).
+    Then you can run `yarn dist` (to package in a distributable format (e.g. dmg, windows installer, deb package)) or `yarn run pack` (only generates the package directory without really packaging it. This is useful for testing purposes).
 
     To ensure your native dependencies are always matched electron version, simply add script `"postinstall": "electron-builder install-app-deps"` to your `package.json`.
 


### PR DESCRIPTION
`yarn pack` is a built-in command of yarn: https://classic.yarnpkg.com/en/docs/cli/pack
We should run `yarn run pack` to execute the npm script.