### PR TITLE
fix: use electron/rebuild Rebuilder directly for cross-platform builds

### DIFF
--- a/.changeset/forty-ways-pay.md
+++ b/.changeset/forty-ways-pay.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"electron-builder": patch
+---
+
+fix: use electron/rebuild Rebuilder directly for cross-platform builds

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -50,7 +50,7 @@
     "@develar/schema-utils": "~2.6.5",
     "@electron/notarize": "^1.2.3",
     "@electron/osx-sign": "^1.0.4",
-    "@electron/rebuild": "^3.2.13",
+    "@electron/rebuild": "3.2.13",
     "@electron/universal": "1.3.4",
     "@malept/flatpak-bundler": "^0.4.0",
     "@types/fs-extra": "9.0.13",

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -495,7 +495,7 @@ export class Packager {
     const frameworkInfo = { version: this.framework.version, useCustomDist: true }
     const config = this.config
     if (config.nodeGypRebuild === true) {
-      await nodeGypRebuild(frameworkInfo, arch)
+      await nodeGypRebuild(frameworkInfo, arch, platform)
     }
 
     if (config.npmRebuild === false) {

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -3,8 +3,10 @@ import { pathExists } from "fs-extra"
 import { homedir } from "os"
 import * as path from "path"
 import { Configuration } from "../configuration"
-import * as electronRebuild from "@electron/rebuild"
+import * as electronRebuild from "@electron/rebuild/lib/rebuild"
 import * as searchModule from "@electron/rebuild/lib/search-module"
+import { EventEmitter } from "stream"
+import { Platform } from "../core"
 
 export async function installOrRebuild(config: Configuration, appDir: string, options: RebuildOptions, forceInstall = false) {
   let isDependenciesInstalled = false
@@ -24,7 +26,8 @@ export async function installOrRebuild(config: Configuration, appDir: string, op
     await installDependencies(appDir, effectiveOptions)
   } else {
     const arch = archFromString(options.arch || process.arch)
-    await rebuild(appDir, config.buildDependenciesFromSource === true, options.frameworkInfo, arch)
+    const platform = Platform.fromString(options.platform || process.platform)
+    await rebuild(appDir, config.buildDependenciesFromSource === true, options.frameworkInfo, arch, platform)
   }
 }
 
@@ -117,8 +120,8 @@ function installDependencies(appDir: string, options: RebuildOptions): Promise<a
   })
 }
 
-export async function nodeGypRebuild(frameworkInfo: DesktopFrameworkInfo, arch: Arch) {
-  return rebuild(process.cwd(), false, frameworkInfo, arch)
+export async function nodeGypRebuild(frameworkInfo: DesktopFrameworkInfo, arch: Arch, platform: Platform) {
+  return rebuild(process.cwd(), false, frameworkInfo, arch, platform)
 }
 
 function getPackageToolPath() {
@@ -146,18 +149,21 @@ export interface RebuildOptions {
 }
 
 /** @internal */
-export async function rebuild(appDir: string, buildFromSource: boolean, frameworkInfo: DesktopFrameworkInfo, arch: Arch) {
-  log.info({ arch: Arch[arch], version: frameworkInfo.version, appDir }, "executing @electron/rebuild")
+export async function rebuild(appDir: string, buildFromSource: boolean, frameworkInfo: DesktopFrameworkInfo, arch: Arch, platform: Platform) {
+  log.info({ arch: Arch[arch], platform, version: frameworkInfo.version, appDir }, "executing @electron/rebuild")
   const rootPath = await searchModule.getProjectRootPath(appDir)
-  const options: electronRebuild.RebuildOptions = {
+  const rebuilderOptions: electronRebuild.RebuilderOptions = {
     buildPath: appDir,
     electronVersion: frameworkInfo.version,
     arch: Arch[arch],
     projectRootPath: rootPath,
     disablePreGypCopy: true,
+    lifecycle: new EventEmitter(),
   }
   if (buildFromSource) {
-    options.prebuildTagPrefix = "totally-not-a-real-prefix-to-force-rebuild"
+    rebuilderOptions.prebuildTagPrefix = "totally-not-a-real-prefix-to-force-rebuild"
   }
-  return electronRebuild.rebuild(options)
+  const rebuilder = new electronRebuild.Rebuilder(rebuilderOptions)
+  rebuilder.platform = platform.nodeName
+  return rebuilder.rebuild()
 }

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -5,7 +5,7 @@ import * as path from "path"
 import { Configuration } from "../configuration"
 import * as electronRebuild from "@electron/rebuild/lib/rebuild"
 import * as searchModule from "@electron/rebuild/lib/search-module"
-import { EventEmitter } from "stream"
+import { EventEmitter } from "events"
 import { Platform } from "../core"
 
 export async function installOrRebuild(config: Configuration, appDir: string, options: RebuildOptions, forceInstall = false) {
@@ -150,7 +150,7 @@ export interface RebuildOptions {
 
 /** @internal */
 export async function rebuild(appDir: string, buildFromSource: boolean, frameworkInfo: DesktopFrameworkInfo, arch: Arch, platform: Platform) {
-  log.info({ arch: Arch[arch], platform, version: frameworkInfo.version, appDir }, "executing @electron/rebuild")
+  log.info({ arch: Arch[arch], platform: platform.name, version: frameworkInfo.version, appDir }, "executing @electron/rebuild")
   const rootPath = await searchModule.getProjectRootPath(appDir)
   const rebuilderOptions: electronRebuild.RebuilderOptions = {
     buildPath: appDir,

--- a/packages/electron-builder/src/cli/cli.ts
+++ b/packages/electron-builder/src/cli/cli.ts
@@ -78,5 +78,5 @@ async function checkIsOutdated() {
 async function rebuildAppNativeCode(args: any) {
   const projectDir = process.cwd()
   // this script must be used only for electron
-  return nodeGypRebuild({ version: await getElectronVersion(projectDir), useCustomDist: true }, args.arch)
+  return nodeGypRebuild({ version: await getElectronVersion(projectDir), useCustomDist: true }, args.arch, args.platform)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
       '@develar/schema-utils': ~2.6.5
       '@electron/notarize': ^1.2.3
       '@electron/osx-sign': ^1.0.4
-      '@electron/rebuild': ^3.2.13
+      '@electron/rebuild': 3.2.13
       '@electron/universal': 1.3.4
       '@malept/flatpak-bundler': ^0.4.0
       '@types/debug': 4.1.7


### PR DESCRIPTION
fix: use electron-rebuilder API directly so as to override the platform for cross-platform prebuild compilations

Credit to debugger @cocktailpeanut in https://github.com/electron-userland/electron-builder/pull/7465
