### PR TITLE
fix(packager): return success status from doSign function calls

### DIFF
--- a/.changeset/real-poets-compare.md
+++ b/.changeset/real-poets-compare.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix packager: return success status from doSign function calls

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -70,7 +70,6 @@ export async function sign(options: WindowsSignOptions, packager: WinPackager): 
       await rename(taskConfiguration.resultOutputPath, options.path)
     }
   }
-
   return true
 }
 

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -70,6 +70,7 @@ export async function sign(options: WindowsSignOptions, packager: WinPackager): 
       await rename(taskConfiguration.resultOutputPath, options.path)
     }
   }
+
   return true
 }
 

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -454,10 +454,6 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       })
       return true
     }
-
-    const appFileName = `${this.appInfo.productFilename}.app`
-    await readDirectoryAndSign(packContext.appOutDir, await readdir(packContext.appOutDir), file => file === appFileName)
-
     if (!isAsar) {
       return true
     }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -376,7 +376,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
   }
 
   //noinspection JSMethodCanBeStatic
-  protected async doSign(opts: SignOptions): Promise<any> {
+  protected doSign(opts: SignOptions): Promise<any> {
     return signAsync(opts)
   }
 
@@ -454,6 +454,9 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       })
       return true
     }
+
+    const appFileName = `${this.appInfo.productFilename}.app`
+    await readDirectoryAndSign(packContext.appOutDir, await readdir(packContext.appOutDir), file => file === appFileName)
     if (!isAsar) {
       return true
     }

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -255,13 +255,11 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   }
 
   private async doSign(options: WindowsSignOptions) {
-    let didSign = true
     for (let i = 0; i < 3; i++) {
       try {
         await sign(options, this)
         return true
       } catch (e: any) {
-        didSign = false
         // https://github.com/electron-userland/electron-builder/issues/1414
         const message = e.message
         if (message != null && message.includes("Couldn't resolve host name")) {
@@ -369,9 +367,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       if (this.shouldSignFile(file)) {
         const parentDir = path.dirname(file)
         if (parentDir !== packContext.appOutDir) {
-          return new CopyFileTransformer(async file => {
-            await this.sign(file)
-          })
+          return new CopyFileTransformer(file => this.sign(file))
         }
       }
       return null


### PR DESCRIPTION
Recent changes (https://github.com/electron-userland/electron-builder/pull/7311) in platform packager `afterSign` hook show that the correct success status was not being returned after signing the app on macOS

This results in the app being signed but the terminal has the following message

>  skipping "afterSign" hook as no signing occurred, perhaps you intended "afterPack"?

found this on electron-builder v24.0.0-alpha.12

_Couldn't get a local development environment properly setup, so hoping someone could help test if these help solve the issue_