### PR TITLE
fix(mac): fix errors using native modules that require rebuild when the mac target is multiple and contains mas

### DIFF
--- a/.changeset/large-brooms-jump.md
+++ b/.changeset/large-brooms-jump.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): fix errors using native modules that require rebuild when both mas and mac targets are specified

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -181,10 +181,12 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       }
     }
 
-    if ((!hasMas || targets.length > 1) && !prepackaged) {
-      const appPath = path.join(this.computeAppOutDir(outDir, arch), `${this.appInfo.productFilename}.app`);
-      await this.doPack(outDir, path.dirname(appPath), this.platform.nodeName as ElectronPlatformName, arch, this.platformSpecificBuildOptions, targets)
-      .then(() => this.packageInDistributableFormat(appPath, arch, targets, taskManager))
+    if (!hasMas || targets.length > 1) {
+      const appPath = prepackaged == null ? path.join(this.computeAppOutDir(outDir, arch), `${this.appInfo.productFilename}.app`) : prepackaged
+      if (prepackaged == null) {
+        await this.doPack(outDir, path.dirname(appPath), this.platform.nodeName as ElectronPlatformName, arch, this.platformSpecificBuildOptions, targets)
+      }
+      this.packageInDistributableFormat(appPath, arch, targets, taskManager)
     }
   }
 

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -170,7 +170,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       ).then(() => this.packageInDistributableFormat(appPath, arch, targets, taskManager))
     }
 
-    const procesTargetPack = async (target: Target) => {
+    const processTargetPack = async (target: Target) => {
       const targetName = target.name
       if (!(targetName === "mas" || targetName === "mas-dev")) {
         return;
@@ -194,7 +194,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
 
     async function processTargetsPack(targets: Array<Target>, index: number) {
       if (index < targets.length) {
-        await procesTargetPack(targets[index]);
+        await processTargetPack(targets[index]);
         await processTargetsPack(targets, index + 1);
       }
     }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -170,10 +170,10 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       ).then(() => this.packageInDistributableFormat(appPath, arch, targets, taskManager))
     }
 
-    for (const target of targets) {
+    const procesTargetPack = async (target: Target) => {
       const targetName = target.name
       if (!(targetName === "mas" || targetName === "mas-dev")) {
-        continue
+        return;
       }
 
       const masBuildOptions = deepAssign({}, this.platformSpecificBuildOptions, this.config.mas)
@@ -191,6 +191,15 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         await this.sign(prepackaged, targetOutDir, masBuildOptions, arch)
       }
     }
+
+    async function processTargetsPack(targets: Array<Target>, index: number) {
+      if (index < targets.length) {
+        await procesTargetPack(targets[index]);
+        await processTargetsPack(targets, index + 1);
+      }
+    }
+
+    await processTargetsPack(targets, 0);
 
     if (nonMasPromise != null) {
       await nonMasPromise


### PR DESCRIPTION
For details about the problem, please see [Issue-7587](https://github.com/electron-userland/electron-builder/issues/7587), [this](https://github.com/Koppel-Zhou/electron-rebuild-error-demo) is a demo created to reproduce the problem