### PR TITLE
fix: MAS builds should respect arch suffix per `defaultArch` config

### DIFF
--- a/.changeset/empty-onions-own.md
+++ b/.changeset/empty-onions-own.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: MAS builds should respect arch suffix per `defaultArch` config

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -181,7 +181,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         })
       }
 
-      const targetOutDir = path.join(outDir, `${targetName}${getArchSuffix(arch)}`)
+      const targetOutDir = path.join(outDir, `${targetName}${getArchSuffix(arch, this.platformSpecificBuildOptions.defaultArch)}`)
       if (prepackaged == null) {
         await this.doPack(outDir, targetOutDir, "mas", arch, masBuildOptions, [target])
         await this.sign(path.join(targetOutDir, `${this.appInfo.productFilename}.app`), targetOutDir, masBuildOptions, arch)


### PR DESCRIPTION
It's possible to force electron-builder to explicitly name build archs by setting, for example `defaultArch: ia32`. In this case, you'll get builds like `dist/mac-x64`, `dist/mac-arm64`. However, MAS builds are not behaving consistently, as defaultArch was ignored.