### PR TITLE
fix(dmg-builder): exec python fail on Macos12.3

### DIFF
--- a/.changeset/rare-dolls-sin.md
+++ b/.changeset/rare-dolls-sin.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+Fix cannot exec python in MacOS 12.3

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -298,7 +298,11 @@ async function customizeDmg(volumePath: string, specification: DmgOptions, packa
   env.iconLocations = await computeDmgEntries(specification, volumePath, packager, asyncTaskManager)
   await asyncTaskManager.awaitTasks()
   const executePython = async (execName: string) => {
-    await exec(process.env.PYTHON_PATH || `/usr/bin/${execName}`, [path.join(getDmgVendorPath(), "dmgbuild/core.py")], {
+    let pythonPath = process.env.PYTHON_PATH
+    if (!pythonPath) {
+      pythonPath = await exec("which", [execName])
+    }
+    await exec(pythonPath, [path.join(getDmgVendorPath(), "dmgbuild/core.py")], {
       cwd: getDmgVendorPath(),
       env,
     })

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -300,7 +300,7 @@ async function customizeDmg(volumePath: string, specification: DmgOptions, packa
   const executePython = async (execName: string) => {
     let pythonPath = process.env.PYTHON_PATH
     if (!pythonPath) {
-      pythonPath = await exec("which", [execName])
+      pythonPath = (await exec("which", [execName])).trim()
     }
     await exec(pythonPath, [path.join(getDmgVendorPath(), "dmgbuild/core.py")], {
       cwd: getDmgVendorPath(),


### PR DESCRIPTION
close: #6767