### PR TITLE
fix: workaround vite replacing process.env in updater

### DIFF
--- a/.changeset/five-worms-work.md
+++ b/.changeset/five-worms-work.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix(electron-updater): workaround vite's process.env.\* replacement

--- a/packages/electron-updater/src/AppAdapter.ts
+++ b/packages/electron-updater/src/AppAdapter.ts
@@ -34,11 +34,11 @@ export function getAppCacheDir() {
   // https://github.com/electron/electron/issues/1404#issuecomment-194391247
   let result: string
   if (process.platform === "win32") {
-    result = process.env.LOCALAPPDATA || path.join(homedir, "AppData", "Local")
+    result = process.env["LOCALAPPDATA"] || path.join(homedir, "AppData", "Local")
   } else if (process.platform === "darwin") {
     result = path.join(homedir, "Library", "Application Support", "Caches")
   } else {
-    result = process.env.XDG_CACHE_HOME || path.join(homedir, ".cache")
+    result = process.env["XDG_CACHE_HOME"] || path.join(homedir, ".cache")
   }
   return result
 }

--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -16,8 +16,8 @@ export class AppImageUpdater extends BaseUpdater {
   }
 
   public isUpdaterActive(): boolean {
-    if (process.env.APPIMAGE == null) {
-      if (process.env.SNAP == null) {
+    if (process.env["APPIMAGE"] == null) {
+      if (process.env["SNAP"] == null) {
         this._logger.warn("APPIMAGE env is not defined, current application is not an AppImage")
       } else {
         this._logger.info("SNAP env is defined, updater is disabled")
@@ -36,7 +36,7 @@ export class AppImageUpdater extends BaseUpdater {
       fileInfo,
       downloadUpdateOptions,
       task: async (updateFile, downloadOptions) => {
-        const oldFile = process.env.APPIMAGE!
+        const oldFile = process.env["APPIMAGE"]!
         if (oldFile == null) {
           throw newError("APPIMAGE env is not defined", "ERR_UPDATER_OLD_FILE_NOT_FOUND")
         }
@@ -74,7 +74,7 @@ export class AppImageUpdater extends BaseUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const appImageFile = process.env.APPIMAGE!
+    const appImageFile = process.env["APPIMAGE"]!
     if (appImageFile == null) {
       throw newError("APPIMAGE env is not defined", "ERR_UPDATER_OLD_FILE_NOT_FOUND")
     }

--- a/packages/electron-updater/src/differentialDownloader/downloadPlanBuilder.ts
+++ b/packages/electron-updater/src/differentialDownloader/downloadPlanBuilder.ts
@@ -87,7 +87,7 @@ export function computeOperations(oldBlockMap: BlockMap, newBlockMap: BlockMap, 
   return operations
 }
 
-const isValidateOperationRange = process.env.DIFFERENTIAL_DOWNLOAD_PLAN_BUILDER_VALIDATE_RANGES === "true"
+const isValidateOperationRange = process.env["DIFFERENTIAL_DOWNLOAD_PLAN_BUILDER_VALIDATE_RANGES"] === "true"
 
 function validateAndAdd(operation: Operation, operations: Array<Operation>, checksum: string, index: number): void {
   if (isValidateOperationRange && operations.length !== 0) {

--- a/packages/electron-updater/src/providerFactory.ts
+++ b/packages/electron-updater/src/providerFactory.ts
@@ -30,7 +30,7 @@ export function createClient(data: PublishConfiguration | AllPublishOptions, upd
   switch (provider) {
     case "github": {
       const githubOptions = data as GithubOptions
-      const token = (githubOptions.private ? process.env.GH_TOKEN || process.env.GITHUB_TOKEN : null) || githubOptions.token
+      const token = (githubOptions.private ? process.env["GH_TOKEN"] || process.env["GITHUB_TOKEN"] : null) || githubOptions.token
       if (token == null) {
         return new GitHubProvider(githubOptions, updater, runtimeOptions)
       } else {

--- a/packages/electron-updater/src/providers/Provider.ts
+++ b/packages/electron-updater/src/providers/Provider.ts
@@ -28,7 +28,7 @@ export abstract class Provider<T extends UpdateInfo> {
 
   private getChannelFilePrefix(): string {
     if (this.runtimeOptions.platform === "linux") {
-      const arch = process.env.TEST_UPDATER_ARCH || process.arch
+      const arch = process.env["TEST_UPDATER_ARCH"] || process.arch
       const archSuffix = arch === "x64" ? "" : `-${arch}`
       return "-linux" + archSuffix
     } else {


### PR DESCRIPTION
Vite replaces process.env.* during builds. 
This leads to problems with the updater. 

A known workaround is to replace process.env.* with process.env["*"].

https://github.com/vitejs/vite/issues/3176