### PR TITLE
fix: Allow `test.js` in compiled asar

### DIFF
--- a/.changeset/cold-carpets-move.md
+++ b/.changeset/cold-carpets-move.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Allowing `test.js` in compiled asar to allow testing mechanisms like Playwright

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -13,7 +13,6 @@ const excludedFiles = new Set(
   )
 )
 const topLevelExcludedFiles = new Set([
-  "test.js",
   "karma.conf.js",
   ".coveralls.yml",
   "README.md",

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -485,6 +485,9 @@ Object {
             "package.json": Object {
               "size": "<size>",
             },
+            "test.js": Object {
+              "size": "<size>",
+            },
           },
         },
         "fs-constants": Object {


### PR DESCRIPTION
Allowing `test.js` in compiled asar to allow testing mechanisms like Playwright

Fixes #7795