### PR TITLE
feat: added `includeExtensions` option

### DIFF
--- a/.changeset/shy-brooms-run.md
+++ b/.changeset/shy-brooms-run.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: added includeExtensions option

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -179,6 +179,9 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 <p><code id="Configuration-includePdb">includePdb</code> = <code>false</code> Boolean - Whether to include PDB files.</p>
 </li>
 <li>
+<p><code id="Configuration-includeExtensions">includeExtensions</code> = Array&lt;String&gt; | String | “undefined” - Whether to include files with given extensions.</p>
+</li>
+<li>
 <p><code id="Configuration-removePackageScripts">removePackageScripts</code> = <code>true</code> Boolean - Whether to remove <code>scripts</code> field from <code>package.json</code> files.</p>
 </li>
 <li>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -7367,6 +7367,23 @@
         "string"
       ]
     },
+    "includeExtensions": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      ],
+      "description": "Whether to include files with given extensions."
+    },
     "includePdb": {
       "default": false,
       "description": "Whether to include PDB files.",

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -262,6 +262,11 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   readonly includePdb?: boolean
 
   /**
+   * Whether to include files with given extensions.
+   */
+  readonly includeExtensions?: Array<string> | string | null
+
+  /**
    * Whether to remove `scripts` field from `package.json` files.
    *
    * @default true

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -182,7 +182,16 @@ export function getMainFileMatchers(
   }
   patterns.splice(insertIndex, 0, ...customFirstPatterns)
 
-  patterns.push(`!**/*.{${excludedExts}${packager.config.includePdb === true ? "" : ",pdb"}}`)
+  let excludedExtsFinal = `${excludedExts}${packager.config.includePdb === true ? "" : ",pdb"}`
+
+  if (packager.config.includeExtensions) {
+    excludedExtsFinal = excludedExtsFinal
+      .split(',')
+      .filter( ext => !packager.config.includeExtensions?.includes(ext))
+      .join(',')
+  }
+
+  patterns.push(`!**/*.{${excludedExtsFinal}}`)
   patterns.push("!**/._*")
   patterns.push("!**/electron-builder.{yaml,yml,json,json5,toml,ts}")
   patterns.push(`!**/{${excludedNames}}`)


### PR DESCRIPTION
Hello,  
After transitioning from version 22.10.5 to the latest version, we encountered an issue where the component crashes because files with the extension `.d.ts` are not included in the build due to the `default exclude pattern`.

This option `includeExtensions` will allow us to exclude this extension from the `default exclude pattern` and also prevent similar problems for users with comparable requests.

Please let me know if I've missed anything