### PR TITLE
fix(updater): Remove checks for app-update.yml when auto-updates are not supported

### DIFF
--- a/.changeset/sweet-parrots-wait.md
+++ b/.changeset/sweet-parrots-wait.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix(updater): Remove checks for app-update.yml when auto-updates are not supported

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -264,15 +264,14 @@ export abstract class AppUpdater extends EventEmitter {
   // noinspection JSUnusedGlobalSymbols
   checkForUpdatesAndNotify(downloadNotification?: DownloadNotification): Promise<UpdateCheckResult | null> {
     return this.checkForUpdates().then(it => {
-      const downloadPromise = it?.downloadPromise
-      if (!it || downloadPromise == null) {
+      if (!it?.downloadPromise) {
         if (this._logger.debug != null) {
           this._logger.debug("checkForUpdatesAndNotify called, downloadPromise is null")
         }
         return it
       }
 
-      void downloadPromise.then(() => {
+      void it.downloadPromise.then(() => {
         const notificationContent = AppUpdater.formatDownloadNotification(it.updateInfo.version, this.app.name, downloadNotification)
         new (require("electron").Notification)(notificationContent).show()
       })

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -224,7 +224,11 @@ export abstract class AppUpdater extends EventEmitter {
   /**
    * Asks the server whether there is an update.
    */
-  checkForUpdates(): Promise<UpdateCheckResult> {
+  checkForUpdates(): Promise<UpdateCheckResult | null> {
+    if (!this.isUpdaterActive()) {
+      return Promise.resolve(null)
+    }
+
     let checkForUpdatesPromise = this.checkForUpdatesPromise
     if (checkForUpdatesPromise != null) {
       this._logger.info("Checking for update (already in progress)")
@@ -259,13 +263,9 @@ export abstract class AppUpdater extends EventEmitter {
 
   // noinspection JSUnusedGlobalSymbols
   checkForUpdatesAndNotify(downloadNotification?: DownloadNotification): Promise<UpdateCheckResult | null> {
-    if (!this.isUpdaterActive()) {
-      return Promise.resolve(null)
-    }
-
     return this.checkForUpdates().then(it => {
-      const downloadPromise = it.downloadPromise
-      if (downloadPromise == null) {
+      const downloadPromise = it?.downloadPromise
+      if (!it || downloadPromise == null) {
         if (this._logger.debug != null) {
           this._logger.debug("checkForUpdatesAndNotify called, downloadPromise is null")
         }

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -1505,7 +1505,7 @@ Object {
               "size": 748,
             },
             "index.js": Object {
-              "size": 5664,
+              "size": 5708,
             },
             "package.json": Object {
               "size": 567,
@@ -1534,7 +1534,7 @@ Object {
               "size": 1081,
             },
             "index.js": Object {
-              "size": 3539,
+              "size": 3973,
             },
             "package.json": Object {
               "size": 789,

--- a/test/src/helpers/updaterTestUtil.ts
+++ b/test/src/helpers/updaterTestUtil.ts
@@ -34,18 +34,18 @@ export async function validateDownload(updater: AppUpdater, expectDownloadPromis
   const actualEvents = trackEvents(updater)
 
   const updateCheckResult = await updater.checkForUpdates()
-  const assets = (updateCheckResult.updateInfo as any).assets
+  const assets = (updateCheckResult?.updateInfo as any).assets
   if (assets != null) {
     for (const asset of assets) {
       delete asset.download_count
     }
   }
 
-  expect(updateCheckResult.updateInfo).toMatchSnapshot()
+  expect(updateCheckResult?.updateInfo).toMatchSnapshot()
   if (expectDownloadPromise) {
     // noinspection JSIgnoredPromiseFromCall
-    expect(updateCheckResult.downloadPromise).toBeDefined()
-    const downloadResult = await updateCheckResult.downloadPromise
+    expect(updateCheckResult?.downloadPromise).toBeDefined()
+    const downloadResult = await updateCheckResult?.downloadPromise
     if (updater instanceof MacUpdater) {
       expect(downloadResult).toEqual([])
     } else {
@@ -53,7 +53,7 @@ export async function validateDownload(updater: AppUpdater, expectDownloadPromis
     }
   } else {
     // noinspection JSIgnoredPromiseFromCall
-    expect(updateCheckResult.downloadPromise).toBeUndefined()
+    expect(updateCheckResult?.downloadPromise).toBeUndefined()
   }
 
   expect(actualEvents).toMatchSnapshot()

--- a/test/src/updater/differentialUpdateTest.ts
+++ b/test/src/updater/differentialUpdateTest.ts
@@ -238,16 +238,16 @@ async function doBuild(outDirs: Array<string>, targets: Map<Platform, Map<Arch, 
 
 async function checkResult(updater: NsisUpdater) {
   const updateCheckResult = await updater.checkForUpdates()
-  const downloadPromise = updateCheckResult.downloadPromise
+  const downloadPromise = updateCheckResult?.downloadPromise
   // noinspection JSIgnoredPromiseFromCall
   expect(downloadPromise).not.toBeNull()
   const files = await downloadPromise
-  const fileInfo: any = updateCheckResult.updateInfo.files[0]
+  const fileInfo: any = updateCheckResult?.updateInfo.files[0]
 
   // because port is random
   expect(fileInfo.url).toBeDefined()
   delete fileInfo.url
-  expect(removeUnstableProperties(updateCheckResult.updateInfo)).toMatchSnapshot()
+  expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
   expect(files!.map(it => path.basename(it))).toMatchSnapshot()
 }
 
@@ -309,7 +309,7 @@ async function testBlockMap(oldDir: string, newDir: string, updaterClass: any, a
       "app-update.yml"
     )
     const doTest = async () => {
-      await tuneTestUpdater(updater, {
+      tuneTestUpdater(updater, {
         platform: platform.nodeName as any,
         isUseDifferentialDownload: true,
       })

--- a/test/src/updater/macUpdaterTest.ts
+++ b/test/src/updater/macUpdaterTest.ts
@@ -51,15 +51,15 @@ test.ifAll.ifNotCi.ifMac("mac updates", async () => {
     // console.log(JSON.stringify(data))
   })
 
-  await tuneTestUpdater(updater)
+  tuneTestUpdater(updater)
   ;(updater as any)._testOnlyOptions.platform = process.platform
   const actualEvents = trackEvents(updater)
 
   const updateCheckResult = await updater.checkForUpdates()
   // todo when will be updated to use files
-  // expect(removeUnstableProperties(updateCheckResult.updateInfo.files)).toMatchSnapshot()
-  const files = await updateCheckResult.downloadPromise
-  expect(files!!.length).toEqual(1)
-  await assertThat(files!![0]).isFile()
+  // expect(removeUnstableProperties(updateCheckResult?.updateInfo.files)).toMatchSnapshot()
+  const files = await updateCheckResult?.downloadPromise
+  expect(files!.length).toEqual(1)
+  await assertThat(files![0]).isFile()
   expect(actualEvents).toMatchSnapshot()
 })

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -34,9 +34,9 @@ test("downgrade (disallowed, beta)", async () => {
   }
 
   const updateCheckResult = await updater.checkForUpdates()
-  expect(removeUnstableProperties(updateCheckResult.updateInfo)).toMatchSnapshot()
+  expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
   // noinspection JSIgnoredPromiseFromCall
-  expect(updateCheckResult.downloadPromise).toBeUndefined()
+  expect(updateCheckResult?.downloadPromise).toBeUndefined()
 
   expect(actualEvents).toEqual(expectedEvents)
 })
@@ -95,8 +95,8 @@ test.skip.ifNotCiWin("sha512 mismatch error event", async () => {
   const actualEvents = trackEvents(updater)
 
   const updateCheckResult = await updater.checkForUpdates()
-  expect(removeUnstableProperties(updateCheckResult.updateInfo)).toMatchSnapshot()
-  await assertThat(updateCheckResult.downloadPromise).throws()
+  expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
+  await assertThat(updateCheckResult?.downloadPromise).throws()
 
   expect(actualEvents).toMatchSnapshot()
 })
@@ -112,9 +112,9 @@ test("file url generic - manual download", async () => {
   const actualEvents = trackEvents(updater)
 
   const updateCheckResult = await updater.checkForUpdates()
-  expect(removeUnstableProperties(updateCheckResult.updateInfo)).toMatchSnapshot()
+  expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
   // noinspection JSIgnoredPromiseFromCall
-  expect(updateCheckResult.downloadPromise).toBeNull()
+  expect(updateCheckResult?.downloadPromise).toBeNull()
   expect(actualEvents).toMatchSnapshot()
 
   await assertThat(path.join((await updater.downloadUpdate())[0])).isFile()
@@ -132,12 +132,12 @@ test("checkForUpdates several times", async () => {
 
   for (let i = 0; i < 10; i++) {
     //noinspection JSIgnoredPromiseFromCall
-    updater.checkForUpdates()
+    void updater.checkForUpdates()
   }
 
   async function checkForUpdates() {
     const updateCheckResult = await updater.checkForUpdates()
-    expect(removeUnstableProperties(updateCheckResult.updateInfo)).toMatchSnapshot()
+    expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
     await checkDownloadPromise(updateCheckResult)
   }
 
@@ -148,8 +148,8 @@ test("checkForUpdates several times", async () => {
   expect(actualEvents).toMatchSnapshot()
 })
 
-async function checkDownloadPromise(updateCheckResult: UpdateCheckResult) {
-  return await assertThat(path.join((await updateCheckResult.downloadPromise)!![0])).isFile()
+async function checkDownloadPromise(updateCheckResult: UpdateCheckResult | null) {
+  return await assertThat(path.join((await updateCheckResult?.downloadPromise)![0])).isFile()
 }
 
 test("file url github", async () => {
@@ -183,7 +183,7 @@ test("file url github pre-release and fullChangelog", async () => {
     expect(info).toMatchSnapshot()
   })
   const updateCheckResult = await validateDownload(updater)
-  expect(updateCheckResult.updateInfo).toMatchSnapshot()
+  expect(updateCheckResult?.updateInfo).toMatchSnapshot()
 })
 
 test.ifEnv(process.env.GH_TOKEN || process.env.GITHUB_TOKEN)("file url github private", async () => {
@@ -271,7 +271,7 @@ test.skip.ifAll("invalid signature", async () => {
     publisherName: ["Foo Bar"],
   })
   const actualEvents = trackEvents(updater)
-  await assertThat(updater.checkForUpdates().then((it): any => it.downloadPromise)).throws()
+  await assertThat(updater.checkForUpdates().then((it): any => it?.downloadPromise)).throws()
   expect(actualEvents).toMatchSnapshot()
 })
 
@@ -318,7 +318,7 @@ test("cancel download with progress", async () => {
   updater.signals.updateCancelled(() => (cancelled = true))
 
   const checkResult = await updater.checkForUpdates()
-  checkResult.cancellationToken!!.cancel()
+  checkResult?.cancellationToken!.cancel()
 
   if (progressEvents.length > 0) {
     const lastEvent = progressEvents[progressEvents.length - 1]
@@ -327,7 +327,7 @@ test("cancel download with progress", async () => {
     expect(lastEvent.transferred).not.toBe(lastEvent.total)
   }
 
-  const downloadPromise = checkResult.downloadPromise!!
+  const downloadPromise = checkResult?.downloadPromise
   await assertThat(downloadPromise).throws()
   expect(cancelled).toBe(true)
 })


### PR DESCRIPTION
Moving `isUpdaterActive` check to `checkForUpdates` which is utilized by `checkForUpdatesAndNotify`. Fixes: #6322