### PR TITLE
fix: support powershell constrained language mode

### DIFF
--- a/.changeset/real-olives-film.md
+++ b/.changeset/real-olives-film.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: support powershell constrained language mode

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -32,7 +32,7 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
     // https://github.com/electron-userland/electron-builder/issues/2535
     execFile(
       "chcp 65001 >NUL & powershell.exe",
-      ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", `Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress`],
+      ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", `"Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress"`],
       {
         shell: true,
         timeout: 20 * 1000,

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -32,14 +32,7 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
     // https://github.com/electron-userland/electron-builder/issues/2535
     execFile(
       "chcp 65001 >NUL & powershell.exe",
-      [
-        "-NoProfile",
-        "-NonInteractive",
-        "-InputFormat",
-        "None",
-        "-Command",
-        `Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress`,
-      ],
+      ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", `Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress`],
       {
         shell: true,
         timeout: 20 * 1000,

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -31,16 +31,17 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
     // https://github.com/electron-userland/electron-builder/issues/2421
     // https://github.com/electron-userland/electron-builder/issues/2535
     execFile(
-      "powershell.exe",
+      "chcp 65001 >NUL & powershell.exe",
       [
         "-NoProfile",
         "-NonInteractive",
         "-InputFormat",
         "None",
         "-Command",
-        `Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress | ForEach-Object { [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($_)) }`,
+        `Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress`,
       ],
       {
+        shell: true,
         timeout: 20 * 1000,
       },
       (error, stdout, stderr) => {
@@ -51,7 +52,7 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
             return
           }
 
-          const data = parseOut(Buffer.from(stdout, "base64").toString("utf-8"))
+          const data = parseOut(stdout)
           if (data.Status === 0) {
             const subject = parseDn(data.SignerCertificate.Subject)
             let match = false


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-builder/issues/6917

In environments where PowerShell is in Constrained Language Mode, `[Convert]::ToBase64String` and `[System.Text.Encoding]::UTF8.GetBytes` won't work.

We're currently converting the output of `Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress` to base64 in powershell to get possibly non-ascii data, which would otherwise be output in the current ANSI code page. This workaround was added in https://github.com/electron-userland/electron-builder/pull/5071, FYI @orzFly @hezhuojie.

I first tried setting PowerShell's `[console]::OutputEncoding`, but that is also not allowed in Constrained Language Mode. So this fix is to run `chcp 65001 > NUL` before running powershell.exe. See https://github.com/PowerShell/PowerShell/issues/7233 for more context on this issue.

In order to test that this works with non-ascii certificate subject names, I created a github release signed with a self-signed certificate with a subject name of `CN=你好` at https://github.com/jeremyspiegel/electron-updater-powershell-test/releases/tag/v1.0.1. I then added the certificate to my Trusted Root Certificate Authorities and added the following test in [test/src/updater/nsisUpdaterTest.ts](https://github.com/electron-userland/electron-builder/blob/f205998999ff615c9ea63184520a1efbbff5a785/test/src/updater/nsisUpdaterTest.ts):
```typescript
test("github powershell", async () => {
  const updater = await createNsisUpdater("1.0.0")
  updater.updateConfigPath = await writeUpdateConfig<GithubOptions>({
    provider: "github",
    owner: "jeremyspiegel",
    repo: "electron-updater-powershell-test",
    publisherName: ["CN=你好"]
  })
  const updateCheckResult = await updater.checkForUpdates()
  const downloadResult = await updateCheckResult?.downloadPromise
  expect(downloadResult).not.toBeUndefined()
})
```

In order to test that this works in PowerShell Constrained Language Mode, I created a system environment variable `__PSLockDownPolicy=4` and ran the above test.