### PR TITLE
fix: Ensure parent directories of symlinks are created

### DIFF
--- a/.changeset/violet-seahorses-wait.md
+++ b/.changeset/violet-seahorses-wait.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Ensure parent directories of symlinks are created when copied directory only contains symlinks

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -2,7 +2,8 @@ import BluebirdPromise from "bluebird-lst"
 import { AsyncTaskManager, log } from "builder-util"
 import { CONCURRENCY, FileCopier, FileTransformer, Link, MAX_FILE_REQUESTS, statOrNull, walk } from "builder-util/out/fs"
 import { Stats } from "fs"
-import { mkdir, readlink, symlink } from "fs/promises"
+import { mkdir, readlink } from "fs/promises"
+import { ensureSymlink } from "fs-extra"
 import * as path from "path"
 import { isLibOrExe } from "../asar/unpackDetector"
 import { Platform } from "../core"
@@ -82,7 +83,7 @@ export async function copyAppFiles(fileSet: ResolvedFileSet, packager: Packager,
     await taskManager.awaitTasks()
   }
   if (links.length > 0) {
-    await BluebirdPromise.map(links, it => symlink(it.link, it.file), CONCURRENCY)
+    await BluebirdPromise.map(links, it => ensureSymlink(it.link, it.file), CONCURRENCY)
   }
 }
 


### PR DESCRIPTION
Current behavior: If a directory includes only symlinks, the directory is not created and so symlink creation fails.  (Version: 23.6.0)

Fix: Create the parent directory or directories if needed using the fs-extra method "ensureSymlink". The dependency "fs-extra" is already present in this package.

Situation I was encountering:  Our application has a directory in which there are currently only symlinks. The directory and contents are not created and the result is a failedTask=build error with message "ENOENT: no such file or directory, symlink 'path-to-target' -> 'path-to-symlink'". (I've redacted the paths.) I observed that if I added even one non-symlink file into the directory, then the directory and all its contents would be created successfully.
