### PR TITLE
fix: specify protocol as https to complete proxy support fix

### DIFF
--- a/.changeset/shiny-kangaroos-juggle.md
+++ b/.changeset/shiny-kangaroos-juggle.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: Explicitly set the protocol to https on the request objects to allow publishing to work from behind a proxy server when the https_proxy environment variable is set.

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -182,6 +182,7 @@ export class GitHubPublisher extends HttpPublisher {
       .doApiRequest(
         configureRequestOptions(
           {
+            protocol: "https:",
             hostname: parsedUrl.hostname,
             path: parsedUrl.path,
             method: "POST",
@@ -263,6 +264,7 @@ export class GitHubPublisher extends HttpPublisher {
       httpExecutor.request(
         configureRequestOptions(
           {
+            protocol: "https:",
             hostname: baseUrl.hostname,
             port: baseUrl.port as any,
             path: this.info.host != null && this.info.host !== "github.com" ? `/api/v3${path.startsWith("/") ? path : `/${path}`}` : path,

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -182,7 +182,7 @@ export class GitHubPublisher extends HttpPublisher {
       .doApiRequest(
         configureRequestOptions(
           {
-            protocol: "https:",
+            protocol: parsedUrl.protocol,
             hostname: parsedUrl.hostname,
             path: parsedUrl.path,
             method: "POST",
@@ -264,7 +264,7 @@ export class GitHubPublisher extends HttpPublisher {
       httpExecutor.request(
         configureRequestOptions(
           {
-            protocol: "https:",
+            protocol: baseUrl.protocol,
             hostname: baseUrl.hostname,
             port: baseUrl.port as any,
             path: this.info.host != null && this.info.host !== "github.com" ? `/api/v3${path.startsWith("/") ? path : `/${path}`}` : path,


### PR DESCRIPTION
Explicitly set the protocol to https on the request objects to allow publishing to work from behind a proxy server when the https_proxy environment variable is set.

Closes #6286