### PR TITLE
fix: When error code is ENOENT, try to use electron.shell.openPath to…

### DIFF
--- a/.changeset/few-eagles-learn.md
+++ b/.changeset/few-eagles-learn.md
@@ -1,0 +1,6 @@
+---
+"electron-updater": patch
+---
+
+
+fix: When error code is ENOENT, try to use electron.shell.openPath to run installer on Windows

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -156,11 +156,15 @@ export class NsisUpdater extends BaseUpdater {
       // https://github.com/electron-userland/electron-builder/issues/1129
       // Node 8 sends errors: https://nodejs.org/dist/latest-v8.x/docs/api/errors.html#errors_common_system_errors
       const errorCode = (e as NodeJS.ErrnoException).code
-      this._logger.info(`Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using elevate if EACCES, and will try to use electron.shell.openItem if ENOENT`)
+      this._logger.info(
+        `Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using elevate if EACCES, and will try to use electron.shell.openItem if ENOENT`
+      )
       if (errorCode === "UNKNOWN" || errorCode === "EACCES") {
         callUsingElevation()
-      } else if (errorCode === 'ENOENT') {
-        require("electron").shell.openPath(options.installerPath).catch((err: Error) => this.dispatchError(err))
+      } else if (errorCode === "ENOENT") {
+        require("electron")
+          .shell.openPath(options.installerPath)
+          .catch((err: Error) => this.dispatchError(err))
       } else {
         this.dispatchError(e)
       }

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -156,9 +156,11 @@ export class NsisUpdater extends BaseUpdater {
       // https://github.com/electron-userland/electron-builder/issues/1129
       // Node 8 sends errors: https://nodejs.org/dist/latest-v8.x/docs/api/errors.html#errors_common_system_errors
       const errorCode = (e as NodeJS.ErrnoException).code
-      this._logger.info(`Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using elevate if EACCES"`)
+      this._logger.info(`Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using elevate if EACCES, and will try to use electron.shell.openItem if ENOENT`)
       if (errorCode === "UNKNOWN" || errorCode === "EACCES") {
         callUsingElevation()
+      } else if (errorCode === 'ENOENT') {
+        require("electron").shell.openPath(options.installerPath).catch(err => this.dispatchError(err))
       } else {
         this.dispatchError(e)
       }

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -160,7 +160,7 @@ export class NsisUpdater extends BaseUpdater {
       if (errorCode === "UNKNOWN" || errorCode === "EACCES") {
         callUsingElevation()
       } else if (errorCode === 'ENOENT') {
-        require("electron").shell.openPath(options.installerPath).catch(err => this.dispatchError(err))
+        require("electron").shell.openPath(options.installerPath).catch((err: Error) => this.dispatchError(err))
       } else {
         this.dispatchError(e)
       }


### PR DESCRIPTION
I found that some Windows machines will report the errorCode `ENOENT` even `options.installerPath` is exist, but electron-updater never handle it! I think `openPath` can solve the problem. 

log:
```
[2023-09-07 11:54:11.500] [main] [info]  Executing: C:\Users\Administrator\AppData\Local\xx-updater\pending\xx-ia32-1.9.1-3.exe with args: --updated,/S,--force-run
[2023-09-07 11:54:11.502] [main] [info]  Cannot run installer: error code: ENOENT, error message: "spawn C:\Users\Administrator\AppData\Local\xx-updater\pending\xx-ia32-1.9.1-3.exe ENOENT", will be executed again using elevate if EACCES"
[2023-09-07 11:54:11.503] [main] [error] Error: Error: spawn C:\Users\Administrator\AppData\Local\xx-updater\pending\xx-ia32-1.9.1-3.exe ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:282:19)
    at onErrorNT (node:internal/child_process:477:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)

```