### PR TITLE
fix(nsis): If window service needs to run installer for update, the installer must have admin previlege. #6786

### DIFF
--- a/.changeset/poor-windows-heal.md
+++ b/.changeset/poor-windows-heal.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+If window service needs to run installer for update, the installer must have admin previlege. Electron-updater detects whether elevating or not using isAdminRightsRequired in update-info.json. And this isAdminRightsRequired true option should be added to latest.yml using nsis's packElevateHelper option

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -159,6 +159,7 @@ export class NsisTarget extends Target {
         .join(", "),
     }
     const isPerMachine = options.perMachine === true
+
     if (!this.isPortable) {
       logFields.oneClick = oneClick
       logFields.perMachine = isPerMachine
@@ -319,7 +320,7 @@ export class NsisTarget extends Target {
       updateInfo = await createBlockmap(installerPath, this, packager, safeArtifactName)
     }
 
-    if (updateInfo != null && isPerMachine && oneClick) {
+    if (updateInfo != null && isPerMachine && (oneClick || options.packElevateHelper)) {
       updateInfo.isAdminRightsRequired = true
     }
 

--- a/test/snapshots/windows/assistedInstallerTest.js.snap
+++ b/test/snapshots/windows/assistedInstallerTest.js.snap
@@ -128,3 +128,29 @@ Object {
   ],
 }
 `;
+
+exports[`assisted, only perMachine and elevated 1`] = `
+Object {
+  "win": Array [
+    Object {
+      "arch": "x64",
+      "file": "Test App ßW Setup 1.1.0.exe",
+      "safeArtifactName": "TestApp-Setup-1.1.0.exe",
+      "updateInfo": Object {
+        "isAdminRightsRequired": true,
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    Object {
+      "file": "Test App ßW Setup 1.1.0.exe.blockmap",
+      "safeArtifactName": "TestApp-Setup-1.1.0.exe.blockmap",
+      "updateInfo": Object {
+        "isAdminRightsRequired": true,
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;

--- a/test/src/windows/assistedInstallerTest.ts
+++ b/test/src/windows/assistedInstallerTest.ts
@@ -147,6 +147,20 @@ test.ifNotCiMac(
   })
 )
 
+test.ifNotCiMac(
+  "assisted, only perMachine and elevated",
+  app({
+    targets: nsisTarget,
+    config: {
+      nsis: {
+        oneClick: false,
+        perMachine: true,
+        packElevateHelper: true
+      },
+    },
+  })
+)
+
 // test release notes also
 test.ifAll.ifNotCiMac(
   "allowToChangeInstallationDirectory",


### PR DESCRIPTION
If the electron app needs a custom NSIS installer script (aka. oneClick option is false), the electron installer cannot get isAdminRightsRequired and failed to update when the electron app is running on window service because it requires installer that being admin rights.
It seems that any other reason does not exist when the electron builder NSIS oneClick option is false, update-info's isAdminRightsRequired is false.
Thank you!