### PR TITLE
fix: Allow MAS builds to be unsigned if `identity: null` is explicitly passed

### DIFF
--- a/.changeset/eleven-trainers-brake.md
+++ b/.changeset/eleven-trainers-brake.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Allow MAS builds to be unsigned if `identity: null` is explicitly passed

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -204,7 +204,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     const options = masOptions == null ? this.platformSpecificBuildOptions : masOptions
     const qualifier = options.identity
 
-    if (!isMas && qualifier === null) {
+    if (qualifier === null) {
       if (this.forceCodeSigning) {
         throw new InvalidConfigurationError("identity explicitly is set to null, but forceCodeSigning is set to true")
       }


### PR DESCRIPTION
Currently, MAS builds are always signed, even if `identity: null` is explicitly passed. In fact, sign is called twice, first time ignored:

```
• skipped macOS code signing  reason=identity explicitly is set to null
  • signing         file=dist/mas-arm64/Nozbe.app identityName=xxxx identityHash=yyy provisioningProfile=none
```

It should be possible to force a MAS build to be unsigned. (in my use case, I need this because I need additional modifications to the app before it can be Universalized, and only then it can be signed)