### PR TITLE
fix: notarization with an apple API key

### DIFF
--- a/.changeset/shaggy-plums-live.md
+++ b/.changeset/shaggy-plums-live.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: notarization with an apple API key

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -544,7 +544,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       return proj
     }
     const { teamId } = options as NotarizeNotaryOptions
-    if (teamId && (legacyLogin || notaryToolLogin)) {
+    if ((teamId || options === true) && (legacyLogin || notaryToolLogin)) {
       const proj: NotaryToolStartOptions = {
         appPath,
         ...(legacyLogin ?? notaryToolLogin!),


### PR DESCRIPTION
Notarization wasn't actually running when the API key is set and notarize was set to true. The notarize tool library throws when a API key is provided and teamId is set, so you have to set notarize to true, but when you do currently, the step never runs.