### PR TITLE
fix: display product names with an & properly

### DIFF
--- a/packages/app-builder-lib/templates/nsis/common.nsh
+++ b/packages/app-builder-lib/templates/nsis/common.nsh
@@ -7,7 +7,11 @@ ShowInstDetails nevershow
   ShowUninstDetails nevershow
 !endif
 FileBufSize 64
-Name "${PRODUCT_NAME}"
+
+# Allows for a product name to display properly if it has an ampersand
+# Doesn't affect anything if there is no double ampersand
+!searchreplace DoubleAmpersand "${PRODUCT_NAME}" "&" "&&"
+Name "${PRODUCT_NAME}" "${DoubleAmpersand}"
 
 !define APP_EXECUTABLE_FILENAME "${PRODUCT_FILENAME}.exe"
 !define UNINSTALL_FILENAME "Uninstall ${PRODUCT_FILENAME}.exe"


### PR DESCRIPTION
If a productName value contains an ampersand (&), then the character does not display correctly within the NSIS Installer window. For example, if the product name is "Joe & Bloggs", in the installer window "Joe  Bloggs" is seen.

NSIS allows for this by allowing the Name attribute to have two values. One with the 'true' name, and one where the ampersand is doubled so that it displays correctly, e.g.

`Name "Joe & Bloggs" "Joe && Bloggs"`

The changes here use the macro !searchreplace to create a new variable with the doubled ampersand and then pass it into the Name attribute. If there is no duplication of the ampersand, the second argument is still passed in, but has no effect.

This would, of course, affect anybody who has already added a double ampersand to their productName to try to escape this.

For my project, I have used patch-package to apply this change for now.