### PR TITLE
fix: properly configure electron-rebuild for monorepos

### DIFF
--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -5,8 +5,9 @@ import { homedir } from "os"
 import * as path from "path"
 import { Configuration } from "../configuration"
 import { NodeModuleDirInfo } from "./packageDependencies"
-import * as electronRebuild from "electron-rebuild"
 import { getElectronVersion } from "../electron/electronVersion"
+import * as electronRebuild from "electron-rebuild"
+import * as searchModule from 'electron-rebuild/lib/src/search-module'
 
 export async function installOrRebuild(config: Configuration, appDir: string, options: RebuildOptions, forceInstall = false) {
   let isDependenciesInstalled = false
@@ -119,7 +120,7 @@ function installDependencies(appDir: string, options: RebuildOptions): Promise<a
 }
 
 export async function nodeGypRebuild(arch: string) {
-  return rebuild(process.cwd(), false, arch)
+  return rebuild(await searchModule.getProjectRootPath(process.cwd()), false, arch)
 }
 
 function getPackageToolPath() {


### PR DESCRIPTION
[WIP]
Using `electron-rebuild` for finding project root for native node addons in order to handle monorepo setups