### PR TITLE
fix: Update MacOS signOptions on macPackager #7317

### DIFF
--- a/.changeset/chilled-shoes-sort.md
+++ b/.changeset/chilled-shoes-sort.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+Update MacOS signOptions on macPackager

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -270,7 +270,6 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     }
 
     const signOptions: any = {
-      "identity-validation": false,
       identityValidation: false,
       // https://github.com/electron-userland/electron-builder/issues/1699
       // kext are signed by the chipset manufacturers. You need a special certificate (only available on request) from Apple to be able to sign kext.
@@ -308,7 +307,6 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       // will fail on 10.14.5+ because a signed but unnotarized app is also rejected.
       "gatekeeper-assess": options.gatekeeperAssess === true,
       // https://github.com/electron-userland/electron-builder/issues/1480
-      "strict-verify": options.strictVerify,
       strictVerify: options.strictVerify,
       hardenedRuntime: isMas ? masOptions && masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
     }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -271,6 +271,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
 
     const signOptions: any = {
       "identity-validation": false,
+      identityValidation: false,
       // https://github.com/electron-userland/electron-builder/issues/1699
       // kext are signed by the chipset manufacturers. You need a special certificate (only available on request) from Apple to be able to sign kext.
       ignore: (file: string) => {
@@ -294,7 +295,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
           https://github.com/electron-userland/electron-builder/issues/5383
           */
       },
-      identity: identity,
+      identity: identity ? identity.name : undefined,
       type,
       platform: isMas ? "mas" : "darwin",
       version: this.config.electronVersion,
@@ -308,6 +309,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       "gatekeeper-assess": options.gatekeeperAssess === true,
       // https://github.com/electron-userland/electron-builder/issues/1480
       "strict-verify": options.strictVerify,
+      strictVerify: options.strictVerify,
       hardenedRuntime: isMas ? masOptions && masOptions.hardenedRuntime === true : options.hardenedRuntime !== false,
     }
 


### PR DESCRIPTION
cc @mmaietta 

Trying (almost) the same fix as suggested by @mayfield in this comment https://github.com/electron-userland/electron-builder/issues/7317#issuecomment-1351168459. I'm leaving the old legacy options in for now, I reckon they will be ignored when using the new https://github.com/electron/osx-sign ?

Not sure if in this case we should leave the legacy stuff in. There's a migration guide that can be checked for reference: https://github.com/electron/osx-sign/blob/a9cfce77512358420a850abfc102f784e02f8138/MIGRATION.md
