### PR TITLE
fix(app-builder-lib): change slash to backslash in buildInstaller'APP_PACKAGE_NAME

### DIFF
--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -18,7 +18,7 @@ import { execWine } from "../../wine"
 import { WinPackager } from "../../winPackager"
 import { archive, ArchiveOptions } from "../archive"
 import { appendBlockmap, configureDifferentialAwareArchiveOptions, createBlockmap, createNsisWebDifferentialUpdateInfo } from "../differentialUpdateInfoBuilder"
-import { getWindowsInstallationDirName } from "../targetUtil"
+import { getWindowsInstallationAppPackageName, getWindowsInstallationDirName } from "../targetUtil"
 import { addCustomMessageFileInclude, createAddLangsMacro, LangConfigurator } from "./nsisLang"
 import { computeLicensePage } from "./nsisLicense"
 import { NsisOptions, PortableOptions } from "./nsisOptions"
@@ -189,7 +189,7 @@ export class NsisTarget extends Target {
       PROJECT_DIR: packager.projectDir,
       BUILD_RESOURCES_DIR: packager.info.buildResourcesDir,
 
-      APP_PACKAGE_NAME: appInfo.name,
+      APP_PACKAGE_NAME: getWindowsInstallationAppPackageName(appInfo.name),
     }
     if (options.customNsisBinary?.debugLogging) {
       defines.ENABLE_LOGGING_ELECTRON_BUILDER = null

--- a/packages/app-builder-lib/src/targets/targetUtil.ts
+++ b/packages/app-builder-lib/src/targets/targetUtil.ts
@@ -39,3 +39,8 @@ export async function createStageDirPath(target: Target, packager: PlatformPacka
 export function getWindowsInstallationDirName(appInfo: AppInfo, isTryToUseProductName: boolean): string {
   return isTryToUseProductName && /^[-_+0-9a-zA-Z .]+$/.test(appInfo.productFilename) ? appInfo.productFilename : appInfo.sanitizedName
 }
+
+// https://github.com/electron-userland/electron-builder/issues/6747
+export function getWindowsInstallationAppPackageName(appName: string): string {
+  return appName.replace(/\//g, "\\")
+}


### PR DESCRIPTION
Added a function util to replace slash with backslash, and modified slash to backslash so that APP_PACKAGE_NAME is the same folder address in Windows NSIS target.
This task will solve the issue #6747.