### PR TITLE
feat: make `--no-sandbox` optional for building with AppImage

### DIFF
--- a/.changeset/plenty-drinks-wash.md
+++ b/.changeset/plenty-drinks-wash.md
@@ -1,5 +1,0 @@
----
-"app-builder-lib": minor
----
-
-feat: make `--no-sandbox` optional for building with AppImage via optional usage of the `executableArgs` field

--- a/.changeset/plenty-drinks-wash.md
+++ b/.changeset/plenty-drinks-wash.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: make `--no-sandbox` optional for building with AppImage via optional usage of the `executableArgs` field

--- a/light-boxes-glow.md
+++ b/light-boxes-glow.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: Make `--no-sandbox` optional for building with AppImage by allowing usage of `executableArgs` as a manual override 

--- a/packages/app-builder-lib/src/targets/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppImageTarget.ts
@@ -20,7 +20,7 @@ export default class AppImageTarget extends Target {
     super("appImage")
 
     this.desktopEntry = new Lazy<string>(() =>
-      helper.computeDesktopEntry(this.options, "AppRun --no-sandbox %U", {
+      helper.computeDesktopEntry(this.options, `AppRun ${[...(this.options.executableArgs ?? ["--no-sandbox"]), "%U"].join(" ")}`, {
         "X-AppImage-Version": `${packager.appInfo.buildVersion}`,
       })
     )

--- a/packages/app-builder-lib/src/targets/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppImageTarget.ts
@@ -19,11 +19,12 @@ export default class AppImageTarget extends Target {
   constructor(ignored: string, private readonly packager: LinuxPackager, private readonly helper: LinuxTargetHelper, readonly outDir: string) {
     super("appImage")
 
-    this.desktopEntry = new Lazy<string>(() =>
-      helper.computeDesktopEntry(this.options, `AppRun ${[...(this.options.executableArgs ?? ["--no-sandbox"]), "%U"].join(" ")}`, {
+    this.desktopEntry = new Lazy<string>(() => {
+      const args = this.options.executableArgs?.join(" ") || "--no-sandbox";
+      helper.computeDesktopEntry(this.options, `AppRun ${args} %U`, {
         "X-AppImage-Version": `${packager.appInfo.buildVersion}`,
-      })
-    )
+      });
+    })
   }
 
   async build(appOutDir: string, arch: Arch): Promise<any> {

--- a/packages/app-builder-lib/src/targets/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppImageTarget.ts
@@ -21,7 +21,7 @@ export default class AppImageTarget extends Target {
 
     this.desktopEntry = new Lazy<string>(() => {
       const args = this.options.executableArgs?.join(" ") || "--no-sandbox";
-      helper.computeDesktopEntry(this.options, `AppRun ${args} %U`, {
+      return helper.computeDesktopEntry(this.options, `AppRun ${args} %U`, {
         "X-AppImage-Version": `${packager.appInfo.buildVersion}`,
       });
     })


### PR DESCRIPTION
I've noticed that `--no-sandbox` is hardcoded into the arguments list when building an `AppImage`. This seems to be a good default for many implementations, but doesn't work for all of them. Example being the Mattermost Desktop App (see this issue: https://github.com/mattermost/desktop/issues/1804)

I've created this PR in order to potentially add an override option for users to specify their own arguments when launching the AppImage, using the `executableArgs` field which doesn't appear to be used by the AppImage at this time.

Let me know if this change makes sense and if I can make any further edits to support this.