### PR TITLE
fix: Execute `afterSign` hook only when signing is completed (BREAKING)

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -390,7 +390,7 @@
           ]
         },
         "token": {
-          "description": "The app password (account>>settings>app-passwords) to support auto-update from private bitbucket repositories.",
+          "description": "The app password (account>settings>app-passwords) to support auto-update from private bitbucket repositories.",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -194,9 +194,9 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     }
   }
 
-  private async sign(appPath: string, outDir: string | null, masOptions: MasConfiguration | null, arch: Arch | null): Promise<void> {
+  private async sign(appPath: string, outDir: string | null, masOptions: MasConfiguration | null, arch: Arch | null): Promise<boolean> {
     if (!isSignAllowed()) {
-      return
+      return false
     }
 
     const isMas = masOptions != null
@@ -208,7 +208,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         throw new InvalidConfigurationError("identity explicitly is set to null, but forceCodeSigning is set to true")
       }
       log.info({ reason: "identity explicitly is set to null" }, "skipped macOS code signing")
-      return
+      return false
     }
 
     const keychainFile = (await this.codeSigningInfo.value).keychainFile
@@ -235,7 +235,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
 
       if (identity == null) {
         await reportError(isMas, certificateTypes, qualifier, keychainFile, this.forceCodeSigning)
-        return
+        return false
       }
     }
 
@@ -336,6 +336,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       await this.doFlat(appPath, artifactPath, masInstallerIdentity, keychainFile)
       await this.dispatchArtifactCreated(artifactPath, null, Arch.x64, this.computeSafeArtifactName(artifactName, "pkg", arch, true, this.platformSpecificBuildOptions.defaultArch))
     }
+
+    return true
   }
 
   private async adjustSignOptions(signOptions: any, masOptions: MasConfiguration | null) {

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -326,10 +326,12 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       packager: this,
       electronPlatformName: platformName,
     }
-    await this.signApp(packContext, isAsar)
-    const afterSign = resolveFunction(this.config.afterSign, "afterSign")
-    if (afterSign != null) {
-      await Promise.resolve(afterSign(packContext))
+    const didSign = await this.signApp(packContext, isAsar)
+    if (didSign) {
+      const afterSign = resolveFunction(this.config.afterSign, "afterSign")
+      if (afterSign != null) {
+        await Promise.resolve(afterSign(packContext))
+      }
     }
   }
 
@@ -423,7 +425,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected signApp(packContext: AfterPackContext, isAsar: boolean): Promise<any> {
-    return Promise.resolve()
+    return Promise.resolve(true)
   }
 
   getIconPath(): Promise<string | null> {

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -367,10 +367,10 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     }
   }
 
-  protected async signApp(packContext: AfterPackContext, isAsar: boolean): Promise<any> {
+  protected async signApp(packContext: AfterPackContext, isAsar: boolean): Promise<boolean> {
     const exeFileName = `${this.appInfo.productFilename}.exe`
     if (this.platformSpecificBuildOptions.signAndEditExecutable === false) {
-      return
+      return false
     }
 
     await BluebirdPromise.map(readdir(packContext.appOutDir), (file: string): any => {
@@ -389,7 +389,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     })
 
     if (!isAsar) {
-      return
+      return false
     }
 
     const signPromise = (filepath: string[]) => {
@@ -398,5 +398,6 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     }
     const filesToSign = await Promise.all([signPromise(["resources", "app.asar.unpacked"]), signPromise(["swiftshader"])])
     await BluebirdPromise.map(filesToSign.flat(1), file => this.sign(file), { concurrency: 4 })
+    return true
   }
 }

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -256,7 +256,8 @@ test.ifLinuxOrDevMac("afterSign", () => {
     },
     {
       packed: async () => {
-        expect(called).toEqual(2)
+        // afterSign is only called when an app is actually signed and ignored otherwise.
+        expect(called).toEqual(1)
       },
     }
   )


### PR DESCRIPTION
Only activating `afterSign` hook if the signing step wasn't explicitly skipped

This is a Breaking Change since previous behavior was always executing `afterSign` hook (albeit, probably incorrectly)

Fixes: #7257