### PR TITLE
fix(linux): native modules overwritten with wrong arch

### DIFF
--- a/.changeset/weak-trains-flash.md
+++ b/.changeset/weak-trains-flash.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(linux): native modules overwritten with wrong arch

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -1,5 +1,5 @@
 import { AsyncTaskManager, log } from "builder-util"
-import { FileCopier, Filter, MAX_FILE_REQUESTS } from "builder-util/out/fs"
+import { DO_NOT_USE_HARD_LINKS, FileCopier, Filter, MAX_FILE_REQUESTS } from "builder-util/out/fs"
 import { symlink, createReadStream, createWriteStream, Stats } from "fs"
 import { writeFile, readFile, mkdir } from "fs/promises"
 import * as path from "path"
@@ -71,7 +71,7 @@ export class AsarPackager {
 
     const transformedFiles = fileSet.transformedFiles
     const taskManager = new AsyncTaskManager(packager.cancellationToken)
-    const fileCopier = new FileCopier()
+    const fileCopier = new FileCopier(DO_NOT_USE_HARD_LINKS)
 
     let currentDirNode: Node | null = null
     let currentDirPath: string | null = null


### PR DESCRIPTION
Fixes: #7608

**Description**
When building an app for multiple Linux architectures, native modules are hardlinked to the modules in `appDir/node_modules/**/*.node` if `CI` env is set. 

When the builder processes the first arch, it works fine. The second arch overwrites `appDir/node_modules/**/*.node`. Since these files are hardlinked to `linux-*unpacked/resources/app.asar.unpacked/node_modules/**/*.node` it overwrites native modules for all archs, so now the first arch distributive is broken.

`FileCopier` in `builder-util/out/fs` copies files by default, but once it detects a CI environment, it switches to hadlinking mode instead.

<details>
  <summary>Example package.json which reproduces the issue</summary>
  
```json
{
  "name": "builder-arm64-linux-issue",
  "version": "1.0.0",
  "main": "index.js",
  "scripts": {
    "build": "env CI=1 electron-builder --linux --x64 --arm64 && find dist/linux-unpacked -name realm.node -exec file {} \\;"
  },
  "build": {
    "linux": {
      "target": {
        "arch": ["x64", "arm64"],
        "target": "dir"
      }
    }
  },
  "devDependencies": {
    "electron": "^29.1.0",
    "electron-builder": "^24.13.3"
  },
  "dependencies": {
    "realm": "^12.6.2"
  }
}
```
  
</details>