### PR TITLE
fix(electron-updater): `null` object error when MacUpdater logs server port before it is listening

### DIFF
--- a/.changeset/stale-carrots-listen.md
+++ b/.changeset/stale-carrots-listen.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix(electron-updater): `null` object error when MacUpdater attempts to log the server port before it is listening

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -80,16 +80,17 @@ export class MacUpdater extends AppUpdater {
     const logContext = `fileToProxy=${zipFileInfo.url.href}`
     this.debug(`Creating proxy server for native Squirrel.Mac (${logContext})`)
     const server = createServer()
+    this.debug(`Proxy server for native Squirrel.Mac is created (${logContext})`)
     server.on("close", () => {
       log.info(`Proxy server for native Squirrel.Mac is closed (${logContext})`)
     })
 
+    // must be called after server is listening, otherwise address is null
     function getServerUrl(): string {
       const address = server.address() as AddressInfo
       return `http://127.0.0.1:${address.port}`
     }
 
-    this.debug(`Proxy server for native Squirrel.Mac is created (address=${getServerUrl()}, ${logContext})`)
     return await new Promise<Array<string>>((resolve, reject) => {
       // insecure random is ok
       const fileUrl = `/${Date.now().toString(16)}-${Math.floor(Math.random() * 9999).toString(16)}.zip`
@@ -145,6 +146,7 @@ export class MacUpdater extends AppUpdater {
 
       this.debug(`Proxy server for native Squirrel.Mac is starting to listen (${logContext})`)
       server.listen(0, "127.0.0.1", () => {
+        this.debug(`Proxy server for native Squirrel.Mac is listening (address=${getServerUrl()}, ${logContext})`)
         this.nativeUpdater.setFeedURL({
           url: getServerUrl(),
           headers: { "Cache-Control": "no-cache" },


### PR DESCRIPTION
This PR addresses an issue where macOS updates fail due to a `null` object reference.

Node's HTTP server `address()` method returns `null` until the server is listening for connections. `electron-updater` 4.4.4 and 4.4.5 contain a bug where `MacUpdater` attempts to log the server port before it is listening, which causes an error.

To fix this while maintaining the completeness of the added logs, I removed the server address from the existing log event but otherwise kept it in place. When the server is listening, a new event is recorded that includes the server address.