### PR TITLE
feat: Provide a custom verify function interface in NsisUpdater

### DIFF
--- a/.changeset/slow-avocados-carry.md
+++ b/.changeset/slow-avocados-carry.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": minor
+---
+
+feat: Provide a custom verify function interface to enable nsis signature verification alternatives instead of powershell

--- a/docs/configuration/win.md
+++ b/docs/configuration/win.md
@@ -60,9 +60,7 @@ exports.default = async function(configuration) {
 
 #### How do use a custom verify function to enable nsis signature verification alternatives instead of powershell?
 
-You need to pass a custom verify function to the nsis updater. For example, if you want to use a native verify function, you can use [win-verify-signature](https://github.com/beyondkmp/win-verify-trust).
-
-The `verifyUpdateCodeSignature` interface
+Use the `verifyUpdateCodeSignature` interface:
 
 ```js
 /**
@@ -72,7 +70,8 @@ The `verifyUpdateCodeSignature` interface
 export type verifyUpdateCodeSignature = (publisherName: string[], path: string) => Promise<string | null>
 ```
 
-pass a custom verify function to the nsis updater
+Pass a custom verify function to the nsis updater. For example, if you want to use a native verify function, you can use [win-verify-signature](https://github.com/beyondkmp/win-verify-trust).
+
 
 ```js
 import { NsisUpdater } from "electron-updater"

--- a/docs/configuration/win.md
+++ b/docs/configuration/win.md
@@ -58,6 +58,50 @@ exports.default = async function(configuration) {
 }
 ```
 
+#### How do use a custom verify function to enable nsis signature verification alternatives instead of powershell?
+
+You need to pass a custom verify function to the nsis updater. For example, if you want to use a native verify function, you can use [win-verify-signature](https://github.com/beyondkmp/win-verify-trust).
+
+The `verifyUpdateCodeSignature` interface
+
+```js
+/**
+*  return null if verify signature succeed
+*  return error message if verify signature failed
+*/
+export type verifyUpdateCodeSignature = (publisherName: string[], path: string) => Promise<string | null>
+```
+
+pass a custom verify function to the nsis updater
+
+```js
+import { NsisUpdater } from "electron-updater"
+import { verifySignatureByPublishName } from "win-verify-signature"
+// Or MacUpdater, AppImageUpdater
+
+export default class AppUpdater {
+    constructor() {
+        const options = {
+            requestHeaders: {
+                // Any request headers to include here
+            },
+            provider: 'generic',
+            url: 'https://example.com/auto-updates'
+        }
+
+        const autoUpdater = new NsisUpdater(options)
+        autoUpdater.verifyUpdateCodeSignature = (publisherName: string[], path: string) => {
+            const result = verifySignatureByPublishName(path, publisherName);
+            if(result.signed) return Promise.resolve(null);
+            return Promise.resolve(result.message);
+        }
+        autoUpdater.addAuthHeader(`Bearer ${token}`)
+        autoUpdater.checkForUpdatesAndNotify()
+    }
+}
+```
+
+
 #### How do create Parallels Windows 10 Virtual Machine?
 
 !!! warning "Disable "Share Mac user folders with Windows""

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -29,8 +29,8 @@ export class NsisUpdater extends BaseUpdater {
     verifySignature(publisherNames, unescapedTempUpdateFile, this._logger)
 
   /**
-   * The verifyUpdateCodeSignature. You can pass [electron-log](https://github.com/megahertz/electron-log), [winston](https://github.com/winstonjs/winston) or another logger with the following interface: `{ info(), warn(), error() }`.
-   * Set it to `null` if you would like to disable a logging feature.
+   * The verifyUpdateCodeSignature. You can pass [win-verify-signature](https://github.com/beyondkmp/win-verify-trust), [winston](https://github.com/winstonjs/winston) or another custom verify function: ` (publisherName: string[], path: string) => Promise<string | null>`.
+   * The default verify function uses [windowsExecutableCodeSignatureVerifier](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts)
    */
   get verifyUpdateCodeSignature(): verifyUpdateCodeSignature {
     return this._verifyUpdateCodeSignature

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -29,7 +29,7 @@ export class NsisUpdater extends BaseUpdater {
     verifySignature(publisherNames, unescapedTempUpdateFile, this._logger)
 
   /**
-   * The verifyUpdateCodeSignature. You can pass [win-verify-signature](https://github.com/beyondkmp/win-verify-trust), [winston](https://github.com/winstonjs/winston) or another custom verify function: ` (publisherName: string[], path: string) => Promise<string | null>`.
+   * The verifyUpdateCodeSignature. You can pass [win-verify-signature](https://github.com/beyondkmp/win-verify-trust) or another custom verify function: ` (publisherName: string[], path: string) => Promise<string | null>`.
    * The default verify function uses [windowsExecutableCodeSignatureVerifier](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts)
    */
   get verifyUpdateCodeSignature(): verifyUpdateCodeSignature {

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -139,4 +139,7 @@ export interface Logger {
   debug?(message: string): void
 }
 
+// return null if verify signature succeed
+// return error message if verify signature failed
+
 export type verifyUpdateCodeSignature = (publisherName: string[], path: string) => Promise<string | null>

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -138,3 +138,5 @@ export interface Logger {
 
   debug?(message: string): void
 }
+
+export type verifyUpdateCodeSignature = (publisherName: string[], path: string) => Promise<string | null>


### PR DESCRIPTION
Replace the PowerShell with [a native verify signature module](https://github.com/beyondkmp/win-verify-trust)， but not all users will have access to a Windows build machine if their project does not currently require a native module. For instance, compiling with Wine on linux/docker would no longer work. 

Providing a custom verify function interface, if the user want to use native verify module, they can pass it and they need to have an access to a windows build machine. If they don't pass it, will use the default verify signature function(https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts).

**Interface**
```js
/**
   * The verifyUpdateCodeSignature. You can pass [win-verify-signature](https://github.com/beyondkmp/win-verify-trust) or another custom verify function: ` (publisherName: string[], path: string) => Promise<string | null>`.
   * The default verify function uses [windowsExecutableCodeSignatureVerifier](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts)
   */
// return null if verify signature succeed
// return error message if verify signature failed
export type verifyUpdateCodeSignature = (publisherName: string[], path: string) => Promise<string | null>
```

**Example**

```js
import { NsisUpdater } from "electron-updater"
import { verifySignatureByPublishName } from "beyondkmp/win-verify-signature"
// Or MacUpdater, AppImageUpdater

export default class AppUpdater {
    constructor() {
        const options = {
            requestHeaders: {
                // Any request headers to include here
            },
            provider: 'generic',
            url: 'https://example.com/auto-updates'
        }

        const autoUpdater = new NsisUpdater(options)
        autoUpdater.verifyUpdateCodeSignature = (publisherName: string[], path: string) => {
            const result = verifySignatureByPublishName(path, publisherName);
            if(result.signed) return Promise.resolve(null);
            return Promise.resolve(result.message);
        }
        autoUpdater.addAuthHeader(`Bearer ${token}`)
        autoUpdater.checkForUpdatesAndNotify()
    }
}
```