### PR TITLE
fix(electron-updater): auto-updates work with filename with whitespaces

### DIFF
--- a/.changeset/breezy-humans-notice.md
+++ b/.changeset/breezy-humans-notice.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+BitbucketProvider converts whitespaces in filenames to underscores as does Bitbucket itself when uploading files

--- a/packages/electron-updater/src/providers/BitbucketProvider.ts
+++ b/packages/electron-updater/src/providers/BitbucketProvider.ts
@@ -33,7 +33,10 @@ export class BitbucketProvider extends Provider<UpdateInfo> {
   }
 
   resolveFiles(updateInfo: UpdateInfo): Array<ResolvedUpdateFileInfo> {
-    return resolveFiles(updateInfo, this.baseUrl)
+    return resolveFiles(
+      { ...updateInfo, files: updateInfo.files?.map(f => ({ ...f, url: f.url.replaceAll(" ", "_") })), path: updateInfo.path?.replaceAll(" ", "_") },
+      this.baseUrl
+    )
   }
 
   toString() {


### PR DESCRIPTION
There was a bug that prevented the auto updater from working if you used Bitbucket and had a whitespace in the productName. The reason was that Bitbucket converts whitespaces into underscores when files are uploaded into the download section. However, in electron-updater whitespaces are escaped with %20, which leads to a 404.

I've added the Bitbucket style conversion into the BitbucketProvider so that auto-updates also work when using whitespaces in productNames.