### PR TITLE
fix(nsis): use atomic rmdir on update

### DIFF
--- a/.changeset/chilly-trains-study.md
+++ b/.changeset/chilly-trains-study.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): use revertible rmdir on update

--- a/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
@@ -126,7 +126,10 @@ Function handleUninstallResult
   Return
 
   ${if} $R0 != 0
+    MessageBox MB_OK|MB_ICONEXCLAMATION "$(uninstallFailed): $R0"
     DetailPrint `Uninstall was not successful. Uninstaller error code: $R0.`
+    SetErrorLevel 2
+    Quit
   ${endif}
 FunctionEnd
 

--- a/packages/app-builder-lib/templates/nsis/messages.yml
+++ b/packages/app-builder-lib/templates/nsis/messages.yml
@@ -144,3 +144,5 @@ areYouSureToUninstall:
   da: Er du sikker på, at du vil afinstallere ${PRODUCT_NAME}?
 decompressionFailed:
   en: Failed to decompress files. Please try running the installer again.
+uninstallFailed:
+  en: Failed to uninstall old application files. Please try running the installer again.

--- a/packages/app-builder-lib/templates/nsis/uninstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/uninstaller.nsh
@@ -28,6 +28,109 @@ Function un.onInit
   !endif
 FunctionEnd
 
+Function un.atomicRMDir
+  Exch $R0
+  Push $R1
+  Push $R2
+  Push $R3
+
+  StrCpy $R3 "$INSTDIR$R0\*.*"
+  FindFirst $R1 $R2 $R3
+
+  loop:
+    StrCmp $R2 "" break
+
+    StrCmp $R2 "." continue
+    StrCmp $R2 ".." continue
+
+    IfFileExists "$INSTDIR$R0\$R2\*.*" isDir isNotDir
+
+    isDir:
+      CreateDirectory "$PLUGINSDIR\old-install$R0\$R2"
+
+      Push "$R0\$R2"
+      Call un.atomicRMDir
+      Pop $R3
+
+      ${if} $R3 != 0
+        Goto done
+      ${endIf}
+
+      Goto continue
+
+    isNotDir:
+      ClearErrors
+      Rename "$INSTDIR$R0\$R2" "$PLUGINSDIR\old-install$R0\$R2"
+
+      # Ignore errors when renaming ourselves.
+      StrCmp "$R0\$R2" "${UNINSTALL_FILENAME}" 0 +2
+      ClearErrors
+
+      IfErrors 0 +3
+      StrCpy $R3 "$INSTDIR$R0\$R2"
+      Goto done
+
+    continue:
+      FindNext $R1 $R2
+      Goto loop
+
+  break:
+    StrCpy $R3 0
+
+  done:
+    FindClose $R1
+
+    StrCpy $R0 $R3
+
+    Pop $R3
+    Pop $R2
+    Pop $R1
+    Exch $R0
+FunctionEnd
+
+Function un.restoreFiles
+  Exch $R0
+  Push $R1
+  Push $R2
+  Push $R3
+
+  StrCpy $R3 "$PLUGINSDIR\old-install$R0\*.*"
+  FindFirst $R1 $R2 $R3
+
+  loop:
+    StrCmp $R2 "" break
+
+    StrCmp $R2 "." continue
+    StrCmp $R2 ".." continue
+
+    IfFileExists "$INSTDIR$R0\$R2\*.*" isDir isNotDir
+
+    isDir:
+      CreateDirectory "$INSTDIR$R0\$R2"
+
+      Push "$R0\$R2"
+      Call un.restoreFiles
+      Pop $R3
+
+      Goto continue
+
+    isNotDir:
+      Rename $PLUGINSDIR\old-install$R0\$R2" "$INSTDIR$R0\$R2"
+
+    continue:
+      FindNext $R1 $R2
+      Goto loop
+
+  break:
+    StrCpy $R0 0
+    FindClose $R1
+
+    Pop $R3
+    Pop $R2
+    Pop $R1
+    Exch $R0
+FunctionEnd
+
 Section "un.install"
   # for assisted installer we check it here to show progress
   !ifndef ONE_CLICK
@@ -37,6 +140,34 @@ Section "un.install"
   !endif
 
   !insertmacro setLinkVars
+
+  # delete the installed files
+  !ifmacrodef customRemoveFiles
+    !insertmacro customRemoveFiles
+  !else
+    ${if} ${isUpdated}
+      CreateDirectory "$PLUGINSDIR\old-install"
+
+      Push ""
+      Call un.atomicRMDir
+      Pop $R0
+
+      ${if} $R0 != 0
+        DetailPrint "File is busy, aborting: $R0"
+
+        # Attempt to restore previous directory
+        Push ""
+        Call un.restoreFiles
+        Pop $R0
+
+        Abort `Can't rename "$INSTDIR" to "$PLUGINSDIR\old-install".`
+      ${endif}
+
+    ${endif}
+
+    # Remove all files (or remaining shallow directories from the block above)
+    RMDir /r $INSTDIR
+  !endif
 
   ${ifNot} ${isKeepShortcuts}
     WinShell::UninstAppUserModelId "${APP_ID}"
@@ -62,13 +193,6 @@ Section "un.install"
 
   !ifmacrodef unregisterFileAssociations
     !insertmacro unregisterFileAssociations
-  !endif
-
-  # delete the installed files
-  !ifmacrodef customRemoveFiles
-    !insertmacro customRemoveFiles
-  !else
-    RMDir /r $INSTDIR
   !endif
 
   Var /GLOBAL isDeleteAppData


### PR DESCRIPTION
Previously uninstaller would run `RMDir /r $INSTDIR` to remove the
currently installed version, but this operation is not atomic and if
some of the files will fail to delete it will leave them in the
directory while erasing the rest. If we are updating, however, this
leads us to a tricky situation where we cannot update these files, but
cannot also cancel the installation. Because of the erased files the app
won't be able to start if the installation won't completely at least
partially. However, the downside of that is that the app can have new
asar.unpacked files along with the old asar, executable, and bindings.

The approach of this change is to recursive use `Rename` instead of a
single `RMDir /r` in uninstaller (when `isUpdated` is true) to move the
whole app directory file by file to a temporary folder. If this
operation fails due to busy files - we use `CopyFiles` to restore all
files that we managed to move so far. Because the whole uninstallation
process becomes interrupted - the app shortcut and file associations
have to be removed only *after* the successful recursive `Rename`.

This error is caught by installer running in an update mode (see
`installUtil.nsh`) and presented to user in a dialog. If this erro
happen the installation does not proceed normally.

In addition to all of the above, this patch simplifies the last resort
measure in `extractAppPackage` which should now only run when old
uninstaller (that still uses `RMDir /r`) leaves busy files behind.

## Testing

Tested by doing normal updates and keeping tmp.exe open as in https://github.com/electron-userland/electron-builder/pull/6547

https://user-images.githubusercontent.com/79877362/149609389-65e1ecc2-82eb-4153-a80b-89a95cbbbacd.mp4

