### PR TITLE
fix: flatpak build failing due to too large icons

### DIFF
--- a/.changeset/nervous-cheetahs-move.md
+++ b/.changeset/nervous-cheetahs-move.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: flatpak build fails due to too large icons

--- a/packages/app-builder-lib/src/targets/FlatpakTarget.ts
+++ b/packages/app-builder-lib/src/targets/FlatpakTarget.ts
@@ -82,6 +82,10 @@ export default class FlatpakTarget extends Target {
   private async copyIcons(stageDir: StageDir) {
     const icons = await this.helper.icons
     const copyIcons = icons.map(async icon => {
+      if (icon.size > 512) {
+        // Flatpak does not allow icons larger than 512 pixels
+        return Promise.resolve();
+      }
       const extWithDot = path.extname(icon.file)
       const sizeName = extWithDot === ".svg" ? "scalable" : `${icon.size}x${icon.size}`
       const iconDst = stageDir.getTempFile(path.join("share", "icons", "hicolor", sizeName, "apps", `${this.appId}${extWithDot}`))


### PR DESCRIPTION
Fixes #7854

> When building for Flatpak, electron-builder (or rather app-builder-bin) creates a set of icons from the Mac icns file which includes a 1024x1024 sized icon. According to the [Flatpak spec](https://docs.flatpak.org/fr/latest/conventions.html#application-icons) however, icons must not be larger than 512px. This is the reason why the Flatpak build fails e.g. with the following error:

