### PR TITLE
feat: add support for riscv64 architecture

### DIFF
--- a/.changeset/violet-days-refuse.md
+++ b/.changeset/violet-days-refuse.md
@@ -1,0 +1,7 @@
+---
+"app-builder-lib": minor
+"builder-util": minor
+"electron-builder": minor
+---
+
+feat: add support for riscv64 architecture

--- a/docs/api/electron-builder.md
+++ b/docs/api/electron-builder.md
@@ -33,6 +33,7 @@ Developer API only. See [Configuration](../configuration/configuration.md) for u
 <li><strong><code id="Arch-armv7l">armv7l</code></strong></li>
 <li><strong><code id="Arch-arm64">arm64</code></strong></li>
 <li><strong><code id="Arch-universal">universal</code></strong></li>
+<li><strong><code id="Arch-riscv64">riscv64</code></strong></li>
 </ul>
 <p><a name="module_electron-builder.build"></a></p>
 <h2 id="electron-builder.build(rawoptions)-%E2%87%92-promise%3Carray%3Cstring%3E%3E"><code>electron-builder.build(rawOptions)</code> ⇒ <code>Promise&lt;Array&lt;String&gt;&gt;</code></h2>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5882,6 +5882,7 @@
                   "arm64",
                   "armv7l",
                   "ia32",
+                  "riscv64",
                   "universal",
                   "x64"
                 ],
@@ -5894,6 +5895,7 @@
                 "arm64",
                 "armv7l",
                 "ia32",
+                "riscv64",
                 "universal",
                 "x64"
               ],

--- a/packages/app-builder-lib/src/linuxPackager.ts
+++ b/packages/app-builder-lib/src/linuxPackager.ts
@@ -81,6 +81,8 @@ export function toAppImageOrSnapArch(arch: Arch): string {
       return "arm"
     case Arch.arm64:
       return "arm_aarch64"
+    case Arch.riscv64:
+      return "riscv64"
 
     default:
       throw new Error(`Unsupported arch ${arch}`)

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -271,6 +271,8 @@ function archNameToTriplet(arch: Arch): string {
       return "arm-linux-gnueabihf"
     case Arch.arm64:
       return "aarch64-linux-gnu"
+    case Arch.riscv64:
+      return "riscv64-linux-gnu"
 
     default:
       throw new Error(`Unsupported arch ${arch}`)

--- a/packages/builder-util/src/arch.ts
+++ b/packages/builder-util/src/arch.ts
@@ -4,9 +4,10 @@ export enum Arch {
   armv7l,
   arm64,
   universal,
+  riscv64,
 }
 
-export type ArchType = "x64" | "ia32" | "armv7l" | "arm64" | "universal"
+export type ArchType = "x64" | "ia32" | "armv7l" | "arm64" | "universal" | "riscv64"
 
 export function toLinuxArchString(arch: Arch, targetName: string): string {
   switch (arch) {
@@ -18,14 +19,15 @@ export function toLinuxArchString(arch: Arch, targetName: string): string {
       return targetName === "snap" || targetName === "deb" ? "armhf" : targetName === "flatpak" ? "arm" : "armv7l"
     case Arch.arm64:
       return targetName === "pacman" || targetName === "rpm" || targetName === "flatpak" ? "aarch64" : "arm64"
-
+    case Arch.riscv64:
+      return "riscv64"
     default:
       throw new Error(`Unsupported arch ${arch}`)
   }
 }
 
 export function getArchCliNames(): Array<string> {
-  return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64]]
+  return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64], Arch[Arch.riscv64]]
 }
 
 export function getArchSuffix(arch: Arch, defaultArch?: string): string {
@@ -45,6 +47,8 @@ export function archFromString(name: string): Arch {
       return Arch.armv7l
     case "universal":
       return Arch.universal
+    case "riscv64":
+      return Arch.riscv64
     default:
       throw new Error(`Unsupported arch ${name}`)
   }

--- a/packages/electron-builder/src/builder.ts
+++ b/packages/electron-builder/src/builder.ts
@@ -18,6 +18,7 @@ export interface CliOptions extends PackagerOptions, PublishOptions {
   armv7l?: boolean
   arm64?: boolean
   universal?: boolean
+  riscv64?: boolean
 
   dir?: boolean
 }
@@ -47,6 +48,9 @@ export function normalizeOptions(args: CliOptions): BuildOptions {
       }
       if (args.universal) {
         result.push(Arch.universal)
+      }
+      if (args.riscv64) {
+        result.push(Arch.riscv64)
       }
 
       return result.length === 0 && currentIfNotSpecified ? [archFromString(process.arch)] : result

--- a/test/src/helpers/downloadElectron.ts
+++ b/test/src/helpers/downloadElectron.ts
@@ -48,6 +48,10 @@ export function downloadAllRequiredElectronVersions(): Promise<any> {
         ? ["ia32", "x64"]
         : require(`${path.join(__dirname, "../../..")}/packages/builder-util/out/util`).getArchCliNames()
     for (const arch of archs) {
+      if (arch === "riscv64") {
+        // No prebuilt electron for riscv64
+        continue
+      }
       versions.push({
         version: ELECTRON_VERSION,
         arch,


### PR DESCRIPTION
Hi, I would like to add riscv64 support for electron-builder.

I would really appreciate it if you could make a new release shortly after this PR is merged.
