### PR TITLE
fix: pin Keygen integration to API v1.0

### DIFF
--- a/.changeset/strong-carrots-invent.md
+++ b/.changeset/strong-carrots-invent.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"electron-updater": patch
+---
+
+Pin Keygen publisher/updater integration to API version v1.0.

--- a/packages/app-builder-lib/src/publish/KeygenPublisher.ts
+++ b/packages/app-builder-lib/src/publish/KeygenPublisher.ts
@@ -59,6 +59,7 @@ export class KeygenPublisher extends HttpPublisher {
       headers: {
         Accept: "application/vnd.api+json",
         "Content-Length": dataLength,
+        "Keygen-Version": "1.0",
       },
     }
     await httpExecutor.doApiRequest(configureRequestOptions(upload, this.auth, "PUT"), this.context.cancellationToken, requestProcessor)
@@ -72,6 +73,7 @@ export class KeygenPublisher extends HttpPublisher {
       headers: {
         "Content-Type": "application/vnd.api+json",
         Accept: "application/vnd.api+json",
+        "Keygen-Version": "1.0",
       },
     }
     const data = {
@@ -105,6 +107,7 @@ export class KeygenPublisher extends HttpPublisher {
       path: `${this.basePath}/${releaseId}`,
       headers: {
         Accept: "application/vnd.api+json",
+        "Keygen-Version": "1.0",
       },
     }
     await httpExecutor.request(configureRequestOptions(req, this.auth, "DELETE"), this.context.cancellationToken)

--- a/packages/electron-updater/src/providers/KeygenProvider.ts
+++ b/packages/electron-updater/src/providers/KeygenProvider.ts
@@ -28,6 +28,7 @@ export class KeygenProvider extends Provider<UpdateInfo> {
         channelUrl,
         {
           Accept: "application/vnd.api+json",
+          "Keygen-Version": "1.0",
         },
         cancellationToken
       )


### PR DESCRIPTION
As part of an upcoming change to Keygen's API, we need to pin electron-builder's integration to v1.0 of Keygen's API so that newer Keygen users on v1.1 (the soon-to-be new default) can still utilize the current integration as-is. I wanted to get this integration updated before we roll out the newer API version in the coming weeks.

Below is a list of notable things that will be changing in v1.1 of Keygen's API:

1. The Release object's has-one Artifact relationship has been replaced with a has-many Artifacts relationship. The endpoint for the has-one Artifact relationship has been deprecated, i.e. `PUT /releases/<release>/artifact`.
1. A `status` attribute has been to the Release object, which can be `DRAFT` or `PUBLISHED`. New Release objects will default to a draft state and must be explicitly published before being made available for upgrades.
1. The following attributes have been moved from the Release object to the Artifact object: `filename`, `filetype`, `filesize`, `platform`, `signature`, and `checksum`.
1. The endpoint for upserting a Release, i.e. `PUT /releases`, has been deprecated.

Essentially, the gist of the change set here is around refactoring Releases to be a versioned "bucket" for Artifacts, rather than a one-to-one relationship between a Release and Artifact. The new object model gets rid of a lot of confusing problems that the previous modeling had, such as conflicting versions when a filetype or filename matched a previous Release.

In v1.1 of Keygen's API, multiple Releases can have Artifacts that have the same filename, e.g. `latest-mac.yml`, and the latest will be retrieved when requesting a particular Artifact by filename, e.g. `GET /artifacts/<filename>`.

These API changes are being made in a backwards-compatible way, with the `Keygen-Version` header used to communicate which API version is requested. All existing electron-builder integrations will continue to work.

I'm going to create a follow up PR that refactors the integration to use v1.1 of Keygen's API.