### PR TITLE
feat: vendor information in releaseInfo

### DIFF
--- a/.changeset/brown-tigers-check.md
+++ b/.changeset/brown-tigers-check.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: optional vendor information in releaseInfo

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4874,6 +4874,10 @@
             "null",
             "string"
           ]
+        },
+        "vendor": {
+          "description": "Vendor-specific informaton",
+          "type": "object"
         }
       },
       "type": "object"

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -147,7 +147,7 @@ export interface ReleaseInfo {
   /**
    * Vendor specific information.
    */
-  vendor?: Record<string, unknown>
+  vendor?: Record<string, unknown> | null
 }
 
 /**

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -143,6 +143,11 @@ export interface ReleaseInfo {
    * The release date.
    */
   releaseDate?: string
+
+  /**
+   * Vendor specific information.
+   */
+  vendor?: Record<string, unknown>
 }
 
 /**


### PR DESCRIPTION
We've been running a version of this patch internally for awhile and decided that it is time to submit it as a Pull Request.

The idea of this change is to allow to pass a custom `vendor` object down to the `.yml` file. This object might have some custom properties on it like `requireManualUpdate` or `minOSVersion` that the vendor's updater could be checking when deciding whether to update to this release or not.

I understand that this will be ignored by the auto-updater bundled in electron-builder, but at least in our case we are running our own updater and we really find this additional information handy.