### PR TITLE
fix: msiWrapped: Normalize target names before checking for NSIS target

### DIFF
--- a/.changeset/shiny-jars-fetch.md
+++ b/.changeset/shiny-jars-fetch.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"electron-builder": patch
+---
+
+When using the msiWrapped target, allow the nsis target to be capitalized in the configuration file

--- a/packages/app-builder-lib/src/targets/MsiWrappedTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiWrappedTarget.ts
@@ -38,7 +38,14 @@ export default class MsiWrappedTarget extends MsiTarget {
 
     const target = config.win.target
     const nsisTarget = "nsis"
-    if (!target.some((t: TargetConfiguration | string) => (typeof t === "string" && t === nsisTarget) || (t as TargetConfiguration).target === nsisTarget)) {
+    if (
+      !target
+        .map((t: TargetConfiguration | string): string => {
+          const result: string = typeof t === "string" ? t : t.target
+          return result.toLowerCase().trim()
+        })
+        .some(t => t === nsisTarget)
+    ) {
       throw new Error("No nsis target found! Please specify an nsis target")
     }
   }

--- a/test/snapshots/windows/msiWrappedTest.js.snap
+++ b/test/snapshots/windows/msiWrappedTest.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`msiWrapped allows capitalized nsis target 1`] = `
+Object {
+  "win": Array [
+    Object {
+      "arch": "x64",
+      "file": "Test MSI 1.1.0.msi",
+      "safeArtifactName": "Test-MSI-1.1.0.msi",
+    },
+    Object {
+      "arch": "x64",
+      "file": "Test MSI Setup 1.1.0.exe",
+      "safeArtifactName": "Test-MSI-Setup-1.1.0.exe",
+      "updateInfo": Object {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    Object {
+      "file": "Test MSI Setup 1.1.0.exe.blockmap",
+      "safeArtifactName": "Test-MSI-Setup-1.1.0.exe.blockmap",
+      "updateInfo": Object {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`msiWrapped impersonate no if not provided 1`] = `
 Object {
   "win": Array [

--- a/test/src/windows/msiWrappedTest.ts
+++ b/test/src/windows/msiWrappedTest.ts
@@ -34,6 +34,26 @@ test.ifAll.ifDevOrWinCi(
 )
 
 test.ifAll.ifDevOrWinCi(
+  "msiWrapped allows capitalized nsis target",
+  app(
+    {
+      targets: Platform.WINDOWS.createTarget(["msiWrapped", "NSIS"]),
+      config: {
+        appId: "build.electron.test.msi.oneClick.perMachine",
+        extraMetadata: {
+          // version: "1.0.0",
+        },
+        productName: "Test MSI",
+        win: {
+          target: ["msiWrapped", "NSIS"],
+        },
+      },
+    },
+    {}
+  )
+)
+
+test.ifAll.ifDevOrWinCi(
   "msiWrapped includes packaged exe",
   app({
     targets: Platform.WINDOWS.createTarget(["msiWrapped", "nsis"]),


### PR DESCRIPTION
Target names are not case sensitive, and are normalized by this function: https://github.com/electron-userland/electron-builder/blob/cd7b79f8273a32d3d6a4f4c4a139d847835df637/packages/app-builder-lib/src/targets/targetFactory.ts#L67-L78

This PR makes it so that the `msiWrapped` target doesn't complain when the `nsis` target has leading/trailing spaces or is not all-lowercase.