### PR TITLE
fix: Duplicate values during deep assign of extra files

### DIFF
--- a/.changeset/mean-cheetahs-look.md
+++ b/.changeset/mean-cheetahs-look.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: Filter out duplicate values during deep assign of extra files by converting to Set first

--- a/packages/builder-util/src/deepAssign.ts
+++ b/packages/builder-util/src/deepAssign.ts
@@ -18,7 +18,7 @@ function assignKey(target: any, from: any, key: string) {
   if (prevValue == null || value == null || !isObject(prevValue) || !isObject(value)) {
     // Merge arrays.
     if (Array.isArray(prevValue) && Array.isArray(value)) {
-      target[key] = prevValue.concat(value)
+      target[key] = Array.from(new Set(prevValue.concat(value)))
     } else {
       target[key] = value
     }


### PR DESCRIPTION
Follow up from: https://github.com/electron-userland/electron-builder/pull/6841#issuecomment-1125215560

Filters out duplicate assign's when cascading configs (files, extraFiles, etc.) by converting to Set first