### PR TITLE
docs: replaced 'access token' with 'app password' from BitbucketOptions

### DIFF
--- a/.changeset/old-shrimps-drive.md
+++ b/.changeset/old-shrimps-drive.md
@@ -1,0 +1,7 @@
+---
+"app-builder-lib": patch
+"builder-util-runtime": patch
+"builder-util": patch
+---
+
+docs: replaced 'access token' with 'app password' from BitbucketOptions

--- a/docs/configuration/publish.md
+++ b/docs/configuration/publish.md
@@ -246,15 +246,15 @@ Define <code>KEYGEN_TOKEN</code> environment variable.</p>
 <a href="https://bitbucket.org/">https://bitbucket.org/</a>
 Define <code>BITBUCKET_TOKEN</code> environment variable.</p>
 <p>For converting an app password to a usable token, you can utilize this</p>
-<pre><code class="hljs language-typescript"><span class="hljs-title function_">convertAppPassword</span>(<span class="hljs-params">owner: <span class="hljs-built_in">string</span>, token: <span class="hljs-built_in">string</span></span>) {
-<span class="hljs-keyword">const</span> base64encodedData = <span class="hljs-title class_">Buffer</span>.<span class="hljs-title function_">from</span>(<span class="hljs-string">`<span class="hljs-subst">${owner}</span>:<span class="hljs-subst">${token.trim()}</span>`</span>).<span class="hljs-title function_">toString</span>(<span class="hljs-string">&quot;base64&quot;</span>)
+<pre><code class="hljs language-typescript"><span class="hljs-title function_">convertAppPassword</span>(<span class="hljs-params">owner: <span class="hljs-built_in">string</span>, appPassword: <span class="hljs-built_in">string</span></span>) {
+<span class="hljs-keyword">const</span> base64encodedData = <span class="hljs-title class_">Buffer</span>.<span class="hljs-title function_">from</span>(<span class="hljs-string">`<span class="hljs-subst">${owner}</span>:<span class="hljs-subst">${appPassword.trim()}</span>`</span>).<span class="hljs-title function_">toString</span>(<span class="hljs-string">&quot;base64&quot;</span>)
 <span class="hljs-keyword">return</span> <span class="hljs-string">`Basic <span class="hljs-subst">${base64encodedData}</span>`</span>
 }
 </code></pre>
 <ul>
 <li><strong><code id="BitbucketOptions-provider">provider</code></strong> “bitbucket” - The provider. Must be <code>bitbucket</code>.</li>
 <li><strong><code id="BitbucketOptions-owner">owner</code></strong> String - Repository owner</li>
-<li><code id="BitbucketOptions-token">token</code> String | “undefined” - The access token to support auto-update from private bitbucket repositories.</li>
+<li><code id="BitbucketOptions-token">token</code> String | “undefined” - The app password (account&gt;settings&gt;app-passwords) to support auto-update from private bitbucket repositories.</li>
 <li><code id="BitbucketOptions-username">username</code> String | “undefined” - The user name to support auto-update from private bitbucket repositories.</li>
 <li><strong><code id="BitbucketOptions-slug">slug</code></strong> String - Repository slug/name</li>
 <li><code id="BitbucketOptions-channel">channel</code> = <code>latest</code> String | “undefined” - The channel.</li>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -334,7 +334,7 @@
     },
     "BitbucketOptions": {
       "additionalProperties": false,
-      "description": "Bitbucket options.\nhttps://bitbucket.org/\nDefine `BITBUCKET_TOKEN` environment variable.\n\nFor converting an app password to a usable token, you can utilize this\n```typescript\nconvertAppPassword(owner: string, token: string) {\nconst base64encodedData = Buffer.from(`${owner}:${token.trim()}`).toString(\"base64\")\nreturn `Basic ${base64encodedData}`\n}\n```",
+      "description": "Bitbucket options.\nhttps://bitbucket.org/\nDefine `BITBUCKET_TOKEN` environment variable.\n\nFor converting an app password to a usable token, you can utilize this\n```typescript\nconvertAppPassword(owner: string, appPassword: string) {\nconst base64encodedData = Buffer.from(`${owner}:${appPassword.trim()}`).toString(\"base64\")\nreturn `Basic ${base64encodedData}`\n}\n```",
       "properties": {
         "channel": {
           "default": "latest",
@@ -390,7 +390,7 @@
           ]
         },
         "token": {
-          "description": "The access token to support auto-update from private bitbucket repositories.",
+          "description": "The app password (account>>settings>app-passwords) to support auto-update from private bitbucket repositories.",
           "type": [
             "null",
             "string"

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -208,8 +208,8 @@ export interface KeygenOptions extends PublishConfiguration {
  * 
  * For converting an app password to a usable token, you can utilize this
 ```typescript
-convertAppPassword(owner: string, token: string) {
-  const base64encodedData = Buffer.from(`${owner}:${token.trim()}`).toString("base64")
+convertAppPassword(owner: string, appPassword: string) {
+  const base64encodedData = Buffer.from(`${owner}:${appPassword.trim()}`).toString("base64")
   return `Basic ${base64encodedData}`
 }
 ```
@@ -226,7 +226,7 @@ export interface BitbucketOptions extends PublishConfiguration {
   readonly owner: string
 
   /**
-   * The access token to support auto-update from private bitbucket repositories.
+   * The app password (account>settings>app-passwords) to support auto-update from private bitbucket repositories.
    */
   readonly token?: string | null
 

--- a/yalc.lock
+++ b/yalc.lock
@@ -1,4 +1,0 @@
-{
-  "version": "v1",
-  "packages": {}
-}

--- a/yalc.lock
+++ b/yalc.lock
@@ -1,0 +1,4 @@
+{
+  "version": "v1",
+  "packages": {}
+}


### PR DESCRIPTION
According to the issue that I opened https://github.com/electron-userland/electron-builder/issues/7323. 
I think now it will be easier to understand. 