### PR TITLE
fix(arm64): RPM architecture name

### DIFF
--- a/.changeset/selfish-games-sniff.md
+++ b/.changeset/selfish-games-sniff.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix(arm64): use RPM architecture `aarch64` in name

--- a/packages/builder-util/src/arch.ts
+++ b/packages/builder-util/src/arch.ts
@@ -17,7 +17,7 @@ export function toLinuxArchString(arch: Arch, targetName: string): string {
     case Arch.armv7l:
       return targetName === "snap" || targetName === "deb" ? "armhf" : targetName === "flatpak" ? "arm" : "armv7l"
     case Arch.arm64:
-      return targetName === "pacman" || targetName === "flatpak" ? "aarch64" : "arm64"
+      return targetName === "pacman" || targetName === "rpm" || targetName === "flatpak" ? "aarch64" : "arm64"
 
     default:
       throw new Error(`Unsupported arch ${arch}`)


### PR DESCRIPTION
It feels like just having `aarch64` in the filename is not sufficient.

```
[root@7b42929061f0 /]# uname -a
Linux 7b42929061f0 5.15.49-linuxkit #1 SMP PREEMPT Tue Sep 13 07:51:32 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux

yum install https://github.com/MuhammedKalkan/OpenLens/releases/download/v6.4.4/OpenLens-6.4.4.aarch64.rpm
Error:
 Problem: conflicting requests
  - package open-lens-6.4.4-1.arm64 does not have a compatible architecture
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

There is also an fix available on [fpm](https://github.com/jordansissel/fpm/commit/cc0a4e736941401ed6f3a5b20269d1415c53f45c), but this requires fpm 1.13.0 or higher