### PR TITLE
fix: add dmg-builder and squirrel-windows to peerDependencies for pnpm

### DIFF
--- a/.changeset/cold-sheep-camp.md
+++ b/.changeset/cold-sheep-camp.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add dmg-builder and squirrel-windows to peer dependency for pnpm

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -105,6 +105,10 @@
     "dmg-builder": "workspace:*",
     "electron-builder-squirrel-windows": "workspace:*"
   },
+  "peerDependencies": {
+    "dmg-builder": "workspace:*",
+    "electron-builder-squirrel-windows": "workspace:*"
+  },
   "//": "electron-builder-squirrel-windows and dmg-builder added as dev dep for tests (as otherwise `require` doesn't work using Yarn 2)",
   "typings": "./out/index.d.ts"
 }


### PR DESCRIPTION
seeing error with pnpm:

```
 ⨯ Cannot find module 'dmg-builder'
Require stack:
- /xxx/node_modules/.pnpm/app-builder-lib@24.13.0_patch_hash=rhv5z6uqia42ljlrohzdneemdi/node_modules/app-builder-lib/out/macPackager.js
- /xxx/node_modules/.pnpm/app-builder-lib@24.13.0_patch_hash=rhv5z6uqia42ljlrohzdneemdi/node_modules/app-builder-lib/out/packager.js
- /xxx/node_modules/.pnpm/app-builder-lib@24.13.0_patch_hash=rhv5z6uqia42ljlrohzdneemdi/node_modules/app-builder-lib/out/index.js
- /xxx/node_modules/.pnpm/electron-builder@24.13.0/node_modules/electron-builder/out/builder.js
- /xxx/node_modules/.pnpm/electron-builder@24.13.0/node_modules/electron-builder/out/cli/cli.js
- /xxx/node_modules/.pnpm/electron-builder@24.13.0/node_modules/electron-builder/cli.js  failedTask=build stackTrace=Error: Cannot find module 'dmg-builder'
```
the `/.pnpm/app-builder-lib@24.13.0/node_modules/`:

<img width="1126" alt="image" src="https://github.com/electron-userland/electron-builder/assets/121891361/65fc17e7-d2d7-4441-92cf-c6139b7a8449">

while it works if I install dmg-builder directly to the entire workspace, I suspect that without it in the dependency, it's not listed in `/.pnpm/app-builder-lib@24.13.0/node_modules/` and results in the error

and honestly it is imported (tho conditionally) to the code directly: https://github.com/electron-userland/electron-builder/blob/040327814e8299340c4755d3ad05958e6925aab1/packages/app-builder-lib/src/macPackager.ts#L86, so seems a better fit to dependencies ? or maybe peer dependencies ? (looks like peerDependencies can work as well: https://pnpm.io/how-peers-are-resolved)