### PR TITLE
fix(msi): manually escape XML special characters when building XML

### DIFF
--- a/.changeset/flat-donkeys-cough.md
+++ b/.changeset/flat-donkeys-cough.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Fix MSI build target to support ampersands in the product name

--- a/packages/app-builder-lib/src/targets/MsiTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiTarget.ts
@@ -211,7 +211,7 @@ export default class MsiTarget extends Target {
       // since RegistryValue can be part of Component, *** *** *** *** *** *** *** *** *** wix cannot auto generate guid
       // https://stackoverflow.com/questions/1405100/change-my-component-guid-in-wix
       let result = `<Component${directoryId === null ? "" : ` Directory="${directoryId}"`}>`
-      result += `\n${fileSpace}  <File Name="${fileName}" Source="$(var.appDir)${path.sep}${packagePath}" ReadOnly="yes" KeyPath="yes"`
+      result += `\n${fileSpace}  <File Name="${xmlAttr(fileName)}" Source="$(var.appDir)${path.sep}${xmlAttr(packagePath)}" ReadOnly="yes" KeyPath="yes"`
       const isMainExecutable = packagePath === `${appInfo.productFilename}.exe`
       if (isMainExecutable) {
         result += ' Id="mainExecutable"'
@@ -224,7 +224,7 @@ export default class MsiTarget extends Target {
         result += `>\n`
         const shortcutName = commonOptions.shortcutName
         if (isCreateDesktopShortcut) {
-          result += `${fileSpace}  <Shortcut Id="desktopShortcut" Directory="DesktopFolder" Name="${shortcutName}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${this.iconId}"/>\n`
+          result += `${fileSpace}  <Shortcut Id="desktopShortcut" Directory="DesktopFolder" Name="${xmlAttr(shortcutName)}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${this.iconId}"/>\n`
         }
 
         const hasMenuCategory = commonOptions.menuCategory != null
@@ -233,8 +233,8 @@ export default class MsiTarget extends Target {
           if (hasMenuCategory) {
             dirs.push(`<Directory Id="${startMenuShortcutDirectoryId}" Name="ProgramMenuFolder:\\${commonOptions.menuCategory}\\"/>`)
           }
-          result += `${fileSpace}  <Shortcut Id="startMenuShortcut" Directory="${startMenuShortcutDirectoryId}" Name="${shortcutName}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${this.iconId}">\n`
-          result += `${fileSpace}    <ShortcutProperty Key="System.AppUserModel.ID" Value="${this.packager.appInfo.id}"/>\n`
+          result += `${fileSpace}  <Shortcut Id="startMenuShortcut" Directory="${startMenuShortcutDirectoryId}" Name="${xmlAttr(shortcutName)}" WorkingDirectory="APPLICATIONFOLDER" Advertise="yes" Icon="${this.iconId}">\n`
+          result += `${fileSpace}    <ShortcutProperty Key="System.AppUserModel.ID" Value="${xmlAttr(this.packager.appInfo.id)}"/>\n`
           result += `${fileSpace}  </Shortcut>\n`
         }
         result += `${fileSpace}</File>`
@@ -255,7 +255,7 @@ export default class MsiTarget extends Target {
               item.description ? `Description="${item.description}"` : ""
             }>\n`
             result += `${fileSpace}    <Extension Id="${ext}" Advertise="yes">\n`
-            result += `${fileSpace}      <Verb Id="open" Command="Open with ${this.packager.appInfo.productName}" Argument="&quot;%1&quot;"/>\n`
+            result += `${fileSpace}      <Verb Id="open" Command="Open with ${xmlAttr(this.packager.appInfo.productName)}" Argument="&quot;%1&quot;"/>\n`
             result += `${fileSpace}    </Extension>\n`
             result += `${fileSpace}  </ProgId>\n`
           }
@@ -272,4 +272,13 @@ export default class MsiTarget extends Target {
 function listToString(list: Array<string>, indentLevel: number) {
   const space = " ".repeat(indentLevel * 2)
   return list.join(`\n${space}`)
+}
+
+function xmlAttr(str: string) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
 }


### PR DESCRIPTION
project.wxs contains invalid XML chars when building a package
containing an ampersand.

All attributes are already escaped thanks to EJS engine but the part
about files is built as a string and injected as-is in the template.

The next step would be to use an EJS template for the files too.

https://github.com/electron-userland/electron-builder/issues/5387