### PR TITLE
feat(mac): Support for a custom 'sign' function in mac config

### DIFF
--- a/.changeset/fresh-poems-greet.md
+++ b/.changeset/fresh-poems-greet.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": minor
+"electron-builder": minor
+---
+
+mac: Support for a custom 'sign' action

--- a/docs/configuration/mac.md
+++ b/docs/configuration/mac.md
@@ -92,6 +92,9 @@ The top-level [mac](configuration.md#Configuration-mac) key contains set of opti
 <p><code id="MacConfiguration-signIgnore">signIgnore</code> Array&lt;String&gt; | String | “undefined” - Regex or an array of regex’s that signal skipping signing a file.</p>
 </li>
 <li>
+<p><code id="MacConfiguration-sign">sign</code> module:app-builder-lib/out/macPackager.__type | String | “undefined” - The custom function (or path to file or module id) to sign an app bundle.</p>
+</li>
+<li>
 <p><code id="MacConfiguration-timestamp">timestamp</code> String | “undefined” - Specify the URL of the timestamp authority server</p>
 </li>
 <li>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2787,6 +2787,20 @@
             "string"
           ]
         },
+        "sign": {
+          "anyOf": [
+            {
+              "typeof": "function"
+            },
+            {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ],
+          "description": "The custom function (or path to file or module id) to sign an app bundle."
+        },
         "signIgnore": {
           "anyOf": [
             {
@@ -3419,6 +3433,20 @@
             "null",
             "string"
           ]
+        },
+        "sign": {
+          "anyOf": [
+            {
+              "typeof": "function"
+            },
+            {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ],
+          "description": "The custom function (or path to file or module id) to sign an app bundle."
         },
         "signIgnore": {
           "anyOf": [

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -39,6 +39,7 @@ export { SnapOptions, PlugDescriptor, SlotDescriptor } from "./options/SnapOptio
 export { Metadata, AuthorMetadata, RepositoryInfo } from "./options/metadata"
 export { AppInfo } from "./appInfo"
 export { SquirrelWindowsOptions } from "./options/SquirrelWindowsOptions"
+export { CustomMacSign, CustomMacSignOptions } from "./macPackager"
 export {
   WindowsSignOptions,
   CustomWindowsSignTaskConfiguration,

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -234,8 +234,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
         }
       }
 
-      const customSign = await resolveFunction(this.appInfo.type, options.sign, "sign")
-      if (!customSign && identity == null) {
+      if (!options.sign && identity == null) {
         await reportError(isMas, certificateTypes, qualifier, keychainFile, this.forceCodeSigning)
         return false
       }

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -396,10 +396,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
   }
 
   //noinspection JSMethodCanBeStatic
-  protected async doSign(opts: SignOptions, masOptions: MasConfiguration | null): Promise<any> {
-    const options = masOptions == null ? this.platformSpecificBuildOptions : masOptions
-
-    const customSign = await resolveFunction(this.appInfo.type, options.sign, "sign")
+  protected async doSign(opts: SignOptions, customSignOptions: MasConfiguration): Promise<any> {
+    const customSign = await resolveFunction(this.appInfo.type, customSignOptions.sign, "sign")
     if (customSign) {
       return customSign(opts, this)
     }

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -1,4 +1,5 @@
 import { PlatformSpecificBuildOptions, TargetConfiguration, TargetSpecificOptions } from "../index"
+import { CustomMacSign } from "../macPackager"
 
 export type MacOsTargetName = "default" | "dmg" | "mas" | "mas-dev" | "pkg" | "7z" | "zip" | "tar.xz" | "tar.lz" | "tar.gz" | "tar.bz2" | "dir"
 
@@ -174,6 +175,11 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    * Regex or an array of regex's that signal skipping signing a file.
    */
   readonly signIgnore?: Array<string> | string | null
+
+  /**
+   * The custom function (or path to file or module id) to sign an app bundle.
+   */
+  readonly sign?: CustomMacSign | string | null
 
   /**
    * Specify the URL of the timestamp authority server


### PR DESCRIPTION
Signal Desktop has a patch to enable this for its builds, but others may want this kind of extensibility in the future, and it matches the Windows config!

Please let me know if I've missed anything!