### PR TITLE
fix: Windows ES module support

### DIFF
--- a/.changeset/orange-goats-brake.md
+++ b/.changeset/orange-goats-brake.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: use `pathToFileUrl` for hooks for Windows ES module support 

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -7,6 +7,7 @@ import { readdir } from "fs/promises"
 import { Lazy } from "lazy-val"
 import { Minimatch } from "minimatch"
 import * as path from "path"
+import { pathToFileURL } from "url"
 import { AppInfo } from "./appInfo"
 import { checkFileInArchive } from "./asar/asarFileChecker"
 import { AsarPackager } from "./asar/asarUtil"
@@ -761,7 +762,8 @@ async function resolveModule<T>(type: string | undefined, name: string): Promise
   const isModuleType = type === "module"
   try {
     if (extension === ".mjs" || (extension === ".js" && isModuleType)) {
-      return await eval("import('" + name + "')")
+      const fileUrl = pathToFileURL(name).href;
+      return await eval("import('" + fileUrl + "')")
     }
   } catch (error) {
     log.debug({ moduleName: name }, "Unable to dynamically import hook, falling back to `require`")


### PR DESCRIPTION
Use `pathToFileUrl` to fix this error on Windows:

```
Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'  failedTask=build stackTrace=Error: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
```

#7935