### PR TITLE
fix: add product scope to Keygen publisher

### DIFF
--- a/.changeset/thirty-numbers-lick.md
+++ b/.changeset/thirty-numbers-lick.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Fix release conflicts for Keygen publisher when releases share the same version across open/licensed products.

--- a/packages/app-builder-lib/src/publish/KeygenPublisher.ts
+++ b/packages/app-builder-lib/src/publish/KeygenPublisher.ts
@@ -194,7 +194,7 @@ export class KeygenPublisher extends HttpPublisher {
   private async getRelease(): Promise<{ data?: KeygenRelease; errors?: KeygenError[] }> {
     const req: RequestOptions = {
       hostname: this.hostname,
-      path: `${this.basePath}/releases/${this.version}`,
+      path: `${this.basePath}/releases/${this.version}?product=${this.info.product}`,
       headers: {
         Accept: "application/vnd.api+json",
         "Keygen-Version": "1.1",


### PR DESCRIPTION
Applying #6975 to the Keygen publisher as well. As covered in the linked PR, in the case of an `OPEN` product, the Keygen publisher's find-or-create method could receive a false positive if an open release is already available which has the same version as the one being created. This resolves the issue by adding a product qualifier to all release `GET` requests.