### PR TITLE
fix(mac): use Identity `hash` instead of `name` if it exists

### DIFF
--- a/.changeset/great-seas-admire.md
+++ b/.changeset/great-seas-admire.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): use Identity `hash` instead of `name` if it exists

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -297,7 +297,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
           https://github.com/electron-userland/electron-builder/issues/5383
           */
       },
-      identity: identity ? identity.name : undefined,
+      identity: identity ? identity.hash || identity.name : undefined,
       type,
       platform: isMas ? "mas" : "darwin",
       version: this.config.electronVersion || undefined,


### PR DESCRIPTION
Fixes: #7620