### PR TITLE
revert: fix(mac): should normalize unicode strings from file system before used in string compare

### DIFF
--- a/.changeset/nine-rings-bow.md
+++ b/.changeset/nine-rings-bow.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix dmg build when productName or executableName contains Unicode

--- a/packages/dmg-builder/vendor/mac_alias/alias.py
+++ b/packages/dmg-builder/vendor/mac_alias/alias.py
@@ -10,7 +10,6 @@ import os
 import os.path
 import stat
 import sys
-from unicodedata import normalize
 
 if sys.platform == 'darwin':
     from . import osx
@@ -389,10 +388,6 @@ class Alias (object):
         # Find the filesystem
         st = osx.statfs(path)
         vol_path = st.f_mntonname
-
-        # File and folder names in HFS+ are normalized to a form similar to NFD.
-        # Must be normalized (NFD->NFC) before use to avoid unicode string comparison issues.
-        vol_path = normalize("NFC", vol_path.decode('utf-8')).encode('utf-8')
 
         # Grab its attributes
         attrs = [osx.ATTR_CMN_CRTIME,


### PR DESCRIPTION
This reverts commit 37a17f222b4802282c0638c163f76df35983c8d3 (#4841).

Since names are normalized to NFD as of #7901, normalizing them back to NFC leads to a similar error:
```
File "node_modules/dmg-builder/vendor/dmgbuild/core.py", line 290, in <module>
    build_dmg()
  File "node_modules/dmg-builder/vendor/dmgbuild/core.py", line 261, in build_dmg
    icvp['backgroundImageAlias'] = biplist.Data(alias.to_bytes())
                                                ^^^^^^^^^^^^^^^^
  File "node_modules/dmg-builder/vendor/mac_alias/alias.py", line 649, in to_bytes
    self._to_fd(b)
  File "node_modules/dmg-builder/vendor/mac_alias/alias.py", line 535, in _to_fd
    cnid_path = struct.pack('>%uI' % len(self.target.cnid_path),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: 'I' format requires 0 <= number <= 4294967295
```

The error ony occurs in:
- `Darwin Mac-1701234016364.local 21.6.0 Darwin Kernel Version 21.6.0: Wed Oct  4 23:55:28 PDT 2023; root:xnu-8020.240.18.704.15~1/RELEASE_X86_64 x86_64` (GitHub Actions `macos-latest`, https://github.com/jebibot/electron-test/actions/runs/7028916259/job/19125658541)
- `Darwin Mac-1701233428287.local 22.6.0 Darwin Kernel Version 22.6.0: Fri Sep 15 13:39:52 PDT 2023; root:xnu-8796.141.3.700.8~1/RELEASE_X86_64 x86_64` (GitHub Actions `macos-13`, https://github.com/jebibot/electron-test/actions/runs/7028916259/job/19125658708)

but not in:
- `Darwin MacBookPro.local 23.1.0 Darwin Kernel Version 23.1.0: Mon Oct  9 21:27:24 PDT 2023; root:xnu-10002.41.9~6/RELEASE_ARM64_T6000 arm64`

It seems like a macOS < 14 issue or an x64 vs. arm64 issue so I couldn't catch it earlier. Sorry, I should've tested more.

This fix was also mentioned in #5977:

> If I try the same exact string in NFD notation, the codesign works but later the dmg build process breaks. I am able to fix this by applying a `patch-package` modification basically reverting https://github.com/electron-userland/electron-builder/pull/4841.

Tested on: https://github.com/jebibot/electron-test/actions/runs/7028981048.