### PR TITLE
chore: add debug data for `hdiutil detach` when it initially fails

### DIFF
--- a/.changeset/long-suits-act.md
+++ b/.changeset/long-suits-act.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+adding `-debug` to `hdiutil detach` for when it fails and attempts a force detach

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -37,7 +37,7 @@ export async function detach(name: string) {
   try {
     await exec("hdiutil", ["detach", "-quiet", name])
   } catch (e: any) {
-    await retry(() => exec("hdiutil", ["detach", "-force", name]), 5, 1000, 500)
+    await retry(() => exec("hdiutil", ["detach", "-force", "-debug", name]), 5, 1000, 500)
   }
 }
 


### PR DESCRIPTION
adding `-debug` to `hdiutil detach` for when it fails and attempts a force detach, such as for errors like "Resource is busy"