### PR TITLE
fix(nsis): Ignore other users processes

### DIFF
--- a/.changeset/few-elephants-rhyme.md
+++ b/.changeset/few-elephants-rhyme.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): Ignore other users processes when installing for only current user
+Closes #6104

--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -35,6 +35,16 @@
     !endif
 !macroend
 
+!macro FIND_PROCESS _FILE _ERR
+  !ifdef INSTALL_MODE_PER_ALL_USERS
+    ${nsProcess::FindProcess} "${_FILE}" ${_ERR}
+  !else
+    # find process owned by current user
+    nsExec::Exec `cmd /c tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq ${_FILE}" | find "${_FILE}"`
+    Pop ${_ERR}
+  !endif
+!macroend
+
 !macro _CHECK_APP_RUNNING
   ${GetProcessInfo} 0 $pid $1 $2 $3 $4
   ${if} $3 != "${APP_EXECUTABLE_FILENAME}"
@@ -43,7 +53,7 @@
       Sleep 300
     ${endIf}
 
-    ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+    !insertmacro FIND_PROCESS "${APP_EXECUTABLE_FILENAME}" $R0
     ${if} $R0 == 0
       ${if} ${isUpdated}
         # allow app to exit without explicit kill
@@ -58,7 +68,11 @@
       DetailPrint `Closing running "${PRODUCT_NAME}"...`
 
       # https://github.com/electron-userland/electron-builder/issues/2516#issuecomment-372009092
-      nsExec::Exec `taskkill /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
+      !ifdef INSTALL_MODE_PER_ALL_USERS
+        nsExec::Exec `taskkill /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"`
+      !else
+        nsExec::Exec `cmd /c taskkill /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid" /fi "USERNAME eq %USERNAME%"`
+      !endif
       # to ensure that files are not "in-use"
       Sleep 300
 
@@ -68,11 +82,17 @@
       loop:
         IntOp $R1 $R1 + 1
 
-        ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+        !insertmacro FIND_PROCESS "${APP_EXECUTABLE_FILENAME}" $R0
         ${if} $R0 == 0
           # wait to give a chance to exit gracefully
           Sleep 1000
-          nsExec::Exec `taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"` $R0
+          !ifdef INSTALL_MODE_PER_ALL_USERS
+            nsExec::Exec `taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"`
+            Pop $R0
+          !else
+            nsExec::Exec `cmd /c taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid" /fi "USERNAME eq %USERNAME%"`
+            Pop $R0
+          !endif
           ${If} $R0 != 0
             DetailPrint `Waiting for "${PRODUCT_NAME}" to close (taskkill exit code $R0).`
             Sleep 2000

--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -88,13 +88,12 @@
           Sleep 1000
           !ifdef INSTALL_MODE_PER_ALL_USERS
             nsExec::Exec `taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid"`
-            Pop $R0
           !else
             nsExec::Exec `cmd /c taskkill /f /im "${APP_EXECUTABLE_FILENAME}" /fi "PID ne $pid" /fi "USERNAME eq %USERNAME%"`
-            Pop $R0
           !endif
-          ${If} $R0 != 0
-            DetailPrint `Waiting for "${PRODUCT_NAME}" to close (taskkill exit code $R0).`
+          !insertmacro FIND_PROCESS "${APP_EXECUTABLE_FILENAME}" $R0
+          ${If} $R0 == 0
+            DetailPrint `Waiting for "${PRODUCT_NAME}" to close.`
             Sleep 2000
           ${else}
             Goto not_running


### PR DESCRIPTION
Only find and kill processes owned by current user on per-user install.

Closes #6104