### PR TITLE
fix(mas): Allow signing with "3rd Party Mac Developer Application"

### DIFF
--- a/.changeset/little-ways-watch.md
+++ b/.changeset/little-ways-watch.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mas): Allow signing with "3rd Party Mac Developer Application"

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -468,5 +468,5 @@ function getCertificateTypes(isMas: boolean, isDevelopment: boolean): CertType[]
   if (isDevelopment) {
     return isMas ? ["Mac Developer", "Apple Development"] : ["Mac Developer", "Developer ID Application"]
   }
-  return isMas ? ["Apple Distribution"] : ["Developer ID Application"]
+  return isMas ? ["3rd Party Mac Developer Application", "Apple Distribution"] : ["Developer ID Application"]
 }


### PR DESCRIPTION
Despite the "Developer" in the name, this is only used for Mac App
Store Distribution.

This was by accident removed in #6105