### PR TITLE
fix: don't use osslsigncode in a vm

### DIFF
--- a/.changeset/spotty-vans-pay.md
+++ b/.changeset/spotty-vans-pay.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Fixes a bug where signtool might not be used in a windows VM

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -145,19 +145,20 @@ export async function getCertificateFromStoreInfo(options: WindowsConfiguration,
 export async function doSign(configuration: CustomWindowsSignTaskConfiguration, packager: WinPackager) {
   // https://github.com/electron-userland/electron-builder/pull/1944
   const timeout = parseInt(process.env.SIGNTOOL_TIMEOUT as any, 10) || 10 * 60 * 1000
-  // unify logic of signtool path location
-  const toolInfo = await getToolPath()
-  const tool = toolInfo.path
   // decide runtime argument by cases
   let args: Array<string>
   let env = process.env
   let vm: VmManager
-  if (configuration.path.endsWith(".appx") || !("file" in configuration.cscInfo!) /* certificateSubjectName and other such options */) {
+  const vmRequired = configuration.path.endsWith(".appx") || !("file" in configuration.cscInfo!) /* certificateSubjectName and other such options */
+  const isWin = process.platform === "win32" || vmRequired
+  const toolInfo = await getToolPath(isWin)
+  const tool = toolInfo.path
+  if (vmRequired) {
     vm = await packager.vm.value
-    args = computeSignToolArgs(configuration, true, vm)
+    args = computeSignToolArgs(configuration, isWin, vm)
   } else {
     vm = new VmManager()
-    args = configuration.computeSignToolArgs(process.platform === "win32")
+    args = configuration.computeSignToolArgs(isWin)
     if (toolInfo.env != null) {
       env = toolInfo.env
     }
@@ -292,7 +293,7 @@ function getWinSignTool(vendorPath: string): string {
   }
 }
 
-async function getToolPath(): Promise<ToolInfo> {
+async function getToolPath(isWin = process.platform === "win32"): Promise<ToolInfo> {
   if (isUseSystemSigncode()) {
     return { path: "osslsigncode" }
   }
@@ -303,7 +304,7 @@ async function getToolPath(): Promise<ToolInfo> {
   }
 
   const vendorPath = await getSignVendorPath()
-  if (process.platform === "win32") {
+  if (isWin) {
     // use modern signtool on Windows Server 2012 R2 to be able to sign AppX
     return { path: getWinSignTool(vendorPath) }
   } else if (process.platform === "darwin") {


### PR DESCRIPTION
We were running into an issue where windows builds on osx were trying to use `osslsigncode` in our parallels VM rather than signtool