### PR TITLE
fix: Invalid code signing for MAS build (#7040)

### DIFF
--- a/.changeset/violet-comics-cover.md
+++ b/.changeset/violet-comics-cover.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Swaps order of Apple certificate selection to fix publishing the MAS package on Mac Apple Store. (#7040)

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -468,5 +468,5 @@ function getCertificateTypes(isMas: boolean, isDevelopment: boolean): CertType[]
   if (isDevelopment) {
     return isMas ? ["Mac Developer", "Apple Development"] : ["Mac Developer", "Developer ID Application"]
   }
-  return isMas ? ["3rd Party Mac Developer Application", "Apple Distribution"] : ["Developer ID Application"]
+  return isMas ? ["Apple Distribution", "3rd Party Mac Developer Application"] : ["Developer ID Application"];
 }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -468,5 +468,5 @@ function getCertificateTypes(isMas: boolean, isDevelopment: boolean): CertType[]
   if (isDevelopment) {
     return isMas ? ["Mac Developer", "Apple Development"] : ["Mac Developer", "Developer ID Application"]
   }
-  return isMas ? ["Apple Distribution", "3rd Party Mac Developer Application"] : ["Developer ID Application"];
+  return isMas ? ["Apple Distribution", "3rd Party Mac Developer Application"] : ["Developer ID Application"]
 }


### PR DESCRIPTION
Swaps `["3rd Party Mac Developer Application", "Apple Distribution"]` to `["Apple Distribution", "3rd Party Mac Developer Application"]` fixing the problem with code signing to publishing the MAS package on Mac Apple Store.

I found the issue #7040 while trying to fix the problem, followed the suggestion, and validated it.