### PR TITLE
fix: nsis-web target set APP_PACKAGE_URL_IS_INCOMPLETE

### DIFF
--- a/.changeset/cuddly-books-approve.md
+++ b/.changeset/cuddly-books-approve.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: nsis-web target set APP_PACKAGE_URL_IS_INCOMPLETE

--- a/packages/app-builder-lib/src/targets/nsis/WebInstallerTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/WebInstallerTarget.ts
@@ -29,10 +29,9 @@ export class WebInstallerTarget extends NsisTarget {
       }
 
       appPackageUrl = computeDownloadUrl(publishConfigs[0], null, packager)
-
-      defines.APP_PACKAGE_URL_IS_INCOMLETE = null
     }
 
+    defines.APP_PACKAGE_URL_IS_INCOMPLETE = null
     defines.APP_PACKAGE_URL = appPackageUrl
   }
 

--- a/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/webPackage.nsh
@@ -5,7 +5,7 @@
   StrCpy $packageUrl "${APP_PACKAGE_URL}"
   StrCpy $packageArch "${APP_PACKAGE_URL}"
 
-  !ifdef APP_PACKAGE_URL_IS_INCOMLETE
+  !ifdef APP_PACKAGE_URL_IS_INCOMPLETE
     !ifdef APP_64_NAME
       !ifdef APP_32_NAME
 	    	!ifdef APP_ARM64_NAME


### PR DESCRIPTION
When specifying `appPackageUrl` in the `NsisWebOptions` config `APP_PACKAGE_URL_IS_INCOMPLETE` would not be set to `null` and thus the installer would not include the packages.

Now I'm not sure if `APP_PACKAGE_URL_IS_INCOMPLETE` is even needed or if the check in `webPackage.nsh` could even be removed.