### PR TITLE
fix: update-desktop-database command not found

### DIFF
--- a/.changeset/angry-goats-hide.md
+++ b/.changeset/angry-goats-hide.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: update-desktop-database command not found

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -6,5 +6,10 @@ ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 # SUID chrome-sandbox for Electron 5+
 chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
 
-update-mime-database /usr/share/mime || true
-update-desktop-database /usr/share/applications || true
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications
+fi

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -6,9 +6,7 @@ ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 # SUID chrome-sandbox for Electron 5+
 chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
 
-if hash update-mime-database 2>/dev/null; then
-    update-mime-database /usr/share/mime
-fi
+update-mime-database /usr/share/mime || true
 
 if hash update-desktop-database 2>/dev/null; then
     update-desktop-database /usr/share/applications


### PR DESCRIPTION
```
/var/lib/dpkg/info/polong.postinst:行10: update-desktop-database：未找到命令
```

Debian 11 KDE can not execute `update-desktop-database`, check if a command exists. 

reference vscode /var/lib/dpkg/info/code.postinst
```
# Update mimetype database to pickup workspace mimetype
if hash update-mime-database 2>/dev/null; then
        update-mime-database /usr/share/mime
fi
```

Test under:
```
Operating System: Debian GNU/Linux 11
KDE Plasma Version: 5.20.5
KDE Frameworks Version: 5.78.0
Qt Version: 5.15.2
Kernel Version: 5.10.0-8-amd64
OS Type: 64-bit
```