### PR TITLE
fix(app-builder-lib): Overriding OutgoingHttpHeaders schema props

### DIFF
--- a/.changeset/polite-bugs-sparkle.md
+++ b/.changeset/polite-bugs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(app-builder-lib): Overriding `additionalProperties` to allow electron-builder's schema validator to read `publish.requestHeaders`

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      master
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4240,7 +4240,22 @@
       "type": "object"
     },
     "OutgoingHttpHeaders": {
-      "additionalProperties": false,
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": [
+              "string",
+              "number"
+            ]
+          }
+        ]
+      },
       "type": "object"
     },
     "PkgBackgroundOptions": {
@@ -4405,7 +4420,7 @@
               "type": "null"
             }
           ],
-          "description": "Identifies applications that must be closed before the package is installed.\\n\\nCorresponds to [must-close](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html#//apple_ref/doc/uid/TP40005370-CH100-SW77)"
+          "description": "Identifies applications that must be closed before the package is installed.\n\nCorresponds to [must-close](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html#//apple_ref/doc/uid/TP40005370-CH100-SW77)."
         },
         "overwriteAction": {
           "anyOf": [

--- a/scripts/fix-schema.js
+++ b/scripts/fix-schema.js
@@ -8,8 +8,25 @@ let o = schema.definitions.PlugDescriptor.additionalProperties.anyOf[0]
 delete o.typeof
 o.type = "object"
 
+schema.definitions.OutgoingHttpHeaders.additionalProperties = {
+  "anyOf": [
+    {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    {
+      "type": [
+        "string",
+        "number"
+      ]
+    }
+  ]
+}
+
 o = schema.definitions.SnapOptions.properties.environment.anyOf[0] = {
-  additionalProperties: {type: "string"},
+  additionalProperties: { type: "string" },
   type: "object",
 }
 


### PR DESCRIPTION
fix: Overriding `additionalProperties` to allow electron-builder's schema validator to read requestHeaders. It seems that the schema generator does not read `NodeJS.Dict<number | string | string[]>` properly, which then doesn't allow any entries for `publish.requestHeaders` to be provided.
Fixes: #6635