### PR TITLE
fix: reset `GYP_MSVS_VERSION` for multi-arch builds before `beforePack`

### DIFF
--- a/.changeset/purple-phones-sin.md
+++ b/.changeset/purple-phones-sin.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: reset `GYP_MSVS_VERSION` for multi-arch builds before `beforePack`

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -19,4 +19,3 @@ issue_labeler_regex_version=0
 * **Target**: 
 
 <!-- Enter your issue details below this comment. -->
-<!-- If you want, you can donate to increase issue priority (https://www.electron.build/donate) -->

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -66,7 +66,7 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 <hr>
 <ul>
 <li><code id="Configuration-linux">linux</code> <a href="linux">LinuxConfiguration</a> - Options related to how build Linux targets.</li>
-<li><code id="Configuration-deb">deb</code> <a href="/configuration/linux#de">DebOptions</a> - Debian package options.</li>
+<li><code id="Configuration-deb">deb</code> <a href="/configuration/linux#deb">DebOptions</a> - Debian package options.</li>
 <li><code id="Configuration-snap">snap</code> <a href="snap">SnapOptions</a> - Snap options.</li>
 <li><code id="Configuration-appImage">appImage</code> <a href="/configuration/linux#appimageoptions">AppImageOptions</a> - AppImage options.</li>
 <li><code id="Configuration-flatpak">flatpak</code> <a href="flatpak">FlatpakOptions</a> - Flatpak options.</li>

--- a/docs/generated/PlatformSpecificBuildOptions.md
+++ b/docs/generated/PlatformSpecificBuildOptions.md
@@ -92,6 +92,7 @@
 <li><code id="ReleaseInfo-releaseNotes">releaseNotes</code> String | “undefined” - The release notes.</li>
 <li><code id="ReleaseInfo-releaseNotesFile">releaseNotesFile</code> String | “undefined” - The path to release notes file. Defaults to <code>release-notes-${platform}.md</code> (where <code>platform</code> it is current platform — <code>mac</code>, <code>linux</code> or <code>windows</code>) or <code>release-notes.md</code> in the <a href="#MetadataDirectories-buildResources">build resources</a>.</li>
 <li><code id="ReleaseInfo-releaseDate">releaseDate</code> String - The release date.</li>
+<li><code id="ReleaseInfo-vendor">vendor</code> Object&lt;String, any&gt; | “undefined” - Vendor specific information.</li>
 </ul>
 </li>
 <li>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -390,7 +390,7 @@
           ]
         },
         "token": {
-          "description": "The app password (account>>settings>app-passwords) to support auto-update from private bitbucket repositories.",
+          "description": "The app password (account>settings>app-passwords) to support auto-update from private bitbucket repositories.",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4876,8 +4876,15 @@
           ]
         },
         "vendor": {
-          "description": "Vendor-specific informaton",
-          "type": "object"
+          "anyOf": [
+            {
+              "typeof": "function"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vendor specific information."
         }
       },
       "type": "object"

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -147,7 +147,7 @@ export interface ReleaseInfo {
   /**
    * Vendor specific information.
    */
-  vendor?: Record<string, unknown> | null
+  vendor?: { [key: string]: any } | null
 }
 
 /**

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -201,6 +201,9 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       return
     }
 
+    // Due to node-gyp rewriting GYP_MSVS_VERSION when reused across the same session, we must reset the env var: https://github.com/electron-userland/electron-builder/issues/7256
+    delete process.env.GYP_MSVS_VERSION
+
     const beforePack = resolveFunction(this.config.beforePack, "beforePack")
     if (beforePack != null) {
       await beforePack({

--- a/scripts/jsdoc2md2html.js
+++ b/scripts/jsdoc2md2html.js
@@ -188,7 +188,7 @@ async function render2(files, jsdoc2MdOptions) {
       return "[AppImageOptions](/configuration/linux#appimageoptions)"
     }
     if (types.some(it => it.endsWith("DebOptions"))) {
-      return "[DebOptions](/configuration/linux#de)"
+      return "[DebOptions](/configuration/linux#deb)"
     }
     if (types.some(it => it.endsWith("LinuxTargetSpecificOptions"))) {
       return "[LinuxTargetSpecificOptions](/configuration/linux#LinuxTargetSpecificOptions)"


### PR DESCRIPTION
Manually resetting `GYP_MSVS_VERSION` for multi-arch builds due to electron-rebuild and node-gyp overwriting the default var
Fixes: #7256 