### PR TITLE
fix(deb): only execute `update-desktop-database` and `update-mime-database` when exists on the system

### DIFF
--- a/.changeset/lovely-fishes-impress.md
+++ b/.changeset/lovely-fishes-impress.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(deb): soft symlink instead of hardlink to handle when /opt is on a separate partition

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -3,15 +3,20 @@
 if type update-alternatives 2>/dev/null >&1; then
     # Remove previous link if it doesn't use update-alternatives
     if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
-      rm -f '/usr/bin/${executable}'
+        rm -f '/usr/bin/${executable}'
     fi
     update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100
 else
-    ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+    ln -s '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 fi
 
 # SUID chrome-sandbox for Electron 5+
 chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
 
-update-mime-database /usr/share/mime || true
-update-desktop-database /usr/share/applications || true
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -5,9 +5,9 @@ if type update-alternatives 2>/dev/null >&1; then
     if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
         rm -f '/usr/bin/${executable}'
     fi
-    update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100
+    update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100 || ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 else
-    ln -s '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+    ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 fi
 
 # SUID chrome-sandbox for Electron 5+

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -541,18 +541,23 @@ exports[`executable path in postinst script 5`] = `
 if type update-alternatives 2>/dev/null >&1; then
     # Remove previous link if it doesn't use update-alternatives
     if [ -L '/usr/bin/Boo' -a -e '/usr/bin/Boo' -a \\"\`readlink '/usr/bin/Boo'\`\\" != '/etc/alternatives/Boo' ]; then
-      rm -f '/usr/bin/Boo'
+        rm -f '/usr/bin/Boo'
     fi
     update-alternatives --install '/usr/bin/Boo' 'Boo' '/opt/foo/Boo' 100
 else
-    ln -sf '/opt/foo/Boo' '/usr/bin/Boo'
+    ln -s '/opt/foo/Boo' '/usr/bin/Boo'
 fi
 
 # SUID chrome-sandbox for Electron 5+
 chmod 4755 '/opt/foo/chrome-sandbox' || true
 
-update-mime-database /usr/share/mime || true
-update-desktop-database /usr/share/applications || true"
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi"
 `;
 
 exports[`no quotes for safe exec name 1`] = `

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -543,9 +543,9 @@ if type update-alternatives 2>/dev/null >&1; then
     if [ -L '/usr/bin/Boo' -a -e '/usr/bin/Boo' -a \\"\`readlink '/usr/bin/Boo'\`\\" != '/etc/alternatives/Boo' ]; then
         rm -f '/usr/bin/Boo'
     fi
-    update-alternatives --install '/usr/bin/Boo' 'Boo' '/opt/foo/Boo' 100
+    update-alternatives --install '/usr/bin/Boo' 'Boo' '/opt/foo/Boo' 100 || ln -sf '/opt/foo/Boo' '/usr/bin/Boo'
 else
-    ln -s '/opt/foo/Boo' '/usr/bin/Boo'
+    ln -sf '/opt/foo/Boo' '/usr/bin/Boo'
 fi
 
 # SUID chrome-sandbox for Electron 5+


### PR DESCRIPTION
Soft symlink as fallback for `update-alternatives` to handle when /opt is on a separate partition

Also only execute `update-desktop-database` and `update-mime-database` when exists on the system

Fixes: #5721