### PR TITLE
fix: cross-platform build for native modules using prebuild

### DIFF
--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -26,7 +26,7 @@ export async function installOrRebuild(config: Configuration, appDir: string, op
     }
     await installDependencies(appDir, effectiveOptions)
   } else {
-    await rebuild(appDir, config.buildDependenciesFromSource === true, options.arch)
+    await rebuild(appDir, config.buildDependenciesFromSource === true, options)
   }
 }
 
@@ -149,18 +149,19 @@ export interface RebuildOptions {
 }
 
 /** @internal */
-export async function rebuild(appDir: string, buildFromSource: boolean, arch = process.arch) {
-  log.info({ appDir, arch }, "executing @electron/rebuild")
-  const options: electronRebuild.RebuildOptions = {
+export async function rebuild(appDir: string, buildFromSource: boolean, options: RebuildOptions) {
+  log.info({ appDir, arch: options.arch, platform: options.platform }, "executing @electron/rebuild")
+  const effectiveOptions: electronRebuild.RebuildOptions = {
     buildPath: appDir,
     electronVersion: await getElectronVersion(appDir),
-    arch,
+    arch: options.arch,
+    platform: options.platform,
     force: true,
     debug: log.isDebugEnabled,
     projectRootPath: await searchModule.getProjectRootPath(appDir),
   }
   if (buildFromSource) {
-    options.prebuildTagPrefix = "totally-not-a-real-prefix-to-force-rebuild"
+    effectiveOptions.prebuildTagPrefix = "totally-not-a-real-prefix-to-force-rebuild"
   }
-  return electronRebuild.rebuild(options)
+  return electronRebuild.rebuild(effectiveOptions)
 }


### PR DESCRIPTION
The `rebuild()` method has not been passing the platform to the electron-rebuild.

This means electron-builder has been using the `process.platform` no matter what platform you specify, which means no cross-platform build if an app includes native modules that include prebuilt binaries.

Combined with the fix for `@electron/rebuild` at https://github.com/electron/rebuild/pull/1072 I have confirmed that now I can successfully build using electron-builder for ALL platforms using the correct native built binaries.