### PR TITLE
fix: add product scope to keygen provider

### DIFF
--- a/.changeset/long-goats-attack.md
+++ b/.changeset/long-goats-attack.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+Fix artifact conflicts for Keygen provider when multiple artifacts share the same filename across products.

--- a/packages/electron-updater/src/providers/KeygenProvider.ts
+++ b/packages/electron-updater/src/providers/KeygenProvider.ts
@@ -12,7 +12,7 @@ export class KeygenProvider extends Provider<UpdateInfo> {
       ...runtimeOptions,
       isUseMultipleRangeRequest: false,
     })
-    this.baseUrl = newBaseUrl(`https://api.keygen.sh/v1/accounts/${this.configuration.account}/artifacts`)
+    this.baseUrl = newBaseUrl(`https://api.keygen.sh/v1/accounts/${this.configuration.account}/artifacts?product=${this.configuration.product}`)
   }
 
   private get channel(): string {


### PR DESCRIPTION
This PR adds a product qualifier to artifact download requests. Resolving an issue where, in the case of a Keygen account distributing multiple products using electron-builder, a conflict can arise due to a shared filename across products. In most cases, this happens with `stable.yml` and its `yml` friends.

This issue will present itself under the following circumstances:

1. One or more products have an `OPEN` distribution strategy, meaning no license is required to view or download the artifacts. For example, Product A has a `LICENSED` distribution strategy, while Product B has an `OPEN` distribution strategy. This may result in Product A's updater requesting the `latest.yml` artifact without a product qualifier, causing our API to return the artifact of Product B, given it was released at a later date or has a higher version number.
2. The licensee has access to more than 1 product via their licenses. For example, when authenticating as a Keygen user who has licenses for both Product A and Product B. This may, again, result in an artifact mix up.

Both of these scenarios result in a failed update.