### PR TITLE
fix(mac): Wrap hditutil detach in retry w/ backoff

### DIFF
--- a/.changeset/large-items-argue.md
+++ b/.changeset/large-items-argue.md
@@ -1,0 +1,6 @@
+---
+"builder-util": patch
+"dmg-builder": patch
+---
+
+fix(mac): wrap hdiutil detach in retry w/ backoff

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -396,14 +396,14 @@ export function executeAppBuilder(
   }
 }
 
-export async function retry<T>(task: () => Promise<T>, retriesLeft: number, interval: number): Promise<T> {
+export async function retry<T>(task: () => Promise<T>, retriesLeft: number, interval: number, backoff = 0, attempt = 0): Promise<T> {
   try {
     return await task()
   } catch (error: any) {
     log.info(`Above command failed, retrying ${retriesLeft} more times`)
     if (retriesLeft > 0) {
-      await new Promise(resolve => setTimeout(resolve, interval))
-      return await retry(task, retriesLeft - 1, interval)
+      await new Promise(resolve => setTimeout(resolve, interval + backoff * attempt))
+      return await retry(task, retriesLeft - 1, interval, backoff, attempt + 1)
     } else {
       throw error
     }

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -1,4 +1,4 @@
-import { exec } from "builder-util"
+import { exec, retry } from "builder-util"
 import { PlatformPackager } from "app-builder-lib"
 import { executeFinally } from "builder-util/out/promise"
 import * as path from "path"
@@ -37,11 +37,7 @@ export async function detach(name: string) {
   try {
     await exec("hdiutil", ["detach", "-quiet", name])
   } catch (e: any) {
-    await new Promise((resolve, reject) => {
-      setTimeout(() => {
-        exec("hdiutil", ["detach", "-force", name]).then(resolve).catch(reject)
-      }, 1000)
-    })
+    await retry(() => exec("hdiutil", ["detach", "-force", name]), 5, 1000, 500)
   }
 }
 


### PR DESCRIPTION
We are [experiencing a lot of flakiness](https://github.com/Expensify/App/issues/20283) with our Electron deploys in a GitHub Actions macos-12 runner. This PR is an attempt to wrap the failing command in a retry, as has been done elsewhere in this repo.

I also added a simple backoff mechanism to the retry function.