### PR TITLE
fix: Update snapcraft.yaml to use gnome-3-38-2004

### DIFF
--- a/.changeset/twelve-snakes-whisper.md
+++ b/.changeset/twelve-snakes-whisper.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Update snapcraft.yaml to use gnome-3-38-2004

--- a/packages/app-builder-lib/templates/snap/snapcraft.yaml
+++ b/packages/app-builder-lib/templates/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ parts:
   app:
     plugin: "nil"
       # cd ~ && rm -rf ~/squashfs-root && unsquashfs /media/psf/ramdisk/electron-builder-test/dist/__snap-x64/se-wo-template_1.1.0_amd64.snap
-      # comm -12 <(ls ~/squashfs-root/usr/lib/x86_64-linux-gnu/) <(ls /snap/gnome-3-28-1804/current/usr/lib/x86_64-linux-gnu/) > /media/psf/Home/f.txt
+      # comm -12 <(ls ~/squashfs-root/usr/lib/x86_64-linux-gnu/) <(ls /snap/gnome-3-38-2004/current/usr/lib/x86_64-linux-gnu/) > /media/psf/Home/f.txt
       # run snap-exclude-list.js
     stage:
       - '-usr/lib/python*'

--- a/packages/app-builder-lib/templates/snap/snapcraft.yaml
+++ b/packages/app-builder-lib/templates/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-base: core18
+base: core20
 grade: stable
 confinement: strict
 parts:
@@ -130,10 +130,10 @@ parts:
       - "-usr/lib/*/libXrandr*"
       - "-usr/lib/*/libXrender*"
 plugs:
-  gnome-3-28-1804:
+  gnome-3-38-2004:
     interface: content
     target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
+    default-provider: gnome-3-38-2004
   gtk-3-themes:
     interface: content
     target: $SNAP/data-dir/themes


### PR DESCRIPTION
The core18 and plug gnome-3-28-1804 lose standard (free/community) support in less than a year in accordance with the Ubuntu LTS timeline as these both correspond with Ubuntu 18.04 LTS, which loses standard support in April 2023 and moves to paid-only support. To continue to have secure builds for Electron apps, new snap builds should move to core20 and use plug gnome-3-38-2004.

As an added bonus, this will also allow Ubuntu and official Ubuntu flavors to seed Electron snaps built with core20 and gnome-3-38-2004 because gnome-3-38-2004 provides the proper facility for this process.