### PR TITLE
fix: compat with newest @types/node

### DIFF
--- a/.changeset/brave-bats-brake.md
+++ b/.changeset/brave-bats-brake.md
@@ -1,0 +1,6 @@
+---
+"builder-util-runtime": patch
+"builder-util": patch
+---
+
+fix: update @types/node for compat with newest @types/node

--- a/.changeset/spicy-kiwis-float.md
+++ b/.changeset/spicy-kiwis-float.md
@@ -1,0 +1,6 @@
+---
+"builder-util-runtime": patch
+"builder-util": patch
+---
+
+fix: compat with newest @types/node

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -440,9 +440,9 @@ Define `KEYGEN_TOKEN` environment variable.
 * **<code id="ReleaseNoteInfo-note">note</code>** String | "undefined" - The note.
 
 <a name="RequestHeaders"></a>
-### `RequestHeaders` ⇐ <code>[key: string]: string</code>
+### `RequestHeaders` ⇐ <code>[key: string]: OutgoingHttpHeader | undefined</code>
 **Kind**: interface of [<code>builder-util-runtime</code>](#module_builder-util-runtime)<br/>
-**Extends**: <code>[key: string]: string</code>  
+**Extends**: <code>[key: string]: OutgoingHttpHeader | undefined</code>  
 <a name="S3Options"></a>
 ### `S3Options` ⇐ <code>[BaseS3Options](electron-builder#BaseS3Options)</code>
 **Kind**: interface of [<code>builder-util-runtime</code>](#module_builder-util-runtime)<br/>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-transform-modules-commonjs": "7.15.4",
     "@changesets/changelog-github": "0.4.7",
     "@changesets/cli": "2.25.0",
-    "@types/node": "16.11.43",
+    "@types/node": "16.18.55",
     "@typescript-eslint/eslint-plugin": "5.41.0",
     "@typescript-eslint/parser": "5.41.0",
     "catharsis": "0.9.0",

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -1,7 +1,7 @@
 import { BinaryToTextEncoding, createHash, Hash } from "crypto"
 import _debug from "debug"
 import { createWriteStream } from "fs"
-import { IncomingMessage, OutgoingHttpHeaders, RequestOptions } from "http"
+import { IncomingMessage, OutgoingHttpHeader, OutgoingHttpHeaders, RequestOptions } from "http"
 import { Socket } from "net"
 import { Transform } from "stream"
 import { URL } from "url"
@@ -12,7 +12,7 @@ import { ProgressCallbackTransform, ProgressInfo } from "./ProgressCallbackTrans
 const debug = _debug("electron-builder")
 
 export interface RequestHeaders extends OutgoingHttpHeaders {
-  [key: string]: string
+  [key: string]: OutgoingHttpHeader | undefined
 }
 
 export interface DownloadOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 2.25.0
         version: 2.25.0(patch_hash=nye7dcohy6yzxjscpnrszvchra)
       '@types/node':
-        specifier: 16.11.43
-        version: 16.11.43
+        specifier: 16.18.55
+        version: 16.18.55
       '@typescript-eslint/eslint-plugin':
         specifier: 5.41.0
         version: 5.41.0(@typescript-eslint/parser@5.41.0)(eslint@8.26.0)(typescript@5.1.6)
@@ -2354,7 +2354,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -2410,7 +2410,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       jest-mock: 27.5.1
 
   /@jest/fake-timers@27.5.1:
@@ -2419,7 +2419,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -2446,7 +2446,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -2548,7 +2548,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       '@types/yargs': 15.0.15
       chalk: 4.1.2
     dev: true
@@ -2559,7 +2559,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       '@types/yargs': 16.0.5
       chalk: 4.1.2
 
@@ -2752,13 +2752,13 @@ packages:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
     dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
 
   /@types/hosted-git-info@3.0.2:
     resolution: {integrity: sha512-RURNTeEFUwF+ifnp7kK3WLLlTmBSlRynLNS9jeAsI6RHtSrupV0l0nO6kmpaz75EUJVexy348bR452SvmH98vQ==}
@@ -2859,6 +2859,9 @@ packages:
   /@types/node@16.11.43:
     resolution: {integrity: sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==}
 
+  /@types/node@16.18.55:
+    resolution: {integrity: sha512-Y1zz/LIuJek01+hlPNzzXQhmq/Z2BCP96j18MSXC0S0jSu/IG4FFxmBs7W4/lI2vPJ7foVfEB0hUVtnOjnCiTg==}
+
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
@@ -2869,7 +2872,7 @@ packages:
   /@types/plist@3.0.2:
     resolution: {integrity: sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==}
     dependencies:
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       xmlbuilder: 15.1.1
     dev: false
 
@@ -6635,7 +6638,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -6764,7 +6767,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -6781,7 +6784,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -6800,7 +6803,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6823,7 +6826,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6844,7 +6847,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -6905,7 +6908,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
@@ -6961,7 +6964,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -7016,7 +7019,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       graceful-fs: 4.2.11
     dev: true
 
@@ -7024,7 +7027,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       graceful-fs: 4.2.11
 
   /jest-snapshot@27.5.1:
@@ -7061,7 +7064,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
@@ -7073,7 +7076,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -7096,7 +7099,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -7106,7 +7109,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -7115,7 +7118,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -9704,7 +9707,7 @@ packages:
       typescript: 5.1.6
     dev: true
 
-  /ts-node@10.9.1(@types/node@16.11.43)(typescript@4.2.4):
+  /ts-node@10.9.1(@types/node@16.18.55)(typescript@4.2.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -9723,7 +9726,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -9859,10 +9862,10 @@ packages:
     hasBin: true
     dependencies:
       '@types/json-schema': 7.0.12
-      '@types/node': 16.11.43
+      '@types/node': 16.18.55
       glob: 7.2.3
       json-stable-stringify: 1.0.2
-      ts-node: 10.9.1(@types/node@16.11.43)(typescript@4.2.4)
+      ts-node: 10.9.1(@types/node@16.18.55)(typescript@4.2.4)
       typescript: 4.2.4
       yargs: 17.7.2
     transitivePeerDependencies:

--- a/scripts/jsdoc/helpers.js
+++ b/scripts/jsdoc/helpers.js
@@ -315,7 +315,7 @@ function identifierToLink(id, root) {
       }
       if (id.endsWith(".RequestHeaders")) {
         // don't want complicate docs, if someone need - just see source code
-        return "[key: string]: string"
+        return "[key: string]: OutgoingHttpHeader | undefined"
       }
 
       console.warn(`Unresolved member (helpers.js) ${id}`)


### PR DESCRIPTION
due to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66783 we got a downstream type error on httpExecutor's RequestHeaders
fixed by using OutgoingHttpHeader from node
bumped repo's @types/node to verify fix