### PR TITLE
fix(nsis): cleanup temporary 7z folder

### DIFF
--- a/.changeset/fifty-schools-arrive.md
+++ b/.changeset/fifty-schools-arrive.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): cleanup temporary 7z folder before the last resort extraction. Fix last resort extraction exiting early.

--- a/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/extractAppPackage.nsh
@@ -113,13 +113,21 @@
       # Try copying a few times before asking for a user action.
       Goto RetryExtract7za
     ${else}
-      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY RetryExtract7za
+      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDRETRY IDCANCEL AbortExtract7za
     ${endIf}
 
     # As an absolutely last resort after a few automatic attempts and user
     # intervention - we will just overwrite everything with `Nsis7z::Extract`
     # even though it is not atomic and will ignore errors.
+
+    # Clear the temporary folder first to make sure we don't use twice as
+    # much disk space.
+    RMDir /r "$PLUGINSDIR\7z-out"
+
     Nsis7z::Extract "${FILE}"
+    Goto DoneExtract7za
+
+  AbortExtract7za:
     Quit
 
   RetryExtract7za:


### PR DESCRIPTION
Before attempting to extract files with non-discriminating
`Nsis7z::Extract` that ignores the errors remove the temporary folder so
that we don't require twice as much disk space for this last resort
measure.

Additionally, replace `Quit` with a `Goto DoneExtract7za` so that the
last resort measure actually works.

## Testing

<img width="420" alt="image" src="https://user-images.githubusercontent.com/79877362/163450526-1d1c8dfd-b189-4556-abb7-3ae1ed30dd73.png">