### PR TITLE
fix(mac): only skip notarization step when `notarize` is explicitly false

### DIFF
--- a/.changeset/twelve-boxes-film.md
+++ b/.changeset/twelve-boxes-film.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): only skip notarization step when `notarize` is explicitly false

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -504,7 +504,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     }
     const options = this.getNotarizeOptions(appPath)
     if (!options) {
-      log.info({ reason: "`notarize` options were unable to be generated" }, "skipped macOS notarization")
+      log.warn({ reason: "`notarize` options were unable to be generated" }, "skipped macOS notarization")
       return
     }
     await notarize(options)

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -498,8 +498,8 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
 
   private async notarizeIfProvided(appPath: string, buildOptions: MacConfiguration) {
     const notarizeOptions = buildOptions.notarize
-    if (!notarizeOptions) {
-      log.info({ reason: "`notarize` options were not provided" }, "skipped macOS notarization")
+    if (notarizeOptions === false) {
+      log.info({ reason: "`notarize` options were set explicitly `false`" }, "skipped macOS notarization")
       return
     }
     const options = this.getNotarizeOptions(appPath)

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -562,7 +562,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
       }
       return proj
     }
-    const { teamId } = options as NotarizeNotaryOptions
+    const teamId = (options as NotarizeNotaryOptions)?.teamId
     if ((teamId || options === true) && (legacyLogin || notaryToolLogin)) {
       const proj: NotaryToolStartOptions = {
         appPath,

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -504,6 +504,7 @@ export default class MacPackager extends PlatformPackager<MacConfiguration> {
     }
     const options = this.getNotarizeOptions(appPath)
     if (!options) {
+      log.info({ reason: "`notarize` options were unable to be generated" }, "skipped macOS notarization")
       return
     }
     await notarize(options)


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/8040