### PR TITLE
fix: Allow building MAS and dmg targets with different appId

### DIFF
--- a/.changeset/famous-shrimps-return.md
+++ b/.changeset/famous-shrimps-return.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Allow building MAS and dmg targets with different appId

--- a/packages/app-builder-lib/src/electron/electronMac.ts
+++ b/packages/app-builder-lib/src/electron/electronMac.ts
@@ -118,10 +118,12 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
     log.warn("build.helper-bundle-id is deprecated, please set as build.mac.helperBundleId")
   }
 
-  const cfBundleIdentifier = filterCFBundleIdentifier((isMas ? packager.config.mas?.appId : packager.platformSpecificBuildOptions.appId) || appInfo.macBundleIdentifier)
+  const defaultAppId = packager.platformSpecificBuildOptions.appId
+  const cfBundleIdentifier = filterCFBundleIdentifier((isMas ? packager.config.mas?.appId : defaultAppId) || defaultAppId || appInfo.macBundleIdentifier)
 
+  const defaultHelperId = packager.platformSpecificBuildOptions.helperBundleId
   const helperBundleIdentifier = filterCFBundleIdentifier(
-    (isMas ? packager.config.mas?.helperBundleId : packager.platformSpecificBuildOptions.helperBundleId) || oldHelperBundleId || `${cfBundleIdentifier}.helper`
+    (isMas ? packager.config.mas?.helperBundleId : defaultHelperId) || defaultHelperId || oldHelperBundleId || `${cfBundleIdentifier}.helper`
   )
 
   appPlist.CFBundleIdentifier = cfBundleIdentifier

--- a/packages/app-builder-lib/src/electron/electronMac.ts
+++ b/packages/app-builder-lib/src/electron/electronMac.ts
@@ -117,7 +117,14 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
   if (oldHelperBundleId != null) {
     log.warn("build.helper-bundle-id is deprecated, please set as build.mac.helperBundleId")
   }
-  const helperBundleIdentifier = filterCFBundleIdentifier(packager.platformSpecificBuildOptions.helperBundleId || oldHelperBundleId || `${appInfo.macBundleIdentifier}.helper`)
+
+  const cfBundleIdentifier = filterCFBundleIdentifier((isMas ? packager.config.mas?.appId : packager.platformSpecificBuildOptions.appId) || appInfo.macBundleIdentifier)
+
+  const helperBundleIdentifier = filterCFBundleIdentifier(
+    (isMas ? packager.config.mas?.helperBundleId : packager.platformSpecificBuildOptions.helperBundleId) || oldHelperBundleId || `${cfBundleIdentifier}.helper`
+  )
+
+  appPlist.CFBundleIdentifier = cfBundleIdentifier
 
   await packager.applyCommonInfo(appPlist, contentsPath)
 
@@ -168,7 +175,7 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
     helperLoginPlist.CFBundleExecutable = `${appFilename} Login Helper`
     helperLoginPlist.CFBundleDisplayName = `${appInfo.productName} Login Helper`
     // noinspection SpellCheckingInspection
-    helperLoginPlist.CFBundleIdentifier = `${appInfo.macBundleIdentifier}.loginhelper`
+    helperLoginPlist.CFBundleIdentifier = `${cfBundleIdentifier}.loginhelper`
     helperLoginPlist.CFBundleVersion = appPlist.CFBundleVersion
   }
 

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -445,8 +445,6 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       appPlist.LSMinimumSystemVersion = minimumSystemVersion
     }
 
-    appPlist.CFBundleIdentifier = appInfo.macBundleIdentifier
-
     appPlist.CFBundleShortVersionString = this.platformSpecificBuildOptions.bundleShortVersion || appInfo.version
     appPlist.CFBundleVersion = appInfo.buildVersion
 


### PR DESCRIPTION
This changes allows packaging different macOS targets with different CFBundleIndetifiers.  
It makes the `createMacApp` to look for a CFBundleIdentifier in mas config, if the app is MAS.
  
Solving the issue related here: #7570 

Current implementation ignores any `appId` specified in `mas`, directly using `appInfo.macBundleIdentifier` when writing Plist file.