### PR TITLE
feat(nsis): add ShutdownBlockReasonCreate for blocking Win Shutdown prompt

### DIFF
--- a/.changeset/olive-planets-grin.md
+++ b/.changeset/olive-planets-grin.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat(nsis): add ShutdownBlockReasonCreate for blocking Windowns Shutdown alert/prompt

--- a/packages/app-builder-lib/templates/nsis/installSection.nsh
+++ b/packages/app-builder-lib/templates/nsis/installSection.nsh
@@ -26,6 +26,9 @@ StrCpy $appExe "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
     FindWindow $0 "#32770" "" $hwndparent $0
     GetDlgItem $0 $0 1000
     SendMessage $0 ${WM_SETTEXT} 0 "STR:$(installing)"
+
+    StrCpy $1 $hwndparent
+		System::Call 'user32::ShutdownBlockReasonCreate(${SYSTYPE_PTR}r1, w "$(installing)")'
   ${endif}
   !insertmacro CHECK_APP_RUNNING
 !else


### PR DESCRIPTION
I want a user to undestand why they cannot shutdown a computer, because the installation process have not been completed yet.
On windows we can use ShutdownBlockReasonCreate to show a better message when shutdown is blocked instaed of default one.
Before
![1](https://user-images.githubusercontent.com/17497724/201985990-5e8a4c47-0e8c-40b0-87cb-b103d928aa02.jpg)

After

![2](https://user-images.githubusercontent.com/17497724/201986470-7b9908cb-240d-46e5-92b3-c487b10b663e.jpg)