### PR TITLE
chore: Add details to entitlement option for macOS configurations

### DIFF
--- a/.changeset/green-buses-beg.md
+++ b/.changeset/green-buses-beg.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: Add documentation details to entitlement option for macOS configurations

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -32,12 +32,15 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   /**
    * The path to entitlements file for signing the app. `build/entitlements.mac.plist` will be used if exists (it is a recommended way to set).
    * MAS entitlements is specified in the [mas](/configuration/mas).
+   * See [this folder in osx-sign's repository](https://github.com/electron/osx-sign/tree/main/entitlements) for examples.
+   * Be aware that your app may crash if the right entitlements are not set like `com.apple.security.cs.allow-jit` for example on arm64 builds with Electron 20+.
+   * See [Signing and Notarizing macOS Builds from the Electron documentation](https://www.electronjs.org/docs/latest/tutorial/code-signing#signing--notarizing-macos-builds) for more information.
    */
   readonly entitlements?: string | null
 
   /**
    * The path to child entitlements which inherit the security settings for signing frameworks and bundles of a distribution. `build/entitlements.mac.inherit.plist` will be used if exists (it is a recommended way to set).
-   * Otherwise [default](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.darwin.inherit.plist).
+   * See [this folder in osx-sign's repository](https://github.com/electron/osx-sign/tree/main/entitlements) for examples.
    *
    * This option only applies when signing with `entitlements` provided.
    */
@@ -329,7 +332,7 @@ export interface DmgContent {
 export interface MasConfiguration extends MacConfiguration {
   /**
    * The path to entitlements file for signing the app. `build/entitlements.mas.plist` will be used if exists (it is a recommended way to set).
-   * Otherwise [default](https://github.com/electron/osx-sign/blob/main/entitlements/default.darwin.plist) is used. 
+   * See [this folder in osx-sign's repository](https://github.com/electron/osx-sign/tree/main/entitlements) for examples.
    * Be aware that your app may crash if the right entitlements are not set like `com.apple.security.cs.allow-jit` for example on arm64 builds with Electron 20+.
    * See [Signing and Notarizing macOS Builds from the Electron documentation](https://www.electronjs.org/docs/latest/tutorial/code-signing#signing--notarizing-macos-builds) for more information.
    */
@@ -337,7 +340,7 @@ export interface MasConfiguration extends MacConfiguration {
 
   /**
    * The path to child entitlements which inherit the security settings for signing frameworks and bundles of a distribution. `build/entitlements.mas.inherit.plist` will be used if exists (it is a recommended way to set).
-   * Otherwise [default](https://github.com/electron/osx-sign/blob/main/entitlements/default.mas.child.plist).
+   * See [this folder in osx-sign's repository](https://github.com/electron/osx-sign/tree/main/entitlements) for examples.
    */
   readonly entitlementsInherit?: string | null
 

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -329,13 +329,15 @@ export interface DmgContent {
 export interface MasConfiguration extends MacConfiguration {
   /**
    * The path to entitlements file for signing the app. `build/entitlements.mas.plist` will be used if exists (it is a recommended way to set).
-   * Otherwise [default](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.plist).
+   * Otherwise [default](https://github.com/electron/osx-sign/blob/main/entitlements/default.darwin.plist) is used. 
+   * Be aware that your app may crash if the right entitlements are not set like `com.apple.security.cs.allow-jit` for example on arm64 builds with Electron 20+.
+   * See [Signing and Notarizing macOS Builds from the Electron documentation](https://www.electronjs.org/docs/latest/tutorial/code-signing#signing--notarizing-macos-builds) for more information.
    */
   readonly entitlements?: string | null
 
   /**
    * The path to child entitlements which inherit the security settings for signing frameworks and bundles of a distribution. `build/entitlements.mas.inherit.plist` will be used if exists (it is a recommended way to set).
-   * Otherwise [default](https://github.com/electron-userland/electron-osx-sign/blob/master/default.entitlements.mas.inherit.plist).
+   * Otherwise [default](https://github.com/electron/osx-sign/blob/main/entitlements/default.mas.child.plist).
    */
   readonly entitlementsInherit?: string | null
 


### PR DESCRIPTION
Added some details on what an entitlment.plist file should contain and why wrong entitlements can make a build crash.

Also updated links to the default entitlement.plist as the previous one was giving a 404 (it's been moved adn renamed). Not sure if I linked the right files though. Maybe adding a link to the whole `entitlements` [folder](https://github.com/electron/osx-sign/tree/main/entitlements) instead  would be more suitable, as it contains self-explanatory filenames for the different usecases ?

Thanks to @jeremyspiegel @mmaietta and @idanwork for helping pinpoint the issue.

Closes #7050