### PR TITLE
fix: remove `com.apple.quarantine` attribute from downloaded update files on mac (#3754)

### DIFF
--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -95,6 +95,15 @@ export class MacUpdater extends AppUpdater {
     const updateFileSize = zipFileInfo.info.size ?? (await stat(downloadedFile)).size
 
     const log = this._logger
+
+    try {
+      this.debug("Clearing quarantine bit")
+      const result = execFileSync("xattr", ["-r", "-d", "com.apple.quarantine", downloadedFile])
+      log.info(`Quarantine bit is cleared: ${result}`)
+    } catch (e) {
+      log.warn(`xattr shell command for clearing quarantine bit failed: ${e}`)
+    }
+
     const logContext = `fileToProxy=${zipFileInfo.url.href}`
     this.debug(`Creating proxy server for native Squirrel.Mac (${logContext})`)
     this.server?.close()

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -100,8 +100,8 @@ export class MacUpdater extends AppUpdater {
       this.debug("Clearing quarantine bit")
       const result = execFileSync("xattr", ["-r", "-d", "com.apple.quarantine", downloadedFile])
       log.info(`Quarantine bit is cleared: ${result}`)
-    } catch (e) {
-      log.warn(`xattr shell command for clearing quarantine bit failed: ${e}`)
+    } catch (e: any) {
+      log.warn(`xattr shell command for clearing quarantine bit failed: ${e.message}`)
     }
 
     const logContext = `fileToProxy=${zipFileInfo.url.href}`


### PR DESCRIPTION
This is a potentioal fix of https://github.com/electron-userland/electron-builder/issues/3754