### PR TITLE
docs: Propose add vite-electron-builder to boilerplates

### DIFF
--- a/.changeset/small-paws-clean.md
+++ b/.changeset/small-paws-clean.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+docs: Ddd vite-electron-builder to boilerplate examples/templates

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ will declare to use node-modules instead of PnP.
 * [electron-boilerplate](https://github.com/szwacz/electron-boilerplate) A minimalistic yet comprehensive boilerplate application.
 * [Vue CLI 3 plugin for Electron](https://nklayman.github.io/vue-cli-plugin-electron-builder) A Vue CLI 3 plugin for Electron with no required configuration.
 * [electron-vue-vite](https://github.com/caoxiemeihao/electron-vue-vite) A real simple Electron + Vue3 + Vite2 boilerplate.
+* [vite-electron-builder](https://github.com/cawa-93/vite-electron-builder) Secure boilerplate for Electron app based on Vite. TypeScript + Vue/React/Angular/Svelte/Vanilla
 
 ## Quick Setup Guide
 


### PR DESCRIPTION
I propose add my own boilerplate [vite-electron-builder](https://github.com/cawa-93/vite-electron-builder) to list. I create it almost 2 year ago.