### PR TITLE
fix(win): use `resultOutputPath` to sign custom location for windows

### DIFF
--- a/.changeset/forty-teachers-run.md
+++ b/.changeset/forty-teachers-run.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: pull `resultOutputPath` from `CustomWindowsSignTaskConfiguration` (fixes: #7910)

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -56,18 +56,14 @@ export async function sign(options: WindowsSignOptions, packager: WinPackager): 
   let isNest = false
   for (const hash of hashes) {
     const taskConfiguration: WindowsSignTaskConfiguration = { ...options, hash, isNest }
-    await Promise.resolve(
-      executor(
-        {
-          ...taskConfiguration,
-          computeSignToolArgs: isWin => computeSignToolArgs(taskConfiguration, isWin),
-        },
-        packager
-      )
-    )
+    const config: CustomWindowsSignTaskConfiguration = {
+      ...taskConfiguration,
+      computeSignToolArgs: isWin => computeSignToolArgs(taskConfiguration, isWin),
+    }
+    await Promise.resolve(executor(config, packager))
     isNest = true
-    if (taskConfiguration.resultOutputPath != null) {
-      await rename(taskConfiguration.resultOutputPath, options.path)
+    if (config.resultOutputPath != null) {
+      await rename(config.resultOutputPath, options.path)
     }
   }
 


### PR DESCRIPTION
fix: pull `resultOutputPath` from `CustomWindowsSignTaskConfiguration` (fixes: #7910)