### PR TITLE
fix: UnhandledPromiseRejectionWarning: Error: spawn UNKNOWN

### DIFF
--- a/.changeset/slow-goats-wink.md
+++ b/.changeset/slow-goats-wink.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+if window system Disable PowerShell in Windows 10 using Local Security Policy, execfile powershell will crash and throw error spawn UNKNOWN, add shell true, will no crash and can catch error in callback, error message more clearly.

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -42,6 +42,7 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
       ],
       {
         timeout: 20 * 1000,
+        shell: true,
       },
       (error, stdout, stderr) => {
         try {


### PR DESCRIPTION
if window system Disable PowerShell in Windows 10 using Local Security Policy, execfile powershell will crash and throw error spawn UNKNOWN, add shell true, will no crash and can catch error in callback, error message more clearly.