### PR TITLE
fix: Fix electron-updater error handling when spawning a process asynchronously

### DIFF
--- a/.changeset/tricky-flies-bow.md
+++ b/.changeset/tricky-flies-bow.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+Fixed error handling when launching updater (fixes NSIS updates when isAdminRightsRequired is incorrectly set to false)

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -144,7 +144,7 @@ export abstract class BaseUpdater extends AppUpdater {
           reject(error)
         })
         p.unref()
-        if (process.pid !== undefined) {
+        if (p.pid !== undefined) {
           resolve(true)
         }
       } catch (error) {


### PR DESCRIPTION
Fixes #7523 

When deciding if a process that we attempted to spawn actually started, we need to look at the PID of the spawned process (which will be `undefined` if it failed to start), not the PID of the original Electron process. #7503 introduced this error.