### PR TITLE
fix: add back missing `createLazyProductionDeps` that was missed during revert

### DIFF
--- a/.changeset/lazy-buttons-invent.md
+++ b/.changeset/lazy-buttons-invent.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"electron-builder": patch
+---
+
+fix: add back missing `createLazyProductionDeps` that was missed during revert

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -153,7 +153,7 @@ function isRunningYarn(execPath: string | null | undefined) {
 
 export interface RebuildOptions {
   frameworkInfo: DesktopFrameworkInfo
-  productionDeps?: Lazy<Array<NodeModuleDirInfo>>
+  productionDeps: Lazy<Array<NodeModuleDirInfo>>
 
   platform?: NodeJS.Platform
   arch?: string
@@ -166,7 +166,7 @@ export interface RebuildOptions {
 /** @internal */
 export async function rebuild(appDir: string, options: RebuildOptions) {
   const configuration: any = {
-    dependencies: await options.productionDeps!.value,
+    dependencies: await options.productionDeps.value,
     nodeExecPath: process.execPath,
     platform: options.platform || process.platform,
     arch: options.arch || process.arch,

--- a/packages/electron-builder/src/cli/install-app-deps.ts
+++ b/packages/electron-builder/src/cli/install-app-deps.ts
@@ -4,6 +4,7 @@ import { getElectronVersion } from "app-builder-lib/out/electron/electronVersion
 import { computeDefaultAppDirectory, getConfig } from "app-builder-lib/out/util/config"
 import { installOrRebuild } from "app-builder-lib/out/util/yarn"
 import { PACKAGE_VERSION } from "app-builder-lib/out/version"
+import { createLazyProductionDeps } from "app-builder-lib/src/util/packageDependencies"
 import { getArchCliNames, log, use } from "builder-util"
 import { printErrorAndExit } from "builder-util/out/promise"
 import { readJson } from "fs-extra"
@@ -62,6 +63,7 @@ export async function installAppDeps(args: any) {
       frameworkInfo: { version, useCustomDist: true },
       platform: args.platform,
       arch: args.arch,
+      productionDeps: createLazyProductionDeps(appDir, null),
     },
     appDir !== projectDir
   )


### PR DESCRIPTION
fixes: #7653