### PR TITLE
feat(app-builder-lib): Add timestamp for electron-osx-sign options

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2621,6 +2621,13 @@
           ],
           "description": "The target package type: list of `default`, `dmg`, `mas`, `mas-dev`, `pkg`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`. Defaults to `default` (dmg and zip for Squirrel.Mac)."
         },
+        "timestamp": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Specify the URL of the timestamp authority server"
+        },
         "type": {
           "anyOf": [
             {
@@ -3212,6 +3219,13 @@
             }
           ],
           "description": "The target package type: list of `default`, `dmg`, `mas`, `mas-dev`, `pkg`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`. Defaults to `default` (dmg and zip for Squirrel.Mac)."
+        },
+        "timestamp": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Specify the URL of the timestamp authority server"
         },
         "type": {
           "anyOf": [

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -241,7 +241,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     let binaries = options.binaries || undefined
     if (binaries) {
       // Accept absolute paths for external binaries, else resolve relative paths from the artifact's app Contents path.
-      const userDefinedBinaries = await Promise.all(binaries.map(async (destination) => { 
+      const userDefinedBinaries = await Promise.all(binaries.map(async (destination) => {
         if (await statOrNull(destination)) {
           return destination
         }
@@ -284,6 +284,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       app: appPath,
       keychain: keychainFile || undefined,
       binaries,
+      timestamp: isMas ? masOptions?.timestamp : options.timestamp,
       requirements: isMas || this.platformSpecificBuildOptions.requirements == null ? undefined : await this.getResource(this.platformSpecificBuildOptions.requirements),
       // https://github.com/electron-userland/electron-osx-sign/issues/196
       // will fail on 10.14.5+ because a signed but unnotarized app is also rejected.

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -170,6 +170,11 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * Regex or an array of regex's that signal skipping signing a file.
    */
   readonly signIgnore?: Array<string> | string | null
+
+  /**
+   * Specify the URL of the timestamp authority server
+   */
+  readonly timestamp?: string | null
 }
 
 export interface DmgOptions extends TargetSpecificOptions {

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -17,6 +17,7 @@ test.ifMac.ifAll("two-package", () =>
         mac: {
           electronUpdaterCompatibility: ">=2.16",
           electronLanguages: ["bn", "en"],
+          timestamp: undefined,
         },
         //tslint:disable-next-line:no-invalid-template-strings
         artifactName: "${name}-${version}-${os}-${arch}.${ext}",


### PR DESCRIPTION
I noticed that the `timestamp` option from electron-osx-sign was missing.