### PR TITLE
feat: Add the accelerate option for s3 buckets

### DIFF
--- a/.changeset/good-balloons-admire.md
+++ b/.changeset/good-balloons-admire.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": minor
+"builder-util-runtime": minor
+---
+
+added the accelerate option to handle accelerated s3 buckets

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4883,7 +4883,7 @@
       "description": "[Amazon S3](https://aws.amazon.com/s3/) options.\nAWS credentials are required, please see [getting your credentials](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/getting-your-credentials.html).\nDefine `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` [environment variables](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html).\nOr in the [~/.aws/credentials](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html).\n\nExample configuration:\n\n```json\n{\n\"build\":\n \"publish\": {\n   \"provider\": \"s3\",\n   \"bucket\": \"bucket-name\"\n }\n}\n}\n```",
       "properties": {
         "accelerate": {
-          "description": "Whether to set the endpoint to use s3 acceleration. Setting this to true will update your endpoint to follow the s3 acceleration URL scheme of `https://{bucketname}.s3-accelerate.amazonaws.com`.",
+          "description": "If set to true, this will enable the s3 accelerated endpoint\nThese endpoints have a particular format of:\n ${bucketname}.s3-accelerate.amazonaws.com",
           "type": "boolean"
         },
         "acl": {

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4882,6 +4882,10 @@
       "additionalProperties": false,
       "description": "[Amazon S3](https://aws.amazon.com/s3/) options.\nAWS credentials are required, please see [getting your credentials](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/getting-your-credentials.html).\nDefine `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` [environment variables](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html).\nOr in the [~/.aws/credentials](http://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html).\n\nExample configuration:\n\n```json\n{\n\"build\":\n \"publish\": {\n   \"provider\": \"s3\",\n   \"bucket\": \"bucket-name\"\n }\n}\n}\n```",
       "properties": {
+        "accelerate": {
+          "description": "Whether to set the endpoint to use s3 acceleration. Setting this to true will update your endpoint to follow the s3 acceleration URL scheme of `https://{bucketname}.s3-accelerate.amazonaws.com`.",
+          "type": "boolean"
+        },
         "acl": {
           "anyOf": [
             {

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -349,6 +349,13 @@ export interface S3Options extends BaseS3Options {
    * The endpoint should be a string like `https://{service}.{region}.amazonaws.com`.
    */
   readonly endpoint?: string | null
+
+  /**
+   * If set to true, this will enable the s3 accelerated endpoint
+   * These endpoints have a particular format of:
+   *  ${bucketname}.s3-accelerate.amazonaws.com
+   */
+  readonly accelerate?: boolean
 }
 
 /**
@@ -385,7 +392,9 @@ export function getS3LikeProviderBaseUrl(configuration: PublishConfiguration) {
 
 function s3Url(options: S3Options) {
   let url: string
-  if (options.endpoint != null) {
+  if (options.accelerate == true) {
+    url = `https://${options.bucket}.s3-accelerate.amazonaws.com`
+  } else if (options.endpoint != null) {
     url = `${options.endpoint}/${options.bucket}`
   } else if (options.bucket.includes(".")) {
     if (options.region == null) {


### PR DESCRIPTION
Currently it appears there's no support for the s3 accelerated bucket option.
Attempting to supply an endpoint causes the bucket to be appended on the URL, pushing the artifacts into a subfolder.

This PR adds the option to 'accelerate' the s3 bucket, where the s3 URL will be formatted as expected by s3.

For more information on s3 bucket acceleration and the expected URL formats, see:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html

Let me know if I missed anything, I'm happy to throw this PR away if I am off the mark, or there's an easier way to achieve this.