### PR TITLE
fix(pkg): provide `BundlePreInstallScriptPath` and/or `BundlePostInstallScriptPath`

### DIFF
--- a/.changeset/mighty-pumpkins-battle.md
+++ b/.changeset/mighty-pumpkins-battle.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(pkg): provide `BundlePreInstallScriptPath` and/or `BundlePostInstallScriptPath` when a pre/postinstall script is provided to pkg installer

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -762,7 +762,7 @@ async function resolveModule<T>(type: string | undefined, name: string): Promise
   const isModuleType = type === "module"
   try {
     if (extension === ".mjs" || (extension === ".js" && isModuleType)) {
-      const fileUrl = pathToFileURL(name).href;
+      const fileUrl = pathToFileURL(name).href
       return await eval("import('" + fileUrl + "')")
     }
   } catch (error) {


### PR DESCRIPTION
Provide `BundlePreInstallScriptPath` and/or `BundlePostInstallScriptPath` when a pre/postinstall script is provided to pkg installer via buildResourcesDir -> `scripts` config

Fixes: #8063