### PR TITLE
feat: Support mjs files for lifecycle operations

### DIFF
--- a/.changeset/real-toes-beam.md
+++ b/.changeset/real-toes-beam.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+Support mjs files for lifecycle scripts

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -6,7 +6,7 @@ import { computeToolEnv, ToolInfo } from "../util/bundledTool"
 import { rename } from "fs-extra"
 import * as os from "os"
 import * as path from "path"
-import { resolveFunction } from "../platformPackager"
+import { importFunction } from "../platformPackager"
 import { isUseSystemSigncode } from "../util/flags"
 import { VmManager } from "../vm/vm"
 import { WinPackager } from "../winPackager"
@@ -52,7 +52,7 @@ export async function sign(options: WindowsSignOptions, packager: WinPackager): 
     hashes = Array.isArray(hashes) ? hashes : [hashes]
   }
 
-  const executor = resolveFunction(options.options.sign, "sign") || doSign
+  const executor = (await importFunction(options.options.sign, "sign")) || doSign
   let isNest = false
   for (const hash of hashes) {
     const taskConfiguration: WindowsSignTaskConfiguration = { ...options, hash, isNest }

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -4,7 +4,7 @@ import { log, InvalidConfigurationError } from "builder-util"
 import { asArray } from "builder-util-runtime"
 import { Packager } from "./packager"
 import { PackagerOptions } from "./packagerApi"
-import { resolveFunction } from "./platformPackager"
+import { importFunction } from "./platformPackager"
 import { PublishManager } from "./publish/PublishManager"
 
 export { Packager, BuildResult } from "./packager"
@@ -76,7 +76,7 @@ export function build(options: PackagerOptions & PublishOptions, packager: Packa
   process.once("SIGINT", sigIntHandler)
 
   const promise = packager.build().then(async buildResult => {
-    const afterAllArtifactBuild = resolveFunction(buildResult.configuration.afterAllArtifactBuild, "afterAllArtifactBuild")
+    const afterAllArtifactBuild = await importFunction(buildResult.configuration.afterAllArtifactBuild, "afterAllArtifactBuild")
     if (afterAllArtifactBuild != null) {
       const newArtifacts = asArray(await Promise.resolve(afterAllArtifactBuild(buildResult)))
       if (newArtifacts.length === 0 || !publishManager.isPublish) {

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -16,7 +16,7 @@ import { Framework } from "./Framework"
 import { LibUiFramework } from "./frameworks/LibUiFramework"
 import { Metadata } from "./options/metadata"
 import { ArtifactBuildStarted, ArtifactCreated, PackagerOptions } from "./packagerApi"
-import { PlatformPackager, resolveFunction } from "./platformPackager"
+import { PlatformPackager, importFunction } from "./platformPackager"
 import { ProtonFramework } from "./ProtonFramework"
 import { computeArchToTargetNamesMap, createTargets, NoOpTarget } from "./targets/targetFactory"
 import { computeDefaultAppDirectory, getConfig, validateConfig } from "./util/config"
@@ -257,7 +257,7 @@ export class Packager {
       },
       "building"
     )
-    const handler = resolveFunction(this.config.artifactBuildStarted, "artifactBuildStarted")
+    const handler = await importFunction(this.config.artifactBuildStarted, "artifactBuildStarted")
     if (handler != null) {
       await Promise.resolve(handler(event))
     }
@@ -271,7 +271,7 @@ export class Packager {
   }
 
   async callArtifactBuildCompleted(event: ArtifactCreated): Promise<void> {
-    const handler = resolveFunction(this.config.artifactBuildCompleted, "artifactBuildCompleted")
+    const handler = await importFunction(this.config.artifactBuildCompleted, "artifactBuildCompleted")
     if (handler != null) {
       await Promise.resolve(handler(event))
     }
@@ -280,14 +280,14 @@ export class Packager {
   }
 
   async callAppxManifestCreated(path: string): Promise<void> {
-    const handler = resolveFunction(this.config.appxManifestCreated, "appxManifestCreated")
+    const handler = await importFunction(this.config.appxManifestCreated, "appxManifestCreated")
     if (handler != null) {
       await Promise.resolve(handler(path))
     }
   }
 
   async callMsiProjectCreated(path: string): Promise<void> {
-    const handler = resolveFunction(this.config.msiProjectCreated, "msiProjectCreated")
+    const handler = await importFunction(this.config.msiProjectCreated, "msiProjectCreated")
     if (handler != null) {
       await Promise.resolve(handler(path))
     }
@@ -503,7 +503,7 @@ export class Packager {
       return
     }
 
-    const beforeBuild = resolveFunction(config.beforeBuild, "beforeBuild")
+    const beforeBuild = await importFunction(config.beforeBuild, "beforeBuild")
     if (beforeBuild != null) {
       const performDependenciesInstallOrRebuild = await beforeBuild({
         appDir: this.appDir,
@@ -532,7 +532,7 @@ export class Packager {
   }
 
   async afterPack(context: AfterPackContext): Promise<any> {
-    const afterPack = resolveFunction(this.config.afterPack, "afterPack")
+    const afterPack = await importFunction(this.config.afterPack, "afterPack")
     const handlers = this.afterPackHandlers.slice()
     if (afterPack != null) {
       // user handler should be last

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -4,7 +4,7 @@ import { lstat, readdir } from "fs-extra"
 import * as path from "path"
 import { excludedNames, FileMatcher } from "../fileMatcher"
 import { Packager } from "../packager"
-import { resolveFunction } from "../platformPackager"
+import { importFunction } from "../platformPackager"
 import { FileCopyHelper } from "./AppFileWalker"
 
 const excludedFiles = new Set(
@@ -42,7 +42,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
     const filter = this.filter
     const metadata = this.metadata
 
-    const onNodeModuleFile = resolveFunction(this.packager.config.onNodeModuleFile, "onNodeModuleFile")
+    const onNodeModuleFile = await importFunction(this.packager.config.onNodeModuleFile, "onNodeModuleFile")
 
     const result: Array<string> = []
     const queue: Array<string> = []


### PR DESCRIPTION
- beforePack
- afterSign
- artifactBuildStarted
- artifactBuildCompleted
- appxManifestCreated
- msiProjectCreated
- beforeBuild
- afterPack
- afterAllArtifactBuild
- sign
- onNodeModuleFile

fixes https://github.com/electron-userland/electron-builder/issues/7441