### PR TITLE
fix(msi): MSI fails to install when deployed machine-wide via GPO

### DIFF
--- a/.changeset/healthy-peaches-deliver.md
+++ b/.changeset/healthy-peaches-deliver.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(msi): MSI fails to install when deployed machine-wide via GPO

--- a/packages/app-builder-lib/templates/msi/template.xml
+++ b/packages/app-builder-lib/templates/msi/template.xml
@@ -18,6 +18,7 @@
 
     <Property Id="ApplicationFolderName" Value="${installationDirectoryWixName}"/>
     <Property Id="WixAppFolder" Value="WixPerUserFolder"/>
+    <Property Id="DISABLEADVTSHORTCUTS" Value="1"/>
 
     {{ if (iconPath) { }}
     <Icon Id="${iconId}" SourceFile="${iconPath}"/>


### PR DESCRIPTION
Disable advertised shortcuts, since MSIs with advertised Start Menu shortcuts that have a
Shortcut Property fail to install when deployed machine-wide via GPO, but work fine in all
other contexts. This might be a bug in Windows, or a misdiagnosis; see #6508 for more details.

Closes #6508
BREAKING CHANGE: Admins using advertisement must apply an MST to re-enable it. See #6508.