### PR TITLE
fix: Lock wine version to v6 in docker image

### DIFF
--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -5,7 +5,7 @@ RUN dpkg --add-architecture i386 && \
   curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
   echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
-  apt-get install -y --no-install-recommends winehq-stable=6.0.2 && \
+  apt-get install -y --no-install-recommends winehq-stable=6.0.4~focal && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -5,7 +5,7 @@ RUN dpkg --add-architecture i386 && \
   curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
   echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
-  apt-get install -y --no-install-recommends winehq-stable=6.0.4-focal && \
+  apt-get install -y --no-install-recommends winehq-stable=6.0.4~focal-1 && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -5,7 +5,13 @@ RUN dpkg --add-architecture i386 && \
   curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
   echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
-  apt-get install -y --no-install-recommends winehq-stable=6.0.4~focal-1 && \
+  apt-get install -y --no-install-recommends \
+    # We can't install `winehq-stable`, we must manually lock each dependency to v6 (ref: https://github.com/electron-userland/electron-builder/issues/6780),
+    winehq-stable=6.0.4~focal-1 \
+    wine-stable=6.0.4~focal-1 \
+    wine-stable-i386=6.0.4~focal-1 \
+    wine-stable-amd64=6.0.4~focal-1 \
+  && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -5,7 +5,7 @@ RUN dpkg --add-architecture i386 && \
   curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
   echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
-  apt-get install -y --no-install-recommends winehq-stable=6.0.4 && \
+  apt-get install -y --no-install-recommends winehq-stable=6.0.2 && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -5,7 +5,7 @@ RUN dpkg --add-architecture i386 && \
   curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
   echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
-  apt-get install -y --no-install-recommends winehq-stable && \
+  apt-get install -y --no-install-recommends winehq-stable=6.0.4 && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -5,7 +5,7 @@ RUN dpkg --add-architecture i386 && \
   curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
   echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
-  apt-get install -y --no-install-recommends winehq-stable=6.0.4~focal && \
+  apt-get install -y --no-install-recommends winehq-stable=6.0.4-focal && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Force winehq to use version 6.0.4 for docker images. Fixes #6780