### PR TITLE
docs: Add customWelcomePage example to Custom NSIS script

### DIFF
--- a/docs/configuration/nsis.md
+++ b/docs/configuration/nsis.md
@@ -37,30 +37,35 @@ Two options are available — [include](#NsisOptions-include) and [script](#Nsis
 Keep in mind — if you customize NSIS script, you should always state about it in the issue reports. And don't expect that your issue will be resolved.
 
 1. Add file `build/installer.nsh`.
-2. Define wanted macro to customise: `customHeader`, `preInit`, `customInit`, `customUnInit`, `customInstall`, `customUnInstall`, `customRemoveFiles`, `customInstallMode`.
-    
+2. Define wanted macro to customise: `customHeader`, `preInit`, `customInit`, `customUnInit`, `customInstall`, `customUnInstall`, `customRemoveFiles`, `customInstallMode`, `customWelcomePage`.
+
     !!! example
         ```nsis
         !macro customHeader
           !system "echo '' > ${BUILD_RESOURCES_DIR}/customHeader"
         !macroend
-        
+
         !macro preInit
           ; This macro is inserted at the beginning of the NSIS .OnInit callback
           !system "echo '' > ${BUILD_RESOURCES_DIR}/preInit"
         !macroend
-        
+
         !macro customInit
           !system "echo '' > ${BUILD_RESOURCES_DIR}/customInit"
         !macroend
-        
+
         !macro customInstall
           !system "echo '' > ${BUILD_RESOURCES_DIR}/customInstall"
         !macroend
-        
+
         !macro customInstallMode
-          # set $isForceMachineInstall or $isForceCurrentInstall 
+          # set $isForceMachineInstall or $isForceCurrentInstall
           # to enforce one or the other modes.
+        !macroend
+
+        !macro customWelcomePage
+          # Welcome Page is not added by default for installer.
+          !insertMacro MUI_PAGE_WELCOME
         !macroend
         ```
 
@@ -81,7 +86,7 @@ If you want to include additional resources for use during installation, such as
 
 ??? question "Is there a way to call just when the app is installed (or uninstalled) manually and not on update?"
     Use `${isUpdated}`.
-    
+
     ```nsis
     ${ifNot} ${isUpdated}
       # your code
@@ -116,7 +121,7 @@ For portable app, following environment variables are available:
 ??? question "How do change the default installation directory to custom?"
 
     It is very specific requirement. Do not do if you are not sure. Add [custom macro](#custom-nsis-script):
-    
+
     ```nsis
     !macro preInit
       SetRegView 64
@@ -129,9 +134,9 @@ For portable app, following environment variables are available:
     ```
 
 ??? question "Is it possible to made single installer that will allow configuring user/machine installation?"
-    
+
     Yes, you need to switch to assisted installer (not default one-click).
-    
+
     package.json
     ```json
     "build": {


### PR DESCRIPTION
The docs doesn't cover customWelcomePage for NSIS installer as it is not possible to configure the Welcome Page using configuration.

This is useful if one need to display Welcome Page for NSIS installer as the default behaviour is intentionally omitted. Refer to https://github.com/electron-userland/electron-builder/issues/1501#issuecomment-297274642