### PR TITLE
feat: Add option for whether to check package.json semver compliance

### DIFF
--- a/.changeset/hip-rules-smoke.md
+++ b/.changeset/hip-rules-smoke.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+Added "checkPackageVersion" config option

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -274,6 +274,13 @@ export interface Configuration extends PlatformSpecificBuildOptions {
    * @default true
    */
   readonly removePackageKeywords?: boolean
+
+  /**
+   * Whether to check the `version` field of `package.json` for semver compliance.
+   *
+   * @default true
+   */
+  readonly checkPackageVersion?: boolean
 }
 
 interface PackContext {

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -306,7 +306,7 @@ export class Packager {
     }
 
     const packageFile = path.join(this.projectDir, "package.json")
-    const checkPackageVersion = configFromOptions?.checkPackageVersion || true
+    const checkPackageVersion = configFromOptions?.checkPackageVersion !== false
     this._devMetadata = await orNullIfFileNotExist(readPackageJson({ packageFile, checkPackageVersion }))
 
     const configuration = await getConfig(this.projectDir, configPath, configFromOptions, new Lazy(() => Promise.resolve(this.devMetadata)))

--- a/packages/app-builder-lib/src/util/normalizePackageData.ts
+++ b/packages/app-builder-lib/src/util/normalizePackageData.ts
@@ -2,9 +2,13 @@ import * as semver from "semver"
 import { fromUrl } from "hosted-git-info"
 import * as url from "url"
 
-export function normalizePackageData(data: any) {
+export interface NormalizePackageDataOptions {
+  checkPackageVersion: boolean
+}
+
+export function normalizePackageData(data: any, options: NormalizePackageDataOptions) {
   for (const it of check) {
-    it(data)
+    it(data, options)
   }
 }
 
@@ -136,10 +140,13 @@ const check = [
       })
     }
   },
-  function fixVersionField(data: any) {
+  function fixVersionField(data: any, options: NormalizePackageDataOptions) {
     const loose = true
     if (!data.version) {
       data.version = ""
+      return true
+    }
+    if (options.checkPackageVersion) {
       return true
     }
     if (!semver.valid(data.version, loose)) {

--- a/packages/app-builder-lib/src/util/packageMetadata.ts
+++ b/packages/app-builder-lib/src/util/packageMetadata.ts
@@ -3,16 +3,20 @@ import { readFile, readJson } from "fs-extra"
 import * as path from "path"
 import * as semver from "semver"
 import { Metadata } from "../options/metadata"
-import { normalizePackageData } from "./normalizePackageData"
+import { type NormalizePackageDataOptions, normalizePackageData } from "./normalizePackageData"
+
+export interface ReadPackageJSONOptions extends NormalizePackageDataOptions {
+  packageFile: string
+}
 
 /** @internal */
-export async function readPackageJson(file: string): Promise<any> {
-  const data = await readJson(file)
-  await authors(file, data)
+export async function readPackageJson(options: ReadPackageJSONOptions): Promise<any> {
+  const data = await readJson(options.packageFile)
+  await authors(options.packageFile, data)
   // remove not required fields because can be used for remote build
   delete data.scripts
   delete data.readme
-  normalizePackageData(data)
+  normalizePackageData(data, options)
   return data
 }
 


### PR DESCRIPTION
This PR adds the `checkPackageVersion` config option. When set to `false`, the `version` field of `package.json` will not be checked for semver compliance. When set to `true` (the default), it will have the current behavior.