### PR TITLE
fix(app-builder-lib): export missing TS types

### DIFF
--- a/.changeset/olive-cobras-boil.md
+++ b/.changeset/olive-cobras-boil.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(app-builder-lib): export missing TS types

--- a/packages/app-builder-lib/src/asar/asar.ts
+++ b/packages/app-builder-lib/src/asar/asar.ts
@@ -2,13 +2,11 @@ import { createFromBuffer } from "chromium-pickle-js"
 import { close, open, read, readFile, Stats } from "fs-extra"
 import * as path from "path"
 
-/** @internal */
 export interface ReadAsarHeader {
   readonly header: string
   readonly size: number
 }
 
-/** @internal */
 export interface NodeIntegrity {
   algorithm: "SHA256"
   hash: string
@@ -34,7 +32,6 @@ export class Node {
   integrity?: NodeIntegrity
 }
 
-/** @internal */
 export class AsarFilesystem {
   private offset = 0
 


### PR DESCRIPTION
See [discussion here](https://github.com/electron-userland/electron-builder/pull/6511#discussion_r818931948).

cc @mmaietta 