### PR TITLE
fix: Allow non-semver versions in getVersionInWeirdWindowsForm

### DIFF
--- a/.changeset/chilled-queens-think.md
+++ b/.changeset/chilled-queens-think.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Allow non-semver version formats on Windows


### PR DESCRIPTION
Fixes #7173

This new code allows the user to not the lower version parts, and have them default to zero instead. With this change the resulting weird-windows-version will be:

```
# this.version -> windows-weird-version (buildNumber = 0)
'1.2.3' => '1.2.3.0'
'1.2' => '1.2.0.0'
'9.2-beta' => '9.2.0.0'
'45' => '45.0.0.0'
'2022.6-beta2-dev-afafaf' => '2022.6.0.0'
```