### PR TITLE
fix(dmg-builder): Support python 3

### DIFF
--- a/.changeset/thick-bikes-sleep.md
+++ b/.changeset/thick-bikes-sleep.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix(dmg-builder): Adding python 3 support to dmg-builder in order to support mac os 12 which has entirely removed python2. Fixes: #6606

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -297,11 +297,17 @@ async function customizeDmg(volumePath: string, specification: DmgOptions, packa
   const asyncTaskManager = new AsyncTaskManager(packager.info.cancellationToken)
   env.iconLocations = await computeDmgEntries(specification, volumePath, packager, asyncTaskManager)
   await asyncTaskManager.awaitTasks()
-
-  await exec(process.env.PYTHON_PATH || "/usr/bin/python", [path.join(getDmgVendorPath(), "dmgbuild/core.py")], {
-    cwd: getDmgVendorPath(),
-    env,
-  })
+  const executePython = async (execName: string) => {
+    await exec(process.env.PYTHON_PATH || `/usr/bin/${execName}`, [path.join(getDmgVendorPath(), "dmgbuild/core.py")], {
+      cwd: getDmgVendorPath(),
+      env,
+    })
+  }
+  try {
+    await executePython("python3")
+  } catch (error) {
+    await executePython("python")
+  }
   return packager.packagerOptions.effectiveOptionComputed == null || !(await packager.packagerOptions.effectiveOptionComputed({ volumePath, specification, packager }))
 }
 

--- a/packages/dmg-builder/vendor/dmgbuild/core.py
+++ b/packages/dmg-builder/vendor/dmgbuild/core.py
@@ -4,6 +4,11 @@ from __future__ import unicode_literals
 import os
 import re
 import sys
+if sys.version_info.major == 3:
+    try:
+        from importlib import reload
+    except ImportError:
+        from imp import reload
 reload(sys)  # Reload is a hack
 sys.setdefaultencoding('UTF8')
 

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -1505,7 +1505,7 @@ Object {
               "size": 748,
             },
             "index.js": Object {
-              "size": 5664,
+              "size": 5708,
             },
             "package.json": Object {
               "size": 567,
@@ -1534,7 +1534,7 @@ Object {
               "size": 1081,
             },
             "index.js": Object {
-              "size": 3539,
+              "size": 3973,
             },
             "package.json": Object {
               "size": 789,


### PR DESCRIPTION
Adding python 3 support to dmg-builder in order to support mac os 12 which has entirely removed python2
Fixes: #6606