### PR TITLE
fix: Stub CircleCI config since we can't disable it from dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:14.17@sha256:b1c0b133fc872314dee5b24e34084693f0747850aad6ac0181b70061e198375f
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - install-dep-cache-{{ checksum "pnpm-lock.yaml" }}
+      - restore_cache:
+          keys:
+            - v-11.0.0-electron
+      - run:
+          command: npm i --prefix=$HOME/.local -g pnpm
+      - run:
+          command: pnpm install --frozen-lockfile
+      - run:
+          command: pnpm compile
+      - save_cache:
+          key: install-dep-cache-{{ checksum "pnpm-lock.yaml" }}
+          paths:
+            - node_modules
+      - run:
+          command: node ./test/out/helpers/downloadElectron.js
+      - save_cache:
+          key: v-11.0.0-electron
+          paths:
+            - ~/.cache/electron
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore:
+                - docs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,6 @@ name: Test
 on:
   push:
   pull_request:
-    branches:
-      - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,6 @@ jobs:
       - name: Determine if Dockerfiles changed
         id: changed-files
         uses: tj-actions/changed-files@v13
-        with:
-          since_last_remote_commit: "true"
 
       - name: Dockerfile has changed, rebuild for tests
         if: ${{ github.event.inputs.build-docker-locally == 'true' }} || contains(steps.changed-files.outputs.all_changed_files, 'Dockerfile') || contains(steps.changed-files.outputs.all_changed_files, 'docker')


### PR DESCRIPTION
Stubbing circleci build to report a green status since we can't turn off the CircleCI build job.