### PR TITLE
Update winOptions.ts

### DIFF
--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -43,7 +43,7 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
    */
   readonly certificatePassword?: string | null
   /**
-   * The name of the subject of the signing certificate. Required only for EV Code Signing and works only on Windows (or on macOS if [Parallels Desktop](https://www.parallels.com/products/desktop/) Windows 10 virtual machines exits).
+   * The name of the subject of the signing certificate, which is often labeled with the field name `issued to`. Required only for EV Code Signing and works only on Windows (or on macOS if [Parallels Desktop](https://www.parallels.com/products/desktop/) Windows 10 virtual machines exits).
    */
   readonly certificateSubjectName?: string | null
   /**


### PR DESCRIPTION
The modified comment propagates into the documentation which users (developers) will see when configuring electron builder.  Developers will need to know how to find the subject of the certificate, but since most certificate displays label the subject with "issued to" this can be confusing.  This note should help with that.