### PR TITLE
fix: Wrap the nsProcess include in a !ifndef

### DIFF
--- a/.changeset/gentle-singers-sip.md
+++ b/.changeset/gentle-singers-sip.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Wrap the nsProcess.nsh include in a !ifndef in case it has already been imported in a custom install script

--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -1,4 +1,6 @@
-!include "nsProcess.nsh"
+!ifndef nsProcess::FindProcess
+    !include "nsProcess.nsh"
+!endif
 
 !ifmacrondef customCheckAppRunning
   !include "getProcessInfo.nsh"


### PR DESCRIPTION
Conditionally include nsProcess only if it has not previously been included or defined. 

There is a use case where you include `nsProcess.nsh` in your own custom install script. If you do that this file throws an error indicating that `nsProcess` has already been defined. I suspect it is due to the invocation order and how your custom scripts logic runs before the logic in this file.