### PR TITLE
fix: Don't use the content-length HTTP header to check size of data

### DIFF
--- a/.changeset/little-spies-double.md
+++ b/.changeset/little-spies-double.md
@@ -1,0 +1,6 @@
+---
+"builder-util-runtime": patch
+"electron-updater": patch
+---
+
+Fix differential downloads when the server compresses the blockmap file HTTP response


### PR DESCRIPTION
Fixes #7543