### PR TITLE
fix(electron-updater): arm64 updating issue with Github private repos as update server

### DIFF
--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -51,7 +51,7 @@ export class MacUpdater extends AppUpdater {
     }
 
     // allow arm64 macs to install universal or rosetta2(x64) - https://github.com/electron-userland/electron-builder/pull/5524
-    const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64")
+    const isArm64 = (file: ResolvedUpdateFileInfo) => (file.url.pathname.includes("arm64") || file.info.url?.includes("arm64"))
     if (files.some(isArm64)) {
       files = files.filter(file => (process.arch === "arm64" || isRosetta) === isArm64(file))
     }


### PR DESCRIPTION
When using a github private repo as update server, the `file.url.pathname` for an arm64 version does not actually include the `arm64` string, and instead it just looks like a github release artifact ID. Looking at `file.info.url`, which contains the actual name of the dmg, seems more robust.