### PR TITLE
chore: renovate bot setting to pin actions to a full length commit SHA

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,8 @@
     ":prNotPending",
     "group:recommended",
     "group:monorepos",
-    ":enableVulnerabilityAlerts"
+    ":enableVulnerabilityAlerts",
+    "helpers:pinGitHubActionDigests"
   ],
   "npm": {
     "extends": [


### PR DESCRIPTION
- https://docs.renovatebot.com/modules/manager/github-actions/#additional-information

- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.
> Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository,
> as they would need to generate a SHA-1 collision for a valid Git object payload.

- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- https://github.com/renovatebot/.github/blob/b0c3aa85ef2bb242580f20b02b380ca532b4ce17/default.json#L13