### PR TITLE
fix (app-builder-lib): bump @electron/universal to 1.2.1

### DIFF
--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "7zip-bin": "~5.1.1",
     "@develar/schema-utils": "~2.6.5",
-    "@electron/universal": "1.2.0",
+    "@electron/universal": "1.2.1",
     "@malept/flatpak-bundler": "^0.4.0",
     "async-exit-hook": "^2.0.1",
     "bluebird-lst": "^1.0.9",


### PR DESCRIPTION
Currently it cannot build an Electron 18 Universal (Mac) app:

`Expected all non-binary files to have identical SHAs when creating a universal build but "Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/MainMenu.nib/keyedobjects-101300.nib" `

Universal 1.2.1 has a fix for this, so bumping the version here too.