### PR TITLE
fix(mac): normalize filename to NFD form

### DIFF
--- a/.changeset/thick-flowers-bathe.md
+++ b/.changeset/thick-flowers-bathe.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix codesign and DMG layout when productName or executableName contains Unicode

--- a/packages/app-builder-lib/src/appInfo.ts
+++ b/packages/app-builder-lib/src/appInfo.ts
@@ -32,7 +32,12 @@ export class AppInfo {
   readonly sanitizedProductName: string
   readonly productFilename: string
 
-  constructor(private readonly info: Packager, buildVersion: string | null | undefined, private readonly platformSpecificOptions: PlatformSpecificBuildOptions | null = null) {
+  constructor(
+    private readonly info: Packager,
+    buildVersion: string | null | undefined,
+    private readonly platformSpecificOptions: PlatformSpecificBuildOptions | null = null,
+    normalizeNfd = false
+  ) {
     this.version = info.metadata.version!
 
     if (buildVersion == null) {
@@ -63,10 +68,10 @@ export class AppInfo {
     }
 
     this.productName = info.config.productName || info.metadata.productName || info.metadata.name!
-    this.sanitizedProductName = sanitizeFileName(this.productName)
+    this.sanitizedProductName = sanitizeFileName(this.productName, normalizeNfd)
 
     const executableName = platformSpecificOptions?.executableName ?? info.config.executableName
-    this.productFilename = executableName != null ? sanitizeFileName(executableName) : this.sanitizedProductName
+    this.productFilename = executableName != null ? sanitizeFileName(executableName, normalizeNfd) : this.sanitizedProductName
   }
 
   get channel(): string | null {

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -58,7 +58,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected prepareAppInfo(appInfo: AppInfo): AppInfo {
-    return new AppInfo(this.info, this.platformSpecificBuildOptions.bundleVersion, this.platformSpecificBuildOptions)
+    // codesign requires the filename to be normalized to the NFD form
+    return new AppInfo(this.info, this.platformSpecificBuildOptions.bundleVersion, this.platformSpecificBuildOptions, true)
   }
 
   async getIconPath(): Promise<string | null> {

--- a/packages/app-builder-lib/src/util/filename.ts
+++ b/packages/app-builder-lib/src/util/filename.ts
@@ -2,8 +2,9 @@
 import * as _sanitizeFileName from "sanitize-filename"
 import * as path from "path"
 
-export function sanitizeFileName(s: string): string {
-  return _sanitizeFileName(s)
+export function sanitizeFileName(s: string, normalizeNfd = false): string {
+  const sanitized = _sanitizeFileName(s)
+  return normalizeNfd ? sanitized.normalize("NFD") : sanitized
 }
 
 // Get the filetype from a filename. Returns a string of one or more file extensions,


### PR DESCRIPTION
Fixes issues when `productName` and `executableName` contain characters that have different NFC and NFD form, e.g., diacritics and Hangul (Korean). These seem to be internally normalized to the NFD form at some point, failing string comparison and other operations. Specifically,
- fixes codesign failing with `code object is not signed at all In subcomponent:`,
  - fixes #6912
  - https://github.com/electron-userland/electron-builder/issues/3169#issuecomment-800113654
  - #5977
  - https://github.com/electron/osx-sign/issues/155
- fixes DMG layout,
  - #1234
  - #1369
  - #6282
- and possibly related:
  - #2125
  - #4697