### PR TITLE
fix: bug #7711.

### DIFF
--- a/.changeset/yellow-games-beg.md
+++ b/.changeset/yellow-games-beg.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: expand macro for ${version}/.icon-ico/ dir on Window's installers

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -679,7 +679,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
   // convert if need, validate size (it is a reason why tool is called even if file has target extension (already specified as foo.icns for example))
   async resolveIcon(sources: Array<string>, fallbackSources: Array<string>, outputFormat: IconFormat): Promise<Array<IconInfo>> {
-    let output = this.expandMacro( this.config.directories!.output! );
+    const output = this.expandMacro(this.config.directories!.output!);
     const args = [
       "icon",
       "--format",

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -679,6 +679,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
   // convert if need, validate size (it is a reason why tool is called even if file has target extension (already specified as foo.icns for example))
   async resolveIcon(sources: Array<string>, fallbackSources: Array<string>, outputFormat: IconFormat): Promise<Array<IconInfo>> {
+    let output = this.expandMacro( this.config.directories!.output! );
     const args = [
       "icon",
       "--format",
@@ -688,7 +689,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       "--root",
       this.projectDir,
       "--out",
-      path.resolve(this.projectDir, this.config.directories!.output!, `.icon-${outputFormat}`),
+      path.resolve(this.projectDir, output, `.icon-${outputFormat}`),
     ]
     for (const source of sources) {
       args.push("--input", source)


### PR DESCRIPTION
Windows build will fail because the icon.ico will put to ${version}/.icon-ico/ dir, not x.x.x/.icon-ico/ dir.