### PR TITLE
fix: re-enable changeDir step for assisted, perMachine installs

### DIFF
--- a/.changeset/sweet-monkeys-listen.md
+++ b/.changeset/sweet-monkeys-listen.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: re-enable changeDir step for assisted, perMachine installs

--- a/packages/app-builder-lib/templates/msi/template.xml
+++ b/packages/app-builder-lib/templates/msi/template.xml
@@ -16,6 +16,7 @@
     <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage='A newer version of "[ProductName]" is already installed.'/>
     <MediaTemplate CompressionLevel="${compressionLevel}" EmbedCab="yes"/>
 
+    <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER"/>
     <Property Id="ApplicationFolderName" Value="${installationDirectoryWixName}"/>
     <Property Id="WixAppFolder" Value="WixPerUserFolder"/>
     <Property Id="DISABLEADVTSHORTCUTS" Value="1"/>
@@ -69,7 +70,11 @@
         <Publish Dialog="InstallScopeDlg" Control="Next" Property="ALLUSERS" Value="1" Order="4">WixAppFolder = "WixPerMachineFolder"</Publish>
         <!-- Run 'FindRelatedProducts' again after changing the install scope, because its first run might have ignored an existing installation based on the default scope at the time. https://stackoverflow.com/a/35064434 -->
         <Publish Dialog="InstallScopeDlg" Control="Next" Event="DoAction" Value="FindRelatedProducts" Order="5">1</Publish>
-        <Publish Dialog="InstallScopeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="6">1</Publish>
+        <Publish Dialog="InstallScopeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="6">WixAppFolder = "WixPerUserFolder"</Publish>
+        <Publish Dialog="InstallScopeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="7">WixAppFolder = "WixPerMachineFolder"</Publish>
+
+        <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" Order="2">1</Publish>
+        <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" Order="2">NOT Installed</Publish>
       </UI>


### PR DESCRIPTION
Hi,
There is no option to change the target directory during the installation process(assisted+perMachine) for MSI. It says 'You can change the default installation folder' but, actually, you can't. This PR should fix it.
1. 
![1111](https://github.com/electron-userland/electron-builder/assets/31886478/1741ae0b-25d0-4a7a-a33f-c7fd5f71c65c)
2.
![2222](https://github.com/electron-userland/electron-builder/assets/31886478/4477aa1d-e02d-4460-979b-de15cc87cf7b)
