### PR TITLE
feat: added env variable for 7z filter

### DIFF
--- a/.changeset/nervous-readers-worry.md
+++ b/.changeset/nervous-readers-worry.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+Added env variable for 7z filter

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -137,6 +137,12 @@ export function compute7zCompressArgs(format: string, options: ArchiveOptions = 
       args.push("-mhc=off")
     }
 
+    // https://www.7-zip.org/7z.html
+    // Filters: BCJ, BCJ2, ARM, ARMT, IA64, PPC, SPARC, ...
+    if (process.env.ELECTRON_BUILDER_7Z_FILTER) {
+      args.push(`-mf=${process.env.ELECTRON_BUILDER_7Z_FILTER}`)
+    }
+
     // args valid only for 7z
     // -mtm=off disable "Stores last Modified timestamps for files."
     args.push("-mtm=off", "-mta=off")


### PR DESCRIPTION
Option for enable compression filter.

Example:
```
process.env.ELECTRON_BUILDER_7Z_FILTER = 'bcj2'
process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL = 5;
```
BCJ2 is sets as default only for compression level 9, but is very slow.

If compression level sets to 5 and filter sets to `-mf=bcj2`, compression is very good with fast speed.
