### PR TITLE
fix(linux): Use ~ as pre-release separator for deb targets

### DIFF
--- a/.changeset/stupid-bears-hammer.md
+++ b/.changeset/stupid-bears-hammer.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Use ~ as pre-release separator for deb targets

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -85,6 +85,8 @@ export class LinuxTargetHelper {
         return version.replace(/-/g, "_")
       case "rpm":
         return version.replace(/-/g, "~")
+      case "deb":
+        return version.replace(/-/g, "~")
       default:
         return version
     }

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -84,7 +84,6 @@ export class LinuxTargetHelper {
       case "pacman":
         return version.replace(/-/g, "_")
       case "rpm":
-        return version.replace(/-/g, "~")
       case "deb":
         return version.replace(/-/g, "~")
       default:


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/7977

This PR translates the `-` pre-release separator (as mandated by the [semver 2.0.0 spec](https://semver.org/), which is the format [accepted by `package.json`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#version)) to a `~`, to match Debian's expectations on package versioning.

See the below examples:
```
### According to semver 2.0, '1.0.0' should be considered greater than '1.0.0-rc1'. But for Debian it's not.
### This means that Debian will consider final releases a "downgrade" compared to the RCs, so it will always prefer installing the RC if both are available
$ dpkg --compare-versions 1.0.0 gt 1.0.0-rc1; echo $?
1
### On the other hand, using '~' instead of '-' yelds the correct ordering
$ dpkg --compare-versions 1.0.0 gt 1.0.0~rc1; echo $?
0
```

The reason why using `~` fixes this is because [Debian orders the `~` "lower" than the end-of-string character](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version), and afaiu the reason such a special character was needed is exactly for use cases such as pre-releases.

This also matches the [fedora recommendations regarding packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_handling_non_sorting_versions_with_tilde_dot_and_caret) (which was first linked in [this analysis](https://github.com/electron-userland/electron-builder/pull/7630#issuecomment-1606199537), but this specific ordering issue was not caught due to the lack of explicit recommendations by Debian).
