### PR TITLE
fix: (mac) Fix intel mac upgrade flow when both x64 and arm64 published

### DIFF
--- a/.changeset/lovely-coats-grow.md
+++ b/.changeset/lovely-coats-grow.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+Fix upgrade flows on intel mac when both x64 and arm64 versions published


### PR DESCRIPTION
On Intel macs, the error `No files provided` is thrown on the latest version of electron-updater (4.5.1) when the latest files include both arm64 and x64 builds.

The current filtering done when there are arm64 files available will return an empty array since there are arm64 files but we are not on a arm64 machine
https://github.com/electron-userland/electron-builder/blob/64fd696527e6f07cea7efc494d667276a9001430/packages/electron-updater/src/MacUpdater.ts#L55-L57

This change adjusts MacUpdater to filter the files to this criteria: 

- On an Intel Mac: Filter files to only include non-arm64 builds
- On an arm64 Mac: Filter files to only include arm64 builds
- If no arm64 builds are available: This will fallback to the condition to filter files to only include non-arm64 builds

**Steps to reproduce the bug:**
1. Install ` "electron-updater": "^4.5.1"`
2. Publish two versions of your app with both `x64` and `arm64` builds
```sh
electron-builder -p always --mac --x64 --arm64 
```
3. On an intel mac try to upgrade from the previous version to another

**Expected Behavior**
The files list is filtered down and the x64/intel build is selected for download

**Actual behavior**
No files are returned after filtering. The ` Error: No files provided` error is thrown