### PR TITLE
feat(archive): skip archive when up to date

### DIFF
--- a/.changeset/forty-hats-press.md
+++ b/.changeset/forty-hats-press.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+feat(archive): skip archive when destination file is already up to date

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -203,8 +203,8 @@ export function computeZipCompressArgs(options: ArchiveOptions = {}) {
 // 7z is very fast, so, use ultra compression
 /** @internal */
 export async function archive(format: string, outFile: string, dirToArchive: string, options: ArchiveOptions = {}): Promise<string> {
-  let outFileStat = await statOrNull(outFile)
-  let dirStat = await statOrNull(dirToArchive)
+  const outFileStat = await statOrNull(outFile)
+  const dirStat = await statOrNull(dirToArchive)
   if (outFileStat && dirStat && outFileStat.mtime > dirStat.mtime) {
     log.info({ reason: "Archive file is up to date", outFile }, `skipped archiving`)
     return outFile


### PR DESCRIPTION
I discovered that when I use the `--dir` option and `--prepackaged -c` to build different installers with various NSIS configurations, electron-builder repeatedly compresses the unpacked directory with 7zip. This process is time-consuming - in my case, it takes about 5 minutes to build one installer. To improve this, I implemented a modification time (mtime) check before the compression step, which is a common practice in build systems like GNU make. This change reduces the build time to 15 seconds per installer, making this use case more practical. It should not break the API.