### PR TITLE
fix: Remove adapter if core22 is set as base on snapcraft

### DIFF
--- a/.changeset/thin-terms-change.md
+++ b/.changeset/thin-terms-change.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": major
+---
+
+Remove extra adapter field if core22 is set as base for snapcraft

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -72,7 +72,7 @@ export default class SnapTarget extends Target {
     if (options.base != null) {
       snap.base = options.base
       // from core22 onwards adapter is legacy
-      if (snap.base === "core22") {
+      if (Number(snap.base.split("core")[1]) >= 22) {
         delete appDescriptor.adapter
       }
     }

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -71,6 +71,10 @@ export default class SnapTarget extends Target {
     }
     if (options.base != null) {
       snap.base = options.base
+      // from core22 onwards adapter is legacy
+      if (snap.base === "core22") {
+        delete appDescriptor.adapter
+      }
     }
     if (options.grade != null) {
       snap.grade = options.grade


### PR DESCRIPTION
Closes #7372

cc @mmaietta 