### PR TITLE
fix: use tag name instead of version when resolving GitHub files

### DIFF
--- a/empty-ties-argue.md
+++ b/empty-ties-argue.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: use git remote's tag name instead of v-prefixed version string when resolving GitHub releases

--- a/packages/electron-updater/src/providers/Provider.ts
+++ b/packages/electron-updater/src/providers/Provider.ts
@@ -55,7 +55,7 @@ export abstract class Provider<T extends UpdateInfo> {
 
   abstract getLatestVersion(): Promise<T>
 
-  abstract resolveFiles(updateInfo: UpdateInfo): Array<ResolvedUpdateFileInfo>
+  abstract resolveFiles(updateInfo: T): Array<ResolvedUpdateFileInfo>
 
   /**
    * Method to perform API request only to resolve update info, but not to download update.

--- a/test/snapshots/updater/nsisUpdaterTest.js.snap
+++ b/test/snapshots/updater/nsisUpdaterTest.js.snap
@@ -107,6 +107,7 @@ Object {
   ],
   "releaseName": "v1.5.2-beta.3",
   "releaseNotes": "",
+  "tag": "v1.5.2-beta.3",
   "version": "1.5.2-beta.3",
 }
 `;
@@ -160,6 +161,7 @@ Object {
   ],
   "releaseName": "1.1.0",
   "releaseNotes": "",
+  "tag": "v1.1.0",
   "version": "1.1.0",
 }
 `;
@@ -174,6 +176,7 @@ Object {
   ],
   "releaseName": "1.1.0",
   "releaseNotes": "",
+  "tag": "v1.1.0",
   "version": "1.1.0",
 }
 `;
@@ -205,6 +208,7 @@ Object {
       "version": "1.5.0",
     },
   ],
+  "tag": "v1.5.2-beta.3",
   "version": "1.5.2-beta.3",
 }
 `;
@@ -228,6 +232,7 @@ Object {
       "version": "1.5.0",
     },
   ],
+  "tag": "v1.5.2-beta.3",
   "version": "1.5.2-beta.3",
 }
 `;
@@ -259,6 +264,7 @@ Object {
       "version": "1.5.0",
     },
   ],
+  "tag": "v1.5.2-beta.3",
   "version": "1.5.2-beta.3",
 }
 `;
@@ -418,6 +424,7 @@ Object {
   ],
   "releaseName": "1.1.0",
   "releaseNotes": "",
+  "tag": "v1.1.0",
   "version": "1.1.0",
 }
 `;


### PR DESCRIPTION
Modify the GitHubProvider to provide the tag name of the latest
release as apart of its UpdateInfo (which is now encapsulated in the
GithubUpdateInfo interface) so that it uses that same tag name later
when it resolves the files to download.

fix electron-userland/electron-builder/issues/6076