### PR TITLE
fix(nsis): Ensure application name sub-folder on fresh installs.

### DIFF
--- a/.changeset/two-goats-shop.md
+++ b/.changeset/two-goats-shop.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): Ensure application name sub-folder on fresh installs.

--- a/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/assistedInstaller.nsh
@@ -31,11 +31,9 @@
 
     # sanitize the MUI_PAGE_DIRECTORY result to make sure it has a application name sub-folder
     Function instFilesPre
-      ${If} ${FileExists} "$INSTDIR\*"
-        ${StrContains} $0 "${APP_FILENAME}" $INSTDIR
-        ${If} $0 == ""
-          StrCpy $INSTDIR "$INSTDIR\${APP_FILENAME}"
-        ${endIf}
+      ${StrContains} $0 "${APP_FILENAME}" $INSTDIR
+      ${If} $0 == ""
+        StrCpy $INSTDIR "$INSTDIR\${APP_FILENAME}"
       ${endIf}
     FunctionEnd
   !endif


### PR DESCRIPTION
During the first program install when the selected directory doesn't exist it's not enforced that path contains application name as sub-folder. On subsequent installs e.g. on update, that condition is enforces though, which creates a new installation in sub-folder.

This tries to address #6885