### PR TITLE
fix: change typed-emitter to tiny-typed-emitter 

### DIFF
--- a/.changeset/proud-balloons-applaud.md
+++ b/.changeset/proud-balloons-applaud.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: change typed-emitter to tiny-typed-emitter to remove rxjs dependency

--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -22,15 +22,15 @@
     "lazy-val": "^1.0.5",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.isequal": "^4.5.0",
-    "semver": "^7.3.8",
-    "typed-emitter": "^2.1.0"
+    "semver": "^7.3.8"
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.13",
     "@types/js-yaml": "4.0.3",
     "@types/lodash.escaperegexp": "4.1.6",
     "@types/lodash.isequal": "4.5.5",
-    "@types/semver": "^7.3.13"
+    "@types/semver": "^7.3.13",
+    "typed-emitter": "^2.1.0"
   },
   "typings": "./out/main.d.ts",
   "publishConfig": {

--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -22,15 +22,15 @@
     "lazy-val": "^1.0.5",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.isequal": "^4.5.0",
-    "semver": "^7.3.8"
+    "semver": "^7.3.8",
+    "tiny-typed-emitter": "^2.1.0"
   },
   "devDependencies": {
     "@types/fs-extra": "9.0.13",
     "@types/js-yaml": "4.0.3",
     "@types/lodash.escaperegexp": "4.1.6",
     "@types/lodash.isequal": "4.5.5",
-    "@types/semver": "^7.3.13",
-    "typed-emitter": "^2.1.0"
+    "@types/semver": "^7.3.13"
   },
   "typings": "./out/main.d.ts",
   "publishConfig": {

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -26,7 +26,7 @@ import { GenericProvider } from "./providers/GenericProvider"
 import { DOWNLOAD_PROGRESS, Logger, Provider, ResolvedUpdateFileInfo, UPDATE_DOWNLOADED, UpdateCheckResult, UpdateDownloadedEvent, UpdaterSignal } from "./main"
 import { createClient, isUrlProbablySupportMultiRangeRequests } from "./providerFactory"
 import { ProviderPlatform } from "./providers/Provider"
-import type TypedEmitter from "typed-emitter"
+import type { TypedEmitter } from "tiny-typed-emitter"
 import Session = Electron.Session
 import { AuthInfo } from "electron"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,13 +394,13 @@ importers:
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
       semver: 7.3.8
-      typed-emitter: 2.1.0
     devDependencies:
       '@types/fs-extra': 9.0.13
       '@types/js-yaml': 4.0.3
       '@types/lodash.escaperegexp': 4.1.6
       '@types/lodash.isequal': 4.5.5
       '@types/semver': 7.3.13
+      typed-emitter: 2.1.0
 
   test:
     specifiers:
@@ -9286,6 +9286,7 @@ packages:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
       tslib: 2.5.0
+    dev: true
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -10112,6 +10113,7 @@ packages:
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: true
 
   /tsutils/3.21.0_typescript@4.8.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -10195,7 +10197,7 @@ packages:
     resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
     optionalDependencies:
       rxjs: 7.8.0
-    dev: false
+    dev: true
 
   /typedarray-to-buffer/3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,7 +385,7 @@ importers:
       lodash.escaperegexp: ^4.1.2
       lodash.isequal: ^4.5.0
       semver: ^7.3.8
-      typed-emitter: ^2.1.0
+      tiny-typed-emitter: ^2.1.0
     dependencies:
       builder-util-runtime: link:../builder-util-runtime
       fs-extra: 10.1.0
@@ -394,13 +394,13 @@ importers:
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
       semver: 7.3.8
+      tiny-typed-emitter: 2.1.0
     devDependencies:
       '@types/fs-extra': 9.0.13
       '@types/js-yaml': 4.0.3
       '@types/lodash.escaperegexp': 4.1.6
       '@types/lodash.isequal': 4.5.5
       '@types/semver': 7.3.13
-      typed-emitter: 2.1.0
 
   test:
     specifiers:
@@ -9962,6 +9962,10 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
+  /tiny-typed-emitter/2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
+    dev: false
+
   /tmp-promise/3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
     dependencies:
@@ -10191,12 +10195,6 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
-    dev: true
-
-  /typed-emitter/2.1.0:
-    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
-    optionalDependencies:
-      rxjs: 7.8.0
     dev: true
 
   /typedarray-to-buffer/3.1.5:


### PR DESCRIPTION
The "typed-emitter" package pulls in a number of dependencies, including the large "rxjs" library.