### PR TITLE
feat: electron/universal has a new minimatch option 'x64ArchFiles'

### DIFF
--- a/.changeset/famous-cheetahs-run.md
+++ b/.changeset/famous-cheetahs-run.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+Expose electron/universal's new "x64ArchFiles" option to allow building universal binaries with single-architecture dependencies

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -129,6 +129,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
           force: true,
           mergeASARs: platformSpecificBuildOptions.mergeASARs ?? true,
           singleArchFiles: platformSpecificBuildOptions.singleArchFiles,
+          x64ArchFiles: platformSpecificBuildOptions.x64ArchFiles,
         })
         await fs.rm(x64AppOutDir, { recursive: true, force: true })
         await fs.rm(arm64AppOutPath, { recursive: true, force: true })

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -192,6 +192,15 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * only if `mergeASARs` is `true`.
    */
   readonly singleArchFiles?: string
+
+  /**
+   * Minimatch pattern of paths that are allowed to be x64 binaries in both
+   * ASAR files
+   *
+   * This option has no effect unless building for "universal" arch and applies
+   * only if `mergeASARs` is `true`.
+   */
+  readonly x64ArchFiles?: string
 }
 
 export interface DmgOptions extends TargetSpecificOptions {


### PR DESCRIPTION
Some projects need to ship x64 binaries which will be run under
Rosetta2 on arm64 Macs.

This option allows a packager to specify that they're aware that
certain files in their distribution which are included in both x64
and arm64 builds are actually x64 binaries in both builds.

Without this option, electron/universal will attempt to lipo
the two binaries together, resulting in a build failure.