### PR TITLE
fix(linux): make semver pre-release versions valid for "pacman" and "rpm" target

### DIFF
--- a/.changeset/honest-comics-bake.md
+++ b/.changeset/honest-comics-bake.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(pacman): replace hyphens with underscores in version

--- a/.changeset/honest-comics-bake.md
+++ b/.changeset/honest-comics-bake.md
@@ -2,4 +2,4 @@
 "app-builder-lib": patch
 ---
 
-fix(pacman): replace hyphens with underscores in version
+fix(linux): make semver pre-release versions valid for `"pacman"` and `"rpm"` target

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -152,7 +152,7 @@ export default class FpmTarget extends Target {
       "--description",
       smarten(target === "rpm" ? this.helper.getDescription(options)! : `${synopsis || ""}\n ${this.helper.getDescription(options)}`),
       "--version",
-      target == "pacman" ? appInfo.version.replace(/-/g, "_") : appInfo.version,
+      this.helper.getSanitizedVersion(target),
       "--package",
       artifactPath,
     ]

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -152,7 +152,7 @@ export default class FpmTarget extends Target {
       "--description",
       smarten(target === "rpm" ? this.helper.getDescription(options)! : `${synopsis || ""}\n ${this.helper.getDescription(options)}`),
       "--version",
-      appInfo.version,
+      target == "pacman" ? appInfo.version.replace(/-/g, "_") : appInfo.version,
       "--package",
       artifactPath,
     ]

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -76,6 +76,20 @@ export class LinuxTargetHelper {
     return options.description || this.packager.appInfo.description
   }
 
+  getSanitizedVersion(target: string) {
+    const {
+      appInfo: { version },
+    } = this.packager
+    switch (target) {
+      case "pacman":
+        return version.replace(/-/g, "_")
+      case "rpm":
+        return version.replace(/-/g, "~")
+      default:
+        return version
+    }
+  }
+
   async writeDesktopEntry(targetSpecificOptions: LinuxTargetSpecificOptions, exec?: string, destination?: string | null, extra?: { [key: string]: string }): Promise<string> {
     const data = await this.computeDesktopEntry(targetSpecificOptions, exec, extra)
     const file = destination || (await this.packager.getTempFile(`${this.packager.appInfo.productFilename}.desktop`))


### PR DESCRIPTION
fix #7601

this replaces all hyphens (`-`) in versions when targeting `"pacman"` with underscores (`_`) to follow [the pacman version format](https://wiki.archlinux.org/title/PKGBUILD#pkgver).

#### notes:

* i am only replacing the version of the package, not of the `.pacman` file, since doing so would (i think) require overwriting the version in `appInfo.version`, which is marked as readonly,
https://github.com/electron-userland/electron-builder/blob/285aa766c2675448689f2e465b6fa2b2acacdbc6/packages/app-builder-lib/src/appInfo.ts#L24
or adding a seperate rule to the `macroExpander`, which, as far as i can tell, does not have access to the current build target (which could be solved fairly easily with a new optional parameter tho)
https://github.com/electron-userland/electron-builder/blob/285aa766c2675448689f2e465b6fa2b2acacdbc6/packages/app-builder-lib/src/util/macroExpander.ts#L4
neither of which seemed like a good idea to me, especially without prior feedback.
it also doesn't matter for `pacman` and looks more consistent with the other installer files, if unchanged.

* i am using `.replace(/-/g, "_")` over `.replaceAll("-", "_")` since the latter was only added in [node v15.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility) and this package still [supports node v14](https://github.com/electron-userland/electron-builder/blob/285aa766c2675448689f2e465b6fa2b2acacdbc6/package.json#L77)

* i have a very limited idea on how this codebase is structured so tell me if i should do something differently
