### PR TITLE
fix(mac): Enhance the usage boundary of iconTextSize (#7769)

### DIFF
--- a/.changeset/funny-geckos-clap.md
+++ b/.changeset/funny-geckos-clap.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix(mac): Validate the usage boundary of iconTextSize (#7769)

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -241,12 +241,14 @@ async function computeAssetSize(cancellationToken: CancellationToken, dmgFile: s
 
 async function customizeDmg(volumePath: string, specification: DmgOptions, packager: MacPackager, backgroundFile: string | null | undefined) {
   const window = specification.window
+  const isValidIconTextSize = !!specification.iconTextSize && specification.iconTextSize >= 10 && specification.iconTextSize <= 16
+  const iconTextSize = isValidIconTextSize ? specification.iconTextSize : 12;
   const env: any = {
     ...process.env,
     volumePath,
     appFileName: `${packager.appInfo.productFilename}.app`,
     iconSize: specification.iconSize || 80,
-    iconTextSize: specification.iconTextSize || 12,
+    iconTextSize,
 
     PYTHONIOENCODING: "utf8",
   }


### PR DESCRIPTION
fix Issue(#7769)