### PR TITLE
fix: move `disableSanityCheckAsar` to within `checkFileInPackage` for non-asar verification

### DIFF
--- a/.changeset/dirty-rats-happen.md
+++ b/.changeset/dirty-rats-happen.md
@@ -2,4 +2,4 @@
 "app-builder-lib": minor
 ---
 
-feat: add disableSanityCheckPackage to allow encrypted asars
+feat: add disableSanityCheckAsar to allow encrypted asars

--- a/.changeset/mighty-spies-knock.md
+++ b/.changeset/mighty-spies-knock.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: move `disableSanityCheckPackage` to within `checkFileInPackage` to not bypass non-asar usage

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -188,7 +188,7 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 <p><code id="Configuration-removePackageKeywords">removePackageKeywords</code> = <code>true</code> Boolean - Whether to remove <code>keywords</code> field from <code>package.json</code> files.</p>
 </li>
 <li>
-<p><code id="Configuration-disableSanityCheckPackage">disableSanityCheckPackage</code> = <code>false</code> Boolean - Whether to disable sanity check asar package (useful for custom electron forks that implement their own encrypted integrity validation)</p>
+<p><code id="Configuration-disableSanityCheckAsar">disableSanityCheckAsar</code> = <code>false</code> Boolean - Whether to disable sanity check asar package (useful for custom electron forks that implement their own encrypted integrity validation)</p>
 </li>
 </ul>
 

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6666,7 +6666,7 @@
         }
       ]
     },
-    "disableSanityCheckPackage": {
+    "disableSanityCheckAsar": {
       "default": false,
       "description": "Whether to disable sanity check asar package (useful for custom electron forks that implement their own encrypted integrity validation)",
       "type": "boolean"

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -284,7 +284,7 @@ export interface Configuration extends PlatformSpecificBuildOptions {
    * Whether to disable sanity check asar package (useful for custom electron forks that implement their own encrypted integrity validation)
    * @default false
    */
-  readonly disableSanityCheckPackage?: boolean
+  readonly disableSanityCheckAsar?: boolean
 }
 
 interface PackContext {

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -316,7 +316,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
 
     const isAsar = asarOptions != null
-    await this.sanityCheckPackage(appOutDir, isAsar, framework, !!this.config.disableSanityCheckPackage)
+    await this.sanityCheckPackage(appOutDir, isAsar, framework, !!this.config.disableSanityCheckAsar)
     if (sign) {
       await this.doSignAfterPack(outDir, appOutDir, platformName, arch, platformSpecificBuildOptions, targets)
     }
@@ -508,8 +508,8 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return path.join(appOutDir, `${this.appInfo.productFilename}.app`, "Contents", "Resources")
   }
 
-  private async checkFileInPackage(resourcesDir: string, file: string, messagePrefix: string, isAsar: boolean, disableSanityCheckPackage: boolean) {
-    if (isAsar && disableSanityCheckPackage) {
+  private async checkFileInPackage(resourcesDir: string, file: string, messagePrefix: string, isAsar: boolean, disableSanityCheckAsar: boolean) {
+    if (isAsar && disableSanityCheckAsar) {
       return
     }
     const relativeFile = path.relative(this.info.appDir, path.resolve(this.info.appDir, file))
@@ -549,7 +549,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
   }
 
-  private async sanityCheckPackage(appOutDir: string, isAsar: boolean, framework: Framework, disableSanityCheckPackage: boolean): Promise<any> {
+  private async sanityCheckPackage(appOutDir: string, isAsar: boolean, framework: Framework, disableSanityCheckAsar: boolean): Promise<any> {
     const outStat = await statOrNull(appOutDir)
     if (outStat == null) {
       throw new Error(`Output directory "${appOutDir}" does not exist. Seems like a wrong configuration.`)
@@ -562,8 +562,8 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
     const resourcesDir = this.getResourcesDir(appOutDir)
     const mainFile = (framework.getMainFile == null ? null : framework.getMainFile(this.platform)) || this.info.metadata.main || "index.js"
-    await this.checkFileInPackage(resourcesDir, mainFile, "Application entry file", isAsar, disableSanityCheckPackage)
-    await this.checkFileInPackage(resourcesDir, "package.json", "Application", isAsar, disableSanityCheckPackage)
+    await this.checkFileInPackage(resourcesDir, mainFile, "Application entry file", isAsar, disableSanityCheckAsar)
+    await this.checkFileInPackage(resourcesDir, "package.json", "Application", isAsar, disableSanityCheckAsar)
   }
 
   // tslint:disable-next-line:no-invalid-template-strings

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -316,9 +316,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
 
     const isAsar = asarOptions != null
-    if (!this.config.disableSanityCheckPackage) {
-      await this.sanityCheckPackage(appOutDir, isAsar, framework)
-    }
+    await this.sanityCheckPackage(appOutDir, isAsar, framework, !!this.config.disableSanityCheckPackage)
     if (sign) {
       await this.doSignAfterPack(outDir, appOutDir, platformName, arch, platformSpecificBuildOptions, targets)
     }
@@ -510,7 +508,10 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return path.join(appOutDir, `${this.appInfo.productFilename}.app`, "Contents", "Resources")
   }
 
-  private async checkFileInPackage(resourcesDir: string, file: string, messagePrefix: string, isAsar: boolean) {
+  private async checkFileInPackage(resourcesDir: string, file: string, messagePrefix: string, isAsar: boolean, disableSanityCheckPackage: boolean) {
+    if (isAsar && disableSanityCheckPackage) {
+      return
+    }
     const relativeFile = path.relative(this.info.appDir, path.resolve(this.info.appDir, file))
     if (isAsar) {
       await checkFileInArchive(path.join(resourcesDir, "app.asar"), relativeFile, messagePrefix)
@@ -548,7 +549,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
   }
 
-  private async sanityCheckPackage(appOutDir: string, isAsar: boolean, framework: Framework): Promise<any> {
+  private async sanityCheckPackage(appOutDir: string, isAsar: boolean, framework: Framework, disableSanityCheckPackage: boolean): Promise<any> {
     const outStat = await statOrNull(appOutDir)
     if (outStat == null) {
       throw new Error(`Output directory "${appOutDir}" does not exist. Seems like a wrong configuration.`)
@@ -561,8 +562,8 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
     const resourcesDir = this.getResourcesDir(appOutDir)
     const mainFile = (framework.getMainFile == null ? null : framework.getMainFile(this.platform)) || this.info.metadata.main || "index.js"
-    await this.checkFileInPackage(resourcesDir, mainFile, "Application entry file", isAsar)
-    await this.checkFileInPackage(resourcesDir, "package.json", "Application", isAsar)
+    await this.checkFileInPackage(resourcesDir, mainFile, "Application entry file", isAsar, disableSanityCheckPackage)
+    await this.checkFileInPackage(resourcesDir, "package.json", "Application", isAsar, disableSanityCheckPackage)
   }
 
   // tslint:disable-next-line:no-invalid-template-strings


### PR DESCRIPTION
fix: move `disableSanityCheckPackage` to within `checkFileInPackage` to not bypass non-asar usage

Renamed to `disableSanityCheckAsar` for more explicit definition