### PR TITLE
fix(packager): report the correct status result when `doSign` exits early

### DIFF
--- a/.changeset/stale-dots-build.md
+++ b/.changeset/stale-dots-build.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+---
+
+fix: report the correct status result when `doSign` exits early from macPackager and winPackager. Updated function definition to return `Promise<boolean>` to properly flag intellisense

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -39,7 +39,7 @@ export interface CustomWindowsSignTaskConfiguration extends WindowsSignTaskConfi
   computeSignToolArgs(isWin: boolean): Array<string>
 }
 
-export async function sign(options: WindowsSignOptions, packager: WinPackager) {
+export async function sign(options: WindowsSignOptions, packager: WinPackager): Promise<boolean> {
   let hashes = options.options.signingHashAlgorithms
   // msi does not support dual-signing
   if (options.path.endsWith(".msi")) {
@@ -70,6 +70,8 @@ export async function sign(options: WindowsSignOptions, packager: WinPackager) {
       await rename(taskConfiguration.resultOutputPath, options.path)
     }
   }
+
+  return true
 }
 
 export interface FileCodeSigningInfo {

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -429,7 +429,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected signApp(packContext: AfterPackContext, isAsar: boolean): Promise<any> {
+  protected signApp(packContext: AfterPackContext, isAsar: boolean): Promise<boolean> {
     return Promise.resolve(false)
   }
 

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -12,7 +12,7 @@ import * as isCI from "is-ci"
 export const MAX_FILE_REQUESTS = 8
 export const CONCURRENCY = { concurrency: MAX_FILE_REQUESTS }
 
-export type AfterCopyFileTransformer = (file: string) => Promise<void>
+export type AfterCopyFileTransformer = (file: string) => Promise<boolean>
 
 export class CopyFileTransformer {
   constructor(public readonly afterCopyTransformer: AfterCopyFileTransformer) {}
@@ -220,7 +220,7 @@ export class FileCopier {
     }
   }
 
-  async copy(src: string, dest: string, stat: Stats | undefined) {
+  async copy(src: string, dest: string, stat: Stats | undefined): Promise<void> {
     let afterCopyTransformer: AfterCopyFileTransformer | null = null
     if (this.transformer != null && stat != null && stat.isFile()) {
       let data = this.transformer(src)


### PR DESCRIPTION
fix: report the correct status result when `doSign` exits early from `macPackager` and `winPackager`. Updated function definition to return `Promise<boolean>` to properly flag intellisense

Follow-up from @nsrCodes PR: https://github.com/electron-userland/electron-builder/pull/7431