### PR TITLE
fix: add reject in handleError in Windows `verifySignature` function

### DIFF
--- a/.changeset/nervous-zebras-accept.md
+++ b/.changeset/nervous-zebras-accept.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: add reject in handleError in Windows `verifySignature` function


### PR DESCRIPTION
We cannot catch the whoops error. Because all synchronous errors are handled. But here the error is generated not while the executor is running, but later. So the promise can’t handle it.

```typescript
new Promise(function(resolve, reject) {
  setTimeout(() => {
    throw new Error("Whoops!");
  }, 1000);
}).catch(e => console.log('test is here:', e));
```

The verifySignature function has the same problem. we cannot catch  the error throw by the function handleError.

```typescript
export function verifySignature(publisherNames: Array<string>, unescapedTempUpdateFile: string, logger: Logger): Promise<string | null> {
  return new Promise<string | null>(resolve => {
    execFile(
      "chcp 65001 >NUL & powershell.exe",
      ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", `"Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress"`],
      {
        shell: true,
        timeout: 20 * 1000,
      },
      (error, stdout, stderr) => {
        try {
          if (error != null || stderr) {
            handleError(logger, error, stderr)
            resolve(null)
            return
          }
```

## Impact
We want to catch all the powershell error because the users have a variety of powershell errors. But his bug, we cannot catch the errors and some users did not succeed in upgrading.

We can use the following code to test this bug in windows

```typescript
const { execFile } = require('child_process');

function runCMD() {
  return new Promise((resolve, reject) => {
    execFile(
      'powershell.exe',
      ['test xxx'],
      (error, stdout, stderr) => {
        try {
          if (error != null || stderr) {
            handleErrorByThrow(error, stderr, reject);
            resolve(null);
            return;
          }
        } catch (e) {
          handleErrorByThrow(e, null, reject);
          return;
        }
      },
    );
  });
}

function handleError(error, stderr, reject) {
  if (error != null) {
    reject(error);
  }

  if (stderr) {
    reject(
      new Error(
        `Cannot execute Get-AuthenticodeSignature, stderr: ${stderr}. Failing signature validation due to unknown stderr.`,
      ),
    );
  }
}

function handleErrorByThrow(error, stderr, reject) {
  if (error != null) {
    throw error;
  }

  if (stderr) {
    throw new Error(`Cannot execute Get-AuthenticodeSignature, stderr: ${stderr}. Failing signature validation due to unknown stderr.`)
  }
}


async function test() {
  try {
    const result = await runCMD();
    console.log(result);  
  } catch (e) {
    console.log('catch is called');
    console.log(e);
  }
}
test();

```

