### PR TITLE
fix: Fix errors using native modules that require rebuild when the target is s multiple and contains mas #7587

### DIFF
--- a/.changeset/famous-shirts-hug.md
+++ b/.changeset/famous-shirts-hug.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Fix rebuild errors using native modules that require rebuild when the target is s multiple and contains mas

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -217,13 +217,12 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       })
     }
 
-    if (this.installAppDependenciesPromise != null) {
-      await this.installAppDependenciesPromise
-    } else {
+    if (this.installAppDependenciesPromise == null) {
       this.installAppDependenciesPromise = this.info.installAppDependencies(this.platform, arch).finally(() => {
         this.installAppDependenciesPromise = null
       })
     }
+    await this.installAppDependenciesPromise
 
     if (this.info.cancellationToken.cancelled) {
       return

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -33,6 +33,7 @@ import { computeFileSets, computeNodeModuleFileSets, copyAppFiles, ELECTRON_COMP
 import { expandMacro as doExpandMacro } from "./util/macroExpander"
 
 export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> {
+  installAppDependenciesPromise: Promise<any> | undefined | null
   get packagerOptions(): PackagerOptions {
     return this.info.options
   }
@@ -216,7 +217,13 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       })
     }
 
-    await this.info.installAppDependencies(this.platform, arch)
+    if (this.installAppDependenciesPromise != null) {
+      await this.installAppDependenciesPromise
+    } else {
+      this.installAppDependenciesPromise = this.info.installAppDependencies(this.platform, arch).finally(() => {
+        this.installAppDependenciesPromise = null
+      })
+    }
 
     if (this.info.cancellationToken.cancelled) {
       return


### PR DESCRIPTION
Fix rebuild errors using native modules that require rebuild when the target is s multiple and contains mas