### PR TITLE
fix: replace deprecated --cache-min option

### DIFF
--- a/.changeset/honest-pandas-sneeze.md
+++ b/.changeset/honest-pandas-sneeze.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: replace deprecated `--cache-min` option and use `--prefer-offline`

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -100,7 +100,7 @@ function installDependencies(appDir: string, options: RebuildOptions): Promise<a
   }
 
   if (!isRunningYarn(execPath)) {
-    execArgs.push("--cache-min", "999999999")
+    execArgs.push("--prefer-offline")
   }
 
   if (execPath == null) {


### PR DESCRIPTION
Closes https://github.com/electron-userland/electron-builder/issues/6130

I found out on https://docs.npmjs.com/cli/v7/using-npm/config#cache-min that we can replace deprecated `--cache-min` with `--prefer-offline` to avoid pnpm install failure.

This is the commit where pnpm added support for `--prefer-offline`: https://github.com/pnpm/pnpm/commit/b553c5cfe07d2fe9c0f6f3f8003950b64ec6b5bb