### PR TITLE
feat: non-silent mode allow not to run the app when the installation is complete

### DIFF
--- a/.changeset/chilly-days-yawn.md
+++ b/.changeset/chilly-days-yawn.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": minor
+---
+
+feat: non-silent mode allow not to run the app when the installation is complete

--- a/docs/api/electron-builder.md
+++ b/docs/api/electron-builder.md
@@ -1,5 +1,5 @@
 Developer API only. See [Configuration](../configuration/configuration.md) for user documentation.
-  
+
 <!-- do not edit. start of generated block -->
 <h1 id="modules">Modules</h1>
 <dl>
@@ -1428,11 +1428,13 @@ return path.join(target.outDir, <code>__${target.name}-${getArtifactArchName(arc
 <li><a href="#module_electron-updater.AppUpdater+setFeedURL"><code>.setFeedURL(options)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+isUpdaterActive"><code>.isUpdaterActive()</code></a> ⇒ <code>Boolean</code></li>
 <li><a href="#module_electron-updater.AppUpdater+quitAndInstall"><code>.quitAndInstall(isSilent, isForceRunAfter)</code></a></li>
+<li><a href="#module_electron-updater.AppUpdater+quitAppAndInstall"><code>.quitAppAndInstall(isForceRunAfter)</code></a></li>
 </ul>
 </li>
 <li><a href="#MacUpdater">.MacUpdater</a> ⇐ <code><a href="#AppUpdater">AppUpdater</a></code>
 <ul>
 <li><a href="#module_electron-updater.MacUpdater+quitAndInstall"><code>.quitAndInstall()</code></a></li>
+<li><a href="#module_electron-updater.MacUpdater+quitAppAndInstall"><code>.quitAppAndInstall()</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+addAuthHeader"><code>.addAuthHeader(token)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdates"><code>.checkForUpdates()</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdatesAndNotify"><code>.checkForUpdatesAndNotify(downloadNotification)</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
@@ -1642,6 +1644,7 @@ return path.join(target.outDir, <code>__${target.name}-${getArtifactArchName(arc
 <li><a href="#module_electron-updater.AppUpdater+setFeedURL"><code>.setFeedURL(options)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+isUpdaterActive"><code>.isUpdaterActive()</code></a> ⇒ <code>Boolean</code></li>
 <li><a href="#module_electron-updater.AppUpdater+quitAndInstall"><code>.quitAndInstall(isSilent, isForceRunAfter)</code></a></li>
+<li><a href="#module_electron-updater.AppUpdater+quitAppAndInstall"><code>.quitAppAndInstall(isForceRunAfter)</code></a></li>
 </ul>
 </li>
 </ul>
@@ -1749,6 +1752,28 @@ This is different from the normal quit event sequence.</p>
 </tr>
 </tbody>
 </table>
+<p><a name="module_electron-updater.AppUpdater+quitAppAndInstall"></a></p>
+<h3 id="appupdater.quitAppAndInstall(isforcerunafter)"><code>appUpdater.quitAppAndInstall(isForceRunAfter)</code></h3>
+<p>Quit the app and explicit installs the update after it has been downloaded.
+It should only be called after <code>update-downloaded</code> has been emitted.</p>
+<p><strong>Note:</strong> <code>autoUpdater.quitAppAndInstall()</code> will close all application windows first and only emit <code>before-quit</code> event on <code>app</code> after that.
+This is different from the normal quit event sequence.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>isForceRunAfter</td>
+<td><code>Boolean</code></td>
+<td>Run the app after finish even on silent install. Not applicable for macOS.</td>
+</tr>
+</tbody>
+</table>
 <p><a name="MacUpdater"></a></p>
 <h2 id="macupdater-%E2%87%90-appupdater">MacUpdater ⇐ <code><a href="#AppUpdater">AppUpdater</a></code></h2>
 <p><strong>Kind</strong>: class of <a href="#module_electron-updater"><code>electron-updater</code></a><br/>
@@ -1757,6 +1782,7 @@ This is different from the normal quit event sequence.</p>
 <li><a href="#MacUpdater">.MacUpdater</a> ⇐ <code><a href="#AppUpdater">AppUpdater</a></code>
 <ul>
 <li><a href="#module_electron-updater.MacUpdater+quitAndInstall"><code>.quitAndInstall()</code></a></li>
+<li><a href="#module_electron-updater.MacUpdater+quitAppAndInstall"><code>.quitAppAndInstall()</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+addAuthHeader"><code>.addAuthHeader(token)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdates"><code>.checkForUpdates()</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdatesAndNotify"><code>.checkForUpdatesAndNotify(downloadNotification)</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
@@ -1770,6 +1796,9 @@ This is different from the normal quit event sequence.</p>
 <p><a name="module_electron-updater.MacUpdater+quitAndInstall"></a></p>
 <h3 id="macupdater.quitandinstall()"><code>macUpdater.quitAndInstall()</code></h3>
 <p><strong>Overrides</strong>: <a href="#module_electron-updater.AppUpdater+quitAndInstall"><code>quitAndInstall</code></a><br>
+<p><a name="module_electron-updater.MacUpdater+quitAppAndInstall"></a></p>
+<h3 id="macupdater.quitandinstall()"><code>macUpdater.quitAppAndInstall()</code></h3>
+<p><strong>Overrides</strong>: <a href="#module_electron-updater.AppUpdater+quitAppAndInstall"><code>quitAppAndInstall</code></a><br>
 <a name="module_electron-updater.AppUpdater+addAuthHeader"></a></p>
 <h3 id="macupdater.addauthheader(token)"><code>macUpdater.addAuthHeader(token)</code></h3>
 <p>Shortcut for explicitly adding auth tokens to request headers</p>

--- a/docs/api/electron-builder.md
+++ b/docs/api/electron-builder.md
@@ -1428,13 +1428,11 @@ return path.join(target.outDir, <code>__${target.name}-${getArtifactArchName(arc
 <li><a href="#module_electron-updater.AppUpdater+setFeedURL"><code>.setFeedURL(options)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+isUpdaterActive"><code>.isUpdaterActive()</code></a> ⇒ <code>Boolean</code></li>
 <li><a href="#module_electron-updater.AppUpdater+quitAndInstall"><code>.quitAndInstall(isSilent, isForceRunAfter)</code></a></li>
-<li><a href="#module_electron-updater.AppUpdater+quitAppAndInstall"><code>.quitAppAndInstall(isForceRunAfter)</code></a></li>
 </ul>
 </li>
 <li><a href="#MacUpdater">.MacUpdater</a> ⇐ <code><a href="#AppUpdater">AppUpdater</a></code>
 <ul>
 <li><a href="#module_electron-updater.MacUpdater+quitAndInstall"><code>.quitAndInstall()</code></a></li>
-<li><a href="#module_electron-updater.MacUpdater+quitAppAndInstall"><code>.quitAppAndInstall()</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+addAuthHeader"><code>.addAuthHeader(token)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdates"><code>.checkForUpdates()</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdatesAndNotify"><code>.checkForUpdatesAndNotify(downloadNotification)</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
@@ -1587,6 +1585,9 @@ return path.join(target.outDir, <code>__${target.name}-${getArtifactArchName(arc
 <p><code id="AppUpdater-autoInstallOnAppQuit">autoInstallOnAppQuit</code> = <code>true</code> Boolean - Whether to automatically install a downloaded update on app quit (if <code>quitAndInstall</code> was not called before).</p>
 </li>
 <li>
+<p><code id="AppUpdater-autoRunAppAfterInstall">autoRunAppAfterInstall</code> = <code>true</code> Boolean - <em>windows-only</em> Whether to run the app after finish install when run the installer <em>NOT in silent mode</em>.</p>
+</li>
+<li>
 <p><code id="AppUpdater-allowPrerelease">allowPrerelease</code> = <code>false</code> Boolean - <em>GitHub provider only.</em> Whether to allow update to pre-release versions. Defaults to <code>true</code> if application version contains prerelease components (e.g. <code>0.12.1-alpha.1</code>, here <code>alpha</code> is a prerelease component), otherwise <code>false</code>.</p>
 <p>If <code>true</code>, downgrade will be allowed (<code>allowDowngrade</code> will be set to <code>true</code>).</p>
 </li>
@@ -1644,7 +1645,6 @@ return path.join(target.outDir, <code>__${target.name}-${getArtifactArchName(arc
 <li><a href="#module_electron-updater.AppUpdater+setFeedURL"><code>.setFeedURL(options)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+isUpdaterActive"><code>.isUpdaterActive()</code></a> ⇒ <code>Boolean</code></li>
 <li><a href="#module_electron-updater.AppUpdater+quitAndInstall"><code>.quitAndInstall(isSilent, isForceRunAfter)</code></a></li>
-<li><a href="#module_electron-updater.AppUpdater+quitAppAndInstall"><code>.quitAppAndInstall(isForceRunAfter)</code></a></li>
 </ul>
 </li>
 </ul>
@@ -1748,29 +1748,7 @@ This is different from the normal quit event sequence.</p>
 <tr>
 <td>isForceRunAfter</td>
 <td><code>Boolean</code></td>
-<td>Run the app after finish even on silent install. Not applicable for macOS. Ignored if <code>isSilent</code> is set to <code>false</code>.</td>
-</tr>
-</tbody>
-</table>
-<p><a name="module_electron-updater.AppUpdater+quitAppAndInstall"></a></p>
-<h3 id="appupdater.quitAppAndInstall(isforcerunafter)"><code>appUpdater.quitAppAndInstall(isForceRunAfter)</code></h3>
-<p>Quit the app and explicit installs the update after it has been downloaded.
-It should only be called after <code>update-downloaded</code> has been emitted.</p>
-<p><strong>Note:</strong> <code>autoUpdater.quitAppAndInstall()</code> will close all application windows first and only emit <code>before-quit</code> event on <code>app</code> after that.
-This is different from the normal quit event sequence.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>isForceRunAfter</td>
-<td><code>Boolean</code></td>
-<td>Run the app after finish even on silent install. Not applicable for macOS.</td>
+<td>Run the app after finish even on silent install. Not applicable for macOS. Ignored if <code>isSilent</code> is set to <code>false</code>(In this case you can still set <code>autoRunAppAfterInstall</code> to <code>false</code> to prevent run the app)</td>
 </tr>
 </tbody>
 </table>
@@ -1782,7 +1760,6 @@ This is different from the normal quit event sequence.</p>
 <li><a href="#MacUpdater">.MacUpdater</a> ⇐ <code><a href="#AppUpdater">AppUpdater</a></code>
 <ul>
 <li><a href="#module_electron-updater.MacUpdater+quitAndInstall"><code>.quitAndInstall()</code></a></li>
-<li><a href="#module_electron-updater.MacUpdater+quitAppAndInstall"><code>.quitAppAndInstall()</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+addAuthHeader"><code>.addAuthHeader(token)</code></a></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdates"><code>.checkForUpdates()</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
 <li><a href="#module_electron-updater.AppUpdater+checkForUpdatesAndNotify"><code>.checkForUpdatesAndNotify(downloadNotification)</code></a> ⇒ <code>Promise&lt; | <a href="#UpdateCheckResult">UpdateCheckResult</a>&gt;</code></li>
@@ -1796,9 +1773,6 @@ This is different from the normal quit event sequence.</p>
 <p><a name="module_electron-updater.MacUpdater+quitAndInstall"></a></p>
 <h3 id="macupdater.quitandinstall()"><code>macUpdater.quitAndInstall()</code></h3>
 <p><strong>Overrides</strong>: <a href="#module_electron-updater.AppUpdater+quitAndInstall"><code>quitAndInstall</code></a><br>
-<p><a name="module_electron-updater.MacUpdater+quitAppAndInstall"></a></p>
-<h3 id="macupdater.quitandinstall()"><code>macUpdater.quitAppAndInstall()</code></h3>
-<p><strong>Overrides</strong>: <a href="#module_electron-updater.AppUpdater+quitAppAndInstall"><code>quitAppAndInstall</code></a><br>
 <a name="module_electron-updater.AppUpdater+addAuthHeader"></a></p>
 <h3 id="macupdater.addauthheader(token)"><code>macUpdater.addAuthHeader(token)</code></h3>
 <p>Shortcut for explicitly adding auth tokens to request headers</p>

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -517,6 +517,17 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
    */
   abstract quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
 
+  /**
+   * Quit the app and explicit installs the update after it has been downloaded.
+   * It should only be called after `update-downloaded` has been emitted.
+   *
+   * **Note:** `autoUpdater.quitAppAndInstall()` will close all application windows first and only emit `before-quit` event on `app` after that.
+   * This is different from the normal quit event sequence.
+   *
+   * @param isForceRunAfter Run the app after finish. Defaults to `false`. Not applicable for macOS.
+   */
+  abstract quitAppAndInstall(isForceRunAfter?: boolean): void
+
   private async loadUpdateConfig(): Promise<any> {
     if (this._appUpdateConfigPath == null) {
       this._appUpdateConfigPath = this.app.appUpdateConfigPath

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -54,6 +54,12 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
   autoInstallOnAppQuit = true
 
   /**
+   * *windows-only* Whether to run the app after finish install when run the installer NOT in silent mode.
+   * @default true
+   */
+  autoRunAppAfterInstall = true
+
+  /**
    * *GitHub provider only.* Whether to allow update to pre-release versions. Defaults to `true` if application version contains prerelease components (e.g. `0.12.1-alpha.1`, here `alpha` is a prerelease component), otherwise `false`.
    *
    * If `true`, downgrade will be allowed (`allowDowngrade` will be set to `true`).
@@ -513,20 +519,10 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
    * This is different from the normal quit event sequence.
    *
    * @param isSilent *windows-only* Runs the installer in silent mode. Defaults to `false`.
-   * @param isForceRunAfter Run the app after finish even on silent install. Not applicable for macOS. Ignored if `isSilent` is set to `false`.
+   * @param isForceRunAfter Run the app after finish even on silent install. Not applicable for macOS.
+   * Ignored if `isSilent` is set to `false`(In this case you can still set `autoRunAppAfterInstall` to `false` to prevent run the app after finish).
    */
   abstract quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
-
-  /**
-   * Quit the app and explicit installs the update after it has been downloaded.
-   * It should only be called after `update-downloaded` has been emitted.
-   *
-   * **Note:** `autoUpdater.quitAppAndInstall()` will close all application windows first and only emit `before-quit` event on `app` after that.
-   * This is different from the normal quit event sequence.
-   *
-   * @param isForceRunAfter Run the app after finish. Defaults to `false`. Not applicable for macOS.
-   */
-  abstract quitAppAndInstall(isForceRunAfter?: boolean): void
 
   private async loadUpdateConfig(): Promise<any> {
     if (this._appUpdateConfigPath == null) {

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -24,6 +24,18 @@ export abstract class BaseUpdater extends AppUpdater {
     }
   }
 
+  quitAppAndInstall(isForceRunAfter = false): void {
+    const isInstalled = this.install(false, isForceRunAfter);
+    if (isInstalled) {
+      setImmediate(() => {
+        require("electron").autoUpdater.emit("before-quit-for-update")
+        this.app.quit()
+      })
+    } else {
+      this.quitAndInstallCalled = false
+    }
+  }
+
   protected executeDownload(taskOptions: DownloadExecutorTask): Promise<Array<string>> {
     return super.executeDownload({
       ...taskOptions,

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -12,22 +12,11 @@ export abstract class BaseUpdater extends AppUpdater {
 
   quitAndInstall(isSilent = false, isForceRunAfter = false): void {
     this._logger.info(`Install on explicit quitAndInstall`)
-    const isInstalled = this.install(isSilent, isSilent ? isForceRunAfter : true)
+    // If NOT in silent mode use `autoRunAppAfterInstall` to determine whether to force run the app
+    const isInstalled = this.install(isSilent, isSilent ? isForceRunAfter : this.autoRunAppAfterInstall)
     if (isInstalled) {
       setImmediate(() => {
         // this event is normally emitted when calling quitAndInstall, this emulates that
-        require("electron").autoUpdater.emit("before-quit-for-update")
-        this.app.quit()
-      })
-    } else {
-      this.quitAndInstallCalled = false
-    }
-  }
-
-  quitAppAndInstall(isForceRunAfter = false): void {
-    const isInstalled = this.install(false, isForceRunAfter);
-    if (isInstalled) {
-      setImmediate(() => {
         require("electron").autoUpdater.emit("before-quit-for-update")
         this.app.quit()
       })

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -233,4 +233,8 @@ export class MacUpdater extends AppUpdater {
       }
     }
   }
+
+  quitAppAndInstall(): void {
+    this.quitAndInstall();
+  }
 }

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -233,8 +233,4 @@ export class MacUpdater extends AppUpdater {
       }
     }
   }
-
-  quitAppAndInstall(): void {
-    this.quitAndInstall();
-  }
 }


### PR DESCRIPTION
Currently method _quitAndInstall_ only in silent installation mode allows user to set "isForceRunAfter" value to decide whether to run the installed application. Actually sometimes in non-silent installation mode, the user does not want to run the installed application after the installation is complete. In order to avoid breaking change previous functionality I add new method _quitAppAndInstall_ , it's will quit the app and explicit installs the update and allows to set "isForceRunAfter" value to decide whether to run the installed application.