### PR TITLE
fix: Allow disabling of webinstaller files to avoid confusion with actual installers

### DIFF
--- a/.changeset/seven-elephants-sing.md
+++ b/.changeset/seven-elephants-sing.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": major
+---
+
+fix: Allow disabling of webinstaller files to avoid confusion with actual installers

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -52,6 +52,17 @@ export abstract class AppUpdater extends EventEmitter {
   allowDowngrade = false
 
   /**
+   * Web installer files might not have signature verification, this switch prevents to load them unless it is needed.
+   *
+   * Currently false to prevent breaking the current API, but it should be changed to default true at some point that
+   * breaking changes are allowed.
+   *
+   * @default false
+   */
+
+  disableWebInstaller = false
+
+  /**
    * The current application version.
    */
   readonly currentVersion: SemVer
@@ -443,6 +454,7 @@ export abstract class AppUpdater extends EventEmitter {
         updateInfoAndProvider,
         requestHeaders: this.computeRequestHeaders(updateInfoAndProvider.provider),
         cancellationToken,
+        disableWebInstaller: this.disableWebInstaller,
       }).catch(e => {
         throw errorHandler(e)
       })
@@ -644,6 +656,7 @@ export interface DownloadUpdateOptions {
   readonly updateInfoAndProvider: UpdateInfoAndProvider
   readonly requestHeaders: OutgoingHttpHeaders
   readonly cancellationToken: CancellationToken
+  readonly disableWebInstaller?: boolean
 }
 
 function hasPrereleaseComponents(version: SemVer) {

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -50,7 +50,6 @@ export class NsisUpdater extends BaseUpdater {
 
         if (isWebInstaller) {
           if (downloadUpdateOptions.disableWebInstaller) {
-            await unlink(packageFile!)
             throw new Error("WebInstaller files are not allowed")
           }
           if (await this.differentialDownloadWebPackage(downloadUpdateOptions, packageInfo!, packageFile!, provider)) {


### PR DESCRIPTION
This PR allows the disabling of web installer files for `electron-updater` when it is only expected that a full installer should be downloaded.

This prevents a potential flaw in which an attacker using a webinstaller could serve a package not authorized by the developer to the end-user with malicious code inside.