### PR TITLE
fix(ci): workflows security hardening

### DIFF
--- a/.github/workflows/label-manager.yml
+++ b/.github/workflows/label-manager.yml
@@ -1,7 +1,12 @@
 on: issues
 name: Create Default Labels
+permissions: {}
 jobs:
   labels:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      issues: write # to add label to issues 
+
     name: DefaultLabelsActions
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -8,8 +8,13 @@ on:
 env:
   HUSKY: 0 # Bypass husky commit hook for CI
 
+permissions: {}
 jobs:
   pr-release:
+    permissions:
+      contents: write # to create release (changesets/action)
+      pull-requests: write # to create pull request (changesets/action)
+
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,9 @@ on:
         description: Force rebuild docker images for CI tests
         required: false
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test-linux:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.