### PR TITLE
fix(mac): signing cert filter incorrectly selects certificates (#6094) (#6101)

### DIFF
--- a/.changeset/great-pumas-trade.md
+++ b/.changeset/great-pumas-trade.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): Adding Developer ID Application entry for development signing when building not a mas target. Fixes: #6094
+fix(mac): Removing 3rd Party Mac Developer Application certificate selector. Fixes: #6101

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -453,7 +453,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
 
 function getCertificateTypes(isMas: boolean, isDevelopment: boolean): CertType[] {
   if (isDevelopment) {
-    return ["Mac Developer", "Apple Development"]
+    return isMas ? ["Mac Developer", "Apple Development"] : ["Developer ID Application"]
   }
-  return isMas ? ["3rd Party Mac Developer Application", "Apple Distribution"] : ["Developer ID Application"]
+  return isMas ? ["Apple Distribution"] : ["Developer ID Application"]
 }


### PR DESCRIPTION
fix(mac): Adding Developer ID Application entry for development signing when building not a mas target. Fixes: #6094
fix(mac): Removing 3rd Party Mac Developer Application certificate selector. Fixes: #6101