### PR TITLE
fix: Update certificate validation on Windows to check full DN

### DIFF
--- a/.changeset/violet-zoos-roll.md
+++ b/.changeset/violet-zoos-roll.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": major
+---
+
+fix: Update certificate validation on Windows to check full DN

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -56,7 +56,7 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
           if (data.Status === 0) {
             const subject = parseDn(data.SignerCertificate.Subject)
             let match = false
-            publisherNames.forEach(name => {
+            for (const name of publisherNames) {
               const dn = parseDn(name)
               if (dn.size) {
                 // if we have a full DN, compare all values
@@ -65,12 +65,13 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
                   return dn.get(key) === subject.get(key)
                 })
               } else if (name === subject.get("CN")!) {
+                logger.warn(`Signature validated using only CN ${name}. Please add your full Distinguished Name (DN) to publisherNames configuration`)
                 match = true
               }
-            })
-            if (match) {
-              resolve(null)
-              return
+              if (match) {
+                resolve(null)
+                return
+              }
             }
           }
 

--- a/test/snapshots/updater/nsisUpdaterTest.js.snap
+++ b/test/snapshots/updater/nsisUpdaterTest.js.snap
@@ -460,3 +460,18 @@ Array [
   "update-downloaded",
 ]
 `;
+
+exports[`valid signature using DN 1`] = `
+Object {
+  "files": Array [
+    Object {
+      "sha512": "xrTrW8dzWYlPnu71Y4lpLIAuIurBZJvZmqEZyz1rzM3CbbE1Z+T+P5qYYZgwmhmXdYPOpvnmYKa0HGdgXggwtQ==",
+      "url": "TestApp-Setup-1.1.0.exe",
+    },
+  ],
+  "releaseName": "1.1.0",
+  "releaseNotes": "",
+  "tag": "v1.1.0",
+  "version": "1.1.0",
+}
+`;

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -240,6 +240,17 @@ test.ifAll.ifWindows("valid signature", async () => {
   await validateDownload(updater)
 })
 
+test.ifAll.ifWindows("valid signature using DN", async () => {
+  const updater = await createNsisUpdater("0.0.1")
+  updater.updateConfigPath = await writeUpdateConfig({
+    provider: "github",
+    owner: "develar",
+    repo: "__test_nsis_release",
+    publisherName: [`CN=Vladimir Krivosheev, O=Vladimir Krivosheev, L=Grunwald, S=Bayern, C=DE`],
+  })
+  await validateDownload(updater)
+})
+
 test.ifAll.ifWindows("invalid signature", async () => {
   const updater = await createNsisUpdater("0.0.1")
   updater.updateConfigPath = await writeUpdateConfig({


### PR DESCRIPTION
This PR changes the certificate validation for NSIS installer to allow for validation of the entire DN instead of just the Common Name portion. This should allow for a more secure certificate validation.