### PR TITLE
feat: use `mergeASARs` API by @electron/universal

### DIFF
--- a/.changeset/clean-kangaroos-serve.md
+++ b/.changeset/clean-kangaroos-serve.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: use `mergeASARs` API by @electron/universal

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "7zip-bin": "~5.1.1",
     "@develar/schema-utils": "~2.6.5",
-    "@electron/universal": "1.0.5",
+    "@electron/universal": "1.2.0",
     "@malept/flatpak-bundler": "^0.4.0",
     "async-exit-hook": "^2.0.1",
     "bluebird-lst": "^1.0.9",

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2578,6 +2578,11 @@
             "string"
           ]
         },
+        "mergeASARs": {
+          "default": false,
+          "description": "Whether to merge ASAR files for different architectures or not.\n\nThis option has no effect unless building for \"universal\" arch.",
+          "type": "boolean"
+        },
         "minimumSystemVersion": {
           "description": "The minimum version of macOS required for the app to run. Corresponds to `LSMinimumSystemVersion`.",
           "type": [
@@ -2701,6 +2706,10 @@
             }
           ],
           "description": "Regex or an array of regex's that signal skipping signing a file."
+        },
+        "singleArchFiles": {
+          "description": "Minimatch pattern of paths that are allowed to be present in one of the\nASAR files, but not in the other.\n\nThis option has no effect unless building for \"universal\" arch and applies\nonly if `mergeASARs` is `true`.",
+          "type": "string"
         },
         "strictVerify": {
           "anyOf": [
@@ -3183,6 +3192,11 @@
             "string"
           ]
         },
+        "mergeASARs": {
+          "default": false,
+          "description": "Whether to merge ASAR files for different architectures or not.\n\nThis option has no effect unless building for \"universal\" arch.",
+          "type": "boolean"
+        },
         "minimumSystemVersion": {
           "description": "The minimum version of macOS required for the app to run. Corresponds to `LSMinimumSystemVersion`.",
           "type": [
@@ -3306,6 +3320,10 @@
             }
           ],
           "description": "Regex or an array of regex's that signal skipping signing a file."
+        },
+        "singleArchFiles": {
+          "description": "Minimatch pattern of paths that are allowed to be present in one of the\nASAR files, but not in the other.\n\nThis option has no effect unless building for \"universal\" arch and applies\nonly if `mergeASARs` is `true`.",
+          "type": "string"
         },
         "strictVerify": {
           "anyOf": [

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2579,7 +2579,7 @@
           ]
         },
         "mergeASARs": {
-          "default": false,
+          "default": true,
           "description": "Whether to merge ASAR files for different architectures or not.\n\nThis option has no effect unless building for \"universal\" arch.",
           "type": "boolean"
         },
@@ -3193,7 +3193,7 @@
           ]
         },
         "mergeASARs": {
-          "default": false,
+          "default": true,
           "description": "Whether to merge ASAR files for different architectures or not.\n\nThis option has no effect unless building for \"universal\" arch.",
           "type": "boolean"
         },

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -127,6 +127,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
           arm64AppPath: path.join(arm64AppOutPath, appFile),
           outAppPath: path.join(appOutDir, appFile),
           force: true,
+          mergeASARs: platformSpecificBuildOptions.mergeASARs,
+          singleArchFiles: platformSpecificBuildOptions.singleArchFiles,
         })
         await fs.rm(x64AppOutDir, { recursive: true, force: true })
         await fs.rm(arm64AppOutPath, { recursive: true, force: true })

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -127,7 +127,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
           arm64AppPath: path.join(arm64AppOutPath, appFile),
           outAppPath: path.join(appOutDir, appFile),
           force: true,
-          mergeASARs: platformSpecificBuildOptions.mergeASARs,
+          mergeASARs: platformSpecificBuildOptions.mergeASARs ?? true,
           singleArchFiles: platformSpecificBuildOptions.singleArchFiles,
         })
         await fs.rm(x64AppOutDir, { recursive: true, force: true })

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -175,6 +175,23 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * Specify the URL of the timestamp authority server
    */
   readonly timestamp?: string | null
+
+  /**
+   * Whether to merge ASAR files for different architectures or not.
+   *
+   * This option has no effect unless building for "universal" arch.
+   * @default false
+   */
+  readonly mergeASARs?: boolean
+
+  /**
+   * Minimatch pattern of paths that are allowed to be present in one of the
+   * ASAR files, but not in the other.
+   *
+   * This option has no effect unless building for "universal" arch and applies
+   * only if `mergeASARs` is `true`.
+   */
+  readonly singleArchFiles?: string
 }
 
 export interface DmgOptions extends TargetSpecificOptions {

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -180,7 +180,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * Whether to merge ASAR files for different architectures or not.
    *
    * This option has no effect unless building for "universal" arch.
-   * @default false
+   * @default true
    */
   readonly mergeASARs?: boolean
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
       '@babel/preset-env': 7.15.6
       '@babel/preset-react': 7.14.5
       '@develar/schema-utils': ~2.6.5
-      '@electron/universal': 1.0.5
+      '@electron/universal': 1.2.0
       '@malept/flatpak-bundler': ^0.4.0
       '@types/debug': 4.1.7
       '@types/ejs': 3.1.0
@@ -120,7 +120,7 @@ importers:
       temp-file: ^3.4.0
     dependencies:
       '@develar/schema-utils': 2.6.5
-      '@electron/universal': 1.0.5
+      '@electron/universal': 1.2.0
       '@malept/flatpak-bundler': 0.4.0
       7zip-bin: 5.1.1
       async-exit-hook: 2.0.1
@@ -2206,8 +2206,8 @@ packages:
       ajv-keywords: 3.5.2_ajv@6.12.6
     dev: false
 
-  /@electron/universal/1.0.5:
-    resolution: {integrity: sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==}
+  /@electron/universal/1.2.0:
+    resolution: {integrity: sha512-eu20BwNsrMPKoe2bZ3/l9c78LclDvxg3PlVXrQf3L50NaUuW5M59gbPytI+V4z7/QMrohUHetQaU0ou+p1UG9Q==}
     engines: {node: '>=8.6'}
     dependencies:
       '@malept/cross-spawn-promise': 1.1.1
@@ -2215,6 +2215,8 @@ packages:
       debug: 4.3.3
       dir-compare: 2.4.0
       fs-extra: 9.1.0
+      minimatch: 3.0.4
+      plist: 3.0.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2648,6 +2650,7 @@ packages:
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
+    requiresBuild: true
     dependencies:
       '@types/minimatch': 3.0.5
       '@types/node': 16.11.12
@@ -5726,7 +5729,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: false
@@ -5918,7 +5921,6 @@ packages:
 
   /graceful-fs/4.2.9:
     resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
-    dev: true
 
   /graceful-readlink/1.0.1:
     resolution: {integrity: sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=}
@@ -7241,7 +7243,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
 
   /jsonify/0.0.0:
     resolution: {integrity: sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=}


### PR DESCRIPTION
@electron/universal@1.2.0 introduced `mergeASARs` and `singleArchFiles`
options that enable merging of x64 and arm64 ASARs into one. This change
adds appropriate properties to the MacConfiguration interface and passes
them along to @electron/universal.

## Testing

Tested by building our app with linked packages.