### PR TITLE
fix(linux): mutually exclusive exec command args

### DIFF
--- a/.changeset/afraid-lizards-juggle.md
+++ b/.changeset/afraid-lizards-juggle.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(linux): If linux executableArgs already contains one of the mutually exclusive(%f / %u / %F / %U) code，don't append %U.

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -105,7 +105,11 @@ export class LinuxTargetHelper {
         exec += " "
         exec += executableArgs.join(" ")
       }
-      exec += " %U"
+      // https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
+      const execCodes = ['%f', '%u', '%F', '%U']
+      if (executableArgs == null || executableArgs.findIndex((arg) => execCodes.includes(arg)) === -1) {
+        exec += " %U"
+      }
     }
 
     const desktopMeta: any = {


### PR DESCRIPTION
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
If linux `executableArgs` already contains one of the mutually exclusive(%f / %u / %F / %U) code，don't append `%U`.