### PR TITLE
fix: Updater "Error: Could not connect to the server." in macOS

### DIFF
--- a/.changeset/metal-elephants-remain.md
+++ b/.changeset/metal-elephants-remain.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: Updater "Error: Could not connect to the server." in macOS. Don't close server directly at quitAndInstall #6743

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -213,14 +213,15 @@ export class MacUpdater extends AppUpdater {
   }
 
   quitAndInstall(): void {
-    this.server?.close()
     if (this.squirrelDownloadedUpdate) {
       // update already fetched by Squirrel, it's ready to install
       this.nativeUpdater.quitAndInstall()
+      this.server?.close()
     } else {
       // Quit and install as soon as Squirrel get the update
       this.nativeUpdater.on("update-downloaded", () => {
         this.nativeUpdater.quitAndInstall()
+        this.server?.close()
       })
 
       if (!this.autoInstallOnAppQuit) {


### PR DESCRIPTION
If squirrelDownloadedUpdate is false, then we still need to have the proxy server opened for the `"update-downloaded"` event. Otherwise you're getting following error:

```
[2022-03-26 17:18:30.258] [info]  Proxy server for native Squirrel.Mac is closed (fileToProxy=https://utils.pacprotocol.com/yansafe-testnet/build/mac/yanSAFE-testnet-2.2.1-testnet.4-arm64-mac.zip)
[2022-03-26 17:18:30.274] [warn]  Error: Verbindung zum Server konnte nicht hergestellt werden.
[2022-03-26 17:18:30.274] [error] Error: Error: Verbindung zum Server konnte nicht hergestellt werden.
```

"Error: Verbindung zum Server konnte nicht hergestellt werden." = "Error: Could not connect to the server."

Moving `this.server.close()` after `this.nativeUpdater.quitAndInstall()` fixes the issue.