### PR TITLE
fix: Revert "feat: Upgrade to Ubuntu 22.04 and python 3.10"

### DIFF
--- a/.changeset/clean-gifts-ring.md
+++ b/.changeset/clean-gifts-ring.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Revert "feat: Upgrade to Ubuntu 22.04 and python 3.10" due to #7092 #7101 and #7102

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:22.04-curl
+FROM buildpack-deps:focal-curl
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -12,7 +12,7 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # libsecret-1-dev is required even for prebuild keytar (https://atom.github.io/node-keytar/)
   apt-get -qq install --no-install-recommends \
         qtbase5-dev build-essential autoconf libssl-dev gcc-multilib g++-multilib \
-        lzip rpm python3.10 libcurl4 git git-lfs ssh unzip libarchive-tools \
+        lzip rpm python libcurl4 git git-lfs ssh unzip libarchive-tools \
         libxtst6 libsecret-1-dev libopenjp2-tools liblzo2-2 \
   && \
   # git-lfs

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -3,14 +3,14 @@ FROM electronuserland/builder:$IMAGE_VERSION
 
 RUN dpkg --add-architecture i386 && \
   curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
-  echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ impish main' > /etc/apt/sources.list.d/winehq.list && \
+  echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     # We can't install `winehq-stable`, we must manually lock each dependency to v6 (ref: https://github.com/electron-userland/electron-builder/issues/6780),
-    winehq-stable=6.0.4~impish-1  \
-    wine-stable=6.0.4~impish-1  \
-    wine-stable-i386=6.0.4~impish-1  \
-    wine-stable-amd64=6.0.4~impish-1  \
+    winehq-stable=6.0.4~focal-1 \
+    wine-stable=6.0.4~focal-1 \
+    wine-stable-i386=6.0.4~focal-1 \
+    wine-stable-amd64=6.0.4~focal-1 \
   && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Reverts electron-userland/electron-builder#6922

Fixes:
https://github.com/electron-userland/electron-builder/issues/7092
https://github.com/electron-userland/electron-builder/issues/7101
https://github.com/electron-userland/electron-builder/issues/7102