### PR TITLE
refactor: update Bitbucket publisher

### DIFF
--- a/.changeset/spotty-clouds-invent.md
+++ b/.changeset/spotty-clouds-invent.md
@@ -1,0 +1,8 @@
+---
+"app-builder-lib": patch
+"builder-util-runtime": patch
+"builder-util": patch
+---
+
+refactor: update Bitbucket publisher to have optional config options for Token and Username (Bitbucket Private Repos)
+

--- a/packages/app-builder-lib/src/publish/BitbucketPublisher.ts
+++ b/packages/app-builder-lib/src/publish/BitbucketPublisher.ts
@@ -5,7 +5,7 @@ import { HttpPublisher, PublishContext } from "electron-publish"
 import { BitbucketOptions } from "builder-util-runtime/out/publishOptions"
 import { configureRequestOptions, HttpExecutor } from "builder-util-runtime"
 import * as FormData from "form-data"
-import { readFile } from "fs/promises"
+import { readFile } from "fs-extra"
 
 export class BitbucketPublisher extends HttpPublisher {
   readonly providerName = "bitbucket"
@@ -18,8 +18,8 @@ export class BitbucketPublisher extends HttpPublisher {
   constructor(context: PublishContext, info: BitbucketOptions) {
     super(context)
 
-    const token = process.env.BITBUCKET_TOKEN
-    const username = process.env.BITBUCKET_USERNAME
+    const token = info.token || process.env.BITBUCKET_TOKEN || null
+    const username = info.username || process.env.BITBUCKET_USERNAME || null
 
     if (isEmptyOrSpaces(token)) {
       throw new InvalidConfigurationError(`Bitbucket token is not set using env "BITBUCKET_TOKEN" (see https://www.electron.build/configuration/publish#BitbucketOptions)`)

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -214,6 +214,16 @@ export interface BitbucketOptions extends PublishConfiguration {
   readonly owner: string
 
   /**
+   * The access token to support auto-update from private bitbucket repositories.
+   */
+  readonly token?: string | null
+
+  /**
+   * The user name to support auto-update from private bitbucket repositories.
+   */
+  readonly username?: string | null
+
+  /**
    * Repository slug/name
    */
   readonly slug: string


### PR DESCRIPTION
- use fs-extra to support Node < v14
- update optional config options for Token and Username (Bitbucket Private Repos)