### PR TITLE
fix(mac): use zip if name contains NFD characters

### DIFF
--- a/.changeset/neat-waves-fly.md
+++ b/.changeset/neat-waves-fly.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix macOS app signature when the name contains NFD-normalized characters

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -1,5 +1,5 @@
 import { path7za } from "7zip-bin"
-import { debug7z, exec } from "builder-util"
+import { debug7z, exec, log } from "builder-util"
 import { exists, unlinkIfExists } from "builder-util/out/fs"
 import { chmod, move } from "fs-extra"
 import * as path from "path"
@@ -166,24 +166,66 @@ export function compute7zCompressArgs(format: string, options: ArchiveOptions = 
   return args
 }
 
+export function computeZipCompressArgs(options: ArchiveOptions = {}) {
+  let storeOnly = options.compression === "store"
+  // do not deref symlinks
+  const args = ["-q", "-r", "-y"]
+  if (debug7z.enabled) {
+    args.push("-v")
+  }
+
+  if (process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL != null) {
+    storeOnly = false
+    args.push(`-${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL}`)
+  } else if (!storeOnly) {
+    // https://github.com/electron-userland/electron-builder/pull/3032
+    args.push("-" + (options.compression === "maximum" ? "9" : "7"))
+  }
+
+  if (options.dictSize != null) {
+    log.warn({ distSize: options.dictSize }, `ignoring unsupported option`)
+  }
+
+  // do not save extra file attributes (Extended Attributes on OS/2, uid/gid and file times on Unix)
+  if (!options.isRegularFile) {
+    args.push("-X")
+  }
+
+  if (options.method != null) {
+    if (options.method !== "DEFAULT") {
+      log.warn({ method: options.method }, `ignoring unsupported option`)
+    }
+  } else {
+    args.push("-Z", storeOnly ? "store" : "deflate")
+  }
+  return args
+}
+
 // 7z is very fast, so, use ultra compression
 /** @internal */
 export async function archive(format: string, outFile: string, dirToArchive: string, options: ArchiveOptions = {}): Promise<string> {
-  const args = compute7zCompressArgs(format, options)
-  // remove file before - 7z doesn't overwrite file, but update
+  let use7z = true
+  if (process.platform === "darwin" && format === "zip" && dirToArchive.normalize("NFC") !== dirToArchive) {
+    log.warn({ reason: "7z doesn't support NFD-normalized filenames" }, `using zip`)
+    use7z = false
+  }
+  const args = use7z ? compute7zCompressArgs(format, options) : computeZipCompressArgs(options)
+  // remove file before - 7z and zip doesn't overwrite file, but update
   await unlinkIfExists(outFile)
 
   args.push(outFile, options.withoutDir ? "." : path.basename(dirToArchive))
   if (options.excluded != null) {
     for (const mask of options.excluded) {
-      args.push(`-xr!${mask}`)
+      args.push(use7z ? `-xr!${mask}` : `-x${mask}`)
     }
   }
 
   try {
-    await chmod(path7za, 0o755)
+    if (use7z) {
+      await chmod(path7za, 0o755)
+    }
     await exec(
-      path7za,
+      use7z ? path7za : "zip",
       args,
       {
         cwd: options.withoutDir ? dirToArchive : path.dirname(dirToArchive),


### PR DESCRIPTION
7z normalizes filenames to the NFC form, so the signature verification fails if filenames contain characters that have different NFC and NFD form, e.g., diacritics and Hangul, and the unarchiver does not normalize them back to the NFD form. The Finder's `Archive Utility` does this, but `ditto` and  `unzip` don't, failing the auto update:
```
Tést 테스트.app: a sealed resource is missing or invalid
file added: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper (Renderer).app
file added: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper.app
file added: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper (GPU).app
file added: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper (Plugin).app
file missing: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper.app
file missing: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper (Plugin).app
file missing: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper (GPU).app
file missing: /Users/y/Downloads/Tést 테스트.app/Contents/Frameworks/Tést 테스트 Helper (Renderer).app
```

Test repo: https://github.com/jebibot/electron-test-2