### PR TITLE
feat: Extending `linux` executableArgs option to be utilized for Snap target (fixes #4587)

### DIFF
--- a/.changeset/empty-ligers-turn.md
+++ b/.changeset/empty-ligers-turn.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": major
+---
+
+Extending `linux` executableArgs option to be utilized for Snap target

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -195,11 +195,18 @@ export default class SnapTarget extends Target {
       Icon: "${SNAP}/meta/gui/icon.png",
     })
 
+    const extraAppArgs: Array<string> = options.executableArgs ?? []
     if (this.isElectronVersionGreaterOrEqualThan("5.0.0") && !isBrowserSandboxAllowed(snap)) {
-      args.push("--extraAppArgs=--no-sandbox")
+      const noSandboxArg = "--no-sandbox"
+      if (!extraAppArgs.includes(noSandboxArg)) {
+        extraAppArgs.push(noSandboxArg)
+      }
       if (this.isUseTemplateApp) {
         args.push("--exclude", "chrome-sandbox")
       }
+    }
+    if (extraAppArgs.length > 0) {
+      args.push("--extraAppArgs=" + extraAppArgs.join(" "))
     }
 
     if (snap.compression != null) {


### PR DESCRIPTION
## Fix #4587

The `executableArgs` option value is ignored for snap target, this PR fixes that bug