### PR TITLE
fix: Change DEBUG_LOGGING env var for nsis installers as part of `customNsisBinary` config

### DIFF
--- a/.changeset/cold-masks-bathe.md
+++ b/.changeset/cold-masks-bathe.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Change DEBUG_LOGGING env var for nsis installers as part of `customNsisBinary` config. Fixes #6715

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   push:
-  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docs/generated/NsisOptions.md
+++ b/docs/generated/NsisOptions.md
@@ -59,6 +59,7 @@
 <li><code id="NsisOptions-unicode">unicode</code> = <code>true</code> Boolean - Whether to create <a href="http://nsis.sourceforge.net/Docs/Chapter1.html#intro-unicode">Unicode installer</a>.</li>
 <li><code id="NsisOptions-guid">guid</code> String | “undefined” - See <a href="../configuration/nsis#guid-vs-application-name">GUID vs Application Name</a>.</li>
 <li><code id="NsisOptions-warningsAsErrors">warningsAsErrors</code> = <code>true</code> Boolean - If <code>warningsAsErrors</code> is <code>true</code> (default): NSIS will treat warnings as errors. If <code>warningsAsErrors</code> is <code>false</code>: NSIS will allow warnings.</li>
+<li><code id="NsisOptions-customNsisBinary">customNsisBinary</code> module:app-builder-lib/out/targets/nsis/nsisOptions.CustomNsisBinary | “undefined” - Allows you to provide your own <code>makensis</code>, such as one with support for debug logging via LogSet and LogText. (Logging also requires option <code>debugLogging = true</code>)</li>
 <li><code id="NsisOptions-runAfterFinish">runAfterFinish</code> = <code>true</code> Boolean - Whether to run the installed application after finish. For assisted installer corresponding checkbox will be removed.</li>
 </ul>
 <hr>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "generate-changeset": "pnpm changeset",
     "generate-docs": "pnpm compile && pnpm jsdoc && pnpm jsdoc2md2html",
     "ci:test": "node ./test/out/helpers/runTests.js",
-    "ci:version": "pnpm changelog && changeset version && node scripts/update-package-version-export.js && pnpm run generate-docs && pnpm run prettier && git add .",
+    "ci:version": "pnpm changelog && changeset version && node scripts/update-package-version-export.js && pnpm run schema && pnpm run generate-docs && pnpm run prettier && git add .",
     "ci:publish": "pnpm compile && pnpm publish -r && changeset tag",
     "schema": "typescript-json-schema packages/app-builder-lib/tsconfig-scheme.json Configuration --out packages/app-builder-lib/scheme.json --noExtraProps --useTypeOfKeyword --strictNullChecks --required && node ./scripts/fix-schema.js",
     "jsdoc": "ts2jsdoc packages/builder-util-runtime packages/builder-util packages/app-builder-lib packages/electron-builder packages/electron-publish packages/electron-updater packages/dmg-builder",

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -419,6 +419,13 @@
             "string"
           ]
         },
+        "debugLogging": {
+          "description": "Whether or not to enable NSIS logging for debugging.\nNote: Requires a debug-enabled NSIS build.\nelectron-builder's included `makensis` does not natively support debug-enabled NSIS installers currently, you must supply your own via `customNsisBinary?: CustomNsisBinary`\nIn your custom nsis scripts, you can leverage this functionality via `LogSet` and `LogText`",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "url": {
           "default": "https://github.com/electron-userland/electron-builder-binaries/releases/download",
           "type": [
@@ -3646,14 +3653,8 @@
             {
               "type": "null"
             }
-          ]
-        },
-        "debugLogging": {
-          "description": "Whether or not to enable NSIS logging for debugging.\nNote: Requires a debug-enabled NSIS build.\nelectron-builder's included `makensis` only supports building debug-enabled NSIS installers on Windows currently\nhttps://github.com/electron-userland/electron-builder/issues/5119#issuecomment-811353612",
-          "type": [
-            "null",
-            "boolean"
-          ]
+          ],
+          "description": "Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)"
         },
         "deleteAppDataOnUninstall": {
           "default": false,
@@ -3970,14 +3971,8 @@
             {
               "type": "null"
             }
-          ]
-        },
-        "debugLogging": {
-          "description": "Whether or not to enable NSIS logging for debugging.\nNote: Requires a debug-enabled NSIS build.\nelectron-builder's included `makensis` only supports building debug-enabled NSIS installers on Windows currently\nhttps://github.com/electron-userland/electron-builder/issues/5119#issuecomment-811353612",
-          "type": [
-            "null",
-            "boolean"
-          ]
+          ],
+          "description": "Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)"
         },
         "deleteAppDataOnUninstall": {
           "default": false,
@@ -4560,14 +4555,8 @@
             {
               "type": "null"
             }
-          ]
-        },
-        "debugLogging": {
-          "description": "Whether or not to enable NSIS logging for debugging.\nNote: Requires a debug-enabled NSIS build.\nelectron-builder's included `makensis` only supports building debug-enabled NSIS installers on Windows currently\nhttps://github.com/electron-userland/electron-builder/issues/5119#issuecomment-811353612",
-          "type": [
-            "null",
-            "boolean"
-          ]
+          ],
+          "description": "Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)"
         },
         "guid": {
           "description": "See [GUID vs Application Name](../configuration/nsis#guid-vs-application-name).",

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -191,8 +191,8 @@ export class NsisTarget extends Target {
 
       APP_PACKAGE_NAME: appInfo.name,
     }
-    if (options.debugLogging) {
-      defines.ENABLE_LOGGING = null
+    if (options.customNsisBinary?.debugLogging) {
+      defines.ENABLE_LOGGING_ELECTRON_BUILDER = null
     }
     if (uninstallAppKey !== guid) {
       defines.UNINSTALL_REGISTRY_KEY_2 = `Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${guid}`
@@ -370,7 +370,7 @@ export class NsisTarget extends Target {
     if (isMacOsCatalina()) {
       try {
         await UninstallerReader.exec(installerPath, uninstallerPath)
-      } catch (error) {
+      } catch (error: any) {
         log.warn(`packager.vm is used: ${error.message}`)
 
         const vm = await packager.vm.value

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -3,25 +3,27 @@ import { CommonWindowsInstallerConfiguration } from "../.."
 
 interface CustomNsisBinary {
   /**
-   * @private
    * @default https://github.com/electron-userland/electron-builder-binaries/releases/download
    */
-
   readonly url: string | null
 
   /**
-   * @private
    * @default VKMiizYdmNdJOWpRGz4trl4lD++BvYP2irAXpMilheUP0pc93iKlWAoP843Vlraj8YG19CVn0j+dCo/hURz9+Q==
    */
-
   readonly checksum?: string | null
 
   /**
-   * @private
    * @default 3.0.4.1
    */
-
   readonly version?: string | null
+
+  /**
+   * Whether or not to enable NSIS logging for debugging.
+   * Note: Requires a debug-enabled NSIS build.
+   * electron-builder's included `makensis` does not natively support debug-enabled NSIS installers currently, you must supply your own via `customNsisBinary?: CustomNsisBinary`
+   * In your custom nsis scripts, you can leverage this functionality via `LogSet` and `LogText`
+   */
+   readonly debugLogging?: boolean | null
 }
 export interface CommonNsisOptions {
   /**
@@ -48,18 +50,9 @@ export interface CommonNsisOptions {
   readonly useZip?: boolean
 
   /**
-   * @private
+   * Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)
    */
   readonly customNsisBinary?: CustomNsisBinary | null
-
-  /**
-   * Whether or not to enable NSIS logging for debugging.
-   * Note: Requires a debug-enabled NSIS build.
-   * electron-builder's included `makensis` only supports building debug-enabled NSIS installers on Windows currently
-   * https://github.com/electron-userland/electron-builder/issues/5119#issuecomment-811353612
-   * @private
-   */
-  readonly debugLogging?: boolean | null
 }
 
 export interface NsisOptions extends CommonNsisOptions, CommonWindowsInstallerConfiguration, TargetSpecificOptions {

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -23,7 +23,7 @@ interface CustomNsisBinary {
    * electron-builder's included `makensis` does not natively support debug-enabled NSIS installers currently, you must supply your own via `customNsisBinary?: CustomNsisBinary`
    * In your custom nsis scripts, you can leverage this functionality via `LogSet` and `LogText`
    */
-   readonly debugLogging?: boolean | null
+  readonly debugLogging?: boolean | null
 }
 export interface CommonNsisOptions {
   /**

--- a/packages/app-builder-lib/templates/nsis/common.nsh
+++ b/packages/app-builder-lib/templates/nsis/common.nsh
@@ -102,14 +102,15 @@ Name "${PRODUCT_NAME}"
 
 !define LogSet "!insertmacro LogSetMacro"
 !macro LogSetMacro SETTING
-  !ifdef ENABLE_LOGGING
+  !ifdef ENABLE_LOGGING_ELECTRON_BUILDER
+    SetOutPath $INSTDIR
     LogSet ${SETTING}
   !endif
 !macroend
  
-!define LogText "!insertmacro LogTextMacro"
-!macro LogTextMacro INPUT_TEXT
-  !ifdef ENABLE_LOGGING
+!define LogText "!insertmacro LogTextMacroEB"
+!macro LogTextMacroEB INPUT_TEXT
+  !ifdef ENABLE_LOGGING_ELECTRON_BUILDER
     LogText ${INPUT_TEXT}
   !endif
 !macroend

--- a/test/src/windows/assistedInstallerTest.ts
+++ b/test/src/windows/assistedInstallerTest.ts
@@ -127,8 +127,8 @@ test.skip.ifNotCiMac(
           url: "https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-3.0.4.2/nsis-3.0.4.2.7z",
           version: "3.0.4.2",
           checksum: "o+YZsXHp8LNihhuk7JsCDhdIgx0MKKK+1b3sGD+4zX5djZULe4/4QMcAsfQ+0r+a8FnwBt7BVBHkIkJHjKQ0sg==",
+          debugLogging: true,
         },
-        debugLogging: true,
       },
     },
   })


### PR DESCRIPTION
Exposing `customNsisBinary` and changing env var for `debugLogging` so that it doesn't conflict with other custom nsis scripts that use `DEBUG_LOGGING` env var. Also adding warning that electron-builder does not natively support the feature.

Fixes: #6715