### PR TITLE
fix(packager): wait for event before starting an upload

### DIFF
--- a/.changeset/angry-starfishes-divide.md
+++ b/.changeset/angry-starfishes-divide.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(packager): wait for event before starting an upload

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -271,12 +271,12 @@ export class Packager {
   }
 
   async callArtifactBuildCompleted(event: ArtifactCreated): Promise<void> {
-    this.dispatchArtifactCreated(event)
-
     const handler = resolveFunction(this.config.artifactBuildCompleted, "artifactBuildCompleted")
     if (handler != null) {
       await Promise.resolve(handler(event))
     }
+    
+    this.dispatchArtifactCreated(event)
   }
 
   async callAppxManifestCreated(path: string): Promise<void> {


### PR DESCRIPTION
When the configuration has a artifactBuildCompleted file which needs to be waited, the upload starts anyway as it listens to the artifactCreated event. This resolves that by first waiting for any hooks, then dispatching the event.