### PR TITLE
docs: add missing PORTABLE_EXECUTABLE_FILE

### DIFF
--- a/.changeset/silly-moose-brush.md
+++ b/.changeset/silly-moose-brush.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+docs: add missing PORTABLE_EXECUTABLE_FILE

--- a/docs/configuration/nsis.md
+++ b/docs/configuration/nsis.md
@@ -107,7 +107,8 @@ To build portable app, set target to `portable` (or pass `--win portable`).
 
 For portable app, following environment variables are available:
 
-* `PORTABLE_EXECUTABLE_DIR` - dir where portable executable located.
+* `PORTABLE_EXECUTABLE_FILE` - path to the portable executable.
+* `PORTABLE_EXECUTABLE_DIR` - directory where the portable executable is located.
 * `PORTABLE_EXECUTABLE_APP_FILENAME` - sanitized app name to use in [file paths](https://github.com/electron-userland/electron-builder/issues/3186#issue-345489962).
 
 ## Common Questions


### PR DESCRIPTION
This environment variable is set and it's very useful, but the documentation missed it.

- https://github.com/electron-userland/electron-builder/blob/8ffd9d42d89634be76fd4554f659f2b2512f2081/packages/app-builder-lib/templates/nsis/portable.nsi#L78
- Refs https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/1331
- Refs https://github.com/electron-userland/electron-builder/issues/3186