### PR TITLE
fix(mac): merge `fileAssociations` with existing `CFBundleDocumentTypes` if defined in `mac.extendInfo`

### DIFF
--- a/.changeset/fifty-lions-burn.md
+++ b/.changeset/fifty-lions-burn.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): merge `fileAssociations` with existing `CFBundleDocumentTypes` if defined in `mac.extendInfo`

--- a/packages/app-builder-lib/src/electron/electronMac.ts
+++ b/packages/app-builder-lib/src/electron/electronMac.ts
@@ -201,7 +201,7 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
 
   const fileAssociations = packager.fileAssociations
   if (fileAssociations.length > 0) {
-    appPlist.CFBundleDocumentTypes = await BluebirdPromise.map(fileAssociations, async fileAssociation => {
+    const documentTypes = await BluebirdPromise.map(fileAssociations, async fileAssociation => {
       const extensions = asArray(fileAssociation.ext).map(normalizeExt)
       const customIcon = await packager.getResource(getPlatformIconFileName(fileAssociation.icon, true), `${extensions[0]}.icns`)
       let iconFile = appPlist.CFBundleIconFile
@@ -223,6 +223,9 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
       }
       return result
     })
+
+    // `CFBundleDocumentTypes` may be defined in `mac.extendInfo`, so we need to merge it in that case
+    appPlist.CFBundleDocumentTypes = [...(appPlist.CFBundleDocumentTypes || []), ...documentTypes]
   }
 
   if (asarIntegrity != null) {

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -69,6 +69,13 @@ Object {
   "CFBundleDisplayName": "Test App ßW",
   "CFBundleDocumentTypes": Array [
     Object {
+      "CFBundleTypeName": "Folders",
+      "CFBundleTypeRole": "Editor",
+      "LSItemContentTypes": Array [
+        "public.folder",
+      ],
+    },
+    Object {
       "CFBundleTypeExtensions": Array [
         "foo",
       ],

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -54,6 +54,13 @@ test.ifMac(
           appId: "foo",
           extendInfo: {
             LSUIElement: true,
+            CFBundleDocumentTypes: [
+              {
+                CFBundleTypeName: "Folders",
+                CFBundleTypeRole: "Editor",
+                LSItemContentTypes: ["public.folder"],
+              },
+            ],
           },
           minimumSystemVersion: "10.12.0",
           fileAssociations: [


### PR DESCRIPTION
`mac.extendInfo` may already contain entries for `CFBundleDocumentTypes`. Before this change, `fileAssociations` would overwrite previous `CFBundleDocumentTypes` properties. Now it merges.

I'm using this functionality so that I can add support for `public.folder`, so users can drag a folder onto the dock icon and the Electron app will recognise it.