### PR TITLE
fix: exclude electron-builder.env from app

### DIFF
--- a/.changeset/silent-cats-travel.md
+++ b/.changeset/silent-cats-travel.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: exclude electron-builder.env from app to avoid packaging env secrets

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -17,7 +17,7 @@ export const excludedNames =
   "__pycache__,.DS_Store,thumbs.db,.gitignore,.gitkeep,.gitattributes,.npmignore," +
   ".idea,.vs,.flowconfig,.jshintrc,.eslintrc,.circleci," +
   ".yarn-integrity,.yarn-metadata.json,yarn-error.log,yarn.lock,package-lock.json,npm-debug.log," +
-  "appveyor.yml,.travis.yml,circle.yml,.nyc_output,.husky,.github"
+  "appveyor.yml,.travis.yml,circle.yml,.nyc_output,.husky,.github,electron-builder.env"
 
 export const excludedExts =
   "iml,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,suo,xproj,cc,d.ts," +


### PR DESCRIPTION
Adds `electron-builder.env` to the default file ignore list.

[Documentation](https://www.electron.build/configuration/configuration) currently suggests the use of this file for environment variable. However, if a developer uses `electron-builder.env` to store secrets (a common development practice), the default configuration will include these secrets in the packaged app. Adding the file to the default ignore list prevents this inadvertent secret disclosure.

Closes #7777 