### PR TITLE
fix(updater): handle errors on responses in differential download

### DIFF
--- a/.changeset/gold-ladybugs-rhyme.md
+++ b/.changeset/gold-ladybugs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: handle errors on responses in differential download (#2398)

--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -228,6 +228,10 @@ export abstract class DifferentialDownloader {
         }
 
         const request = this.httpExecutor.createRequest(requestOptions, response => {
+          response.on("error", reject)
+          response.on("abort", () => {
+            reject(new Error("response has been aborted by the server"))
+          })
           // Electron net handles redirects automatically, our NodeJS test server doesn't use redirects - so, we don't check 3xx codes.
           if (response.statusCode >= 400) {
             reject(createHttpError(response))


### PR DESCRIPTION
the error will just be thrown by the net module if there's no error handler, leading to issues like #2398

our use case is that we get a lot of reports about these uncatchable errors with each release (https://github.com/tutao/tutanota/issues/5338)

I'm not sure if there needs to be additional cleanup after the first response fails, but it seems to fix the problem in my local tests and tries to fall back to full download properly.