### PR TITLE
fix: optimize macCodeSign

### DIFF
--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -67,7 +67,7 @@ export async function reportError(
   if (qualifier == null) {
     logFields.reason = ""
     if (isAutoDiscoveryCodeSignIdentity()) {
-      logFields.reason += `cannot find valid "${certificateTypes.join(", ")}" identity${isMas ? "" : ` or custom non-Apple code signing certificate`}`
+      logFields.reason += `cannot find valid "${certificateTypes.join(", ")}" identity${isMas ? "" : ` or custom non-Apple code signing certificate, it could cause some undefined behaviour, e.g. macOS localized description not visible`}`
     }
     logFields.reason += ", see https://electron.build/code-signing"
     if (!isAutoDiscoveryCodeSignIdentity()) {


### PR DESCRIPTION
In the M1 macOS laptop, If you skip code signing, it will cause your bundled macOS app not to work as behavior.
1. Localization description will not visible in the request permission action.
2. The request permission grant notify will trigger multiple times
I suggest that we can have an indicator description to guide our developer to know this case.