### PR TITLE
fix: use `buildVersion` not `buildNumber` for fpm `--iteration` flag

### DIFF
--- a/.changeset/tidy-singers-carry.md
+++ b/.changeset/tidy-singers-carry.md
@@ -1,0 +1,7 @@
+---
+"app-builder-lib": minor
+"electron-builder": minor
+"builder-util": patch
+---
+
+Allow explicit `buildNumber` in config. `buildNumber` will take precedence over any environment variables (#6945)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -92,11 +92,14 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 <li>
 <p><code id="Configuration-npmRebuild">npmRebuild</code> = <code>true</code> Boolean - Whether to <a href="https://docs.npmjs.com/cli/rebuild">rebuild</a> native dependencies before starting to package the app.</p>
 </li>
+<li>
+<p><code id="Configuration-buildNumber">buildNumber</code> String | “undefined” - The build number. Maps to the <code>--iteration</code> flag for builds using FPM on Linux. If not defined, then it will fallback to <code>BUILD_NUMBER</code> or <code>TRAVIS_BUILD_NUMBER</code> or <code>APPVEYOR_BUILD_NUMBER</code> or <code>CIRCLE_BUILD_NUM</code> or <code>BUILD_BUILDNUMBER</code> or <code>CI_PIPELINE_IID</code> env.</p>
+</li>
 </ul>
 <hr>
 <ul>
 <li>
-<p><code id="Configuration-buildVersion">buildVersion</code> String | “undefined” - The build version. Maps to the <code>CFBundleVersion</code> on macOS, and <code>FileVersion</code> metadata property on Windows. Defaults to the <code>version</code>. If <code>TRAVIS_BUILD_NUMBER</code> or <code>APPVEYOR_BUILD_NUMBER</code> or <code>CIRCLE_BUILD_NUM</code> or <code>BUILD_NUMBER</code> or <code>bamboo.buildNumber</code> or <code>CI_PIPELINE_IID</code> env defined, it will be used as a build version (<code>version.build_number</code>).</p>
+<p><code id="Configuration-buildVersion">buildVersion</code> String | “undefined” - The build version. Maps to the <code>CFBundleVersion</code> on macOS, and <code>FileVersion</code> metadata property on Windows. Defaults to the <code>version</code>. If <code>buildVersion</code> is not defined and <code>buildNumber</code> (or one of the <code>buildNumber</code> envs) is defined, it will be used as a build version (<code>version.buildNumber</code>).</p>
 </li>
 <li>
 <p><code id="Configuration-electronCompile">electronCompile</code> Boolean - Whether to use <a href="http://github.com/electron/electron-compile">electron-compile</a> to compile app. Defaults to <code>true</code> if <code>electron-compile</code> in the dependencies. And <code>false</code> if in the <code>devDependencies</code> or doesn’t specified.</p>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6315,8 +6315,15 @@
       "description": "Whether to build the application native dependencies from source.",
       "type": "boolean"
     },
+    "buildNumber": {
+      "description": "The build number.  Maps to the `--iteration` flag for builds using FPM on Linux. If not defined then will fallback to `BUILD_NUMBER` or `TRAVIS_BUILD_NUMBER` or `APPVEYOR_BUILD_NUMBER` or `CIRCLE_BUILD_NUM` or `BUILD_BUILDNUMBER` or `CI_PIPELINE_IID` env.",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "buildVersion": {
-      "description": "The build version. Maps to the `CFBundleVersion` on macOS, and `FileVersion` metadata property on Windows. Defaults to the `version`.\nIf `TRAVIS_BUILD_NUMBER` or `APPVEYOR_BUILD_NUMBER` or `CIRCLE_BUILD_NUM` or `BUILD_NUMBER` or `bamboo.buildNumber` or `CI_PIPELINE_IID` env defined, it will be used as a build version (`version.build_number`).",
+      "description": "The build version. Maps to the `CFBundleVersion` on macOS, and `FileVersion` metadata property on Windows. Defaults to the `version`.\nIf `buildVersion` is not defined and `buildNumber` (or one of the `buildNumber envs) is defined, it will be used as a build version (`version.buildNumber`).",
       "type": [
         "null",
         "string"

--- a/packages/app-builder-lib/src/appInfo.ts
+++ b/packages/app-builder-lib/src/appInfo.ts
@@ -39,13 +39,14 @@ export class AppInfo {
       buildVersion = info.config.buildVersion
     }
 
-    this.buildNumber =
+    const buildEnvs =
       process.env.BUILD_NUMBER ||
       process.env.TRAVIS_BUILD_NUMBER ||
       process.env.APPVEYOR_BUILD_NUMBER ||
       process.env.CIRCLE_BUILD_NUM ||
       process.env.BUILD_BUILDNUMBER ||
       process.env.CI_PIPELINE_IID
+    this.buildNumber = info.config.buildNumber || buildEnvs
     if (buildVersion == null) {
       buildVersion = this.version
       if (!isEmptyOrSpaces(this.buildNumber)) {

--- a/packages/app-builder-lib/src/appInfo.ts
+++ b/packages/app-builder-lib/src/appInfo.ts
@@ -39,14 +39,14 @@ export class AppInfo {
       buildVersion = info.config.buildVersion
     }
 
-    const buildEnvs =
+    const buildNumberEnvs =
       process.env.BUILD_NUMBER ||
       process.env.TRAVIS_BUILD_NUMBER ||
       process.env.APPVEYOR_BUILD_NUMBER ||
       process.env.CIRCLE_BUILD_NUM ||
       process.env.BUILD_BUILDNUMBER ||
       process.env.CI_PIPELINE_IID
-    this.buildNumber = info.config.buildNumber || buildEnvs
+    this.buildNumber = info.config.buildNumber || buildNumberEnvs
     if (buildVersion == null) {
       buildVersion = this.version
       if (!isEmptyOrSpaces(this.buildNumber)) {

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -131,13 +131,13 @@ export interface Configuration extends PlatformSpecificBuildOptions {
 
   /**
    * The build number. Maps to the `--iteration` flag for builds using FPM on Linux.
-   * If not defined then will fallback to `BUILD_NUMBER` or `TRAVIS_BUILD_NUMBER` or `APPVEYOR_BUILD_NUMBER` or `CIRCLE_BUILD_NUM` or `BUILD_BUILDNUMBER` or `CI_PIPELINE_IID` env.
+   * If not defined, then it will fallback to `BUILD_NUMBER` or `TRAVIS_BUILD_NUMBER` or `APPVEYOR_BUILD_NUMBER` or `CIRCLE_BUILD_NUM` or `BUILD_BUILDNUMBER` or `CI_PIPELINE_IID` env.
    */
   readonly buildNumber?: string | null
 
   /**
    * The build version. Maps to the `CFBundleVersion` on macOS, and `FileVersion` metadata property on Windows. Defaults to the `version`.
-   * If `buildVersion` is not defined and `buildNumber` (or one of the `buildNumber envs) is defined, it will be used as a build version (`version.buildNumber`).
+   * If `buildVersion` is not defined and `buildNumber` (or one of the `buildNumber` envs) is defined, it will be used as a build version (`version.buildNumber`).
    */
   readonly buildVersion?: string | null
 

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -130,8 +130,14 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   readonly npmRebuild?: boolean
 
   /**
+   * The build number. Maps to the `--iteration` flag for builds using FPM on Linux.
+   * If not defined then will fallback to `BUILD_NUMBER` or `TRAVIS_BUILD_NUMBER` or `APPVEYOR_BUILD_NUMBER` or `CIRCLE_BUILD_NUM` or `BUILD_BUILDNUMBER` or `CI_PIPELINE_IID` env.
+   */
+  readonly buildNumber?: string | null
+
+  /**
    * The build version. Maps to the `CFBundleVersion` on macOS, and `FileVersion` metadata property on Windows. Defaults to the `version`.
-   * If `TRAVIS_BUILD_NUMBER` or `APPVEYOR_BUILD_NUMBER` or `CIRCLE_BUILD_NUM` or `BUILD_NUMBER` or `bamboo.buildNumber` or `CI_PIPELINE_IID` env defined, it will be used as a build version (`version.build_number`).
+   * If `buildVersion` is not defined and `buildNumber` (or one of the `buildNumber envs) is defined, it will be used as a build version (`version.buildNumber`).
    */
   readonly buildVersion?: string | null
 

--- a/packages/app-builder-lib/src/targets/fpm.ts
+++ b/packages/app-builder-lib/src/targets/fpm.ts
@@ -181,7 +181,7 @@ export default class FpmTarget extends Target {
     }
 
     use(packager.info.metadata.license, it => args.push("--license", it))
-    use(appInfo.buildVersion, it =>
+    use(appInfo.buildNumber, it =>
       args.push(
         "--iteration",
         // dashes are not supported for iteration in older versions of fpm

--- a/packages/app-builder-lib/src/targets/fpm.ts
+++ b/packages/app-builder-lib/src/targets/fpm.ts
@@ -180,10 +180,17 @@ export default class FpmTarget extends Target {
       }
     }
 
-    use(packager.info.metadata.license, it => args.push("--license", it!))
-    use(appInfo.buildNumber, it => args.push("--iteration", it!))
+    use(packager.info.metadata.license, it => args.push("--license", it))
+    use(appInfo.buildVersion, it =>
+      args.push(
+        "--iteration",
+        // dashes are not supported for iteration in older versions of fpm
+        // https://github.com/jordansissel/fpm/issues/1833
+        it.split("-").join("_")
+      )
+    )
 
-    use(options.fpm, it => args.push(...(it as any)))
+    use(options.fpm, it => args.push(...it))
 
     args.push(`${appOutDir}/=${installPrefix}/${appInfo.sanitizedProductName}`)
     for (const icon of await this.helper.icons) {

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -297,7 +297,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     }
 
     use(appInfo.companyName, it => args.push("--set-version-string", "CompanyName", it))
-    use(this.platformSpecificBuildOptions.legalTrademarks, it => args.push("--set-version-string", "LegalTrademarks", it!))
+    use(this.platformSpecificBuildOptions.legalTrademarks, it => args.push("--set-version-string", "LegalTrademarks", it))
     const iconPath = await this.getIconPath()
     use(iconPath, it => {
       files.push(it)

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -265,7 +265,8 @@ export class ExecError extends Error {
   }
 }
 
-export function use<T, R>(value: T | null, task: (it: T) => R): R | null {
+type Nullish = null | undefined
+export function use<T, R>(value: T | Nullish, task: (value: T) => R): R | null {
   return value == null ? null : task(value)
 }
 

--- a/packages/electron-builder/src/cli/install-app-deps.ts
+++ b/packages/electron-builder/src/cli/install-app-deps.ts
@@ -50,7 +50,7 @@ export async function installAppDeps(args: any) {
   const [appDir, version] = await Promise.all<string>([
     computeDefaultAppDirectory(
       projectDir,
-      use(config.directories, it => it!.app)
+      use(config.directories, it => it.app)
     ),
     getElectronVersion(projectDir, config, packageMetadata),
   ])


### PR DESCRIPTION
Fixes #6945.

`buildNumber` is not overridable in the config and is provided directly by the CI, this should be `buildVersion` instead.

Dashes are not supported for iteration in some versions of fpm, so I replaced dashes with underscores. https://github.com/jordansissel/fpm/issues/1833

Also, the linter complained, so I fixed up the type definition for the `use` function.