### PR TITLE
feat: allow specifying recommended dependencies for deb target

### DIFF
--- a/.changeset/sixty-paws-rush.md
+++ b/.changeset/sixty-paws-rush.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+Add ability to specify recommended deb dependencies

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -721,6 +721,20 @@
             }
           ]
         },
+        "recommends": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The [recommended package dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps).."
+        },
         "synopsis": {
           "description": "The [short description](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Description).",
           "type": [

--- a/packages/app-builder-lib/src/options/linuxOptions.ts
+++ b/packages/app-builder-lib/src/options/linuxOptions.ts
@@ -113,6 +113,11 @@ export interface DebOptions extends LinuxTargetSpecificOptions {
   readonly depends?: Array<string> | null
 
   /**
+   * The [recommended package dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps)..
+   */
+  readonly recommends?: Array<string> | null
+
+  /**
    * The [package category](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Section).
    */
   readonly packageCategory?: string | null

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -1,5 +1,5 @@
 import { path7za } from "7zip-bin"
-import { Arch, executeAppBuilder, getArchSuffix, log, TmpDir, toLinuxArchString, use, serializeToYaml } from "builder-util"
+import { Arch, executeAppBuilder, getArchSuffix, log, TmpDir, toLinuxArchString, use, serializeToYaml, asArray } from "builder-util"
 import { unlinkIfExists } from "builder-util/out/fs"
 import { outputFile, stat } from "fs-extra"
 import { mkdir, readFile } from "fs/promises"
@@ -198,17 +198,8 @@ export default class FpmTarget extends Target {
 
     if (target === "deb") {
       const recommends = (options as DebOptions).recommends
-      if (recommends != null) {
-        if (Array.isArray(recommends)) {
-          fpmConfiguration.customRecommends = recommends
-        } else {
-          // noinspection SuspiciousTypeOfGuard
-          if (typeof recommends === "string") {
-            fpmConfiguration.customRecommends = [recommends as string]
-          } else {
-            throw new Error(`recommends must be Array or String, but specified as: ${recommends}`)
-          }
-        }
+      if (recommends) {
+        fpmConfiguration.customRecommends = asArray(recommends)
       }
     }
 

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -196,6 +196,22 @@ export default class FpmTarget extends Target {
       }
     }
 
+    if (target === "deb") {
+      const recommends = (options as DebOptions).recommends
+      if (recommends != null) {
+        if (Array.isArray(recommends)) {
+          fpmConfiguration.customRecommends = recommends
+        } else {
+          // noinspection SuspiciousTypeOfGuard
+          if (typeof recommends === "string") {
+            fpmConfiguration.customRecommends = [recommends as string]
+          } else {
+            throw new Error(`recommends must be Array or String, but specified as: ${recommends}`)
+          }
+        }
+      }
+    }
+
     use(packager.info.metadata.license, it => args.push("--license", it))
     use(appInfo.buildNumber, it =>
       args.push(
@@ -274,6 +290,7 @@ interface FpmConfiguration {
   target: string
   args: Array<string>
   customDepends?: Array<string>
+  customRecommends?: Array<string>
   compression?: string | null
 }
 


### PR DESCRIPTION
Closes https://github.com/develar/app-builder/issues/87

`deb.fpm: ['--deb-recommend=blah']` is insufficient as https://github.com/develar/app-builder always forces a `libappindicator3-1` into the recommendeds.