### PR TITLE
fix(nsis): should close app when `Silent` and `ONE_CLICK`

### DIFF
--- a/packages/app-builder-lib/templates/nsis/uninstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/uninstaller.nsh
@@ -1,13 +1,19 @@
+Function un.checkAppRunning
+  !insertmacro CHECK_APP_RUNNING
+FunctionEnd
+
 Function un.onInit
   !insertmacro check64BitAndSetRegView
 
-  ${IfNot} ${Silent}
+  ${If} ${Silent}
+    call un.checkAppRunning
+  ${else}
     !ifdef ONE_CLICK
       MessageBox MB_OKCANCEL "$(areYouSureToUninstall)" IDOK +2
       Quit
 
       # one-click installer executes uninstall section in the silent mode, but we must show message dialog if silent mode was not explicitly set by user (using /S flag)
-      !insertmacro CHECK_APP_RUNNING
+      call un.checkAppRunning
       SetSilent silent
     !endif
   ${endIf}
@@ -20,9 +26,11 @@ Function un.onInit
 FunctionEnd
 
 Section "un.install"
+  # for assisted installer we check it here to show progress
   !ifndef ONE_CLICK
-    # for assisted installer we check it here to show progress
-    !insertmacro CHECK_APP_RUNNING
+    ${IfNot} ${Silent}
+      call un.checkAppRunning
+    ${endIf}
   !endif
 
   !insertmacro setLinkVars


### PR DESCRIPTION
Currently, if uninstall When `Silent is true` and `ONE_CLICK is defined`, the uninstaller will try to unisntall the app without closing it, which cases problems if uninstall it sliently when the app is running, the uninstaller can't remove all files, so left a broken app dir.

How to reproduce:
create an app, set `"oneClick": true` in config, make a `NSIS` installer, install it and try `Uninstall {appName}.exe /S` to silently uninstall it when the app is **running**.
Actual behavior: see above description.
Expected behavior: close the app then do the uninstall.