### PR TITLE
fix: Windows update fails for custom paths that require admin rights

### DIFF
--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -57,19 +57,18 @@ export abstract class BaseUpdater extends AppUpdater {
     this.quitAndInstallCalled = true
 
     try {
-      this._logger.info(`Install: isSilent: ${isSilent}, isForceRunAfter: ${isForceRunAfter}`)
-      
       let installPathRequiresElevation = false
-      if (process.platform === 'win32') {
+      if (process.platform === "win32") {
         try {
-          var accessTestPath = path.join(path.dirname(process.execPath), 'access')
-          fs.writeFileSync(accessTestPath, ' ')
+          const accessTestPath = path.join(path.dirname(process.execPath), "access")
+          fs.writeFileSync(accessTestPath, " ")
         } catch(err) {
           // Require admin rights if needed
           installPathRequiresElevation = true
         }
       }
-      
+
+      this._logger.info(`Install: isSilent: ${isSilent}, isForceRunAfter: ${isForceRunAfter}, installPathRequiresElevation: ${installPathRequiresElevation}`)
       return this.doInstall({
         installerPath,
         isSilent,

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -60,8 +60,9 @@ export abstract class BaseUpdater extends AppUpdater {
       let installPathRequiresElevation = false
       if (process.platform === "win32") {
         try {
-          const accessTestPath = path.join(path.dirname(process.execPath), "access")
+          const accessTestPath = path.join(path.dirname(process.execPath), `access-${Math.floor(Math.random() * 100)}.tmp`)
           fs.writeFileSync(accessTestPath, " ")
+          fs.rmSync(accessTestPath)
         } catch(err) {
           // Require admin rights if needed
           installPathRequiresElevation = true


### PR DESCRIPTION
Proposed fix to the situation on Windows where an Electron is installed for all users of the machine e.g. into Program Files, but fails to update (installed app version is deleted but the update is never installed) due to failure to request admin rights.

node v12.16.2
npm v6.14.4

Current build.nsis settings in package.json: 
{
	"oneClick": false,
	"allowToChangeInstallationDirectory": true,
	"allowElevation": true,
	...
}