### PR TITLE
fix(msi): fix broken shortcut icon when using msi target

### DIFF
--- a/.changeset/tiny-dolls-smoke.md
+++ b/.changeset/tiny-dolls-smoke.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix (msi): broken shortcut icon for desktop and startup entry (#5965)

--- a/packages/app-builder-lib/src/options/MsiOptions.ts
+++ b/packages/app-builder-lib/src/options/MsiOptions.ts
@@ -23,4 +23,9 @@ export interface MsiOptions extends CommonWindowsInstallerConfiguration, TargetS
    * Any additional arguments to be passed to the WiX installer compiler, such as `["-ext", "WixUtilExtension"]`
    */
   readonly additionalWixArgs?: Array<string> | null
+
+  /**
+   * The [shortcut iconId](https://wixtoolset.org/documentation/manual/v4/reference/wxs/shortcut/). Optional, by default generated using app file name.
+   */
+  readonly iconId?: string
 }

--- a/packages/app-builder-lib/src/targets/MsiTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiTarget.ts
@@ -156,11 +156,13 @@ export default class MsiTarget extends Target {
     const compression = this.packager.compression
     const options = this.options
     const iconPath = await this.packager.getIconPath()
+    const iconId = `${appInfo.productFilename}Icon.exe`.replace(/\s/g, "")
     return (await projectTemplate.value)({
       ...commonOptions,
       isCreateDesktopShortcut: commonOptions.isCreateDesktopShortcut !== DesktopShortcutCreationPolicy.NEVER,
       isRunAfterFinish: options.runAfterFinish !== false,
       iconPath: iconPath == null ? null : this.vm.toVmFile(iconPath),
+      iconId: iconId,
       compressionLevel: compression === "store" ? "none" : "high",
       version: appInfo.getVersionInWeirdWindowsForm(),
       productName: appInfo.productName,
@@ -221,8 +223,9 @@ export default class MsiTarget extends Target {
       if (isMainExecutable && (isCreateDesktopShortcut || commonOptions.isCreateStartMenuShortcut)) {
         result += `>\n`
         const shortcutName = commonOptions.shortcutName
+        const iconId = `${appInfo.productFilename}Icon.exe`.replace(/\s/g, "")
         if (isCreateDesktopShortcut) {
-          result += `${fileSpace}  <Shortcut Id="desktopShortcut" Directory="DesktopFolder" Name="${shortcutName}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="icon.ico"/>\n`
+          result += `${fileSpace}  <Shortcut Id="desktopShortcut" Directory="DesktopFolder" Name="${shortcutName}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${iconId}"/>\n`
         }
 
         const hasMenuCategory = commonOptions.menuCategory != null
@@ -231,7 +234,7 @@ export default class MsiTarget extends Target {
           if (hasMenuCategory) {
             dirs.push(`<Directory Id="${startMenuShortcutDirectoryId}" Name="ProgramMenuFolder:\\${commonOptions.menuCategory}\\"/>`)
           }
-          result += `${fileSpace}  <Shortcut Id="startMenuShortcut" Directory="${startMenuShortcutDirectoryId}" Name="${shortcutName}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="icon.ico">\n`
+          result += `${fileSpace}  <Shortcut Id="startMenuShortcut" Directory="${startMenuShortcutDirectoryId}" Name="${shortcutName}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${iconId}">\n`
           result += `${fileSpace}    <ShortcutProperty Key="System.AppUserModel.ID" Value="${this.packager.appInfo.id}"/>\n`
           result += `${fileSpace}  </Shortcut>\n`
         }

--- a/packages/app-builder-lib/templates/msi/template.xml
+++ b/packages/app-builder-lib/templates/msi/template.xml
@@ -20,8 +20,8 @@
     <Property Id="WixAppFolder" Value="WixPerUserFolder"/>
 
     {{ if (iconPath) { }}
-    <Icon Id="icon.ico" SourceFile="${iconPath}"/>
-    <Property Id="ARPPRODUCTICON" Value="icon.ico"/>
+    <Icon Id="${iconId}" SourceFile="${iconPath}"/>
+    <Property Id="ARPPRODUCTICON" Value="${iconId}"/>
     {{ } -}}
 
     {{ if (isAssisted || isRunAfterFinish) { }}


### PR DESCRIPTION
fix (msi): broken shortcut icon (#5965)

Add MSI option "iconId", replaces old static "icon.ico" icon identifier.