### PR TITLE
fix: duplicated uploads

### DIFF
--- a/.changeset/poor-jobs-fold.md
+++ b/.changeset/poor-jobs-fold.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Only schedule upload for unique files after `afterAllArtifactBuild`

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -89,6 +89,10 @@ export function build(options: PackagerOptions & PublishOptions, packager: Packa
       }
 
       for (const newArtifact of newArtifacts) {
+        if (buildResult.artifactPaths.includes(newArtifact)) {
+          log.warn({ newArtifact }, "skipping publish of artifact, already published");
+          continue;
+        }
         buildResult.artifactPaths.push(newArtifact)
         for (const publishConfiguration of publishConfigurations) {
           publishManager.scheduleUpload(


### PR DESCRIPTION
Only schedule upload for unique files, otherwise it would try to upload the same files multiple times.