### PR TITLE
fix(dmg-builder): the "import" unbound issue

### DIFF
--- a/.changeset/cold-crabs-destroy.md
+++ b/.changeset/cold-crabs-destroy.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix(dmg-builder): the "import" unbound issue

--- a/packages/dmg-builder/vendor/dmgbuild/core.py
+++ b/packages/dmg-builder/vendor/dmgbuild/core.py
@@ -4,13 +4,16 @@ from __future__ import unicode_literals
 import os
 import re
 import sys
+
 if sys.version_info.major == 3:
-    try:
-        from importlib import reload
-    except ImportError:
-        from imp import reload
-reload(sys)  # Reload is a hack
-sys.setdefaultencoding('UTF8')
+  try:
+      from importlib import reload
+  except ImportError:
+      from imp import reload
+  reload(sys)  # To workaround the unbound issue
+else:
+  reload(sys)  # Reload is a hack
+  sys.setdefaultencoding('UTF8')
 
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), "..")))
 


### PR DESCRIPTION
Fix #6606

python3 can't run our modified script since it can't find `reload` properly:

<img width="604" alt="截圖 2022-02-24 下午1 49 52" src="https://user-images.githubusercontent.com/28441561/155465916-83409a95-d0d3-4435-85ad-59f9267218b2.png">

As `executePython("python3")` failed, it fellback to `executePython("python")` and fail:

<img width="278" alt="截圖 2022-02-24 下午3 28 38" src="https://user-images.githubusercontent.com/28441561/155478141-bb65609c-f7e9-490a-8275-bded80ca61ef.png">

```
NestedError: Cannot cleanup: 

Error #1 --------------------------------------------------------------------------------
Error: Exit code: ENOENT. spawn /usr/bin/python ENOENT
    at /Users/pan93412/Projects/YesPlayMusic/node_modules/builder-util/src/util.ts:133:18
    at exithandler (node:child_process:406:5)
    at ChildProcess.errorhandler (node:child_process:418:5)
    at ChildProcess.emit (node:events:520:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)

Error #2 --------------------------------------------------------------------------------
Error: Exit code: ENOENT. spawn /usr/bin/python ENOENT
    at /Users/pan93412/Projects/YesPlayMusic/node_modules/builder-util/src/util.ts:133:18
    at exithandler (node:child_process:406:5)
    at ChildProcess.errorhandler (node:child_process:418:5)
    at ChildProcess.emit (node:events:520:28)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
    at throwError (/Users/pan93412/Projects/YesPlayMusic/node_modules/builder-util/src/asyncTaskManager.ts:88:11)
    at checkErrors (/Users/pan93412/Projects/YesPlayMusic/node_modules/builder-util/src/asyncTaskManager.ts:53:9)
    at AsyncTaskManager.awaitTasks (/Users/pan93412/Projects/YesPlayMusic/node_modules/builder-util/src/asyncTaskManager.ts:58:5)
    at Packager.doBuild (/Users/pan93412/Projects/YesPlayMusic/node_modules/app-builder-lib/src/packager.ts:453:23)
    at Object.executeFinally (/Users/pan93412/Projects/YesPlayMusic/node_modules/builder-util/src/promise.ts:12:14)
    at Packager._build (/Users/pan93412/Projects/YesPlayMusic/node_modules/app-builder-lib/src/packager.ts:376:31)
    at Packager.build (/Users/pan93412/Projects/YesPlayMusic/node_modules/app-builder-lib/src/packager.ts:337:12)
    at Object.executeFinally (/Users/pan93412/Projects/YesPlayMusic/node_modules/builder-util/src/promise.ts:12:14)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```