### PR TITLE
feat: add nsis option to remove the default uninstall welcome page

### DIFF
--- a/.changeset/tasty-pianos-jump.md
+++ b/.changeset/tasty-pianos-jump.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: add nsis option to remove the default uninstall welcome page

--- a/docs/generated/NsisOptions.md
+++ b/docs/generated/NsisOptions.md
@@ -27,6 +27,7 @@
 <li><code id="NsisOptions-installerSidebar">installerSidebar</code> String | “undefined” - <em>assisted installer only.</em> <code>MUI_WELCOMEFINISHPAGE_BITMAP</code>, relative to the <a href="/configuration/configuration#MetadataDirectories-buildResources">build resources</a> or to the project directory. Defaults to <code>build/installerSidebar.bmp</code> or <code>${NSISDIR}\\Contrib\\Graphics\\Wizard\\nsis3-metro.bmp</code>. Image size 164 × 314 pixels.</li>
 <li><code id="NsisOptions-uninstallerSidebar">uninstallerSidebar</code> String | “undefined” - <em>assisted installer only.</em> <code>MUI_UNWELCOMEFINISHPAGE_BITMAP</code>, relative to the <a href="/configuration/configuration#MetadataDirectories-buildResources">build resources</a> or to the project directory. Defaults to <code>installerSidebar</code> option or <code>build/uninstallerSidebar.bmp</code> or <code>build/installerSidebar.bmp</code> or <code>${NSISDIR}\\Contrib\\Graphics\\Wizard\\nsis3-metro.bmp</code></li>
 <li><code id="NsisOptions-uninstallDisplayName">uninstallDisplayName</code> = <code>${productName} ${version}</code> String - The uninstaller display name in the control panel.</li>
+<li><code id="NsisOptions-removeDefaultUninstallWelcomePage">removeDefaultUninstallWelcomePage</code> = <code>false</code> Boolean - <em>assisted installer only.</em> remove the default uninstall welcome page</li>
 </ul>
 <hr>
 <ul>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -3914,6 +3914,11 @@
             }
           ]
         },
+        "removeDefaultUninstallWelcomePage": {
+          "default": false,
+          "description": "*assisted installer only.* remove the default uninstall welcome page.",
+          "type": "boolean"
+        },
         "runAfterFinish": {
           "default": true,
           "description": "Whether to run the installed application after finish. For assisted installer corresponding checkbox will be removed.",
@@ -4231,6 +4236,11 @@
               ]
             }
           ]
+        },
+        "removeDefaultUninstallWelcomePage": {
+          "default": false,
+          "description": "*assisted installer only.* remove the default uninstall welcome page.",
+          "type": "boolean"
         },
         "runAfterFinish": {
           "default": true,

--- a/packages/app-builder-lib/src/targets/nsis/Defines.ts
+++ b/packages/app-builder-lib/src/targets/nsis/Defines.ts
@@ -76,6 +76,8 @@ export type Defines = {
 
   allowToChangeInstallationDirectory?: null
 
+  removeDefaultUninstallWelcomePage?: null
+
   MENU_FILENAME?: string
 
   SHORTCUT_NAME?: string

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -481,6 +481,10 @@ export class NsisTarget extends Target {
       defines.allowToChangeInstallationDirectory = null
     }
 
+    if (options.removeDefaultUninstallWelcomePage) {
+      defines.removeDefaultUninstallWelcomePage = null
+    }
+
     const commonOptions = getEffectiveOptions(options, packager)
 
     if (commonOptions.menuCategory != null) {

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -87,6 +87,12 @@ export interface NsisOptions extends CommonNsisOptions, CommonWindowsInstallerCo
   readonly allowToChangeInstallationDirectory?: boolean
 
   /**
+   * *assisted installer only.* remove the default uninstall welcome page.
+   * @default false
+   */
+  readonly removeDefaultUninstallWelcomePage?: boolean
+
+  /**
    * The path to installer icon, relative to the [build resources](/configuration/configuration#MetadataDirectories-buildResources) or to the project directory.
    * Defaults to `build/installerIcon.ico` or application icon.
    */

--- a/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
@@ -39,12 +39,12 @@
       ${endIf}
     FunctionEnd
   !endif
-  
+
   # after change installation directory and before install start, you can show custom page here.
   !ifmacrodef customPageAfterChangeDir
     !insertmacro customPageAfterChangeDir
   !endif
-  
+
   !insertmacro MUI_PAGE_INSTFILES
   !ifmacrodef customFinishPage
     !insertmacro customFinishPage
@@ -65,7 +65,9 @@
     !insertmacro MUI_PAGE_FINISH
   !endif
 !else
-  !insertmacro MUI_UNPAGE_WELCOME
+  !ifndef removeDefaultUninstallWelcomePage
+    !insertmacro MUI_UNPAGE_WELCOME
+  !endif
   !ifndef INSTALL_MODE_PER_ALL_USERS
     !insertmacro PAGE_INSTALL_MODE
   !endif


### PR DESCRIPTION
<subject>add nsis option to remove the default uninstall welcome page</subject> <BLANK LINE>
<Scope>nsis</scope>
<body>until now we can't modify the default unwelcome page, this feature adds the option removeDefaultUninstallWelcomePage to give the possibility to remove from the nsis option this default page in order to custom it in the installer.nsh </body> <BLANK LINE>
<footer>BREAKING CHANGE: the nsis option removeDefaultUninstallWelcomePage is used in the assistedInstaller.nsh to decide if we must add the MUI_UNPAGE_WELCOME or not. based on the issue based on this issue https://github.com/electron-userland/electron-builder/issues/6987 </footer>