### PR TITLE
chore: Exit prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "app-builder-lib": "22.14.13",


### PR DESCRIPTION
chore: Exiting `pre` mode to trigger a new 23.0.0 major version release