### PR TITLE
fix: More small security fixes

### DIFF
--- a/.changeset/neat-socks-dress.md
+++ b/.changeset/neat-socks-dress.md
@@ -1,0 +1,6 @@
+---
+"electron-updater": patch
+---
+
+- Removed backtick escaping for Windows code signing as it is unnecessary for Powershell and can cause the script to attempt to access the wrong file
+- Updated the proxy filename to be more secure (512-bit string)

--- a/.changeset/real-avocados-search.md
+++ b/.changeset/real-avocados-search.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: More small security fixes

--- a/.changeset/real-avocados-search.md
+++ b/.changeset/real-avocados-search.md
@@ -1,5 +1,0 @@
----
-"electron-updater": patch
----
-
-fix: More small security fixes

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -118,7 +118,7 @@ export class MacUpdater extends AppUpdater {
       const authInfo = Buffer.from(`autoupdater:${pass}`, "ascii")
 
       // insecure random is ok
-      const fileUrl = `/${Date.now().toString(16)}-${Math.floor(Math.random() * 9999).toString(16)}.zip`
+      const fileUrl = `/${randomBytes(64).toString("hex")}.zip`
       this.server!.on("request", (request: IncomingMessage, response: ServerResponse) => {
         const requestUrl = request.url!
         log.info(`${requestUrl} requested`)

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -22,12 +22,11 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
     // https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7
     // * Double quotes `"` are treated literally within single-quoted strings;
     // * Single quotes can be escaped by doubling them: 'don''t' -> don't;
-    // * Backticks can be escaped by doubling them: 'A backtick (``) character';
     //
     // Also note that at this point the file has already been written to the disk, thus we are
     // guaranteed that the path will not contain any illegal characters like <>:"/\|?*
     // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
-    const tempUpdateFile = unescapedTempUpdateFile.replace(/'/g, "''").replace(/`/g, "``")
+    const tempUpdateFile = unescapedTempUpdateFile.replace(/'/g, "''")
 
     // https://github.com/electron-userland/electron-builder/issues/2421
     // https://github.com/electron-userland/electron-builder/issues/2535


### PR DESCRIPTION
2 more small fixes:
- Removed backtick escaping for Windows code signing as it is unnecessary for Powershell and can cause the script to attempt to access the wrong file
- Updated the proxy filename to be more secure (512-bit string)

Let me know if I need to split these up or if I can leave it as one commit.