### PR TITLE
fix: default downloaded file name

### DIFF
--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -636,7 +636,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
         return path.basename(urlPath)
       } else {
         // url like /latest, generate name
-        return `update.${taskOptions.fileExtension}`
+        return taskOptions.fileInfo.info.url
       }
     }
 


### PR DESCRIPTION
This small pr should fix that the electron updater sets the filenames to `update.AppImage` for private repositories.

Should fix:
- #7022 
- #5477 
- #5239 
- #3664 
- #3639