### PR TITLE
fix: request headers type error

### DIFF
--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -12,7 +12,7 @@ import { ProgressCallbackTransform, ProgressInfo } from "./ProgressCallbackTrans
 const debug = _debug("electron-builder")
 
 export interface RequestHeaders extends OutgoingHttpHeaders {
-  [key: string]: string
+  [key: string]: number | string | string[]
 }
 
 export interface DownloadOptions {


### PR DESCRIPTION
fixed tsc errors

```bash
$ tsc && electron-rebuild
node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"accept-charset"' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"accept-encoding"' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"accept-language"' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"content-length"' of type 'string | number' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"proxy-authenticate"' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"sec-websocket-extensions"' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"sec-websocket-protocol"' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"set-cookie"' of type 'string | string[]' is not assignable to string index type 'string'. 

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property '"www-authenticate"' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property 'accept' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property 'connection' of type 'string | string[]' is not assignable to string index type 'string'.   

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property 'cookie' of type 'string | string[]' is not assignable to string index type 'string'.       

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property 'dav' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property 'link' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property 'prgama' of type 'string | string[]' is not assignable to string index type 'string'.       

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~

node_modules/electron-updater/node_modules/builder-util-runtime/out/httpExecutor.d.ts:13:5 - error TS2411: Property 'via' of type 'string | string[]' is not assignable to string index type 'string'.

13     [key: string]: string;
       ~~~~~~~~~~~~~~~~~~~~~~


Found 16 errors.

error Command failed with exit code 2.
```