### PR TITLE
fix: add afterPack call after macOS universal package is created

### DIFF
--- a/.changeset/wet-ligers-heal.md
+++ b/.changeset/wet-ligers-heal.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+add afterPack call after macOS universal package is created

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -132,7 +132,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         })
         await fs.rm(x64AppOutDir, { recursive: true, force: true })
         await fs.rm(arm64AppOutPath, { recursive: true, force: true })
-        
+
         // Give users a final opportunity to perform things on the combined universal package before signing
         const packContext: AfterPackContext = {
           appOutDir,

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -132,6 +132,18 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         })
         await fs.rm(x64AppOutDir, { recursive: true, force: true })
         await fs.rm(arm64AppOutPath, { recursive: true, force: true })
+        
+        // Give users a final opportunity to perform things on the combined universal package before signing
+        const packContext: AfterPackContext = {
+          appOutDir,
+          outDir,
+          arch,
+          targets,
+          packager: this,
+          electronPlatformName: platformName,
+        }
+        await this.info.afterPack(packContext)
+
         await this.doSignAfterPack(outDir, appOutDir, platformName, arch, platformSpecificBuildOptions, targets)
         break
       }


### PR DESCRIPTION
The universal target for macOS fires the afterPack hook after both x64 and arm64, but not after the final package has been created. This is a problem, as there may need to be some final opportunity to adjust the final package before signing in doSignAfterPack.

**Context**:
In my scenario, this comes up when I'm embedding a macOS appex extension (not a kernel extension) in my PlugIns folder. I can't pre-sign my extension, as electron-builder and by extension, @electron/universal seems to require that my extension is separated out into 2 distinct arch extensions (x64, and arm64) for combining them via makeUniversalApp.

I cannot sign these in the current afterPack hooks, because each arch-dependent package gets signed, and then upon the attempted package combination, fails as the packages are different (they'll contain the non-binary signatures, which will be different).

electron-builder will not sign extensions inside of Content/PlugIns when supplied to the "binaries" option, either as it is purposely excluded from signing (even if the assumption that anything here is a kernel extension is erroneous) (see: https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/src/macPackager.ts#L271). "binaries" cannot contain their own entitlements anyway, making the removal of this exclusion a bad solution.

doSignAfterPack will fail validation unless the embedded appex is properly signed beforehand. It appears the only place to perform this operation will be this PR's new afterPack call after both x64 and arm64 have both been combined into the final package.
