### PR TITLE
fix(deps): Update 7zip-bin to support Windows on ARM

### DIFF
--- a/.changeset/quick-comics-cross.md
+++ b/.changeset/quick-comics-cross.md
@@ -1,0 +1,8 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+"electron-builder-squirrel-windows": patch
+"electron-builder": patch
+---
+
+fix(deps): Update 7zip-bin to support Windows on ARM

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -46,7 +46,7 @@
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "dependencies": {
-    "7zip-bin": "~5.1.1",
+    "7zip-bin": "~5.2.0",
     "@develar/schema-utils": "~2.6.5",
     "@electron/notarize": "2.1.0",
     "@electron/osx-sign": "1.0.5",

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -1,7 +1,7 @@
 import { path7za } from "7zip-bin"
 import { Arch, executeAppBuilder, getArchSuffix, log, TmpDir, toLinuxArchString, use, serializeToYaml, asArray } from "builder-util"
 import { unlinkIfExists } from "builder-util/out/fs"
-import { outputFile, stat } from "fs-extra"
+import { chmod, outputFile, stat } from "fs-extra"
 import { mkdir, readFile } from "fs/promises"
 import * as path from "path"
 import { smarten } from "../appInfo"
@@ -234,6 +234,7 @@ export default class FpmTarget extends Target {
       return
     }
 
+    await chmod(path7za, 0o755)
     const env = {
       ...process.env,
       SZA_PATH: path7za,

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -1,7 +1,7 @@
 import { path7za } from "7zip-bin"
 import { debug7z, exec } from "builder-util"
 import { exists, unlinkIfExists } from "builder-util/out/fs"
-import { move } from "fs-extra"
+import { chmod, move } from "fs-extra"
 import * as path from "path"
 import { create, CreateOptions, FileOptions } from "tar"
 import { TmpDir } from "temp-file"
@@ -55,6 +55,7 @@ export async function tar(
     compression,
   })
   args.push(outFile, tarFile)
+  await chmod(path7za, 0o755)
   await exec(
     path7za,
     args,
@@ -180,6 +181,7 @@ export async function archive(format: string, outFile: string, dirToArchive: str
   }
 
   try {
+    await chmod(path7za, 0o755)
     await exec(
       path7za,
       args,

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -5,7 +5,7 @@ import { CURRENT_APP_INSTALLER_FILE_NAME, CURRENT_APP_PACKAGE_FILE_NAME, Package
 import { exists, statOrNull, walk } from "builder-util/out/fs"
 import _debug from "debug"
 import * as fs from "fs"
-import { readFile, stat, unlink } from "fs-extra"
+import { chmod, readFile, stat, unlink } from "fs-extra"
 import * as path from "path"
 import { getBinFromUrl } from "../../binDownload"
 import { Target } from "../../core"
@@ -42,7 +42,7 @@ export class NsisTarget extends Target {
 
   /** @private */
   readonly archs: Map<Arch, string> = new Map()
-  readonly isAsyncSupported = false;
+  readonly isAsyncSupported = false
 
   constructor(readonly packager: WinPackager, readonly outDir: string, targetName: string, protected readonly packageHelper: AppPackageHelper) {
     super(targetName)
@@ -250,7 +250,7 @@ export class NsisTarget extends Target {
           await packager.dispatchArtifactCreated(file, this, arch)
           packageFiles[Arch[arch]] = fileInfo
         }
-
+        await chmod(path7za, 0o755)
         const archiveInfo = (await exec(path7za, ["l", file])).trim()
         // after adding blockmap data will be "Warnings: 1" in the end of output
         const match = /(\d+)\s+\d+\s+\d+\s+files/.exec(archiveInfo)

--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "@types/debug": "^4.1.6",
-    "7zip-bin": "~5.1.1",
+    "7zip-bin": "~5.2.0",
     "app-builder-bin": "4.0.0",
     "bluebird-lst": "^1.0.9",
     "builder-util-runtime": "workspace:*",

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -7,6 +7,7 @@ import { spawn as _spawn } from "cross-spawn"
 import { createHash } from "crypto"
 import _debug from "debug"
 import { dump } from "js-yaml"
+import { chmod } from "fs-extra"
 import * as path from "path"
 import { debug, log } from "./log"
 import { install as installSourceMap } from "source-map-support"
@@ -349,13 +350,14 @@ export class InvalidConfigurationError extends Error {
   }
 }
 
-export function executeAppBuilder(
+export async function executeAppBuilder(
   args: Array<string>,
   childProcessConsumer?: (childProcess: ChildProcess) => void,
   extraOptions: SpawnOptions = {},
   maxRetries = 0
 ): Promise<string> {
   const command = appBuilderPath
+  await chmod(path7za, 0o755)
   const env: any = {
     ...process.env,
     SZA_PATH: path7za,

--- a/packages/electron-builder-squirrel-windows/package.json
+++ b/packages/electron-builder-squirrel-windows/package.json
@@ -25,7 +25,7 @@
     "@types/fs-extra": "9.0.13"
   },
   "optionalDependencies": {
-    "7zip-bin": "~5.1.1"
+    "7zip-bin": "~5.2.0"
   },
   "types": "./out/SquirrelWindowsTarget.d.ts"
 }

--- a/packages/electron-builder-squirrel-windows/src/squirrelPack.ts
+++ b/packages/electron-builder-squirrel-windows/src/squirrelPack.ts
@@ -4,7 +4,7 @@ import { copyFile, walk } from "builder-util/out/fs"
 import { compute7zCompressArgs } from "app-builder-lib/out/targets/archive"
 import { execWine, prepareWindowsExecutableArgs as prepareArgs } from "app-builder-lib/out/wine"
 import { WinPackager } from "app-builder-lib/out/winPackager"
-import { createWriteStream, stat, unlink, writeFile } from "fs-extra"
+import { chmod, createWriteStream, stat, unlink, writeFile } from "fs-extra"
 import * as path from "path"
 import * as archiver from "archiver"
 import * as fs from "fs/promises"
@@ -126,6 +126,7 @@ export class SquirrelBuilder {
 
   private async createEmbeddedArchiveFile(nupkgPath: string, dirToArchive: string) {
     const embeddedArchiveFile = await this.packager.getTempFile("setup.zip")
+    await chmod(path7za, 0o755)
     await exec(
       path7za,
       compute7zCompressArgs("zip", {
@@ -228,7 +229,8 @@ async function pack(options: SquirrelOptions, directory: string, updateFile: str
   await archivePromise
 }
 
-function execSw(options: SquirrelOptions, args: Array<string>) {
+async function execSw(options: SquirrelOptions, args: Array<string>) {
+  await chmod(path7za, 0o755)
   return exec(process.platform === "win32" ? path.join(options.vendorPath, "Update.com") : "mono", prepareArgs(args, path.join(options.vendorPath, "Update-Mono.exe")), {
     env: {
       ...process.env,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
   packages/app-builder-lib:
     dependencies:
       7zip-bin:
-        specifier: ~5.1.1
-        version: 5.1.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@develar/schema-utils':
         specifier: ~2.6.5
         version: 2.6.5
@@ -274,8 +274,8 @@ importers:
   packages/builder-util:
     dependencies:
       7zip-bin:
-        specifier: ~5.1.1
-        version: 5.1.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@types/debug':
         specifier: ^4.1.6
         version: 4.1.7
@@ -451,8 +451,8 @@ importers:
         version: 10.1.0
     optionalDependencies:
       7zip-bin:
-        specifier: ~5.1.1
-        version: 5.1.1
+        specifier: ~5.2.0
+        version: 5.2.0
     devDependencies:
       '@types/archiver':
         specifier: 5.3.1
@@ -559,8 +559,8 @@ importers:
   test:
     dependencies:
       7zip-bin:
-        specifier: ~5.1.1
-        version: 5.1.1
+        specifier: ~5.2.0
+        version: 5.2.0
       '@electron/osx-sign':
         specifier: ^1.0.4
         version: 1.0.5
@@ -655,8 +655,8 @@ importers:
 
 packages:
 
-  /7zip-bin@5.1.1:
-    resolution: {integrity: sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==}
+  /7zip-bin@5.2.0:
+    resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
     dev: false
 
   /@aashutoshrathi/word-wrap@1.2.6:

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "7zip-bin": "~5.1.1",
+    "7zip-bin": "~5.2.0",
     "@electron/osx-sign": "^1.0.4",
     "@jest/core": "^27.5.1",
     "app-builder-lib": "workspace:*",

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -10,7 +10,7 @@ import { computeArchToTargetNamesMap } from "app-builder-lib/out/targets/targetF
 import { getLinuxToolsPath } from "app-builder-lib/out/targets/tools"
 import { convertVersion } from "electron-builder-squirrel-windows/out/squirrelPack"
 import { PublishPolicy } from "electron-publish"
-import { emptyDir, writeJson } from "fs-extra"
+import { chmod, emptyDir, writeJson } from "fs-extra"
 import * as fs from "fs/promises"
 import { load } from "js-yaml"
 import * as path from "path"
@@ -438,6 +438,7 @@ export async function getTarExecutable() {
 }
 
 async function getContents(packageFile: string) {
+  await chmod(path7x, 0o755)
   const result = await execShell(`ar p '${packageFile}' data.tar.xz | ${await getTarExecutable()} -t -I'${path7x}'`, {
     maxBuffer: 10 * 1024 * 1024,
     env: {


### PR DESCRIPTION
Update `7zip-bin` to 5.2.0 which includes `win\arm64\7za.exe`.

Fixes error below when running `npx electron-builder --win` on Windows on ARM.

```
  ⨯ Exit code: ENOENT. spawn x\node_modules\app-builder-lib\node_modules\7zip-bin\win\arm64\7za.exe ENOENT  failedTask=build stackTrace=Error: Exit code: ENOENT.
```