### PR TITLE
fix(nsis): specify full path to system's find

### DIFF
--- a/.changeset/nine-ants-wait.md
+++ b/.changeset/nine-ants-wait.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): specify full path to system's find

--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -40,7 +40,7 @@
     ${nsProcess::FindProcess} "${_FILE}" ${_ERR}
   !else
     # find process owned by current user
-    nsExec::Exec `cmd /c tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq ${_FILE}" | find "${_FILE}"`
+    nsExec::Exec `cmd /c tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq ${_FILE}" | %SYSTEMROOT%\System32\find.exe "${_FILE}"`
     Pop ${_ERR}
   !endif
 !macroend


### PR DESCRIPTION
GIT-SCM installation can override window's native `find` command line
tool with the one from unix tools. This in turn changes the exit code of
the whole find process command and makes us detect the app as running
even though it is not.

Credit and original fix by @theAddict

See https://github.com/signalapp/Signal-Desktop/issues/5856