### PR TITLE
docs fix) codeblock not working in auto-update.md

### DIFF
--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -32,11 +32,11 @@ All these targets are default, custom configuration is not required. (Though it 
 
 3. Use `autoUpdater` from `electron-updater` instead of `electron`:
 
-    ```js tab="JavaScript"
+    ```js
     const { autoUpdater } = require("electron-updater")
     ```
 
-    ```js tab="ES2015"
+    ```js
     import { autoUpdater } from "electron-updater"
     ```
 


### PR DESCRIPTION
It seems this part doesnt render properly (auto-update.md / [docs](https://www.electron.build/auto-update.html))

![image](https://user-images.githubusercontent.com/30289254/139803792-daabceb4-60bd-4c50-9e83-6356227f3cc3.png)


```markdown
    ```js tab="JavaScript"
    const { autoUpdater } = require("electron-updater")
    ```

    ```js tab="ES2015"
    import { autoUpdater } from "electron-updater"
    ```
```


So i removed tab="" attribute