### PR TITLE
chore: use github changelogs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.0/schema.json",
-  "changelog": "@changesets/changelog-git",
+  "changelog": ["@changesets/changelog-github", { "repo": "electron-userland/electron-builder" }],
   "commit": false,
   "linked": [[
     "app-builder-lib",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "7.14.5",
-    "@changesets/changelog-git": "0.1.7",
+    "@changesets/changelog-github": "^0.4.0",
     "@changesets/cli": "2.16.0",
     "@typescript-eslint/eslint-plugin": "4.28.5",
     "@typescript-eslint/parser": "4.28.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
   .:
     specifiers:
       '@babel/plugin-transform-modules-commonjs': 7.14.5
-      '@changesets/changelog-git': 0.1.7
+      '@changesets/changelog-github': ^0.4.0
       '@changesets/cli': 2.16.0
       '@typescript-eslint/eslint-plugin': 4.28.5
       '@typescript-eslint/parser': 4.28.5
@@ -31,7 +31,7 @@ importers:
       dmg-license: 1.0.9
     devDependencies:
       '@babel/plugin-transform-modules-commonjs': 7.14.5
-      '@changesets/changelog-git': 0.1.7
+      '@changesets/changelog-github': 0.4.0
       '@changesets/cli': 2.16.0
       '@typescript-eslint/eslint-plugin': 4.28.5_fb136327aebe99aff77fb6e94f9d56f0
       '@typescript-eslint/parser': 4.28.5_eslint@7.30.0+typescript@4.3.5
@@ -1808,10 +1808,12 @@ packages:
       semver: 5.7.1
     dev: true
 
-  /@changesets/changelog-git/0.1.7:
-    resolution: {integrity: sha512-fQbJpmCNp2od6w0aRFYoo+kUXnArLXimE84cS37cUGtkf0OWmNub45bDB1dx8v3UXoqPwBdQTuUVRBR6M64rDw==}
+  /@changesets/changelog-github/0.4.0:
+    resolution: {integrity: sha512-4GphTAdHJfECuuQg4l0eFGYyUh26mfyXpAi2FImrQvaN+boqTM+9EAAJe2b8Y3OKRfoET+ihgo+LARhW2xJoiw==}
     dependencies:
+      '@changesets/get-github-info': 0.5.0
       '@changesets/types': 4.0.0
+      dotenv: 8.6.0
     dev: true
 
   /@changesets/cli/2.16.0:
@@ -1876,6 +1878,13 @@ packages:
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 5.7.1
+    dev: true
+
+  /@changesets/get-github-info/0.5.0:
+    resolution: {integrity: sha512-vm5VgHwrxkMkUjFyn3UVNKLbDp9YMHd3vMf1IyJoa/7B+6VpqmtAaXyDS0zBLfN5bhzVCHrRnj4GcZXXcqrFTw==}
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.6.1
     dev: true
 
   /@changesets/get-release-plan/3.0.0:
@@ -4070,6 +4079,10 @@ packages:
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
 
+  /dataloader/1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+    dev: true
+
   /dateformat/3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
     dev: true
@@ -4323,6 +4336,11 @@ packages:
   /dotenv-expand/5.1.0:
     resolution: {integrity: sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==}
     dev: false
+
+  /dotenv/8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
+    dev: true
 
   /dotenv/9.0.2:
     resolution: {integrity: sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==}
@@ -6949,6 +6967,11 @@ packages:
   /node-addon-api/1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
     dev: false
+
+  /node-fetch/2.6.1:
+    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
+    engines: {node: 4.x || >=6.0.0}
+    dev: true
 
   /node-int64/0.4.0:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}


### PR DESCRIPTION
Migrating changesets to use changelog-github to add additional annotations to our releases
Example: https://github.com/atlassian/changesets/blob/main/packages/changelog-github/CHANGELOG.md