### PR TITLE
fix: formatting of Code in the MacOS PKG docs

### DIFF
--- a/.changeset/heavy-buttons-thank.md
+++ b/.changeset/heavy-buttons-thank.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: formatting of Code in the MacOS PKG docs

--- a/docs/configuration/pkg.md
+++ b/docs/configuration/pkg.md
@@ -24,7 +24,7 @@ The top-level [pkg](configuration.md#Configuration-pkg) key contains set of opti
 <p><code id="PkgOptions-identity">identity</code> String | “undefined” - The name of certificate to use when signing. Consider using environment variables <a href="/code-signing">CSC_LINK or CSC_NAME</a> instead of specifying this option.</p>
 </li>
 <li>
-<p><code id="PkgOptions-license">license</code> String | “undefined” - The path to EULA license file. Defaults to <code>license.txt</code> or <code>eula.txt</code> (or uppercase variants). In addition to <code>txt, </code>rtf<code>and</code>html<code>supported (don't forget to use</code>target=&quot;_blank&quot;` for links).</p>
+<p><code id="PkgOptions-license">license</code> String | “undefined” - The path to EULA license file. Defaults to <code>license.txt</code> or <code>eula.txt</code> (or uppercase variants). In addition to <code>txt</code>, <code>rtf</code> and <code>html</code> supported (don’t forget to use <code>target=&quot;_blank&quot;</code> for links).</p>
 </li>
 <li>
 <p><code id="PkgOptions-background">background</code> <a href="#PkgBackgroundOptions">PkgBackgroundOptions</a> | “undefined” - Options for the background image for the installer.</p>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4450,7 +4450,7 @@
           ]
         },
         "license": {
-          "description": "The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt, `rtf` and `html` supported (don't forget to use `target=\"_blank\"` for links).",
+          "description": "The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt`, `rtf` and `html` supported (don't forget to use `target=\"_blank\"` for links).",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/src/options/pkgOptions.ts
+++ b/packages/app-builder-lib/src/options/pkgOptions.ts
@@ -63,7 +63,7 @@ export interface PkgOptions extends TargetSpecificOptions {
   readonly identity?: string | null
 
   /**
-   * The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt, `rtf` and `html` supported (don't forget to use `target="_blank"` for links).
+   * The path to EULA license file. Defaults to `license.txt` or `eula.txt` (or uppercase variants). In addition to `txt`, `rtf` and `html` supported (don't forget to use `target="_blank"` for links).
    */
   readonly license?: string | null
 


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/18656830/190586897-4006f01e-920f-49f4-bc6a-3b2a22cb94e3.png)

After:
![grafik](https://user-images.githubusercontent.com/18656830/190587024-f1a866d7-76f5-476a-b2a9-d5f738bf3ec1.png)
