### PR TITLE
fix: set github release name to match the app version

### DIFF
--- a/.changeset/blue-carrots-begin.md
+++ b/.changeset/blue-carrots-begin.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: set github release name to match the app version

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -228,6 +228,7 @@ export class GitHubPublisher extends HttpPublisher {
   private createRelease() {
     return this.githubRequest<Release>(`/repos/${this.info.owner}/${this.info.repo}/releases`, this.token, {
       tag_name: this.tag,
+      name: this.version,
       draft: this.releaseType === "draft",
       prerelease: this.releaseType === "prerelease",
     })


### PR DESCRIPTION
This reverts commit [6a116b027504d1b3d44f78ba3df20f68d01dcb32](https://github.com/electron-userland/electron-builder/commit/6a116b027504d1b3d44f78ba3df20f68d01dcb32).

The GitHub release name is set to the version number instead of being left undefined.

Fixes  #6819 