### PR TITLE
feat: upgrade Keygen integration to v1.1

### DIFF
--- a/.changeset/seven-frogs-attend.md
+++ b/.changeset/seven-frogs-attend.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": minor
+"electron-updater": minor
+---
+
+Upgrade Keygen publisher/updater integration to API version v1.1.

--- a/packages/electron-updater/src/providers/KeygenProvider.ts
+++ b/packages/electron-updater/src/providers/KeygenProvider.ts
@@ -28,7 +28,7 @@ export class KeygenProvider extends Provider<UpdateInfo> {
         channelUrl,
         {
           Accept: "application/vnd.api+json",
-          "Keygen-Version": "1.0",
+          "Keygen-Version": "1.1",
         },
         cancellationToken
       )

--- a/test/src/ArtifactPublisherTest.ts
+++ b/test/src/ArtifactPublisherTest.ts
@@ -132,8 +132,8 @@ test.ifEnv(process.env.KEYGEN_TOKEN)("Keygen upload", async () => {
     {
       provider: "keygen",
       // electron-builder-test
-      product: "43981278-96e7-47de-b8c2-98d59987206b",
-      account: "cdecda36-3ef0-483e-ad88-97e7970f3149",
+      product: process.env.KEYGEN_PRODUCT || "43981278-96e7-47de-b8c2-98d59987206b",
+      account: process.env.KEYGEN_ACCOUNT || "cdecda36-3ef0-483e-ad88-97e7970f3149",
       platform: Platform.MAC.name,
     } as KeygenOptions,
     versionNumber()

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -55,8 +55,8 @@ test.ifEnv(process.env.KEYGEN_TOKEN)("file url keygen", async () => {
   updater.addAuthHeader(`Bearer ${process.env.KEYGEN_TOKEN}`)
   updater.updateConfigPath = await writeUpdateConfig<KeygenOptions>({
     provider: "keygen",
-    product: "43981278-96e7-47de-b8c2-98d59987206b",
-    account: "cdecda36-3ef0-483e-ad88-97e7970f3149",
+    product: process.env.KEYGEN_PRODUCT || "43981278-96e7-47de-b8c2-98d59987206b",
+    account: process.env.KEYGEN_ACCOUNT || "cdecda36-3ef0-483e-ad88-97e7970f3149",
   })
   await validateDownload(updater)
 })


### PR DESCRIPTION
Follow up to #6909, which covers the API changes more in-depth. This should have no breaking changes for app's that are upgrading from v1.0 to v1.1 of the API, since it's only related to publishing (the auto-upgrade functionality still works as it did before from a consumer standpoint), so I think it's safe to include in a minor electron-builder update.

I don't think this should be merged until #6920 is out, to give an option to pin to v1.0 for whatever reason (via #6909).