### PR TITLE
feat(msi): add fileAssociation support for MSI target

### DIFF
--- a/.changeset/giant-dryers-beg.md
+++ b/.changeset/giant-dryers-beg.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat(msi): add fileAssociation support for MSI target

--- a/.changeset/serious-peas-help.md
+++ b/.changeset/serious-peas-help.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": major
+---
+
+BREAKING CHANGE: remove MSI option `iconId`

--- a/packages/app-builder-lib/src/options/FileAssociation.ts
+++ b/packages/app-builder-lib/src/options/FileAssociation.ts
@@ -1,9 +1,9 @@
 /**
  * File associations.
  *
- * macOS (corresponds to [CFBundleDocumentTypes](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-101685)) and NSIS only.
+ * macOS (corresponds to [CFBundleDocumentTypes](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-101685)), NSIS, and MSI only.
  *
- * On Windows works only if [nsis.perMachine](https://electron.build/configuration/configuration#NsisOptions-perMachine) is set to `true`.
+ * On Windows (NSIS) works only if [nsis.perMachine](https://electron.build/configuration/configuration#NsisOptions-perMachine) is set to `true`.
  */
 export interface FileAssociation {
   /**
@@ -29,7 +29,7 @@ export interface FileAssociation {
   /**
    * The path to icon (`.icns` for MacOS and `.ico` for Windows), relative to `build` (build resources directory). Defaults to `${firstExt}.icns`/`${firstExt}.ico` (if several extensions specified, first is used) or to application icon.
    *
-   * Not supported on Linux, file issue if need (default icon will be `x-office-document`).
+   * Not supported on Linux, file issue if need (default icon will be `x-office-document`). Not supported on MSI.
    */
   readonly icon?: string | null
 

--- a/packages/app-builder-lib/src/options/MsiOptions.ts
+++ b/packages/app-builder-lib/src/options/MsiOptions.ts
@@ -23,9 +23,4 @@ export interface MsiOptions extends CommonWindowsInstallerConfiguration, TargetS
    * Any additional arguments to be passed to the WiX installer compiler, such as `["-ext", "WixUtilExtension"]`
    */
   readonly additionalWixArgs?: Array<string> | null
-
-  /**
-   * The [shortcut iconId](https://wixtoolset.org/documentation/manual/v4/reference/wxs/shortcut/). Optional, by default generated using app file name.
-   */
-  readonly iconId?: string
 }

--- a/packages/app-builder-lib/src/targets/MsiTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiTarget.ts
@@ -46,11 +46,15 @@ export default class MsiTarget extends Target {
    */
   private get productMsiIdPrefix() {
     const sanitizedId = this.packager.appInfo.productFilename.replace(/[^\w.]/g, "").replace(/^[^A-Za-z_]+/, "")
-    return sanitizedId.length > 0 ? sanitizedId : "ElectronApp"
+    return sanitizedId.length > 0 ? sanitizedId : "App" + this.upgradeCode.replace(/-/g, "")
   }
 
   private get iconId() {
-    return this.options.iconId ?? `${this.productMsiIdPrefix}Icon.exe`
+    return `${this.productMsiIdPrefix}Icon.exe`
+  }
+
+  private get upgradeCode(): string {
+    return (this.options.upgradeCode || UUID.v5(this.packager.appInfo.id, ELECTRON_BUILDER_UPGRADE_CODE_NS_UUID)).toUpperCase()
   }
 
   async build(appOutDir: string, arch: Arch) {
@@ -178,7 +182,7 @@ export default class MsiTarget extends Target {
       compressionLevel: compression === "store" ? "none" : "high",
       version: appInfo.getVersionInWeirdWindowsForm(),
       productName: appInfo.productName,
-      upgradeCode: (options.upgradeCode || UUID.v5(appInfo.id, ELECTRON_BUILDER_UPGRADE_CODE_NS_UUID)).toUpperCase(),
+      upgradeCode: this.upgradeCode,
       manufacturer: companyName || appInfo.productName,
       appDescription: appInfo.description,
       // https://stackoverflow.com/questions/1929038/compilation-error-ice80-the-64bitcomponent-uses-32bitdirectory


### PR DESCRIPTION
Also fix iconId sometimes containing invalid characters, and iconId config option being ignored (was added in #6247, but it doesn't seem to have been used).

Marking this as a draft and targeting [v23.0.0-alpha](https://github.com/electron-userland/electron-builder/tree/v23.0.0-alpha) because I think there's some more related changes that should be made:
- I'm not sure why the iconId config option was added, and I think it should be removed. I don't see why anyone would want to manually configure it when we should be able to generate it ourselves. Even if the product name contains all invalid-for-MSI-Id characters, we could still generate a valid unique Id somehow (base64, seeded RNG, whatever).
  - Even if we _do_ want to keep the option to manually configure it, it's now too specific – we also need a product-specific Id prefix for ProgId Ids with this PR, and possibly others in the future.
- I didn't support FileAssociation.icon yet, but I'd be willing to if someone wants to lend a hand. The WiX side should be easy (add more [Icon](https://github.com/aplum/electron-builder/blob/4090ab62f16f05c5aa2bf7b2491415efd4594158/packages/app-builder-lib/templates/msi/template.xml#L23) elements as needed, reference their Ids [here](https://github.com/aplum/electron-builder/blob/4090ab62f16f05c5aa2bf7b2491415efd4594158/packages/app-builder-lib/src/targets/MsiTarget.ts#L266)), but I can't justify the time to figure out getting/converting the icon file since I don't need this feature at my job.

Also, I didn't use the FileAssociation.name config. I'm not sure what the expected values look like here, but the given example ("PNG") doesn't match up with the recommended format where it's used in [NsisTarget](https://github.com/electron-userland/electron-builder/blob/82ce942069dd54094951f6db890d335366048d4f/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts#L685) – in the [docs](https://nsis.sourceforge.io/FileAssoc) the example value is "myapp.textfile", which matches the format used in WiX [ProgId Id examples](https://www.firegiant.com/wix/tutorial/getting-started/beyond-files/). So in NSIS it looks like we should generate that value ourselves, as done in MSI ProgId here. Furthermore, on [Mac targets](https://github.com/electron-userland/electron-builder/blob/96d7813362d319c3141d78e179c3f6d71c798fab/packages/app-builder-lib/src/electron/electronMac.ts#L203) `name` is used for CFBundleTypeName, which I'm not familiar with but [this example](https://developer.apple.com/library/archive/qa/qa1959/_index.html) uses "Adobe PDF" and iMovie.app on my Mac uses values like "Color Preset"… so I'm thinking maybe the `name` and `description` options should be merged?

Closes #3694, #6488