### PR TITLE
feat:  Added support for overriding ‘preAutoEntitlements’ for electron/osx-sign

### DIFF
--- a/.changeset/four-starfishes-invite.md
+++ b/.changeset/four-starfishes-invite.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: Added support for overriding ‘preAutoEntitlements’ for electron/osx-sign

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2679,6 +2679,11 @@
           ],
           "description": "Options to use for @electron/notarize (ref: https://github.com/electron/notarize).\nSupports both `legacy` and `notarytool` notarization tools. Use `false` to explicitly disable\n\nNote: You MUST specify `APPLE_ID` and `APPLE_APP_SPECIFIC_PASSWORD` via environment variables to activate notarization step"
         },
+        "preAutoEntitlements": {
+          "default": true,
+          "description": "Whether to enable entitlements automation from @electron/osx-sign.",
+          "type": "boolean"
+        },
         "protocols": {
           "anyOf": [
             {
@@ -3303,6 +3308,11 @@
             }
           ],
           "description": "Options to use for @electron/notarize (ref: https://github.com/electron/notarize).\nSupports both `legacy` and `notarytool` notarization tools. Use `false` to explicitly disable\n\nNote: You MUST specify `APPLE_ID` and `APPLE_APP_SPECIFIC_PASSWORD` via environment variables to activate notarization step"
+        },
+        "preAutoEntitlements": {
+          "default": true,
+          "description": "Whether to enable entitlements automation from @electron/osx-sign.",
+          "type": "boolean"
         },
         "protocols": {
           "anyOf": [

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -306,6 +306,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       binaries,
       // https://github.com/electron-userland/electron-builder/issues/1480
       strictVerify: options.strictVerify,
+      preAutoEntitlements: options.preAutoEntitlements,
       optionsForFile: await this.getOptionsForFile(appPath, isMas, customSignOptions),
       provisioningProfile: customSignOptions.provisioningProfile || undefined,
     }

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -165,6 +165,12 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   readonly strictVerify?: boolean
 
   /**
+   * Whether to enable entitlements automation from @electron/osx-sign.
+   * @default true
+   */
+  readonly preAutoEntitlements?: boolean
+
+  /**
    * Regex or an array of regex's that signal skipping signing a file.
    */
   readonly signIgnore?: Array<string> | string | null


### PR DESCRIPTION
We recently upgraded from v22 to v24, and start getting `Not available for testing` in testflight, after comparing the entitlements, it looks like the issue is due to auto entitlements from osx-sign, after disabling it locally the issue is resolved.

Also this should address https://github.com/electron-userland/electron-builder/issues/7579


default should be true as osx-sign is checking for false with `===`: https://github.com/electron/osx-sign/blob/cd9e8f1146610fb0f1bb0d88a5219b208594e5b1/src/sign.ts#L211