### PR TITLE
fix(app-builder-lib): export missing TS types

### DIFF
--- a/.changeset/twenty-dragons-carry.md
+++ b/.changeset/twenty-dragons-carry.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(app-builder-lib): export missing TS types

--- a/packages/app-builder-lib/src/asar/asar.ts
+++ b/packages/app-builder-lib/src/asar/asar.ts
@@ -14,7 +14,6 @@ export interface NodeIntegrity {
   blocks: Array<string>
 }
 
-/** @internal */
 export class Node {
   // we don't use Map because later it will be stringified
   files?: { [key: string]: Node }


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-builder/issues/7296
Based on https://github.com/electron-userland/electron-builder/pull/6692