### PR TITLE
chore(deps): Include all DefinitelyTyped packages as dev dependencies

### DIFF
--- a/.changeset/cyan-carpets-allow.md
+++ b/.changeset/cyan-carpets-allow.md
@@ -1,0 +1,8 @@
+---
+"builder-util": patch
+"electron-builder": patch
+"electron-publish": patch
+"electron-updater": patch
+---
+
+Removed DefinitelyTyped dependencies from production dependencies list

--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -16,8 +16,6 @@
   ],
   "dependencies": {
     "7zip-bin": "~5.1.1",
-    "@types/debug": "^4.1.6",
-    "@types/fs-extra": "^9.0.11",
     "app-builder-bin": "4.0.0",
     "bluebird-lst": "^1.0.9",
     "builder-util-runtime": "workspace:*",
@@ -36,6 +34,8 @@
   "typings": "./out/util.d.ts",
   "devDependencies": {
     "@types/cross-spawn": "6.0.2",
+    "@types/debug": "^4.1.6",
+    "@types/fs-extra": "^9.0.11",
     "@types/is-ci": "3.0.0",
     "@types/js-yaml": "4.0.3",
     "@types/source-map-support": "0.5.4"

--- a/packages/electron-builder/package.json
+++ b/packages/electron-builder/package.json
@@ -50,7 +50,6 @@
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "dependencies": {
-    "@types/yargs": "^17.0.16",
     "app-builder-lib": "workspace:*",
     "builder-util": "workspace:*",
     "builder-util-runtime": "workspace:*",
@@ -65,7 +64,8 @@
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.13",
-    "@types/is-ci": "3.0.0"
+    "@types/is-ci": "3.0.0",
+    "@types/yargs": "^17.0.16"
   },
   "typings": "./out/index.d.ts",
   "publishConfig": {

--- a/packages/electron-publish/package.json
+++ b/packages/electron-publish/package.json
@@ -15,7 +15,6 @@
     "out"
   ],
   "dependencies": {
-    "@types/fs-extra": "^9.0.11",
     "builder-util": "workspace:*",
     "builder-util-runtime": "workspace:*",
     "chalk": "^4.1.2",
@@ -25,6 +24,7 @@
   },
   "typings": "./out/publisher.d.ts",
   "devDependencies": {
+    "@types/fs-extra": "^9.0.11",
     "@types/mime": "2.0.3"
   }
 }

--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -16,7 +16,6 @@
     "out"
   ],
   "dependencies": {
-    "@types/semver": "^7.3.13",
     "builder-util-runtime": "workspace:*",
     "fs-extra": "^10.1.0",
     "js-yaml": "^4.1.0",
@@ -30,7 +29,8 @@
     "@types/fs-extra": "9.0.13",
     "@types/js-yaml": "4.0.3",
     "@types/lodash.escaperegexp": "4.1.6",
-    "@types/lodash.isequal": "4.5.5"
+    "@types/lodash.isequal": "4.5.5",
+    "@types/semver": "^7.3.13"
   },
   "typings": "./out/main.d.ts",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,6 @@ importers:
       temp-file: ^3.4.0
     dependencies:
       7zip-bin: 5.1.1
-      '@types/debug': 4.1.7
-      '@types/fs-extra': 9.0.13
       app-builder-bin: 4.0.0
       bluebird-lst: 1.0.9
       builder-util-runtime: link:../builder-util-runtime
@@ -230,6 +228,8 @@ importers:
       temp-file: 3.4.0
     devDependencies:
       '@types/cross-spawn': 6.0.2
+      '@types/debug': 4.1.7
+      '@types/fs-extra': 9.0.13
       '@types/is-ci': 3.0.0
       '@types/js-yaml': 4.0.3
       '@types/source-map-support': 0.5.4
@@ -290,7 +290,6 @@ importers:
       simple-update-notifier: ^1.1.0
       yargs: ^17.6.2
     dependencies:
-      '@types/yargs': 17.0.22
       app-builder-lib: link:../app-builder-lib
       builder-util: link:../builder-util
       builder-util-runtime: link:../builder-util-runtime
@@ -305,6 +304,7 @@ importers:
     devDependencies:
       '@types/fs-extra': 9.0.13
       '@types/is-ci': 3.0.0
+      '@types/yargs': 17.0.22
 
   packages/electron-builder-squirrel-windows:
     specifiers:
@@ -361,7 +361,6 @@ importers:
       lazy-val: ^1.0.5
       mime: ^2.5.2
     dependencies:
-      '@types/fs-extra': 9.0.13
       builder-util: link:../builder-util
       builder-util-runtime: link:../builder-util-runtime
       chalk: 4.1.2
@@ -369,6 +368,7 @@ importers:
       lazy-val: 1.0.5
       mime: 2.6.0
     devDependencies:
+      '@types/fs-extra': 9.0.13
       '@types/mime': 2.0.3
 
   packages/electron-updater:
@@ -387,7 +387,6 @@ importers:
       semver: ^7.3.8
       typed-emitter: ^2.1.0
     dependencies:
-      '@types/semver': 7.3.13
       builder-util-runtime: link:../builder-util-runtime
       fs-extra: 10.1.0
       js-yaml: 4.1.0
@@ -401,6 +400,7 @@ importers:
       '@types/js-yaml': 4.0.3
       '@types/lodash.escaperegexp': 4.1.6
       '@types/lodash.isequal': 4.5.5
+      '@types/semver': 7.3.13
 
   test:
     specifiers:
@@ -2670,6 +2670,7 @@ packages:
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
     dependencies:
       '@types/ms': 0.7.31
+    dev: true
 
   /@types/ejs/3.1.0:
     resolution: {integrity: sha512-DCg+Ka+uDQ31lJ/UtEXVlaeV3d6t81gifaVWKJy4MYVVgvJttyX/viREy+If7fz+tK/gVxTGMtyrFPnm4gjrVA==}
@@ -2679,6 +2680,7 @@ packages:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
       '@types/node': 16.11.43
+    dev: true
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -2801,6 +2803,7 @@ packages:
 
   /@types/ms/0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
+    dev: true
 
   /@types/node/12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2845,6 +2848,7 @@ packages:
 
   /@types/semver/7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
 
   /@types/semver/7.3.8:
     resolution: {integrity: sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==}
@@ -2889,7 +2893,7 @@ packages:
     resolution: {integrity: sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==}
     dependencies:
       '@types/yargs-parser': 21.0.0
-    dev: false
+    dev: true
 
   /@typescript-eslint/eslint-plugin/5.41.0_huremdigmcnkianavgfk3x6iou:
     resolution: {integrity: sha512-DXUS22Y57/LAFSg3x7Vi6RNAuLpTXwxB9S2nIA7msBb/Zt8p7XqMwdpdc1IU7CkOQUPgAqR5fWvxuKCbneKGmA==}
@@ -3383,6 +3387,7 @@ packages:
   /assert-plus/1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+    requiresBuild: true
     dev: false
 
   /assign-symbols/1.0.0:
@@ -3593,6 +3598,7 @@ packages:
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    requiresBuild: true
     dev: false
 
   /better-path-resolve/1.0.0:
@@ -4290,6 +4296,7 @@ packages:
 
   /core-util-is/1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+    requiresBuild: true
     dev: false
 
   /core-util-is/1.0.3:
@@ -7435,6 +7442,7 @@ packages:
 
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    requiresBuild: true
 
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -9466,6 +9474,7 @@ packages:
   /slice-ansi/3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
@@ -10367,6 +10376,7 @@ packages:
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    requiresBuild: true
     dependencies:
       punycode: 2.3.0
 
@@ -10644,6 +10654,7 @@ packages:
   /xmlbuilder/15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+    requiresBuild: true
     dev: false
 
   /xmlchars/2.2.0:


### PR DESCRIPTION
There were a good number of DefinitelyTyped packages in the non-dev dependencies.