### PR TITLE
docs: fix typo

### DIFF
--- a/.changeset/smart-countries-decide.md
+++ b/.changeset/smart-countries-decide.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(docs): typo of docs/generated/NsisOptions.md.

--- a/docs/generated/NsisOptions.md
+++ b/docs/generated/NsisOptions.md
@@ -37,7 +37,7 @@
 <p><code id="NsisOptions-script">script</code> String | “undefined” - The path to NSIS script to customize installer. Defaults to <code>build/installer.nsi</code>. See <a href="#custom-nsis-script">Custom NSIS script</a>.</p>
 </li>
 <li>
-<p><code id="NsisOptions-license">license</code> String | “undefined” - The path to EULA license file. Defaults to <code>license.txt</code> or <code>eula.txt</code> (or uppercase variants). In addition to <code>txt</code>, <code>rtf</code> and <code>html</code> supported (don't forget to use <code>target=&quot;_blank&quot;</code> for links).</p>
+<p><code id="NsisOptions-license">license</code> String | “undefined” - The path to EULA license file. Defaults to <code>license.txt</code> or <code>eula.txt</code> (or uppercase variants). In addition to <code>txt</code>, <code>rtf</code> and <code>html</code> supported (don’t forget to use <code>target=&quot;_blank&quot;</code> for links).</p>
 <p>Multiple license files in different languages are supported — use lang postfix (e.g. <code>_de</code>, <code>_ru</code>). For example, create files <code>license_de.txt</code> and <code>license_en.txt</code> in the build resources. If OS language is german, <code>license_de.txt</code> will be displayed. See map of <a href="https://github.com/meikidd/iso-639-1/blob/master/src/data.js">language code to name</a>.</p>
 <p>Appropriate license file will be selected by user OS language.</p>
 </li>

--- a/docs/generated/NsisOptions.md
+++ b/docs/generated/NsisOptions.md
@@ -37,8 +37,8 @@
 <p><code id="NsisOptions-script">script</code> String | “undefined” - The path to NSIS script to customize installer. Defaults to <code>build/installer.nsi</code>. See <a href="#custom-nsis-script">Custom NSIS script</a>.</p>
 </li>
 <li>
-<p><code id="NsisOptions-license">license</code> String | “undefined” - The path to EULA license file. Defaults to <code>license.txt</code> or <code>eula.txt</code> (or uppercase variants). In addition to <code>txt, </code>rtf<code>and</code>html<code>supported (don't forget to use</code>target=&quot;_blank&quot;` for links).</p>
-<p>Multiple license files in different languages are supported — use lang postfix (e.g. <code>_de</code>, <code>_ru</code>)). For example, create files <code>license_de.txt</code> and <code>license_en.txt</code> in the build resources. If OS language is german, <code>license_de.txt</code> will be displayed. See map of <a href="https://github.com/meikidd/iso-639-1/blob/master/src/data.js">language code to name</a>.</p>
+<p><code id="NsisOptions-license">license</code> String | “undefined” - The path to EULA license file. Defaults to <code>license.txt</code> or <code>eula.txt</code> (or uppercase variants). In addition to <code>txt</code>, <code>rtf</code> and <code>html</code> supported (don't forget to use <code>target=&quot;_blank&quot;</code> for links).</p>
+<p>Multiple license files in different languages are supported — use lang postfix (e.g. <code>_de</code>, <code>_ru</code>). For example, create files <code>license_de.txt</code> and <code>license_en.txt</code> in the build resources. If OS language is german, <code>license_de.txt</code> will be displayed. See map of <a href="https://github.com/meikidd/iso-639-1/blob/master/src/data.js">language code to name</a>.</p>
 <p>Appropriate license file will be selected by user OS language.</p>
 </li>
 <li>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -3785,7 +3785,7 @@
           ]
         },
         "license": {
-          "description": "The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt, `rtf` and `html` supported (don't forget to use `target=\"_blank\"` for links).\n\nMultiple license files in different languages are supported — use lang postfix (e.g. `_de`, `_ru`)). For example, create files `license_de.txt` and `license_en.txt` in the build resources.\nIf OS language is german, `license_de.txt` will be displayed. See map of [language code to name](https://github.com/meikidd/iso-639-1/blob/master/src/data.js).\n\nAppropriate license file will be selected by user OS language.",
+          "description": "The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt`, `rtf` and `html` supported (don't forget to use `target=\"_blank\"` for links).\n\nMultiple license files in different languages are supported — use lang postfix (e.g. `_de`, `_ru`). For example, create files `license_de.txt` and `license_en.txt` in the build resources.\nIf OS language is german, `license_de.txt` will be displayed. See map of [language code to name](https://github.com/meikidd/iso-639-1/blob/master/src/data.js).\n\nAppropriate license file will be selected by user OS language.",
           "type": [
             "null",
             "string"
@@ -4103,7 +4103,7 @@
           ]
         },
         "license": {
-          "description": "The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt, `rtf` and `html` supported (don't forget to use `target=\"_blank\"` for links).\n\nMultiple license files in different languages are supported — use lang postfix (e.g. `_de`, `_ru`)). For example, create files `license_de.txt` and `license_en.txt` in the build resources.\nIf OS language is german, `license_de.txt` will be displayed. See map of [language code to name](https://github.com/meikidd/iso-639-1/blob/master/src/data.js).\n\nAppropriate license file will be selected by user OS language.",
+          "description": "The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt`, `rtf` and `html` supported (don't forget to use `target=\"_blank\"` for links).\n\nMultiple license files in different languages are supported — use lang postfix (e.g. `_de`, `_ru`). For example, create files `license_de.txt` and `license_en.txt` in the build resources.\nIf OS language is german, `license_de.txt` will be displayed. See map of [language code to name](https://github.com/meikidd/iso-639-1/blob/master/src/data.js).\n\nAppropriate license file will be selected by user OS language.",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -132,9 +132,9 @@ export interface NsisOptions extends CommonNsisOptions, CommonWindowsInstallerCo
   readonly script?: string | null
 
   /**
-   * The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt, `rtf` and `html` supported (don't forget to use `target="_blank"` for links).
+   * The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt`, `rtf` and `html` supported (don't forget to use `target="_blank"` for links).
    *
-   * Multiple license files in different languages are supported — use lang postfix (e.g. `_de`, `_ru`)). For example, create files `license_de.txt` and `license_en.txt` in the build resources.
+   * Multiple license files in different languages are supported — use lang postfix (e.g. `_de`, `_ru`). For example, create files `license_de.txt` and `license_en.txt` in the build resources.
    * If OS language is german, `license_de.txt` will be displayed. See map of [language code to name](https://github.com/meikidd/iso-639-1/blob/master/src/data.js).
    *
    * Appropriate license file will be selected by user OS language.


### PR DESCRIPTION
FIx typo of `docs/generated/NsisOptions.md`.