### PR TITLE
fix: get CI tag in GitHub Actions

### DIFF
--- a/.changeset/two-eels-kiss.md
+++ b/.changeset/two-eels-kiss.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: get CI tag in GitHub Actions

--- a/packages/electron-publish/src/publisher.ts
+++ b/packages/electron-publish/src/publisher.ts
@@ -131,6 +131,12 @@ export abstract class HttpPublisher extends Publisher {
 
 export function getCiTag() {
   const tag =
-    process.env.TRAVIS_TAG || process.env.APPVEYOR_REPO_TAG_NAME || process.env.CIRCLE_TAG || process.env.BITRISE_GIT_TAG || process.env.CI_BUILD_TAG || process.env.BITBUCKET_TAG
+    process.env.TRAVIS_TAG ||
+    process.env.APPVEYOR_REPO_TAG_NAME ||
+    process.env.CIRCLE_TAG ||
+    process.env.BITRISE_GIT_TAG ||
+    process.env.CI_BUILD_TAG ||
+    process.env.BITBUCKET_TAG ||
+    (process.env.GITHUB_REF_TYPE === "tag" ? process.env.GITHUB_REF_NAME : null)
   return tag != null && tag.length > 0 ? tag : null
 }


### PR DESCRIPTION
fixes https://github.com/electron-userland/electron-builder/issues/7066

If we use `getCiTag()` on GitHub Actions, we should return `GITHUB_REF_NAME`.
https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables