### PR TITLE
feat: add Github Actions environment variable to isPullRequest method

### DIFF
--- a/.changeset/chilled-items-fail.md
+++ b/.changeset/chilled-items-fail.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+feat: add Github Actions environment variable to isPullRequest method to detect if build is a PR

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -327,7 +327,11 @@ export function isPullRequest() {
   }
 
   return (
-    isSet(process.env.TRAVIS_PULL_REQUEST) || isSet(process.env.CIRCLE_PULL_REQUEST) || isSet(process.env.BITRISE_PULL_REQUEST) || isSet(process.env.APPVEYOR_PULL_REQUEST_NUMBER)
+    isSet(process.env.TRAVIS_PULL_REQUEST) ||
+    isSet(process.env.CIRCLE_PULL_REQUEST) ||
+    isSet(process.env.BITRISE_PULL_REQUEST) ||
+    isSet(process.env.APPVEYOR_PULL_REQUEST_NUMBER) ||
+    isSet(process.env.GITHUB_BASE_REF)
   )
 }
 


### PR DESCRIPTION
add GithubActions environment variable to isPullRequest method.
GITHUB_BASE_REF environment variable is set in pull request build.
see: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables