### PR TITLE
fix: Don't notarize mas builds

### DIFF
--- a/.changeset/smooth-lies-thank.md
+++ b/.changeset/smooth-lies-thank.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: don't notarize mas builds

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -331,7 +331,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       await this.dispatchArtifactCreated(artifactPath, null, Arch.x64, this.computeSafeArtifactName(artifactName, "pkg", arch, true, this.platformSpecificBuildOptions.defaultArch))
     }
 
-    await this.notarizeIfProvided(appPath)
+    if (!isMas) await this.notarizeIfProvided(appPath)
     return true
   }
 

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -331,7 +331,9 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       await this.dispatchArtifactCreated(artifactPath, null, Arch.x64, this.computeSafeArtifactName(artifactName, "pkg", arch, true, this.platformSpecificBuildOptions.defaultArch))
     }
 
-    if (!isMas) await this.notarizeIfProvided(appPath)
+if (!isMas) { 
+   await this.notarizeIfProvided(appPath)
+}
     return true
   }
 


### PR DESCRIPTION
I just switched from `electron-builder-notarize` to the new built in `notarize` system. `electron-builder-notarize` will check and not notarize `mas` builds: https://github.com/karaggeorge/electron-builder-notarize/blob/efb683af5f4c5428ea6aa02df6a09a360563bfa0/index.js#L49 however https://github.com/electron/notarize does not seem to do that. This causes the notarization to fail because Mac App Store signed `mas` builds cannot be notarized:
```bash
Processing: /Users/runner/work/lossless-cut/lossless-cut/dist/mas-universal/LosslessCut.app
...
CloudKit query for LosslessCut.app (2/830f452ef727fad7dc1ae62586bf2442bff5fcb5) failed due to "Record not found".
Could not find base64 encoded ticket in response for 2/830f452ef727fad7dc1ae62586bf2442bff5fcb5
The staple and validate action failed! Error 65.
```
see build https://github.com/mifi/lossless-cut/actions/runs/6572171949/job/17852779360

however after this fix it works:
- https://github.com/mifi/lossless-cut/blob/master/.yarn/patches/app-builder-lib-npm-24.8.0-51e1f5cd3f.patch
- https://github.com/mifi/lossless-cut/actions/runs/6584989580/job/17890562604
