### PR TITLE
fix(signing): Include swiftshader in signing directories for windows

### DIFF
--- a/.changeset/lucky-mice-smell.md
+++ b/.changeset/lucky-mice-smell.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(signing): Include swiftshader in signing directories for windows


### PR DESCRIPTION
This PR adds `swiftshader` to the directories that contain `.dll` file that are required to be sign for windows in order  to satisfy AppLocker policy.

Closes https://github.com/electron-userland/electron-builder/issues/5236