### PR TITLE
docs: Amended codesigning docs

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,4 +1,6 @@
-macOS and Windows code signing is supported. Windows is dual code-signed (SHA1 & SHA256 hashing algorithms).
+macOS and Windows code signing is supported. If the configuration values are provided correctly in your package.json, then signing should be automatically executed.
+
+Windows is dual code-signed (SHA1 & SHA256 hashing algorithms).
 
 On a macOS development machine, a valid and appropriate identity from your keychain will be automatically used.
 
@@ -73,3 +75,10 @@ Please note — Gatekeeper only recognises [Apple digital certificates](http://s
 To disable Code Signing when building for macOS leave all the above vars unset except for `CSC_IDENTITY_AUTO_DISCOVERY` which needs to be set to `false`. This can be done by running `export CSC_IDENTITY_AUTO_DISCOVERY=false`. 
 
 Another way — set `mac.identity` to `null`. You can pass aditional configuration using CLI as well: `-c.mac.identity=null`.
+
+## Alternative methods of codesigning
+
+Codesigning via Electron Builder's configuration (via package.json) is not the only way to sign an application. Some people find it easier to codesign using a GUI tool. A couple of examples include:
+- [SSL manager](https://www.ssl.com/ssl-manager)
+- [DigiCert utility for Windows](https://www.digicert.com/support/tools/certificate-utility-for-windows)
+Of course any comprehensive discussion of such tools is beyond the scope of this documentation.


### PR DESCRIPTION
- Made it clear that ' If the configuration values are provided correctly in your package.json, then signing should be automatically executed.' (as answered in a previous discussion)
- Added alternative codesigning methods paragraph. This makes it clear to noobs that there are alternative methods of codesigning, so they dont not have to wrestle with fully understanding the built in process and can instead choose