### PR TITLE
feat: Add base option for snapcraft

### DIFF
--- a/.changeset/lazy-icons-ring.md
+++ b/.changeset/lazy-icons-ring.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": major
+---
+
+Add base option for snapcraft

--- a/docs/configuration/snap.md
+++ b/docs/configuration/snap.md
@@ -3,6 +3,9 @@ The top-level [snap](configuration.md#Configuration-snap) key contains set of op
 <!-- do not edit. start of generated block -->
 <ul>
 <li>
+<p><code id="SnapOptions-base">base</code> String | “undefined” - A snap of type base to be used as the execution environment for this snap. Examples: <code>core</code>, <code>core18</code>, <code>core20</code>. Defaults to <code>core18</code></p>
+</li>
+<li>
 <p><code id="SnapOptions-confinement">confinement</code> = <code>strict</code> “devmode” | “strict” | “classic” | “undefined” - The type of <a href="https://snapcraft.io/docs/reference/confinement">confinement</a> supported by the snap.</p>
 </li>
 <li>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5094,6 +5094,13 @@
           "description": "Whether or not the snap should automatically start on login.",
           "type": "boolean"
         },
+        "base": {
+          "description": "A snap of type base to be used as the execution environment for this snap. Examples: `core`, `core18`, `core20`. Defaults to `core18`",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "buildPackages": {
           "anyOf": [
             {

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -2,7 +2,6 @@ import { TargetSpecificOptions } from "../core"
 import { CommonLinuxOptions } from "./linuxOptions"
 
 export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
-
   /**
    * A snap of type base to be used as the execution environment for this snap. Examples: `core`, `core18`, `core20`. Defaults to `core18`
    */

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -2,6 +2,12 @@ import { TargetSpecificOptions } from "../core"
 import { CommonLinuxOptions } from "./linuxOptions"
 
 export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
+
+  /**
+   * A snap of type base to be used as the execution environment for this snap. Examples: `core`, `core18`, `core20`. Defaults to `core18`
+   */
+  readonly base?: string | null
+
   /**
    * The type of [confinement](https://snapcraft.io/docs/reference/confinement) supported by the snap.
    * @default strict

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -69,6 +69,9 @@ export default class SnapTarget extends Target {
     if (this.isUseTemplateApp) {
       delete appDescriptor.adapter
     }
+    if (options.base != null) {
+      snap.base = options.base
+    }
     if (options.grade != null) {
       snap.grade = options.grade
     }

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -297,6 +297,39 @@ test.ifDevOrLinuxCi(
 )
 
 test.ifDevOrLinuxCi(
+  "default base",
+  app({
+    targets: snapTarget,
+    config: {
+      productName: "Sep",
+    },
+    effectiveOptionComputed: async ({ snap }) => {
+      expect(snap).toMatchSnapshot()
+      expect(snap.base).toBe("core18")
+      return true
+    },
+  })
+)
+
+test.ifDevOrLinuxCi(
+  "base option",
+  app({
+    targets: snapTarget,
+    config: {
+      productName: "Sep",
+      snap: {
+        base: 'core22',
+      },
+    },
+    effectiveOptionComputed: async ({ snap }) => {
+      expect(snap).toMatchSnapshot()
+      expect(snap.base).toBe("core22")
+      return true
+    },
+  })
+)
+
+test.ifDevOrLinuxCi(
   "use template app",
   app({
     targets: snapTarget,

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -318,7 +318,7 @@ test.ifDevOrLinuxCi(
     config: {
       productName: "Sep",
       snap: {
-        base: 'core22',
+        base: "core22",
       },
     },
     effectiveOptionComputed: async ({ snap }) => {


### PR DESCRIPTION
Related to https://github.com/electron-userland/electron-builder/issues/7319 and https://github.com/electron-userland/electron-builder/pull/6976

This would unblock users facing issues related use to the older `core18` base type.

Motivation for this PR came from https://github.com/Kong/insomnia/issues/5531. 

@mmaietta let me know if there's anything that I can do to help move either this PR or https://github.com/electron-userland/electron-builder/pull/6976 forward. ~~I'm not sure if I'm also missing some changes e.g. (like the changeset mentioned bellow, or how to update the docs)~~ Updated changeset, schema and docs.

