### PR TITLE
fix(mac): notary with pure api key auth

### DIFF
--- a/.changeset/metal-adults-impress.md
+++ b/.changeset/metal-adults-impress.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix notary with pure api key auth

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -562,6 +562,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     }
     if (notaryToolLogin) {
       return {
+        tool: 'notarytool',
         appPath,
         ...notaryToolLogin,
       }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -560,6 +560,12 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         ascProvider: ascProvider || undefined,
       }
     }
+    if (notaryToolLogin) {
+      return {
+        appPath,
+        ...notaryToolLogin,
+      }
+    }
     return undefined
   }
 }


### PR DESCRIPTION
#7861 added ways of api key auth. However, if we'd like to use api key, `teamId` must not be provided.

https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/src/macPackager.ts#L550C9-L550C15

The validation logic can be found at: https://github.com/electron/notarize/blob/main/src/validate-args.ts#L92-L98