### PR TITLE
Added deb and rpm to the auto-updatable targets list

### DIFF
--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -6,7 +6,7 @@ See [publish configuration](configuration/publish.md) for information on how to 
 ## Auto-updatable Targets
 
 * macOS: DMG.
-* Linux: AppImage.
+* Linux: AppImage, DEB and RPM.
 * Windows: NSIS.
 
 All these targets are default, custom configuration is not required. (Though it is possible to [pass in additional configuration, e.g. request headers](#custom-options-instantiating-updater-directly).)


### PR DESCRIPTION
This PR has been made to add "deb" and "rpm" targets to the list of auto-updatable targets, as deb and rpm auto-updaters seem to have been implemented in `electron-updater` since v24.0.0, which released in March.