### PR TITLE
feat(updater): Add Channel Support for Github with PreRelease

### DIFF
--- a/.changeset/github-channel-support.md
+++ b/.changeset/github-channel-support.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+feat(updater): Add Channel Support for Github with PreRelease

--- a/.changeset/github-channel-support.md
+++ b/.changeset/github-channel-support.md
@@ -1,5 +1,5 @@
 ---
-"electron-updater": patch
+"electron-updater": minor
 ---
 
 feat(updater): Add Channel Support for Github with PreRelease

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -109,7 +109,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
 
     let rawData: string
     let channelFile: string = ''
-    let channelFileUrl: string = ''
+    let channelFileUrl: any = ''
     const fetchData = async (channelName: string) => {
       channelFile = getChannelFilename(channelName)
       channelFileUrl = newUrlFromBase(this.getBaseDownloadPath(String(tag), channelFile), this.baseUrl)

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -73,7 +73,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
           
 
           const shouldFetchVersion = !currentChannel || ['alpha', 'beta'].includes(currentChannel)
-          const isCustomChannel = !['alpha', 'beta'].includes(hrefChannel)
+          const isCustomChannel = !['alpha', 'beta'].includes(String(hrefChannel))
           // Allow moving from alpha to beta but not down
           const channelMismatch = currentChannel === 'beta' && hrefChannel === 'alpha'
           

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -105,7 +105,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
     }
 
     let rawData: string
-    let channelFile: string = ""
+    let channelFile = ""
     let channelFileUrl: any = ""
     const fetchData = async (channelName: string) => {
       channelFile = getChannelFilename(channelName)

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -57,35 +57,33 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
     let tag: string | null = null
     try {
       if (this.updater.allowPrerelease) {
-        const currentChannel = this.updater?.channel || String(semver.prerelease(this.updater.currentVersion)?.[0]) ||  null
+        const currentChannel = this.updater?.channel || String(semver.prerelease(this.updater.currentVersion)?.[0]) || null
         for (const element of feed.getElements("entry")) {
           // noinspection TypeScriptValidateJSTypes
           const hrefElement = hrefRegExp.exec(element.element("link").attribute("href"))!
 
           // If this is null then something is wrong and skip this release
-          if (hrefElement === null)
-            continue
+          if (hrefElement === null) continue
 
           // This Release's Tag
           const hrefTag = hrefElement[1]
           //Get Channel from this release's tag
-          const hrefChannel = semver.prerelease(hrefTag)?.[0] || null 
-          
+          const hrefChannel = semver.prerelease(hrefTag)?.[0] || null
 
-          const shouldFetchVersion = !currentChannel || ['alpha', 'beta'].includes(currentChannel)
-          const isCustomChannel = !['alpha', 'beta'].includes(String(hrefChannel))
+          const shouldFetchVersion = !currentChannel || ["alpha", "beta"].includes(currentChannel)
+          const isCustomChannel = !["alpha", "beta"].includes(String(hrefChannel))
           // Allow moving from alpha to beta but not down
-          const channelMismatch = currentChannel === 'beta' && hrefChannel === 'alpha'
-          
+          const channelMismatch = currentChannel === "beta" && hrefChannel === "alpha"
+
           if (shouldFetchVersion && !isCustomChannel && !channelMismatch) {
-             tag = hrefTag
-             break
+            tag = hrefTag
+            break
           }
 
           const isNextPreRelease = hrefChannel && hrefChannel === currentChannel
           if (isNextPreRelease) {
-             tag = hrefTag
-             break
+            tag = hrefTag
+            break
           }
         }
       } else {
@@ -106,36 +104,34 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
       throw newError(`No published versions on GitHub`, "ERR_UPDATER_NO_PUBLISHED_VERSIONS")
     }
 
-
     let rawData: string
-    let channelFile: string = ''
-    let channelFileUrl: any = ''
+    let channelFile: string = ""
+    let channelFileUrl: any = ""
     const fetchData = async (channelName: string) => {
       channelFile = getChannelFilename(channelName)
       channelFileUrl = newUrlFromBase(this.getBaseDownloadPath(String(tag), channelFile), this.baseUrl)
       const requestOptions = this.createRequestOptions(channelFileUrl)
       try {
-          return (await this.executor.request(requestOptions, cancellationToken))!
+        return (await this.executor.request(requestOptions, cancellationToken))!
       } catch (e) {
-          if (e instanceof HttpError && e.statusCode === 404) {
-              throw newError(`Cannot find ${channelFile} in the latest release artifacts (${channelFileUrl}): ${e.stack || e.message}`, "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND")
-          }
-          throw e
+        if (e instanceof HttpError && e.statusCode === 404) {
+          throw newError(`Cannot find ${channelFile} in the latest release artifacts (${channelFileUrl}): ${e.stack || e.message}`, "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND")
+        }
+        throw e
       }
-  }
-  
-  try {
-      const channel = this.updater.allowPrerelease ? this.getCustomChannelName(String(semver.prerelease(tag)?.[0] || 'latest')) : this.getDefaultChannelName()
-      rawData = await fetchData(channel)
-  } catch (e) {
-      if (this.updater.allowPrerelease) {
-          // Allow fallback to `latest.yml`
-          rawData = await fetchData(this.getDefaultChannelName())
-      } else {
-          throw e
-      }
-  }
+    }
 
+    try {
+      const channel = this.updater.allowPrerelease ? this.getCustomChannelName(String(semver.prerelease(tag)?.[0] || "latest")) : this.getDefaultChannelName()
+      rawData = await fetchData(channel)
+    } catch (e) {
+      if (this.updater.allowPrerelease) {
+        // Allow fallback to `latest.yml`
+        rawData = await fetchData(this.getDefaultChannelName())
+      } else {
+        throw e
+      }
+    }
 
     const result = parseUpdateInfo(rawData, channelFile, channelFileUrl)
     if (result.releaseName == null) {

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -54,10 +54,10 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
     const feed = parseXml(feedXml)
     // noinspection TypeScriptValidateJSTypes
     let latestRelease = feed.element("entry", false, `No published versions on GitHub`)
-    let tag: string | null
+    let tag: string | null = null
     try {
       if (this.updater.allowPrerelease) {
-        const currentChannel = this.updater?.channel || this.updater.currentVersion.prerelease?.[0] ||  null;
+        const currentChannel = this.updater?.channel || String(semver.prerelease(this.updater.currentVersion)?.[0]) ||  null;
         for (const element of feed.getElements("entry")) {
           // noinspection TypeScriptValidateJSTypes
           const hrefElement = hrefRegExp.exec(element.element("link").attribute("href"))!
@@ -106,7 +106,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
       throw newError(`No published versions on GitHub`, "ERR_UPDATER_NO_PUBLISHED_VERSIONS")
     }
 
-    const channelFile = getChannelFilename(this.updater.allowPrerelease ? this.getCustomChannelName(semver.prerelease(tag)?.[0] || 'latest') : this.getDefaultChannelName())
+    const channelFile = getChannelFilename(this.updater.allowPrerelease ? this.getCustomChannelName(String(semver.prerelease(tag)?.[0]) || 'latest') : this.getDefaultChannelName())
     const channelFileUrl = newUrlFromBase(this.getBaseDownloadPath(tag, channelFile), this.baseUrl)
     const requestOptions = this.createRequestOptions(channelFileUrl)
     let rawData: string

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -31,7 +31,7 @@ export abstract class BaseGitHubProvider<T extends UpdateInfo> extends Provider<
   protected computeGithubBasePath(result: string): string {
     // https://github.com/electron-userland/electron-builder/issues/1903#issuecomment-320881211
     const host = this.options.host
-    return host != null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result
+    return host !== null && host !== "github.com" && host !== "api.github.com" ? `/api/v3${result}` : result
   }
 }
 
@@ -63,24 +63,28 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
           const hrefElement = hrefRegExp.exec(element.element("link").attribute("href"))!
 
           // If this is null then something is wrong and skip this release
-          if (hrefElement == null) continue
+          if (hrefElement === null)
+            continue
 
           //Get Channel from this release
           const hrefChannel = semver.prerelease(hrefElement[1])?.[0] || null ;
 
           //If no channel is set by the current version, then grab latest (including prerelease)
-          if (currentChannel == null || currentChannel == 'alpha' || currentChannel == 'beta'){
+          if (currentChannel === null || currentChannel === 'alpha' || currentChannel === 'beta'){
             // Skip any "custom" channels
-            if (hrefChannel != null && hrefChannel !== 'alpha' && hrefChannel !== 'beta') continue
+            if (hrefChannel != null && hrefChannel !== 'alpha' && hrefChannel !== 'beta')
+              continue
             // Skip alphas if in Beta Channel
-            if (currentChannel == 'beta' && hrefChannel == 'alpha') continue
+            if (currentChannel === 'beta' && hrefChannel === 'alpha')
+              continue
             // Get tag
             tag = hrefChannel
             break
           }
 
           // Skip Production release
-          if (hrefChannel == null) continue
+          if (hrefChannel === null)
+            continue
 
           // Get next release in the same channel
           if (hrefChannel === currentChannel) {
@@ -106,7 +110,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
       throw newError(`No published versions on GitHub`, "ERR_UPDATER_NO_PUBLISHED_VERSIONS")
     }
 
-    const channelFile = getChannelFilename(this.updater.allowPrerelease ? this.getCustomChannelName(String(semver.prerelease(tag)?.[0]) || 'latest') : this.getDefaultChannelName())
+    const channelFile = getChannelFilename(this.updater.allowPrerelease ? this.getCustomChannelName(String(semver.prerelease(tag)?.[0] || 'latest')) : this.getDefaultChannelName())
     const channelFileUrl = newUrlFromBase(this.getBaseDownloadPath(tag, channelFile), this.baseUrl)
     const requestOptions = this.createRequestOptions(channelFileUrl)
     let rawData: string

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -66,7 +66,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
           if (hrefElement == null) continue
 
           //Get Channel from this release
-          const hrefChannel = semver.prerelease(hrefElement[1])?.[0]
+          const hrefChannel = semver.prerelease(hrefElement[1])?.[0] || null ;
 
           //If no channel is set by the current version, then grab latest (including prerelease)
           if (currentChannel == null || currentChannel == 'alpha' || currentChannel == 'beta'){
@@ -75,7 +75,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
             // Skip alphas if in Beta Channel
             if (currentChannel == 'beta' && hrefChannel == 'alpha') continue
             // Get tag
-            tag = element
+            tag = hrefChannel
             break
           }
 
@@ -84,7 +84,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
 
           // Get next release in the same channel
           if (hrefChannel === currentChannel) {
-            tag = element
+            tag = hrefChannel
             break
           }
         }


### PR DESCRIPTION
Allows for apps to run updates using provided channel track.
This only works if `options.allowPreRelease` is true.

If Channel is set in the updater, then latest will return the latest release that satisfies the logic in the [builder docs](https://www.electron.build/tutorials/release-using-channels.html#your-application)

If Channel is NOT set but prerelease is set, then latest will return the latest release.

technically this also supports custom channels, but if you run one of those you will never be able to return to the Latest track. 

I have marked this as a PR Draft as I would like to get discussion to make sure my logic is correct as well as this being my first contribution to this repo.

Tag:
#1722
#4988