### PR TITLE
feat: Yarn 2&3 Compatibility Configuration

### DIFF
--- a/.changeset/unlucky-shoes-crash.md
+++ b/.changeset/unlucky-shoes-crash.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Yarn 2&3 Compatibility Configuration

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -75,7 +75,8 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 <li><code id="Configuration-freebsd">freebsd</code> <a href="/configuration/linux#LinuxTargetSpecificOptions">LinuxTargetSpecificOptions</a></li>
 <li><code id="Configuration-p5p">p5p</code> <a href="/configuration/linux#LinuxTargetSpecificOptions">LinuxTargetSpecificOptions</a></li>
 <li><code id="Configuration-apk">apk</code> <a href="/configuration/linux#LinuxTargetSpecificOptions">LinuxTargetSpecificOptions</a></li>
-<li><code id="Configuration-includeSubNodeModules">includeSubNodeModules</code> = <code>false</code> Boolean - Whether to include <em>all</em> of the submodules node_modules directories</li>
+<li><code id="Configuration-includeSubNodeModules">includeSubNodeModules</code> = <code>false</code> Boolean - Whether to include <em>all</em> of the submodules <code>node_modules</code> directories</li>
+<li><code id="Configuration-includeYarnSubNodeModules">includeYarnSubNodeModules</code> = <code>false</code> Boolean - Whether to include <em>all</em> of the submodules <code>.yarn</code> directories</li>
 </ul>
 <hr>
 <ul>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6530,6 +6530,11 @@
       "description": "Whether to include *all* of the submodules node_modules directories",
       "type": "boolean"
     },
+    "includeYarnSubNodeModules": {
+      "default": false,
+      "description": "Whether to include *all* of the submodules .yarn directories",
+      "type": "boolean"
+    },
     "launchUiVersion": {
       "description": "*libui-based frameworks only* The version of LaunchUI you are packaging for. Applicable for Windows only. Defaults to version suitable for used framework version.",
       "type": [

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -108,6 +108,12 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   includeSubNodeModules?: boolean
 
   /**
+   * Whether to include *all* of the submodules .yarn directories
+   * @default false
+   */
+  includeYarnSubNodeModules?: boolean
+
+  /**
    * Whether to build the application native dependencies from source.
    * @default false
    */

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -187,7 +187,9 @@ export function getMainFileMatchers(
   if (isElectronCompile) {
     patterns.push("!.cache{,/**/*}")
   }
-  patterns.push("!.yarn{,/**/*}")
+  if (!packager.config.includeYarnSubNodeModules) {
+    patterns.push("!.yarn{,/**/*}")
+  }
 
   // https://github.com/electron-userland/electron-builder/issues/1969
   // exclude ony for app root, use .yarnclean to clean node_modules

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -156,7 +156,9 @@ export function getMainFileMatchers(
     patterns.push("package.json")
   }
 
-  customFirstPatterns.push("!**/node_modules")
+  if (!packager.config.includeYarnSubNodeModules) {
+    customFirstPatterns.push("!**/node_modules")
+  }
 
   // https://github.com/electron-userland/electron-builder/issues/1482
   const relativeBuildResourceDir = path.relative(matcher.from, buildResourceDir)


### PR DESCRIPTION
Added a new  configuration option `includeYarnSubNodeModules` = `false`.
Did not forget the scheme, md and kept the same logistical order, please approve will save my insanity!

Preview:
![image](https://user-images.githubusercontent.com/41600149/172037746-95efb671-b004-4ec1-8bae-b2a5e24ab71e.png)

Implemention:
![image](https://user-images.githubusercontent.com/41600149/172037763-048e47c0-8915-47ec-ad59-7036c874254b.png)
![image](https://user-images.githubusercontent.com/41600149/172039240-9844b45c-da13-4d46-a9f2-5722570dd914.png)

It's `false` by default meaning this line will always run as usual, only if I set it to true it will remove the yarn exclusion glob `!.yarn{,/**/*}` which I need removed badly, please

Notice that unplugged plugins will not get copied because of line 160 in my second image ^^

The reason yarn 3 unplugged plugins will not get copied properly is the following:

![image](https://user-images.githubusercontent.com/41600149/172039664-a1c10360-0255-4a36-b8e0-75d4b84434a6.png)

yarn unplugged plugins are inside a `node_modules` folder inside `.yarn` ..

![image](https://user-images.githubusercontent.com/41600149/172039650-f20f646d-f71c-45e8-919a-9f8d929bf4b5.png)

More Info: https://github.com/electron-userland/electron-builder/issues/6926