### PR TITLE
fix(electron-updater): fix backward compatibility for GitHub provider without channels

### DIFF
--- a/.changeset/fair-gifts-explain.md
+++ b/.changeset/fair-gifts-explain.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix(electron-updater): fix backward compatibility for GitHub provider without channels

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -58,32 +58,38 @@ export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
     try {
       if (this.updater.allowPrerelease) {
         const currentChannel = this.updater?.channel || (semver.prerelease(this.updater.currentVersion)?.[0] as string) || null
-        for (const element of feed.getElements("entry")) {
+        
+        if (currentChannel === null) {
           // noinspection TypeScriptValidateJSTypes
-          const hrefElement = hrefRegExp.exec(element.element("link").attribute("href"))!
+          tag = hrefRegExp.exec(latestRelease.element("link").attribute("href"))![1]
+        } else {
+          for (const element of feed.getElements("entry")) {
+            // noinspection TypeScriptValidateJSTypes
+            const hrefElement = hrefRegExp.exec(element.element("link").attribute("href"))!
 
-          // If this is null then something is wrong and skip this release
-          if (hrefElement === null) continue
+            // If this is null then something is wrong and skip this release
+            if (hrefElement === null) continue
 
-          // This Release's Tag
-          const hrefTag = hrefElement[1]
-          //Get Channel from this release's tag
-          const hrefChannel = (semver.prerelease(hrefTag)?.[0] as string) || null
+            // This Release's Tag
+            const hrefTag = hrefElement[1]
+            //Get Channel from this release's tag
+            const hrefChannel = (semver.prerelease(hrefTag)?.[0] as string) || null
 
-          const shouldFetchVersion = !currentChannel || ["alpha", "beta"].includes(currentChannel)
-          const isCustomChannel = !["alpha", "beta"].includes(String(hrefChannel))
-          // Allow moving from alpha to beta but not down
-          const channelMismatch = currentChannel === "beta" && hrefChannel === "alpha"
+            const shouldFetchVersion = !currentChannel || ["alpha", "beta"].includes(currentChannel)
+            const isCustomChannel = !["alpha", "beta"].includes(String(hrefChannel))
+            // Allow moving from alpha to beta but not down
+            const channelMismatch = currentChannel === "beta" && hrefChannel === "alpha"
 
-          if (shouldFetchVersion && !isCustomChannel && !channelMismatch) {
-            tag = hrefTag
-            break
-          }
+            if (shouldFetchVersion && !isCustomChannel && !channelMismatch) {
+              tag = hrefTag
+              break
+            }
 
-          const isNextPreRelease = hrefChannel && hrefChannel === currentChannel
-          if (isNextPreRelease) {
-            tag = hrefTag
-            break
+            const isNextPreRelease = hrefChannel && hrefChannel === currentChannel
+            if (isNextPreRelease) {
+              tag = hrefTag
+              break
+            }
           }
         }
       } else {


### PR DESCRIPTION
Adding support for channels on GitHub was breaking change for those using only pre-release status without channel tags.

- [ ] TODO: update documentation 


### Issues with the current solution (without this PR):

**Example 1:**
- User has app version 1.0.0 with `allowPrerelease=true`
- App has available updates on GitHub:
  - 2.0.0-beta
  - 4.0.0 latest
  
Expected result is to offer latest 4.0.0 version, but in current state it offers 2.0.0-beta. 



**Example 2:**
- User has app version 1.0.0 with `allowPrerelease=true`
- App has available updates on GitHub:
  - 2.0.0 latest
  - 3.0.0 in pre-release state
  
Expected result is to offer pre-released 3.0.0 version, but in current state it offers no update at all.

