### PR TITLE
fix: product file name is too long causing the find process exe failed

### DIFF
--- a/.changeset/happy-otters-heal.md
+++ b/.changeset/happy-otters-heal.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(win): product file name is too long causes the find process exe to fail

--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -42,7 +42,7 @@
     ${nsProcess::FindProcess} "${_FILE}" ${_ERR}
   !else
     # find process owned by current user
-    nsExec::Exec `cmd /c tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq ${_FILE}" | %SYSTEMROOT%\System32\find.exe "${_FILE}"`
+    nsExec::Exec `cmd /c tasklist /FI "USERNAME eq %USERNAME%" /FI "IMAGENAME eq ${_FILE}" /FO csv | %SYSTEMROOT%\System32\find.exe "${_FILE}"`
     Pop ${_ERR}
   !endif
 !macroend


### PR DESCRIPTION
On Windows 11, when the length of APP_EXECUTABLE_FILENAME exceeds 25 characters, the image name found through the tasklist command will be omitted, causing subsequent finde.exe to fail to find the specified process.