### PR TITLE
fix(mac): pass in correct notarize options

### DIFF
--- a/.changeset/popular-countries-type.md
+++ b/.changeset/popular-countries-type.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): pass in correct notarize options

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -332,7 +332,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     }
 
     if (!isMas) {
-      await this.notarizeIfProvided(appPath)
+      await this.notarizeIfProvided(appPath, options)
     }
     return true
   }
@@ -481,10 +481,10 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     return true
   }
 
-  private async notarizeIfProvided(appPath: string) {
-    const notarizeOptions = this.platformSpecificBuildOptions.notarize
-    if (notarizeOptions === false) {
-      log.info({ reason: "`notarizeOptions` is explicitly set to false" }, "skipped macOS notarization")
+  private async notarizeIfProvided(appPath: string, buildOptions: MacConfiguration) {
+    const notarizeOptions = buildOptions.notarize
+    if (!notarizeOptions) {
+      log.info({ reason: "`notarize` options were not provided" }, "skipped macOS notarization")
       return
     }
     const appleId = process.env.APPLE_ID

--- a/packages/app-builder-lib/src/targets/FlatpakTarget.ts
+++ b/packages/app-builder-lib/src/targets/FlatpakTarget.ts
@@ -84,7 +84,7 @@ export default class FlatpakTarget extends Target {
     const copyIcons = icons.map(async icon => {
       if (icon.size > 512) {
         // Flatpak does not allow icons larger than 512 pixels
-        return Promise.resolve();
+        return Promise.resolve()
       }
       const extWithDot = path.extname(icon.file)
       const sizeName = extWithDot === ".svg" ? "scalable" : `${icon.size}x${icon.size}`


### PR DESCRIPTION
Pass buildOptions down to notarization to explicitly pull build options for `mas`. Don't run notarize if options are not provided
Fix: #7873