### PR TITLE
fix: Add "arm" as an alias for armv7l

### DIFF
--- a/.changeset/mean-elephants-sin.md
+++ b/.changeset/mean-elephants-sin.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: Add "arm" as an alias for armv7l as process.arch outputs arm on armv7l hosts

--- a/packages/builder-util/src/arch.ts
+++ b/packages/builder-util/src/arch.ts
@@ -40,6 +40,7 @@ export function archFromString(name: string): Arch {
       return Arch.ia32
     case "arm64":
       return Arch.arm64
+    case "arm":
     case "armv7l":
       return Arch.armv7l
     case "universal":


### PR DESCRIPTION
Add "arm" as an alias for armv7l as `process.arch` outputs `arm` on armv7l hosts