### PR TITLE
fix: console log data is far too large

### DIFF
--- a/.changeset/honest-comics-switch.md
+++ b/.changeset/honest-comics-switch.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: removing data from error being thrown. It's unnecessary and also unnecessarily large to be passing to the console. Resolves: #6131

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -154,7 +154,7 @@ export class NsisUpdater extends BaseUpdater {
         try {
           return JSON.parse(gunzipSync(data).toString())
         } catch (e) {
-          throw new Error(`Cannot parse blockmap "${url.href}", error: ${e}, raw data: ${data}`)
+          throw new Error(`Cannot parse blockmap "${url.href}", error: ${e}`)
         }
       }
 


### PR DESCRIPTION
Removing `data` from error being thrown. It's unnecessary and also unnecessarily large to be passing to the console
Resolves: #6131