### PR TITLE
docs: Fix typos in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 You decided to contribute to this project? Great, thanks a lot for pushing it.
 
 This project adheres to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-By participating, you are expected to uphold this code. Please file issue to report unacceptable behavior.
+By participating, you are expected to uphold this code. Please file an issue to report unacceptable behavior.
 
 This repository has a mono-repo structure consisting of multiple packages. Try to take a look at the [packages directory](https://github.com/electron-userland/electron-builder/tree/master/packages)!
 
@@ -37,7 +37,7 @@ popd
 ```
 
 Publish the electron-builder packages to `yalc`'s local store via these commands that you need to run from `electron-builder/packages`.
-Unfortunately,the `yalc publish` command cannot pass multiple packages.
+Unfortunately, the `yalc publish` command cannot pass multiple packages.
 
 ```
 yalc publish app-builder-lib


### PR DESCRIPTION
Fixed typos in CONTRIBUTING.md.

This line:
By participating, you are expected to uphold this code. Please file issue to report unacceptable behavior.
changed to:
By participating, you are expected to uphold this code. Please file an issue to report unacceptable behavior.

Added space after comma in this line:
Unfortunately,the `yalc publish` command cannot pass multiple packages.
changed to:
Unfortunately, the `yalc publish` command cannot pass multiple packages.

