### PR TITLE
fix: missing html extension for multi language license files in nsis target

### DIFF
--- a/.changeset/plenty-spoons-prove.md
+++ b/.changeset/plenty-spoons-prove.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add missing html extension for multi language license files in nsis target

--- a/packages/app-builder-lib/src/util/license.ts
+++ b/packages/app-builder-lib/src/util/license.ts
@@ -45,7 +45,7 @@ export async function getLicenseFiles(packager: PlatformPackager<any>): Promise<
   return getLicenseAssets(
     (await packager.resourceList).filter(it => {
       const name = it.toLowerCase()
-      return (name.startsWith("license_") || name.startsWith("eula_")) && (name.endsWith(".rtf") || name.endsWith(".txt"))
+      return (name.startsWith("license_") || name.startsWith("eula_")) && (name.endsWith(".rtf") || name.endsWith(".txt") || name.endsWith(".html"))
     }),
     packager
   )


### PR DESCRIPTION
Regarding issue #7334  
[https://github.com/electron-userland/electron-builder/issues/7334]( https://github.com/electron-userland/electron-builder/issues/7334)
there was missing the `.html` extension.