### PR TITLE
fix: inappropriate `electron-updater` cache directory on macOS

### DIFF
--- a/.changeset/smooth-hounds-peel.md
+++ b/.changeset/smooth-hounds-peel.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: use appropriate `electron-updater` cache directory on macOS

--- a/packages/electron-updater/src/AppAdapter.ts
+++ b/packages/electron-updater/src/AppAdapter.ts
@@ -36,7 +36,7 @@ export function getAppCacheDir() {
   if (process.platform === "win32") {
     result = process.env["LOCALAPPDATA"] || path.join(homedir, "AppData", "Local")
   } else if (process.platform === "darwin") {
-    result = path.join(homedir, "Library", "Application Support", "Caches")
+    result = path.join(homedir, "Library", "Caches")
   } else {
     result = process.env["XDG_CACHE_HOME"] || path.join(homedir, ".cache")
   }


### PR DESCRIPTION
On macOS, `~/Library/Application Support` is where applications persist data, and caches are stored in `~/Library/Caches`.

Currently `electron-updater` mistakenly created its own `Caches` directory under `~/Library/Application Support`, which is bad practice and not align with e.g. the usage of `XDG_CACHE_HOME` below.