### PR TITLE
fix: Extract `NotarizeNotaryOptions` and `NotarizeLegacyOptions` to explicitly define required vars

### DIFF
--- a/.changeset/nice-dogs-remain.md
+++ b/.changeset/nice-dogs-remain.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Extract `NotarizeNotaryOptions` and `NotarizeLegacyOptions` to explicitly define required vars

--- a/docs/configuration/mac.md
+++ b/docs/configuration/mac.md
@@ -105,7 +105,7 @@ The top-level [mac](configuration.md#Configuration-mac) key contains set of opti
 <p>This option has no effect unless building for “universal” arch and applies only if <code>mergeASARs</code> is <code>true</code>.</p>
 </li>
 <li>
-<p><code id="MacConfiguration-notarize">notarize</code> module:app-builder-lib/out/options/macOptions.NotarizeOptions | Boolean | “undefined” - Options to use for @electron/notarize (ref: <a href="https://github.com/electron/notarize">https://github.com/electron/notarize</a>). Supports both <code>legacy</code> and <code>notarytool</code> notarization tools. Use <code>false</code> to explicitly disable</p>
+<p><code id="MacConfiguration-notarize">notarize</code> module:app-builder-lib/out/options/macOptions.NotarizeLegacyOptions | module:app-builder-lib/out/options/macOptions.NotarizeNotaryOptions | Boolean | “undefined” - Options to use for @electron/notarize (ref: <a href="https://github.com/electron/notarize">https://github.com/electron/notarize</a>). Supports both <code>legacy</code> and <code>notarytool</code> notarization tools. Use <code>false</code> to explicitly disable</p>
 <p>Note: You MUST specify <code>APPLE_ID</code> and <code>APPLE_APP_SPECIFIC_PASSWORD</code> via environment variables to activate notarization step</p>
 </li>
 </ul>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2668,7 +2668,10 @@
         "notarize": {
           "anyOf": [
             {
-              "$ref": "#/definitions/NotarizeOptions"
+              "$ref": "#/definitions/NotarizeLegacyOptions"
+            },
+            {
+              "$ref": "#/definitions/NotarizeNotaryOptions"
             },
             {
               "type": [
@@ -3298,7 +3301,10 @@
         "notarize": {
           "anyOf": [
             {
-              "$ref": "#/definitions/NotarizeOptions"
+              "$ref": "#/definitions/NotarizeLegacyOptions"
+            },
+            {
+              "$ref": "#/definitions/NotarizeNotaryOptions"
             },
             {
               "type": [
@@ -3872,7 +3878,7 @@
       },
       "type": "object"
     },
-    "NotarizeOptions": {
+    "NotarizeLegacyOptions": {
       "additionalProperties": false,
       "properties": {
         "appBundleId": {
@@ -3888,15 +3894,21 @@
             "null",
             "string"
           ]
-        },
-        "teamId": {
-          "description": "The team ID you want to notarize under. Only needed if using `notarytool`",
-          "type": [
-            "null",
-            "string"
-          ]
         }
       },
+      "type": "object"
+    },
+    "NotarizeNotaryOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "teamId": {
+          "description": "The team ID you want to notarize under for when using `notarytool`",
+          "type": "string"
+        }
+      },
+      "required": [
+        "teamId"
+      ],
       "type": "object"
     },
     "NsisOptions": {

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -212,10 +212,10 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    *
    * Note: You MUST specify `APPLE_ID` and `APPLE_APP_SPECIFIC_PASSWORD` via environment variables to activate notarization step
    */
-  readonly notarize?: NotarizeOptions | boolean | null
+  readonly notarize?: NotarizeLegacyOptions | NotarizeNotaryOptions | boolean | null
 }
 
-export interface NotarizeOptions {
+export interface NotarizeLegacyOptions {
   /**
    * The app bundle identifier your Electron app is using. E.g. com.github.electron. Useful if notarization ID differs from app ID (unlikely).
    * Only used by `legacy` notarization tool
@@ -226,11 +226,13 @@ export interface NotarizeOptions {
    * Your Team Short Name. Only used by `legacy` notarization tool
    */
   readonly ascProvider?: string | null
+}
 
+export interface NotarizeNotaryOptions {
   /**
-   * The team ID you want to notarize under. Only needed if using `notarytool`
+   * The team ID you want to notarize under for when using `notarytool`
    */
-  readonly teamId?: string | null
+  readonly teamId: string
 }
 
 export interface DmgOptions extends TargetSpecificOptions {

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -679,7 +679,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
   // convert if need, validate size (it is a reason why tool is called even if file has target extension (already specified as foo.icns for example))
   async resolveIcon(sources: Array<string>, fallbackSources: Array<string>, outputFormat: IconFormat): Promise<Array<IconInfo>> {
-    const output = this.expandMacro(this.config.directories!.output!);
+    const output = this.expandMacro(this.config.directories!.output!)
     const args = [
       "icon",
       "--format",


### PR DESCRIPTION
Extracting Notarize Notary and Legacy options into distinct interfaces so that only `teamId` is allowed when using `notary` tool.

Ref: https://github.com/electron-userland/electron-builder/issues/7683#issuecomment-1726471047