### PR TITLE
refactor: Add better typing support on AppUpdater as an event emitter

### DIFF
--- a/.changeset/thin-toys-report.md
+++ b/.changeset/thin-toys-report.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+Added types for AppUpdater's events

--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -29,7 +29,8 @@
     "@types/fs-extra": "9.0.13",
     "@types/js-yaml": "4.0.3",
     "@types/lodash.escaperegexp": "4.1.6",
-    "@types/lodash.isequal": "4.5.5"
+    "@types/lodash.isequal": "4.5.5",
+    "typed-emitter": "^2.1.0"
   },
   "typings": "./out/main.d.ts",
   "publishConfig": {

--- a/packages/electron-updater/src/electronHttpExecutor.ts
+++ b/packages/electron-updater/src/electronHttpExecutor.ts
@@ -1,4 +1,5 @@
 import { DownloadOptions, HttpExecutor, configureRequestOptions, configureRequestUrl } from "builder-util-runtime"
+import { AuthInfo } from "electron"
 import { RequestOptions } from "http"
 import Session = Electron.Session
 import ClientRequest = Electron.ClientRequest
@@ -15,7 +16,7 @@ export function getNetSession(): Session {
 export class ElectronHttpExecutor extends HttpExecutor<Electron.ClientRequest> {
   private cachedSession: Session | null = null
 
-  constructor(private readonly proxyLoginCallback?: (authInfo: any, callback: LoginCallback) => void) {
+  constructor(private readonly proxyLoginCallback?: (authInfo: AuthInfo, callback: LoginCallback) => void) {
     super()
   }
 

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -56,8 +56,8 @@ export interface UpdateCheckResult {
 
 export type UpdaterEvents = "login" | "checking-for-update" | "update-available" | "update-not-available" | "update-cancelled" | "download-progress" | "update-downloaded" | "error"
 
-export const DOWNLOAD_PROGRESS: UpdaterEvents = "download-progress"
-export const UPDATE_DOWNLOADED: UpdaterEvents = "update-downloaded"
+export const DOWNLOAD_PROGRESS = "download-progress"
+export const UPDATE_DOWNLOADED = "update-downloaded"
 
 export type LoginHandler = (authInfo: any, callback: LoginCallback) => void
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,7 @@ importers:
       lodash.escaperegexp: ^4.1.2
       lodash.isequal: ^4.5.0
       semver: ^7.3.5
+      typed-emitter: ^2.1.0
     dependencies:
       '@types/semver': 7.3.9
       builder-util-runtime: link:../builder-util-runtime
@@ -394,6 +395,7 @@ importers:
       '@types/js-yaml': 4.0.3
       '@types/lodash.escaperegexp': 4.1.6
       '@types/lodash.isequal': 4.5.5
+      typed-emitter: 2.1.0
 
   test:
     specifiers:
@@ -11117,6 +11119,12 @@ packages:
   /type-fest/0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /typed-emitter/2.1.0:
+    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
+    optionalDependencies:
+      rxjs: 7.5.5
     dev: true
 
   /typedarray-to-buffer/3.1.5:

--- a/test/src/helpers/updaterTestUtil.ts
+++ b/test/src/helpers/updaterTestUtil.ts
@@ -82,7 +82,7 @@ export function tuneTestUpdater(updater: AppUpdater, options?: TestOnlyUpdaterOp
 
 export function trackEvents(updater: AppUpdater) {
   const actualEvents: Array<string> = []
-  for (const eventName of ["checking-for-update", "update-available", "update-downloaded", "error"]) {
+  for (const eventName of ["checking-for-update", "update-available", "update-downloaded", "error"] as const) {
     updater.addListener(eventName, () => {
       actualEvents.push(eventName)
     })

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -26,7 +26,7 @@ test("downgrade (disallowed, beta)", async () => {
   })
 
   const actualEvents: Array<string> = []
-  const expectedEvents = ["checking-for-update", "update-not-available"]
+  const expectedEvents = ["checking-for-update", "update-not-available"] as const
   for (const eventName of expectedEvents) {
     updater.addListener(eventName, () => {
       actualEvents.push(eventName)


### PR DESCRIPTION
- Helps with not having to look up the specific types for the events
  that are emitted

Signed-off-by: Sebastian Malton <sebastian@malton.name>