### PR TITLE
fix: Make nsis builds (and portable builds) not run in parallel

### DIFF
--- a/.changeset/tough-roses-attend.md
+++ b/.changeset/tough-roses-attend.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: run nsis and portable builds sequentially. fixes #7791

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -42,6 +42,7 @@ export class NsisTarget extends Target {
 
   /** @private */
   readonly archs: Map<Arch, string> = new Map()
+  readonly isAsyncSupported = false;
 
   constructor(readonly packager: WinPackager, readonly outDir: string, targetName: string, protected readonly packageHelper: AppPackageHelper) {
     super(targetName)


### PR DESCRIPTION
This fixes #7791 by making `nsis` and `portable` builds not run in parallel.

This change should not break anyone's build process, but it could make it slower. However, I think slower is better than sometimes broken.