### PR TITLE
feat: In non-silent installation mode, allows the user to decide whether to run the installed application

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -504,7 +504,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
    * This is different from the normal quit event sequence.
    *
    * @param isSilent *windows-only* Runs the installer in silent mode. Defaults to `false`.
-   * @param isForceRunAfter Run the app after finish even on silent install. Not applicable for macOS. Ignored if `isSilent` is set to `false`.
+   * @param isForceRunAfter Run the app after finish even on silent install. Not applicable for macOS.
    */
   abstract quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
 

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -12,7 +12,7 @@ export abstract class BaseUpdater extends AppUpdater {
 
   quitAndInstall(isSilent = false, isForceRunAfter = false): void {
     this._logger.info(`Install on explicit quitAndInstall`)
-    const isInstalled = this.install(isSilent, isSilent ? isForceRunAfter : true)
+    const isInstalled = this.install(isSilent, isForceRunAfter)
     if (isInstalled) {
       setImmediate(() => {
         // this event is normally emitted when calling quitAndInstall, this emulates that


### PR DESCRIPTION
Currently only in silent installation mode allows user to set "isForceRunAfter" value to decide whether to run the installed application. Actually sometimes in non-silent installation mode, the user does not want to run the installed application after the installation is complete.