### PR TITLE
feat: Force updater to only look for non-arm binaries

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -87,6 +87,16 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
   disableWebInstaller = false
 
   /**
+   * Mac only. Force the updater to only upgrade to an x86 update.
+   *
+   * This doesn't work for universal builds.
+   *
+   * @default false
+   *
+   */
+  forceX86 = false
+
+  /**
    * The current application version.
    */
   readonly currentVersion: SemVer

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -63,7 +63,7 @@ export class MacUpdater extends AppUpdater {
       log.warn(`uname shell command to check for arm64 failed: ${e}`)
     }
 
-    isArm64Mac = isArm64Mac || process.arch === "arm64" || isRosetta
+    isArm64Mac = (isArm64Mac || process.arch === "arm64" || isRosetta) && !this.forceX86
 
     // allow arm64 macs to install universal or rosetta2(x64) - https://github.com/electron-userland/electron-builder/pull/5524
     const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64") || file.info.url?.includes("arm64")


### PR DESCRIPTION
Fix #6851 

This would allow code to override the ARM64 check and force upgrading of apps to x86_64 only.

Why is this useful?
- Some native libraries are only available for x86 which breaks apps (cough, Oracle, cough)