### PR TITLE
fix: Emit 'before-quit-for-update' when updating via novel means

### DIFF
--- a/.changeset/sixty-queens-tell.md
+++ b/.changeset/sixty-queens-tell.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+Emulate electron.autoUpdater's event lifecycle for AppImageUpdater

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -17,6 +17,8 @@ export abstract class BaseUpdater extends AppUpdater {
     const isInstalled = this.install(isSilent, isSilent ? isForceRunAfter : true)
     if (isInstalled) {
       setImmediate(() => {
+        // this event is normally emitted when calling quitAndInstall, this emulates that
+        require("electron").autoUpdater.emit("before-quit-for-update")
         this.app.quit()
       })
     } else {


### PR DESCRIPTION
Signed-off-by: Sebastian Malton <sebastian@malton.name>

fixes #6394 