### PR TITLE
fix(nsis): fix typo in German installer message

### DIFF
--- a/.changeset/soft-planes-jam.md
+++ b/.changeset/soft-planes-jam.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): fix typo in German installer message

--- a/packages/app-builder-lib/templates/nsis/assistedMessages.yml
+++ b/packages/app-builder-lib/templates/nsis/assistedMessages.yml
@@ -242,7 +242,7 @@ loginWithAdminAccount:
   ko: 계속하려면 관리자 그룹의 구성원인 계정으로 로그인해야 합니다...
 perUserInstallExists:
   en: There is already a per-user installation.
-  de: Es existiert bereits eine Installtion für den ausgewählten Benutzer.
+  de: Es existiert bereits eine Installation für den ausgewählten Benutzer.
   ru: Уже есть установленная программа для отдельного пользователя.
   cs: Již existuje instalace pro uživatele.
   fr: Il y a déjà une installation par utilisateur.


### PR DESCRIPTION
This fixes a typo in a German NSIS installer message (perUserInstallExists).