### PR TITLE
fix: prevent infinite looping of overwriteArtifact

### DIFF
--- a/.changeset/wild-crabs-prove.md
+++ b/.changeset/wild-crabs-prove.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: prevent infinite error looping of overwriteArtifact during github artifact uploads

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -198,12 +198,10 @@ export class GitHubPublisher extends HttpPublisher {
         requestProcessor
       )
       .catch(e => {
-        if (this.doesErrorMeanAlreadyExists(e)) {
-          return this.overwriteArtifact(fileName, release).then(() => this.doUploadFile(attemptNumber, parsedUrl, fileName, dataLength, requestProcessor, release))
-        }
-
         if (attemptNumber > 3) {
           return Promise.reject(e)
+        } else if (this.doesErrorMeanAlreadyExists(e)) {
+          return this.overwriteArtifact(fileName, release).then(() => this.doUploadFile(attemptNumber + 1, parsedUrl, fileName, dataLength, requestProcessor, release))
         } else {
           return new Promise((resolve, reject) => {
             const newAttemptNumber = attemptNumber + 1


### PR DESCRIPTION
In the case that overriding an existing github artifact fails, it will continually retry until github reaches an API limit. This change should prevent retrying an unnecessary amount of times (but doesn't fix the root issue of why the override failed in the first place).