### PR TITLE
fix: fixes for server auth for MacUpdater

### DIFF
--- a/.changeset/good-scissors-listen.md
+++ b/.changeset/good-scissors-listen.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: fixes for server auth for MacUpdater


### PR DESCRIPTION
This PR fixes a few issues I found when I was testing the MacUpdater:
- `crypto` doesn't export a default module, so you have to import the method you want.
- We were encoding the auth header backwards, now we encode into `base64` and decode to `ascii`
- There's an issue with Electron/Squirrel.Mac in which when the proxy server is hit to get the file, it doesn't send any of the specified headers. So I had to rework to just check the first hit for authentication (which you need to get the file name anyways), and the second for the first itself will not be authenticated. Since the file name is randomly generated, this should still avoid the security issue in which an attacker could shut down the server. NOTE: We might want to make the file name a little more secure, but that's up for debate.

Let me know if I need to adjust anything :)