### PR TITLE
docs: add tips for Debian and KDE

### DIFF
--- a/docs/generated/DebOptions.md
+++ b/docs/generated/DebOptions.md
@@ -1,5 +1,5 @@
 <ul>
-<li><code id="DebOptions-depends">depends</code> Array&lt;String&gt; | “undefined” - Package dependencies. Defaults to <code>[&quot;gconf2&quot;, &quot;gconf-service&quot;, &quot;libnotify4&quot;, &quot;libappindicator1&quot;, &quot;libxtst6&quot;, &quot;libnss3&quot;]</code>.</li>
+<li><code id="DebOptions-depends">depends</code> Array&lt;String&gt; | “undefined” - Package dependencies. Defaults to <code>[&quot;gconf2&quot;, &quot;gconf-service&quot;, &quot;libnotify4&quot;, &quot;libappindicator1&quot;, &quot;libxtst6&quot;, &quot;libnss3&quot;]</code>. If need to support Debian, <code>libappindicator1</code> should be removed, <a href="https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037">deprecated in Debian</a>. If need to support KDE, <code>gconf2</code> and <code>gconf-service</code> should be removed, <a href="https://packages.debian.org/bullseye/gconf2">for GNOME and no longer used by GNOME</a>.</li>
 <li><code id="DebOptions-packageCategory">packageCategory</code> String | “undefined” - The <a href="https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Section">package category</a>.</li>
 <li><code id="DebOptions-priority">priority</code> String | “undefined” - The <a href="https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Priority">Priority</a> attribute.</li>
 </ul>


### PR DESCRIPTION
* [libappindicator: deprecated in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037)
* `gconf2` and `gconf-service` useless for KDE, package is for legacy applications and no longer used by GNOME.

Test under:
```
Operating System: Debian GNU/Linux 11
KDE Plasma Version: 5.20.5
KDE Frameworks Version: 5.78.0
Qt Version: 5.15.2
Kernel Version: 5.10.0-8-amd64
OS Type: 64-bit
```