### PR TITLE
fix: quitAndInstall not working on macOS with autoInstallOnAppQuit=false

### DIFF
--- a/.changeset/olive-weeks-look.md
+++ b/.changeset/olive-weeks-look.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+Fix updating only on demand not working on macOS

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -176,18 +176,18 @@ export class MacUpdater extends AppUpdater {
       // update already fetched by Squirrel, it's ready to install
       this.nativeUpdater.quitAndInstall()
     } else {
+      // Quit and install as soon as Squirrel get the update
+      this.nativeUpdater.on("update-downloaded", () => {
+        this.nativeUpdater.quitAndInstall()
+      })
+
       if (!this.autoInstallOnAppQuit) {
         /**
          * If this was not `true` previously then MacUpdater.doDownloadUpdate()
          * would not actually initiate the downloading by electron's autoUpdater
          */
-        this.nativeUpdater.checkForUpdates();
+        this.nativeUpdater.checkForUpdates()
       }
-
-      // Quit and install as soon as Squirrel get the update
-      this.nativeUpdater.on("update-downloaded", () => {
-        this.nativeUpdater.quitAndInstall()
-      })
     }
   }
 }

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -176,7 +176,15 @@ export class MacUpdater extends AppUpdater {
       // update already fetched by Squirrel, it's ready to install
       this.nativeUpdater.quitAndInstall()
     } else {
-      // quit and install as soon as Squirrel get the update
+      if (!this.autoInstallOnAppQuit) {
+        /**
+         * If this was not `true` previously then MacUpdater.doDownloadUpdate()
+         * would not actually initiate the downloading by electron's autoUpdater
+         */
+        this.nativeUpdater.checkForUpdates();
+      }
+
+      // Quit and install as soon as Squirrel get the update
       this.nativeUpdater.on("update-downloaded", () => {
         this.nativeUpdater.quitAndInstall()
       })


### PR DESCRIPTION
- Would never call nativeUpdater.checkForUpdates() if not installing on
  quit. Thus neither squirrelDownloadedUpdate was true nor the
  nativeUpdater's event "update-downloaded" be emitted. Leading to
  nothing happening.

- This commit fixes it by calling the checkForUpdates() in
  MacUpdater.quitAndInstall() when necessary

Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #6389 