### PR TITLE
fix: Merge arrays from same config key.

### DIFF
--- a/.changeset/good-cooks-sniff.md
+++ b/.changeset/good-cooks-sniff.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: Merge arrays from same config key in cascading electron-builder configs, such as `files`

--- a/packages/builder-util/src/deepAssign.ts
+++ b/packages/builder-util/src/deepAssign.ts
@@ -16,7 +16,12 @@ function assignKey(target: any, from: any, key: string) {
 
   const prevValue = target[key]
   if (prevValue == null || value == null || !isObject(prevValue) || !isObject(value)) {
-    target[key] = value
+    // Merge arrays.
+    if (Array.isArray(prevValue) && Array.isArray(value)) {
+      target[key] = prevValue.concat(value)
+    } else {
+      target[key] = value
+    }
   } else {
     target[key] = assign(prevValue, value)
   }


### PR DESCRIPTION
With these changes, electron-builder can merge extraResources from parent config and current conifg. For example:
common.json:
```
{
  "extends": null,
  "extraResources": [
    "common/*.files",
    "common.file"
  ]
}
```
specific.json:
```
{
  "extends": "common.json",
  "extraResources": [
    {
      "from": "specific",
      "to": ".",
      "filter": ["file.txt"]
    },
  ]
}
```
The merged config - dist/builder-effective-config.yaml:
```
directories:
  output: dist
  buildResources: build
extends: common.json
extraResources:
  - filter:
      - common/*.files
      - common.file
  - from: specific
    filter:
      - file.txt
files: []
electronVersion: 16.2.3
```