### PR TITLE
fix(publish): Bitbucket publish can have username different from owner

### DIFF
--- a/.changeset/young-roses-sniff.md
+++ b/.changeset/young-roses-sniff.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Introduced env var to allow custom username for Bitbucket publish. This allows you to user a username different from the owner. No changes to interfaces or signatures that require changes in consumers.

--- a/packages/app-builder-lib/src/publish/BitbucketPublisher.ts
+++ b/packages/app-builder-lib/src/publish/BitbucketPublisher.ts
@@ -1,4 +1,4 @@
-import { Arch, InvalidConfigurationError, isEmptyOrSpaces } from "builder-util"
+import { Arch, InvalidConfigurationError, isEmptyOrSpaces, log } from "builder-util"
 import { httpExecutor } from "builder-util/out/nodeHttpExecutor"
 import { ClientRequest, RequestOptions } from "http"
 import { HttpPublisher, PublishContext } from "electron-publish"
@@ -6,6 +6,7 @@ import { BitbucketOptions } from "builder-util-runtime/out/publishOptions"
 import { configureRequestOptions, HttpExecutor } from "builder-util-runtime"
 import * as FormData from "form-data"
 import { readFile } from "fs/promises"
+
 export class BitbucketPublisher extends HttpPublisher {
   readonly providerName = "bitbucket"
   readonly hostname = "api.bitbucket.org"
@@ -23,8 +24,13 @@ export class BitbucketPublisher extends HttpPublisher {
     if (isEmptyOrSpaces(token)) {
       throw new InvalidConfigurationError(`Bitbucket token is not set using env "BITBUCKET_TOKEN" (see https://www.electron.build/configuration/publish#BitbucketOptions)`)
     }
+
+    if (isEmptyOrSpaces(username)) {
+      log.warn('No Bitbucket username provided via "BITBUCKET_USERNAME". Defaulting to use repo owner.')
+    }
+
     this.info = info
-    this.auth = BitbucketPublisher.convertAppPassword(this.info.owner, token, username)
+    this.auth = BitbucketPublisher.convertAppPassword(username ?? this.info.owner, token)
     this.basePath = `/2.0/repositories/${this.info.owner}/${this.info.slug}/downloads`
   }
 
@@ -62,8 +68,8 @@ export class BitbucketPublisher extends HttpPublisher {
     return `Bitbucket (owner: ${owner}, slug: ${slug}, channel: ${channel})`
   }
 
-  static convertAppPassword(owner: string, token: string, username?: string) {
-    const base64encodedData = Buffer.from(`${username ?? owner}:${token.trim()}`).toString("base64")
+  static convertAppPassword(username: string, token: string) {
+    const base64encodedData = Buffer.from(`${username}:${token.trim()}`).toString("base64")
     return `Basic ${base64encodedData}`
   }
 }

--- a/packages/app-builder-lib/src/publish/BitbucketPublisher.ts
+++ b/packages/app-builder-lib/src/publish/BitbucketPublisher.ts
@@ -18,11 +18,13 @@ export class BitbucketPublisher extends HttpPublisher {
     super(context)
 
     const token = process.env.BITBUCKET_TOKEN
+    const username = process.env.BITBUCKET_USERNAME
+
     if (isEmptyOrSpaces(token)) {
       throw new InvalidConfigurationError(`Bitbucket token is not set using env "BITBUCKET_TOKEN" (see https://www.electron.build/configuration/publish#BitbucketOptions)`)
     }
     this.info = info
-    this.auth = BitbucketPublisher.convertAppPassword(this.info.owner, token)
+    this.auth = BitbucketPublisher.convertAppPassword(this.info.owner, token, username)
     this.basePath = `/2.0/repositories/${this.info.owner}/${this.info.slug}/downloads`
   }
 
@@ -60,8 +62,8 @@ export class BitbucketPublisher extends HttpPublisher {
     return `Bitbucket (owner: ${owner}, slug: ${slug}, channel: ${channel})`
   }
 
-  static convertAppPassword(owner: string, token: string) {
-    const base64encodedData = Buffer.from(`${owner}:${token.trim()}`).toString("base64")
+  static convertAppPassword(owner: string, token: string, username?: string) {
+    const base64encodedData = Buffer.from(`${username ?? owner}:${token.trim()}`).toString("base64")
     return `Basic ${base64encodedData}`
   }
 }


### PR DESCRIPTION
The way BitbucketPublisher is written, you can't use it to publish to repositories if you are not the owner of them. The PR introduces a new environment variable that allows you to change the override the username if necessary.

Closes https://github.com/electron-userland/electron-builder/issues/6292