### PR TITLE
fix: updating SignOptions to leverage `optionsForFile` for entitlements

### DIFF
--- a/.changeset/old-melons-taste.md
+++ b/.changeset/old-melons-taste.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: updating SignOptions to leverage `optionsForFile` for entitlements

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,6 +71,7 @@ jobs:
       - name: Test
         run: pnpm ci:test
         env:
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
           TEST_FILES: masTest,dmgTest,filesTest,macPackagerTest
           FORCE_COLOR: 1
   
@@ -116,6 +117,6 @@ jobs:
       - name: Test
         run: pnpm ci:test
         env:
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
           TEST_FILES: ${{ matrix.testFiles }}
           FORCE_COLOR: 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,7 +71,6 @@ jobs:
       - name: Test
         run: pnpm ci:test
         env:
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
           TEST_FILES: masTest,dmgTest,filesTest,macPackagerTest
           FORCE_COLOR: 1
   

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,6 +116,6 @@ jobs:
       - name: Test
         run: pnpm ci:test
         env:
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           TEST_FILES: ${{ matrix.testFiles }}
           FORCE_COLOR: 1

--- a/docs/configuration/mac.md
+++ b/docs/configuration/mac.md
@@ -84,7 +84,7 @@ The top-level [mac](configuration.md#Configuration-mac) key contains set of opti
 <p><code id="MacConfiguration-gatekeeperAssess">gatekeeperAssess</code> = <code>false</code> Boolean - Whether to let @electron/osx-sign validate the signing or not.</p>
 </li>
 <li>
-<p><code id="MacConfiguration-strictVerify">strictVerify</code> = <code>true</code> Array&lt;String&gt; | String | Boolean - Whether to let @electron/osx-sign verify the contents or not.</p>
+<p><code id="MacConfiguration-strictVerify">strictVerify</code> = <code>true</code> Boolean - Whether to let @electron/osx-sign verify the contents or not.</p>
 </li>
 <li>
 <p><code id="MacConfiguration-signIgnore">signIgnore</code> Array&lt;String&gt; | String | “undefined” - Regex or an array of regex’s that signal skipping signing a file.</p>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2776,22 +2776,9 @@
           ]
         },
         "strictVerify": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": [
-                "string",
-                "boolean"
-              ]
-            }
-          ],
           "default": true,
-          "description": "Whether to let @electron/osx-sign verify the contents or not."
+          "description": "Whether to let @electron/osx-sign verify the contents or not.",
+          "type": "boolean"
         },
         "target": {
           "anyOf": [
@@ -3414,22 +3401,9 @@
           ]
         },
         "strictVerify": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": [
-                "string",
-                "boolean"
-              ]
-            }
-          ],
           "default": true,
-          "description": "Whether to let @electron/osx-sign verify the contents or not."
+          "description": "Whether to let @electron/osx-sign verify the contents or not.",
+          "type": "boolean"
         },
         "target": {
           "anyOf": [

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -344,7 +344,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
 
     const getEntitlements = (filePath: string) => {
       // check if root app, then use main entitlements
-      if (filePath.includes(appPath)) {
+      if (filePath === appPath) {
         if (customSignOptions.entitlements) {
           return customSignOptions.entitlements
         }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -342,7 +342,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     const entitlementsSuffix = masOptions == null ? "mac" : "mas"
 
     const getEntitlements = (filePath: string) => {
-      if (filePath === appPath) {
+      // check if root app, then use main entitlements
+      if (filePath.includes(appPath)) {
         if (customSignOptions.entitlements) {
           return customSignOptions.entitlements
         }
@@ -354,10 +355,12 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         }
       }
 
+      // It's a login helper...
       if (filePath.includes("Library/LoginItems")) {
         return customSignOptions.entitlementsLoginHelper
       }
 
+      // Only remaining option is that it's inherited entitlements
       if (customSignOptions.entitlementsInherit) {
         return customSignOptions.entitlementsInherit
       }

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -167,7 +167,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * Whether to let @electron/osx-sign verify the contents or not.
    * @default true
    */
-  readonly strictVerify?: Array<string> | string | boolean
+  readonly strictVerify?: boolean
 
   /**
    * Regex or an array of regex's that signal skipping signing a file.

--- a/test/fixtures/test-app-one/build/entitlements.mac.inherit.plist
+++ b/test/fixtures/test-app-one/build/entitlements.mac.inherit.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
+</plist>

--- a/test/fixtures/test-app-one/build/entitlements.mac.login.plist
+++ b/test/fixtures/test-app-one/build/entitlements.mac.login.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
+</plist>

--- a/test/fixtures/test-app-one/build/entitlements.mac.plist
+++ b/test/fixtures/test-app-one/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- https://github.com/electron/electron-notarize#prerequisites -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- https://github.com/electron-userland/electron-builder/issues/3940 -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/test/src/PublishManagerTest.ts
+++ b/test/src/PublishManagerTest.ts
@@ -1,4 +1,4 @@
-import { createTargets, Platform } from "electron-builder"
+import { Arch, createTargets, Platform } from "electron-builder"
 import { outputFile } from "fs-extra"
 import * as path from "path"
 import { GithubOptions, GenericServerOptions, SpacesOptions, KeygenOptions } from "builder-util-runtime"
@@ -39,7 +39,7 @@ function keygenPublisher(): KeygenOptions {
 test.ifNotWindows.ifDevOrLinuxCi(
   "generic, github and spaces",
   app({
-    targets: Platform.MAC.createTarget("zip"),
+    targets: Platform.MAC.createTarget("zip", Arch.x64),
     config: {
       generateUpdatesFilesForAllChannels: true,
       mac: {
@@ -67,7 +67,7 @@ test.ifMac(
   "mac artifactName ",
   app(
     {
-      targets: Platform.MAC.createTarget("zip"),
+      targets: Platform.MAC.createTarget("zip", Arch.x64),
       config: {
         // tslint:disable-next-line:no-invalid-template-strings
         artifactName: "${productName}_${version}_${os}.${ext}",

--- a/test/src/mac/dmgTest.ts
+++ b/test/src/mac/dmgTest.ts
@@ -9,6 +9,7 @@ import { assertThat } from "../helpers/fileAssert"
 import { app, assertPack, copyTestAsset } from "../helpers/packTester"
 
 const dmgTarget = Platform.MAC.createTarget("dmg", Arch.x64)
+const defaultTarget = Platform.MAC.createTarget(undefined, Arch.x64)
 
 test.ifMac(
   "dmg",
@@ -79,7 +80,7 @@ test.ifMac("custom background - new way", () => {
   return assertPack(
     "test-app-one",
     {
-      targets: dmgTarget,
+      targets: defaultTarget,
       config: {
         publish: null,
         mac: {
@@ -116,7 +117,7 @@ test.ifAll.ifMac("retina background as 2 png", () => {
   return assertPack(
     "test-app-one",
     {
-      targets: dmgTarget,
+      targets: defaultTarget,
       config: {
         publish: null,
       },
@@ -149,7 +150,7 @@ test.ifAll.ifMac("retina background as 2 png", () => {
 
 test.skip.ifMac.ifAll("no Applications link", () => {
   return assertPack("test-app-one", {
-    targets: dmgTarget,
+    targets: defaultTarget,
     config: {
       publish: null,
       productName: "NoApplicationsLink",
@@ -258,7 +259,7 @@ test.ifAll.ifMac(
 
 test.ifAll.ifMac("disable dmg icon (light), bundleVersion", () => {
   return assertPack("test-app-one", {
-    targets: dmgTarget,
+    targets: defaultTarget,
     config: {
       publish: null,
       dmg: {

--- a/test/src/mac/dmgTest.ts
+++ b/test/src/mac/dmgTest.ts
@@ -1,4 +1,4 @@
-import { exec } from "builder-util"
+import { Arch, exec } from "builder-util"
 import { copyFile } from "builder-util/out/fs"
 import { attachAndExecute, getDmgTemplatePath } from "dmg-builder/out/dmgUtil"
 import { Platform } from "electron-builder"
@@ -8,7 +8,7 @@ import * as fs from "fs/promises"
 import { assertThat } from "../helpers/fileAssert"
 import { app, assertPack, copyTestAsset } from "../helpers/packTester"
 
-const dmgTarget = Platform.MAC.createTarget("dmg")
+const dmgTarget = Platform.MAC.createTarget("dmg", Arch.x64)
 
 test.ifMac(
   "dmg",
@@ -79,7 +79,7 @@ test.ifMac("custom background - new way", () => {
   return assertPack(
     "test-app-one",
     {
-      targets: Platform.MAC.createTarget(),
+      targets: dmgTarget,
       config: {
         publish: null,
         mac: {
@@ -116,7 +116,7 @@ test.ifAll.ifMac("retina background as 2 png", () => {
   return assertPack(
     "test-app-one",
     {
-      targets: Platform.MAC.createTarget(),
+      targets: dmgTarget,
       config: {
         publish: null,
       },
@@ -149,7 +149,7 @@ test.ifAll.ifMac("retina background as 2 png", () => {
 
 test.skip.ifMac.ifAll("no Applications link", () => {
   return assertPack("test-app-one", {
-    targets: Platform.MAC.createTarget(),
+    targets: dmgTarget,
     config: {
       publish: null,
       productName: "NoApplicationsLink",
@@ -258,7 +258,7 @@ test.ifAll.ifMac(
 
 test.ifAll.ifMac("disable dmg icon (light), bundleVersion", () => {
   return assertPack("test-app-one", {
-    targets: Platform.MAC.createTarget(),
+    targets: dmgTarget,
     config: {
       publish: null,
       dmg: {

--- a/test/src/mac/macArchiveTest.ts
+++ b/test/src/mac/macArchiveTest.ts
@@ -1,4 +1,4 @@
-import { exec } from "builder-util"
+import { Arch, exec } from "builder-util"
 import { parseXml } from "builder-util-runtime"
 import { Platform } from "electron-builder"
 import { outputFile } from "fs-extra"
@@ -22,7 +22,7 @@ test.ifAll.ifMac(
   "empty installLocation",
   app(
     {
-      targets: Platform.MAC.createTarget("pkg"),
+      targets: Platform.MAC.createTarget("pkg", Arch.x64),
       config: {
         pkg: {
           installLocation: "",
@@ -42,7 +42,7 @@ test.ifAll.ifMac(
   "extraDistFiles",
   app(
     {
-      targets: Platform.MAC.createTarget("zip"),
+      targets: Platform.MAC.createTarget("zip", Arch.x64),
       config: {
         mac: {
           extraDistFiles: "extra.txt",
@@ -62,7 +62,7 @@ test.ifAll.ifMac(
   "pkg extended configuration",
   app(
     {
-      targets: Platform.MAC.createTarget("pkg"),
+      targets: Platform.MAC.createTarget("pkg", Arch.x64),
       config: {
         pkg: {
           isRelocatable: false,
@@ -110,7 +110,7 @@ test.ifAll.ifMac(
   "pkg scripts",
   app(
     {
-      targets: Platform.MAC.createTarget("pkg"),
+      targets: Platform.MAC.createTarget("pkg", Arch.x64),
     },
     {
       signed: false,

--- a/test/src/mac/macIconTest.ts
+++ b/test/src/mac/macIconTest.ts
@@ -1,4 +1,4 @@
-import { DIR_TARGET, Platform } from "electron-builder"
+import { Arch, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { CheckingMacPackager } from "../helpers/CheckingPackager"
@@ -8,23 +8,25 @@ async function assertIcon(platformPackager: CheckingMacPackager) {
   const file = await platformPackager.getIconPath()
   expect(file).toBeDefined()
 
-  const result = await platformPackager.resolveIcon([file!!], [], "set")
+  const result = await platformPackager.resolveIcon([file!], [], "set")
   result.forEach(it => {
     it.file = path.basename(it.file)
   })
   expect(result).toMatchSnapshot()
 }
 
+const targets = Platform.MAC.createTarget(DIR_TARGET, Arch.x64)
+
 test.ifMac.ifAll("icon set", () => {
   let platformPackager: CheckingMacPackager | null = null
   return app(
     {
-      targets: Platform.MAC.createTarget(DIR_TARGET),
+      targets,
       platformPackagerFactory: packager => (platformPackager = new CheckingMacPackager(packager)),
     },
     {
       projectDirCreated: projectDir => Promise.all([fs.unlink(path.join(projectDir, "build", "icon.icns")), fs.unlink(path.join(projectDir, "build", "icon.ico"))]),
-      packed: () => assertIcon(platformPackager!!),
+      packed: () => assertIcon(platformPackager!),
     }
   )()
 })
@@ -33,7 +35,7 @@ test.ifMac.ifAll("custom icon set", () => {
   let platformPackager: CheckingMacPackager | null = null
   return app(
     {
-      targets: Platform.MAC.createTarget(DIR_TARGET),
+      targets,
       config: {
         mac: {
           icon: "customIconSet",
@@ -57,7 +59,7 @@ test.ifMac.ifAll("custom icon set with only 512 and 128", () => {
   let platformPackager: CheckingMacPackager | null = null
   return app(
     {
-      targets: Platform.MAC.createTarget(DIR_TARGET),
+      targets,
       config: {
         mac: {
           icon: "..",
@@ -82,7 +84,7 @@ test.ifMac.ifAll("png icon", () => {
   let platformPackager: CheckingMacPackager | null = null
   return app(
     {
-      targets: Platform.MAC.createTarget(DIR_TARGET),
+      targets,
       config: {
         mac: {
           icon: "icons/512x512.png",
@@ -101,7 +103,7 @@ test.ifMac.ifAll("default png icon", () => {
   let platformPackager: CheckingMacPackager | null = null
   return app(
     {
-      targets: Platform.MAC.createTarget(DIR_TARGET),
+      targets,
       platformPackagerFactory: packager => (platformPackager = new CheckingMacPackager(packager)),
     },
     {
@@ -122,7 +124,7 @@ test.ifMac.ifAll("png icon small", () => {
   let platformPackager: CheckingMacPackager | null = null
   return app(
     {
-      targets: Platform.MAC.createTarget(DIR_TARGET),
+      targets,
       config: {
         mac: {
           icon: "icons/128x128.png",

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -1,5 +1,5 @@
 import { copyOrLinkFile } from "builder-util/out/fs"
-import { createTargets, DIR_TARGET, Platform } from "electron-builder"
+import { Arch, createTargets, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { assertThat } from "../helpers/fileAssert"
@@ -37,7 +37,7 @@ test.ifMac(
   "one-package",
   app(
     {
-      targets: Platform.MAC.createTarget(),
+      targets: Platform.MAC.createTarget(undefined, Arch.x64),
       config: {
         appId: "bar",
         publish: {
@@ -95,7 +95,7 @@ test.ifMac(
 test.ifMac.ifAll(
   "electronDist",
   appThrows({
-    targets: Platform.MAC.createTarget(DIR_TARGET),
+    targets: Platform.MAC.createTarget(DIR_TARGET, Arch.x64),
     config: {
       electronDist: "foo",
     },

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -1,5 +1,5 @@
 import { copyOrLinkFile } from "builder-util/out/fs"
-import { Arch, createTargets, DIR_TARGET, Platform } from "electron-builder"
+import { createTargets, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { assertThat } from "../helpers/fileAssert"
@@ -9,7 +9,7 @@ test.ifMac.ifAll("two-package", () =>
   assertPack(
     "test-app",
     {
-      targets: createTargets([Platform.MAC], "zip", "x64"),
+      targets: createTargets([Platform.MAC], null, "all"),
       config: {
         extraMetadata: {
           repository: "foo/bar",
@@ -37,7 +37,7 @@ test.ifMac(
   "one-package",
   app(
     {
-      targets: Platform.MAC.createTarget("dir", Arch.x64),
+      targets: Platform.MAC.createTarget(),
       config: {
         appId: "bar",
         publish: {

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -1,5 +1,5 @@
 import { copyOrLinkFile } from "builder-util/out/fs"
-import { createTargets, DIR_TARGET, Platform } from "electron-builder"
+import { Arch, createTargets, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { assertThat } from "../helpers/fileAssert"
@@ -9,7 +9,7 @@ test.ifMac.ifAll("two-package", () =>
   assertPack(
     "test-app",
     {
-      targets: createTargets([Platform.MAC], null, "all"),
+      targets: createTargets([Platform.MAC], "zip", "x64"),
       config: {
         extraMetadata: {
           repository: "foo/bar",
@@ -37,7 +37,7 @@ test.ifMac(
   "one-package",
   app(
     {
-      targets: Platform.MAC.createTarget(),
+      targets: Platform.MAC.createTarget("dir", Arch.x64),
       config: {
         appId: "bar",
         publish: {

--- a/test/src/mac/masTest.ts
+++ b/test/src/mac/masTest.ts
@@ -2,8 +2,6 @@ import { Platform } from "electron-builder"
 import * as path from "path"
 import { CheckingMacPackager } from "../helpers/CheckingPackager"
 import { assertPack, createMacTargetTest, signed } from "../helpers/packTester"
-import * as fs from "fs/promises"
-import { SignOptions } from "@electron/osx-sign/dist/cjs/types"
 
 if (process.platform !== "darwin") {
   fit("Skip mas tests because platform is not macOS", () => {
@@ -19,6 +17,13 @@ test("mas", createMacTargetTest(["mas"]))
 test.ifNotCi.ifAll("dev", createMacTargetTest(["mas-dev"]))
 test.ifNotCi.ifAll("mas and 7z", createMacTargetTest(["mas", "7z"]))
 
+const entitlement = (fileName: string) => path.join("build", fileName)
+const entitlementsConfig = {
+  entitlements: entitlement("entitlements.mac.plist"),
+  entitlementsInherit: entitlement("entitlements.mac.inherit.plist"),
+  entitlementsLoginHelper: entitlement("entitlements.mac.login.plist"),
+}
+
 test.skip.ifAll("custom mas", () => {
   let platformPackager: CheckingMacPackager | null = null
   return assertPack(
@@ -30,19 +35,18 @@ test.skip.ifAll("custom mas", () => {
         mac: {
           target: ["mas"],
         },
-        mas: {
-          entitlements: "mas-entitlements file path",
-          entitlementsInherit: "mas-entitlementsInherit file path",
-        },
+        mas: entitlementsConfig,
       },
     }),
     {
-      packed: () => {
-        expect(platformPackager!!.effectiveSignOptions).toMatchObject({
-          entitlements: "mas-entitlements file path",
-          "entitlements-inherit": "mas-entitlementsInherit file path",
-        } as Partial<SignOptions>)
-        return Promise.resolve(null)
+      checkMacApp(appDir, info) {
+        const appEntitlements = (filePath: string) => platformPackager!.effectiveSignOptions?.optionsForFile?.(filePath)
+        expect(appEntitlements(appDir)?.entitlements).toBe(entitlementsConfig.entitlements)
+        expect(appEntitlements("Library/LoginItems")?.entitlements).toBe(entitlementsConfig.entitlementsLoginHelper)
+        expect(appEntitlements("anything")?.entitlements).toBe(entitlementsConfig.entitlementsInherit)
+
+        expect(appEntitlements(appDir)?.hardenedRuntime).toBe(false)
+        return Promise.resolve()
       },
     }
   )
@@ -50,33 +54,30 @@ test.skip.ifAll("custom mas", () => {
 
 test.ifAll.ifNotCi("entitlements in the package.json", () => {
   let platformPackager: CheckingMacPackager | null = null
-  let entitlement = (fileName: string) => path.join(__dirname, "..", "..", "fixtures", "test-app-one", "build", fileName)
   return assertPack(
     "test-app-one",
     signed({
       targets: Platform.MAC.createTarget(),
       platformPackagerFactory: (packager, platform) => (platformPackager = new CheckingMacPackager(packager)),
       config: {
-        mac: {
-          entitlements: entitlement("entitlements.mac.plist"),
-          entitlementsInherit: entitlement("entitlements.mac.inherit.plist"),
-          entitlementsLoginHelper: entitlement("entitlements.mac.login.plist"),
-        },
+        mac: entitlementsConfig,
       },
     }),
     {
-      packed: () => {
-        expect(platformPackager!!.effectiveSignOptions).toMatchObject({
-          entitlements: "osx-entitlements file path",
-          "entitlements-inherit": "osx-entitlementsInherit file path",
-        })
+      checkMacApp(appDir, info) {
+        const appEntitlements = (filePath: string) => platformPackager!.effectiveSignOptions?.optionsForFile?.(filePath)
+        expect(appEntitlements(appDir)?.entitlements).toBe(entitlementsConfig.entitlements)
+        expect(appEntitlements("Library/LoginItems")?.entitlements).toBe(entitlementsConfig.entitlementsLoginHelper)
+        expect(appEntitlements("anything")?.entitlements).toBe(entitlementsConfig.entitlementsInherit)
+
+        expect(appEntitlements(appDir)?.hardenedRuntime).toBe(true)
         return Promise.resolve()
       },
     }
   )
 })
 
-test.ifAll.ifNotCi("entitlements in build dir", () => {
+test.ifAll.ifNotCi("entitlements template", () => {
   let platformPackager: CheckingMacPackager | null = null
   return assertPack(
     "test-app-one",
@@ -85,16 +86,11 @@ test.ifAll.ifNotCi("entitlements in build dir", () => {
       platformPackagerFactory: (packager, platform) => (platformPackager = new CheckingMacPackager(packager)),
     }),
     {
-      projectDirCreated: projectDir =>
-        Promise.all([
-          fs.writeFile(path.join(projectDir, "build", "entitlements.mac.plist"), ""),
-          fs.writeFile(path.join(projectDir, "build", "entitlements.mac.inherit.plist"), ""),
-        ]),
-      packed: context => {
-        expect(platformPackager!!.effectiveSignOptions).toMatchObject({
-          entitlements: path.join(context.projectDir, "build", "entitlements.mac.plist"),
-          "entitlements-inherit": path.join(context.projectDir, "build", "entitlements.mac.inherit.plist"),
-        })
+      checkMacApp(appDir, info) {
+        const appEntitlements = (filePath: string) => platformPackager!.effectiveSignOptions?.optionsForFile?.(filePath)
+        expect(appEntitlements(appDir)?.entitlements).toBe(entitlementsConfig.entitlements)
+        expect(appEntitlements("Library/LoginItems")?.entitlements).toBe(entitlementsConfig.entitlements)
+        expect(appEntitlements("anything")?.entitlements).toBe(entitlementsConfig.entitlements)
         return Promise.resolve()
       },
     }

--- a/test/src/mac/masTest.ts
+++ b/test/src/mac/masTest.ts
@@ -3,6 +3,7 @@ import * as path from "path"
 import { CheckingMacPackager } from "../helpers/CheckingPackager"
 import { assertPack, createMacTargetTest, signed } from "../helpers/packTester"
 import * as fs from "fs/promises"
+import { SignOptions } from "@electron/osx-sign/dist/cjs/types"
 
 if (process.platform !== "darwin") {
   fit("Skip mas tests because platform is not macOS", () => {
@@ -40,7 +41,7 @@ test.skip.ifAll("custom mas", () => {
         expect(platformPackager!!.effectiveSignOptions).toMatchObject({
           entitlements: "mas-entitlements file path",
           "entitlements-inherit": "mas-entitlementsInherit file path",
-        })
+        } as Partial<SignOptions>)
         return Promise.resolve(null)
       },
     }
@@ -49,6 +50,7 @@ test.skip.ifAll("custom mas", () => {
 
 test.ifAll.ifNotCi("entitlements in the package.json", () => {
   let platformPackager: CheckingMacPackager | null = null
+  let entitlement = (fileName: string) => path.join(__dirname, "..", "..", "fixtures", "test-app-one", "build", fileName)
   return assertPack(
     "test-app-one",
     signed({
@@ -56,8 +58,9 @@ test.ifAll.ifNotCi("entitlements in the package.json", () => {
       platformPackagerFactory: (packager, platform) => (platformPackager = new CheckingMacPackager(packager)),
       config: {
         mac: {
-          entitlements: "osx-entitlements file path",
-          entitlementsInherit: "osx-entitlementsInherit file path",
+          entitlements: entitlement("entitlements.mac.plist"),
+          entitlementsInherit: entitlement("entitlements.mac.inherit.plist"),
+          entitlementsLoginHelper: entitlement("entitlements.mac.login.plist"),
         },
       },
     }),

--- a/test/src/mac/masTest.ts
+++ b/test/src/mac/masTest.ts
@@ -1,4 +1,4 @@
-import { Platform } from "electron-builder"
+import { Arch, Platform } from "electron-builder"
 import * as path from "path"
 import { CheckingMacPackager } from "../helpers/CheckingPackager"
 import { assertPack, createMacTargetTest, signed } from "../helpers/packTester"
@@ -24,12 +24,14 @@ const entitlementsConfig = {
   entitlementsLoginHelper: entitlement("entitlements.mac.login.plist"),
 }
 
+const targets = Platform.MAC.createTarget(undefined, Arch.x64)
+
 test.skip.ifAll("custom mas", () => {
   let platformPackager: CheckingMacPackager | null = null
   return assertPack(
     "test-app-one",
     signed({
-      targets: Platform.MAC.createTarget(),
+      targets,
       platformPackagerFactory: (packager, platform) => (platformPackager = new CheckingMacPackager(packager)),
       config: {
         mac: {
@@ -57,7 +59,7 @@ test.ifAll.ifNotCi("entitlements in the package.json", () => {
   return assertPack(
     "test-app-one",
     signed({
-      targets: Platform.MAC.createTarget(),
+      targets,
       platformPackagerFactory: (packager, platform) => (platformPackager = new CheckingMacPackager(packager)),
       config: {
         mac: entitlementsConfig,
@@ -82,7 +84,7 @@ test.ifAll.ifNotCi("entitlements template", () => {
   return assertPack(
     "test-app-one",
     signed({
-      targets: Platform.MAC.createTarget(),
+      targets,
       platformPackagerFactory: (packager, platform) => (platformPackager = new CheckingMacPackager(packager)),
     }),
     {

--- a/test/src/updater/differentialUpdateTest.ts
+++ b/test/src/updater/differentialUpdateTest.ts
@@ -176,7 +176,7 @@ test.skip("dmg", async () => {
   const outDirs: Array<string> = []
   const tmpDir = new TmpDir("differential-updater-test")
   if (process.env.__SKIP_BUILD == null) {
-    await doBuild(outDirs, Platform.MAC.createTarget(), tmpDir, {
+    await doBuild(outDirs, Platform.MAC.createTarget(undefined, Arch.x64), tmpDir, {
       mac: {
         electronUpdaterCompatibility: ">=2.17.0",
       },


### PR DESCRIPTION
Adding additional typesafety and fixing large issue where entitlements don't seem to be applied properly due to major semver bump in electron/osx-sign

Fixes: https://github.com/electron-userland/electron-builder/issues/7471