### PR TITLE
fix: Use full path to macOS signing utilities

### DIFF
--- a/.changeset/thirty-bobcats-beg.md
+++ b/.changeset/thirty-bobcats-beg.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Use full path to macOS signing utilities


### PR DESCRIPTION
Rather than using something arbitrary, found on `PATH`, this makes sure we run Apple's signing utilities

Fixes #7997.