### PR TITLE
fix: removing stdio from spawnSync to fix crash on rpm/deb updaters

### DIFF
--- a/.changeset/strange-planes-judge.md
+++ b/.changeset/strange-planes-judge.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: removing stdio from spawnSync to fix crash on rpm/deb updaters

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -119,7 +119,6 @@ export abstract class BaseUpdater extends AppUpdater {
   protected spawnSyncLog(cmd: string, args: string[] = [], env = {}): string {
     this._logger.info(`Executing: ${cmd} with args: ${args}`)
     const response = spawnSync(cmd, args, {
-      stdio: "inherit",
       env: { ...process.env, ...env },
       encoding: "utf-8",
       shell: true,


### PR DESCRIPTION
Fixes: #7569