### PR TITLE
fix(NSIS): prevent partial overwrites

### DIFF
--- a/.changeset/nervous-cherries-speak.md
+++ b/.changeset/nervous-cherries-speak.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): Prevent partial updates from happening


### PR DESCRIPTION
`Nsis7z::Extract` ignores the errors when copying the files and thus can
leave us with the app that has old asar and bindings, but new assets. In
addition to that, the app will firmly believe that it is still running
an old version and would attempt to repeatedly auto-update until fixed,
leading to excessive bandwidth use and very unhappy customers.

This change extracts the contents of 7z archive into a separate
directory before attempting to copy them with `CopyFiles` function that
(unlike `Nsis7z::Extract`) does detect and report failures. To make our
lives easier the `CopyFiles` will also erase all files on a failure so
after retrying a few times we will ultimately have to fallback to old 7z
extraction directly into output folder.

### Testing

The easiest way to trigger the failure is to:

1. Go to the application folder
2. Copy exe file to `tmp.exe`
3. Start `tmp.exe` (thus locking the asar, bindings, and dlls)
4. Try to install over with freshly built installer