### PR TITLE
fix: github provider prerelease typescript cast

### DIFF
--- a/.changeset/giant-dancers-march.md
+++ b/.changeset/giant-dancers-march.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: github provider prerelease check incorrectly casts undefined to String. Resolves #6809

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -57,7 +57,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
     let tag: string | null = null
     try {
       if (this.updater.allowPrerelease) {
-        const currentChannel = this.updater?.channel || String(semver.prerelease(this.updater.currentVersion)?.[0]) || null
+        const currentChannel = this.updater?.channel || semver.prerelease(this.updater.currentVersion)?.[0] as string || null
         for (const element of feed.getElements("entry")) {
           // noinspection TypeScriptValidateJSTypes
           const hrefElement = hrefRegExp.exec(element.element("link").attribute("href"))!
@@ -68,7 +68,7 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
           // This Release's Tag
           const hrefTag = hrefElement[1]
           //Get Channel from this release's tag
-          const hrefChannel = semver.prerelease(hrefTag)?.[0] || null
+          const hrefChannel = semver.prerelease(hrefTag)?.[0] as string || null
 
           const shouldFetchVersion = !currentChannel || ["alpha", "beta"].includes(currentChannel)
           const isCustomChannel = !["alpha", "beta"].includes(String(hrefChannel))


### PR DESCRIPTION
This PR address issue #6809 by casting channel string in typescript, instead of converting undefined to a string 'undefined' in javascript.