### PR TITLE
fix(app-builder-lib): channel alternation for github is not working

### DIFF
--- a/.changeset/channel-alternation-github.md
+++ b/.changeset/channel-alternation-github.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Enable channel alternation for github publishing provider.

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -525,7 +525,7 @@
       "additionalProperties": false,
       "properties": {
         "checksum": {
-          "default": "o+YZsXHp8LNihhuk7JsCDhdIgx0MKKK+1b3sGD+4zX5djZULe4/4QMcAsfQ+0r+a8FnwBt7BVBHkIkJHjKQ0sg==",
+          "default": "VKMiizYdmNdJOWpRGz4trl4lD++BvYP2irAXpMilheUP0pc93iKlWAoP843Vlraj8YG19CVn0j+dCo/hURz9+Q==",
           "type": [
             "null",
             "string"
@@ -1505,6 +1505,14 @@
       "additionalProperties": false,
       "description": "[GitHub](https://help.github.com/articles/about-releases/) options.\n\nGitHub [personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) is required. You can generate by going to [https://github.com/settings/tokens/new](https://github.com/settings/tokens/new). The access token should have the repo scope/permission.\nDefine `GH_TOKEN` environment variable.",
       "properties": {
+        "channel": {
+          "default": "latest",
+          "description": "The channel.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "host": {
           "default": "github.com",
           "description": "The host (including the port if need).",

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -116,6 +116,12 @@ export interface GithubOptions extends PublishConfiguration {
   readonly private?: boolean | null
 
   /**
+   * The channel.
+   * @default latest
+   */
+  readonly channel?: string | null
+
+  /**
    * The type of release. By default `draft` release will be created.
    *
    * Also you can set release type using environment variable. If `EP_DRAFT`is set to `true` — `draft`, if `EP_PRE_RELEASE`is set to `true` — `prerelease`.
@@ -193,7 +199,7 @@ export interface KeygenOptions extends PublishConfiguration {
  * Bitbucket options.
  * https://bitbucket.org/
  * Define `BITBUCKET_TOKEN` environment variable.
- * 
+ *
  * For converting an app password to a usable token, you can utilize this
 ```typescript
 convertAppPassword(owner: string, token: string) {
@@ -282,9 +288,9 @@ export interface BaseS3Options extends PublishConfiguration {
  * AWS credentials are required, please see [getting your credentials](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/getting-your-credentials.html).
  * Define `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` [environment variables](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html).
  * Or in the [~/.aws/credentials](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html).
- * 
+ *
  * Example configuration:
- * 
+ *
 ```json
 {
   "build":


### PR DESCRIPTION
After upgrading from v22.11.11 to v22.14.8 I can't alternate the channel file name anymore due to schema validation.