### PR TITLE
feat: add downloadAlternateFFmpeg option

### DIFF
--- a/.changeset/silly-carpets-attend.md
+++ b/.changeset/silly-carpets-attend.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: Adding new downloadAlternateFFmpeg option to download non-proprietary ffmpeg library

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6416,6 +6416,11 @@
       ],
       "description": "macOS DMG options."
     },
+    "downloadAlternateFFmpeg": {
+      "default": false,
+      "description": "Whether to download the alternate FFmpeg library from Electron's release assets and replace the default FFmpeg library prior to signing",
+      "type": "boolean"
+    },
     "electronBranding": {
       "$ref": "#/definitions/ElectronBrandingOptions",
       "description": "The branding used by Electron's distributables. This is needed if a fork has modified Electron's BRANDING.json file."

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -142,6 +142,11 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   readonly buildVersion?: string | null
 
   /**
+   * Whether to download the alternate FFmpeg library from Electron's release assets and replace the default FFmpeg library prior to signing
+   */
+  readonly downloadAlternateFFmpeg?: boolean
+
+  /**
    * Whether to use [electron-compile](http://github.com/electron/electron-compile) to compile app. Defaults to `true` if `electron-compile` in the dependencies. And `false` if in the `devDependencies` or doesn't specified.
    */
   readonly electronCompile?: boolean


### PR DESCRIPTION
This is a possible solution to the question proposed in #7210 addressing the need/desire to have an automatic FFmpeg download as part of downloading the standard electron distributable.