### PR TITLE
fix: use nullish coalescing operator for hardenedRuntime default

### DIFF
--- a/.changeset/slow-buttons-provide.md
+++ b/.changeset/slow-buttons-provide.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: use nullish coalescing operator for hardenedRuntime default value

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -384,7 +384,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       const entitlements = getEntitlements(filePath)
       const args = {
         entitlements: entitlements || undefined,
-        hardenedRuntime: hardenedRuntime || undefined,
+        hardenedRuntime: hardenedRuntime ?? undefined,
         timestamp: customSignOptions.timestamp || undefined,
         requirements: requirements || undefined,
       }


### PR DESCRIPTION
right now if `hardenedRuntime` is set to false, it default to `undefined`, while osx-sign is defaulting it to `true`, so basically the `false` will never work.