### PR TITLE
fix: Missing quote syntax error in nsis uninstaller

### DIFF
--- a/packages/app-builder-lib/templates/nsis/uninstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/uninstaller.nsh
@@ -115,7 +115,7 @@ Function un.restoreFiles
       Goto continue
 
     isNotDir:
-      Rename $PLUGINSDIR\old-install$R0\$R2" "$INSTDIR$R0\$R2"
+      Rename "$PLUGINSDIR\old-install$R0\$R2" "$INSTDIR$R0\$R2"
 
     continue:
       FindNext $R1 $R2


### PR DESCRIPTION
for issue https://github.com/electron-userland/electron-builder/issues/7489