### PR TITLE
fix: pass publish options to snap publisher

### DIFF
--- a/.changeset/swift-dingos-live.md
+++ b/.changeset/swift-dingos-live.md
@@ -1,0 +1,12 @@
+---
+"app-builder-lib": patch
+"dmg-builder": patch
+"electron-builder": patch
+"electron-builder-squirrel-windows": patch
+"electron-forge-maker-appimage": patch
+"electron-forge-maker-nsis": patch
+"electron-forge-maker-nsis-web": patch
+"electron-forge-maker-snap": patch
+---
+
+fix: pass publish options to snap publisher

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -1,15 +1,16 @@
 import { Arch, deepAssign, executeAppBuilder, InvalidConfigurationError, log, replaceDefault as _replaceDefault, serializeToYaml, toLinuxArchString } from "builder-util"
-import { asArray } from "builder-util-runtime"
+import { SnapStoreOptions, asArray } from "builder-util-runtime"
 import { outputFile, readFile } from "fs-extra"
 import { load } from "js-yaml"
 import * as path from "path"
 import * as semver from "semver"
-import { Target } from "../core"
+import { Publish, Target } from "../core"
 import { LinuxPackager } from "../linuxPackager"
 import { PlugDescriptor, SnapOptions } from "../options/SnapOptions"
 import { getTemplatePath } from "../util/pathManager"
 import { LinuxTargetHelper } from "./LinuxTargetHelper"
 import { createStageDirPath } from "./targetUtil"
+import { Configuration } from "../configuration"
 
 const defaultPlugs = ["desktop", "desktop-legacy", "home", "x11", "wayland", "unity7", "browser-support", "network", "gsettings", "audio-playback", "pulseaudio", "opengl"]
 
@@ -245,7 +246,7 @@ export default class SnapTarget extends Target {
 
     await executeAppBuilder(args)
 
-    const publishConfig = findSnapPublishConfig(this.packager.config);
+    const publishConfig = findSnapPublishConfig(this.packager.config)
 
     await packager.info.callArtifactBuildCompleted({
       file: artifactPath,
@@ -262,49 +263,53 @@ export default class SnapTarget extends Target {
   }
 }
 
-function findSnapPublishConfig(config: Configuration): SnapStoreOptions | null {
-  if (!config)
-      return null;
+function findSnapPublishConfig(config?: Configuration): SnapStoreOptions | null {
+  if (!config) {
+    return null
+  }
 
   if (config.linux?.publish) {
-      const configCandidate = findSnapPublishConfigInPublishNode(config.linux.publish);
+    const configCandidate = findSnapPublishConfigInPublishNode(config.linux.publish)
 
-      if (configCandidate)
-          return configCandidate;
+    if (configCandidate) {
+      return configCandidate
+    }
   }
 
-  if (config.publish){
-      const configCandidate = findSnapPublishConfigInPublishNode(config.publish);
+  if (config.publish) {
+    const configCandidate = findSnapPublishConfigInPublishNode(config.publish)
 
-      if (configCandidate)
-          return configCandidate;
+    if (configCandidate) {
+      return configCandidate
+    }
   }
 
-  return null;
+  return null
 }
 
 function findSnapPublishConfigInPublishNode(configPublishNode: Publish): SnapStoreOptions | null {
-  if (!configPublishNode)
-      return null;
-
-  if (Array.isArray(configPublishNode)) {
-      for (const configObj of configPublishNode) {
-          if (isSnapStoreOptions(configObj))
-              return configObj;
-      }
+  if (!configPublishNode) {
+    return null
   }
 
-  if (typeof configPublishNode === `object` && isSnapStoreOptions(configPublishNode))
-      return configPublishNode;
+  if (Array.isArray(configPublishNode)) {
+    for (const configObj of configPublishNode) {
+      if (isSnapStoreOptions(configObj)) {
+        return configObj
+      }
+    }
+  }
 
-  return null;
+  if (typeof configPublishNode === `object` && isSnapStoreOptions(configPublishNode)) {
+    return configPublishNode
+  }
+
+  return null
 }
 
 function isSnapStoreOptions(configPublishNode: Publish): configPublishNode is SnapStoreOptions {
-  const snapStoreOptionsCandidate = configPublishNode as SnapStoreOptions;
-
-  return snapStoreOptionsCandidate.provider !== undefined 
-    && snapStoreOptionsCandidate.provider === `snapStore`;
+  const snapStoreOptionsCandidate = configPublishNode as SnapStoreOptions
+  return snapStoreOptionsCandidate?.provider === `snapStore`
 }
 
 function archNameToTriplet(arch: Arch): string {


### PR DESCRIPTION
This fixes #7907 "The channels option from SnapStoreOptions is not applied when publishing using Snapcraft"