### PR TITLE
docs: add snap base core22 as an option

### DIFF
--- a/.changeset/bright-toys-camp.md
+++ b/.changeset/bright-toys-camp.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+minor addition to docs for snap. add snap recommended core22 option.

--- a/docs/configuration/snap.md
+++ b/docs/configuration/snap.md
@@ -3,7 +3,7 @@ The top-level [snap](configuration.md#Configuration-snap) key contains set of op
 <!-- do not edit. start of generated block -->
 <ul>
 <li>
-<p><code id="SnapOptions-base">base</code> String | “undefined” - A snap of type base to be used as the execution environment for this snap. Examples: <code>core</code>, <code>core18</code>, <code>core20</code>. Defaults to <code>core18</code></p>
+<p><code id="SnapOptions-base">base</code> String | “undefined” - A snap of type base to be used as the execution environment for this snap. Examples: <code>core</code>, <code>core18</code>, <code>core20</code>, <code>core22</code>. Defaults to <code>core18</code></p>
 </li>
 <li>
 <p><code id="SnapOptions-confinement">confinement</code> = <code>strict</code> “devmode” | “strict” | “classic” | “undefined” - The type of <a href="https://snapcraft.io/docs/reference/confinement">confinement</a> supported by the snap.</p>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5295,7 +5295,7 @@
           "type": "boolean"
         },
         "base": {
-          "description": "A snap of type base to be used as the execution environment for this snap. Examples: `core`, `core18`, `core20`. Defaults to `core18`",
+          "description": "A snap of type base to be used as the execution environment for this snap. Examples: `core`, `core18`, `core20`, `core22`. Defaults to `core18`",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -3,7 +3,7 @@ import { CommonLinuxOptions } from "./linuxOptions"
 
 export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
   /**
-   * A snap of type base to be used as the execution environment for this snap. Examples: `core`, `core18`, `core20`. Defaults to `core18`
+   * A snap of type base to be used as the execution environment for this snap. Examples: `core`, `core18`, `core20`, `core22`. Defaults to `core18`
    */
   readonly base?: string | null
 


### PR DESCRIPTION
https://snapcraft.io/docs/base-snaps#Choosing%20a%20base

> core22 is the currently recommended base for the majority of snaps. But much like choosing a distribution base for a project or server, the best base for an application is dependent on an application’s requirements and which plugins or extensions a base supports. If there are specific dependencies that cannot be easily met with core22 then core20 is a valid and supported alternative, as is the older core18.

