### PR TITLE
fix(mac): sign NSIS on mac 

### DIFF
--- a/.changeset/eighty-bobcats-eat.md
+++ b/.changeset/eighty-bobcats-eat.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): sign NSIS on mac

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -56,14 +56,18 @@ export async function sign(options: WindowsSignOptions, packager: WinPackager): 
   let isNest = false
   for (const hash of hashes) {
     const taskConfiguration: WindowsSignTaskConfiguration = { ...options, hash, isNest }
-    const config: CustomWindowsSignTaskConfiguration = {
-      ...taskConfiguration,
-      computeSignToolArgs: isWin => computeSignToolArgs(taskConfiguration, isWin),
-    }
-    await Promise.resolve(executor(config, packager))
+    await Promise.resolve(
+      executor(
+        {
+          ...taskConfiguration,
+          computeSignToolArgs: isWin => computeSignToolArgs(taskConfiguration, isWin),
+        },
+        packager
+      )
+    )
     isNest = true
-    if (config.resultOutputPath != null) {
-      await rename(config.resultOutputPath, options.path)
+    if (taskConfiguration.resultOutputPath != null) {
+      await rename(taskConfiguration.resultOutputPath, options.path)
     }
   }
 


### PR DESCRIPTION
Revert "fix(win): use `resultOutputPath` to sign custom location for windows (#7919)". The property `resultOutputPath` is not meant to be overridden externally during the `sign` hook, other internal app-builder-lib logic explicitly depends on it for when the host machine is not Windows.

This reverts commit 4e930a74d7c2e9b53d47e37997b444da95680a24.

Fixes: #7973