### PR TITLE
fix: signing of user-defined binaries

### DIFF
--- a/.changeset/eleven-rivers-confess.md
+++ b/.changeset/eleven-rivers-confess.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Fix error thrown due to duplicated signing of user-defined binaries on mac when resolving relative path

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -243,7 +243,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     let binaries = options.binaries || undefined
     if (binaries) {
       // Accept absolute paths for external binaries, else resolve relative paths from the artifact's app Contents path.
-      const userDefinedBinaries = await Promise.all(
+      binaries = await Promise.all(
         binaries.map(async destination => {
           if (await statOrNull(destination)) {
             return destination
@@ -251,9 +251,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
           return path.resolve(appPath, destination)
         })
       )
-      // Insert at front to prioritize signing. We still sort by depth next
-      binaries = userDefinedBinaries.concat(binaries)
-      log.info("Signing addtional user-defined binaries: " + JSON.stringify(userDefinedBinaries, null, 1))
+      log.info("Signing addtional user-defined binaries: " + JSON.stringify(binaries, null, 1))
     }
 
     const signOptions: any = {


### PR DESCRIPTION
Without this PR, the `binaries`'s absolutely calculated paths will be concatenated with to their non-absolute paths.
This causes an error when building, where it tries to sign **both** the absolute **and** relative paths, failing on the relative paths. Example:

package.json:
```
    "mas": {
      "binaries": [
        "Contents/Resources/ffmpeg",
        "Contents/Resources/ffprobe"
      ]
    }
```

Build output from `electron-builder --mac -m mas-dev`:
```
  • Signing addtional user-defined binaries: [
 "/Users/mifi/lossless-cut/dist/mas-dev/LosslessCut.app/Contents/Resources/ffmpeg",
 "/Users/mifi/lossless-cut/dist/mas-dev/LosslessCut.app/Contents/Resources/ffprobe"
]
  • signing         file=dist/mas-dev/LosslessCut.app identityName=Apple Development: Mikael Finstad (JH4PH8B3C8) identityHash=7BB49C65719719783C5DA0B9A1F667707A0EA8B6 provisioningProfile=LosslessCut_Dev.provisionprofile
  ⨯ Command failed: codesign --sign 7BB49C65719719783C5DA0B9A1F667707A0EA8B6 --force --timestamp --entitlements entitlements.mas.inherit.plist Contents/Resources/ffmpeg
Contents/Resources/ffmpeg: No such file or directory
```

With this fix, it will instead only sign the `resolve`'d paths and not fail:

```
  • Signing addtional user-defined binaries: [
 "/Users/mifi/lossless-cut/dist/mas-dev/LosslessCut.app/Contents/Resources/ffmpeg",
 "/Users/mifi/lossless-cut/dist/mas-dev/LosslessCut.app/Contents/Resources/ffprobe"
]
  • signing         file=dist/mas-dev/LosslessCut.app identityName=Apple Development: Mikael Finstad (JH4PH8B3C8) identityHash=7BB49C65719719783C5DA0B9A1F667707A0EA8B6 provisioningProfile=LosslessCut_Dev.provisionprofile
# No error
```