### PR TITLE
fix: order files in asar for incremental updates

### DIFF
--- a/.changeset/fair-pants-talk.md
+++ b/.changeset/fair-pants-talk.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: order files within asar for smaller incremental updates

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -38,10 +38,18 @@ export class AsarPackager {
     }
     await mkdir(path.dirname(this.outFile), { recursive: true })
     const unpackedFileIndexMap = new Map<ResolvedFileSet, Set<number>>()
-    for (const fileSet of fileSets) {
+    const orderedFileSets = [
+      // Write dependencies first to minimize offset changes to asar header
+      ...fileSets.slice(1),
+
+      // Finish with the app files that change most often
+      fileSets[0],
+    ].map(orderFileSet)
+
+    for (const fileSet of orderedFileSets) {
       unpackedFileIndexMap.set(fileSet, await this.createPackageFromFiles(fileSet, packager.info))
     }
-    await this.writeAsarFile(fileSets, unpackedFileIndexMap)
+    await this.writeAsarFile(orderedFileSets, unpackedFileIndexMap)
   }
 
   private async createPackageFromFiles(fileSet: ResolvedFileSet, packager: Packager) {
@@ -268,5 +276,58 @@ function copyFileOrData(fileCopier: FileCopier, data: string | Buffer | undefine
     return fileCopier.copy(source, destination, stats)
   } else {
     return writeFile(destination, data)
+  }
+}
+
+function orderFileSet(fileSet: ResolvedFileSet): ResolvedFileSet {
+  const sortedFileEntries = Array.from(fileSet.files.entries())
+
+  sortedFileEntries.sort(([, a], [, b]) => {
+    if (a === b) {
+      return 0
+    }
+
+    // Place addons last because their signature change
+    const isAAddon = a.endsWith(".node")
+    const isBAddon = b.endsWith(".node")
+    if (isAAddon && !isBAddon) {
+      return 1
+    }
+    if (isBAddon && !isAAddon) {
+      return -1
+    }
+
+    // Otherwise order by name
+    return a < b ? -1 : 1
+  })
+
+  let transformedFiles: Map<number, string | Buffer> | undefined
+  if (fileSet.transformedFiles) {
+    transformedFiles = new Map()
+
+    const indexMap = new Map<number, number>()
+    for (const [newIndex, [oldIndex]] of sortedFileEntries.entries()) {
+      indexMap.set(oldIndex, newIndex)
+    }
+
+    for (const [oldIndex, value] of fileSet.transformedFiles) {
+      const newIndex = indexMap.get(oldIndex)
+      if (newIndex === undefined) {
+        const file = fileSet.files[oldIndex]
+        throw new Error(`Internal error: ${file} was lost while ordering asar`)
+      }
+
+      transformedFiles.set(newIndex, value)
+    }
+  }
+
+  const { src, destination, metadata } = fileSet
+
+  return {
+    src,
+    destination,
+    metadata,
+    files: sortedFileEntries.map(([, file]) => file),
+    transformedFiles,
   }
 }

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -10,11 +10,11 @@ exports[`conflict versions 2`] = `
 Object {
   "files": Object {
     "index.html": Object {
-      "offset": "0",
+      "offset": "9018",
       "size": 841,
     },
     "index.js": Object {
-      "offset": "841",
+      "offset": "9859",
       "size": 2501,
     },
     "node_modules": Object {
@@ -22,7 +22,7 @@ Object {
         "foo": Object {
           "files": Object {
             "package.json": Object {
-              "offset": "3643",
+              "offset": "0",
               "size": 127,
             },
           },
@@ -30,15 +30,15 @@ Object {
         "ms": Object {
           "files": Object {
             "index.js": Object {
-              "offset": "8080",
+              "offset": "4437",
               "size": 3034,
             },
             "license.md": Object {
-              "offset": "11114",
+              "offset": "7471",
               "size": 1077,
             },
             "package.json": Object {
-              "offset": "12191",
+              "offset": "8548",
               "size": 470,
             },
           },
@@ -46,7 +46,7 @@ Object {
       },
     },
     "package.json": Object {
-      "offset": "3342",
+      "offset": "12360",
       "size": 301,
     },
   },
@@ -63,11 +63,11 @@ exports[`yarn several workspaces 2`] = `
 Object {
   "files": Object {
     "index.html": Object {
-      "offset": "0",
+      "offset": "19060",
       "size": 841,
     },
     "index.js": Object {
-      "offset": "841",
+      "offset": "19901",
       "size": 2501,
     },
     "node_modules": Object {
@@ -75,51 +75,51 @@ Object {
         "electron-log": Object {
           "files": Object {
             "LICENSE": Object {
-              "offset": "7962",
+              "offset": "4310",
               "size": 1082,
             },
             "index.js": Object {
-              "offset": "9044",
+              "offset": "5392",
               "size": 140,
             },
             "lib": Object {
               "files": Object {
                 "format.js": Object {
-                  "offset": "12250",
+                  "offset": "5532",
                   "size": 1021,
                 },
                 "log.js": Object {
-                  "offset": "13271",
+                  "offset": "6553",
                   "size": 877,
                 },
                 "transports": Object {
                   "files": Object {
                     "console.js": Object {
-                      "offset": "14148",
+                      "offset": "7430",
                       "size": 343,
                     },
                     "file": Object {
                       "files": Object {
                         "find-log-path.js": Object {
-                          "offset": "16786",
+                          "offset": "7773",
                           "size": 2078,
                         },
                         "get-app-name.js": Object {
-                          "offset": "18864",
+                          "offset": "9851",
                           "size": 1780,
                         },
                         "index.js": Object {
-                          "offset": "20644",
+                          "offset": "11631",
                           "size": 2068,
                         },
                       },
                     },
                     "log-s.js": Object {
-                      "offset": "14491",
+                      "offset": "13699",
                       "size": 1751,
                     },
                     "renderer-console.js": Object {
-                      "offset": "16242",
+                      "offset": "15450",
                       "size": 544,
                     },
                   },
@@ -127,15 +127,15 @@ Object {
               },
             },
             "main.js": Object {
-              "offset": "9184",
+              "offset": "15994",
               "size": 1343,
             },
             "package.json": Object {
-              "offset": "10527",
+              "offset": "17337",
               "size": 745,
             },
             "renderer.js": Object {
-              "offset": "11272",
+              "offset": "18082",
               "size": 978,
             },
           },
@@ -143,15 +143,15 @@ Object {
         "ms": Object {
           "files": Object {
             "index.js": Object {
-              "offset": "3652",
+              "offset": "0",
               "size": 2764,
             },
             "license.md": Object {
-              "offset": "6416",
+              "offset": "2764",
               "size": 1077,
             },
             "package.json": Object {
-              "offset": "7493",
+              "offset": "3841",
               "size": 469,
             },
           },
@@ -159,7 +159,7 @@ Object {
       },
     },
     "package.json": Object {
-      "offset": "3342",
+      "offset": "22402",
       "size": 310,
     },
   },
@@ -176,11 +176,11 @@ exports[`yarn two package.json w/ native module 2`] = `
 Object {
   "files": Object {
     "index.html": Object {
-      "offset": "0",
+      "offset": "50776",
       "size": 841,
     },
     "index.js": Object {
-      "offset": "841",
+      "offset": "51617",
       "size": 2501,
     },
     "node_modules": Object {
@@ -188,37 +188,37 @@ Object {
         "debug": Object {
           "files": Object {
             "LICENSE": Object {
-              "offset": "3545",
+              "offset": "0",
               "size": 1107,
             },
             "dist": Object {
               "files": Object {
                 "debug.js": Object {
-                  "offset": "22149",
+                  "offset": "1107",
                   "size": 27572,
                 },
               },
             },
             "package.json": Object {
-              "offset": "4652",
+              "offset": "28679",
               "size": 947,
             },
             "src": Object {
               "files": Object {
                 "browser.js": Object {
-                  "offset": "5599",
+                  "offset": "29626",
                   "size": 5831,
                 },
                 "common.js": Object {
-                  "offset": "11430",
+                  "offset": "35457",
                   "size": 5930,
                 },
                 "index.js": Object {
-                  "offset": "17360",
+                  "offset": "41387",
                   "size": 314,
                 },
                 "node.js": Object {
-                  "offset": "17674",
+                  "offset": "41701",
                   "size": 4475,
                 },
               },
@@ -228,15 +228,15 @@ Object {
         "ms": Object {
           "files": Object {
             "index.js": Object {
-              "offset": "49721",
+              "offset": "46176",
               "size": 3024,
             },
             "license.md": Object {
-              "offset": "52745",
+              "offset": "49200",
               "size": 1079,
             },
             "package.json": Object {
-              "offset": "53824",
+              "offset": "50279",
               "size": 497,
             },
           },
@@ -244,7 +244,7 @@ Object {
       },
     },
     "package.json": Object {
-      "offset": "3342",
+      "offset": "54118",
       "size": 203,
     },
   },
@@ -261,11 +261,11 @@ exports[`yarn workspace 2`] = `
 Object {
   "files": Object {
     "index.html": Object {
-      "offset": "0",
+      "offset": "137310",
       "size": 841,
     },
     "index.js": Object {
-      "offset": "841",
+      "offset": "138151",
       "size": 2501,
     },
     "node_modules": Object {
@@ -275,71 +275,71 @@ Object {
             "core": Object {
               "files": Object {
                 "LICENSE": Object {
-                  "offset": "3722",
+                  "offset": "0",
                   "size": 1527,
                 },
                 "dist": Object {
                   "files": Object {
                     "base.js": Object {
-                      "offset": "6015",
+                      "offset": "1527",
                       "size": 17489,
                     },
                     "base.js.map": Object {
-                      "offset": "23504",
+                      "offset": "19016",
                       "size": 16432,
                     },
                     "dsn.js": Object {
-                      "offset": "39936",
+                      "offset": "35448",
                       "size": 4214,
                     },
                     "dsn.js.map": Object {
-                      "offset": "44150",
+                      "offset": "39662",
                       "size": 5742,
                     },
                     "error.js": Object {
-                      "offset": "49892",
+                      "offset": "45404",
                       "size": 1180,
                     },
                     "error.js.map": Object {
-                      "offset": "51072",
+                      "offset": "46584",
                       "size": 844,
                     },
                     "index.js": Object {
-                      "offset": "51916",
+                      "offset": "47428",
                       "size": 475,
                     },
                     "index.js.map": Object {
-                      "offset": "52391",
+                      "offset": "47903",
                       "size": 589,
                     },
                     "interfaces.js": Object {
-                      "offset": "52980",
+                      "offset": "48492",
                       "size": 649,
                     },
                     "interfaces.js.map": Object {
-                      "offset": "53629",
+                      "offset": "49141",
                       "size": 11257,
                     },
                     "sdk.js": Object {
-                      "offset": "64886",
+                      "offset": "60398",
                       "size": 1039,
                     },
                     "sdk.js.map": Object {
-                      "offset": "65925",
+                      "offset": "61437",
                       "size": 1554,
                     },
                     "status.js": Object {
-                      "offset": "67479",
+                      "offset": "62991",
                       "size": 1630,
                     },
                     "status.js.map": Object {
-                      "offset": "69109",
+                      "offset": "64621",
                       "size": 2118,
                     },
                   },
                 },
                 "package.json": Object {
-                  "offset": "5249",
+                  "offset": "66739",
                   "size": 766,
                 },
               },
@@ -347,119 +347,119 @@ Object {
             "shim": Object {
               "files": Object {
                 "LICENSE": Object {
-                  "offset": "71227",
+                  "offset": "67505",
                   "size": 1527,
                 },
                 "dist": Object {
                   "files": Object {
                     "domain.js": Object {
-                      "offset": "89033",
+                      "offset": "69032",
                       "size": 672,
                     },
                     "domain.js.map": Object {
-                      "offset": "89705",
+                      "offset": "69704",
                       "size": 1230,
                     },
                     "global.js": Object {
-                      "offset": "90935",
+                      "offset": "70934",
                       "size": 500,
                     },
                     "global.js.map": Object {
-                      "offset": "91435",
+                      "offset": "71434",
                       "size": 906,
                     },
                     "index.js": Object {
-                      "offset": "92341",
+                      "offset": "72340",
                       "size": 826,
                     },
                     "index.js.map": Object {
-                      "offset": "93167",
+                      "offset": "73166",
                       "size": 920,
                     },
                     "interfaces.js": Object {
-                      "offset": "94087",
+                      "offset": "74086",
                       "size": 115,
                     },
                     "interfaces.js.map": Object {
-                      "offset": "94202",
+                      "offset": "74201",
                       "size": 501,
                     },
                     "models.js": Object {
-                      "offset": "94703",
+                      "offset": "74702",
                       "size": 522,
                     },
                     "models.js.map": Object {
-                      "offset": "95225",
+                      "offset": "75224",
                       "size": 2711,
                     },
                     "sdk.js": Object {
-                      "offset": "97936",
+                      "offset": "77935",
                       "size": 7245,
                     },
                     "sdk.js.map": Object {
-                      "offset": "105181",
+                      "offset": "85180",
                       "size": 10056,
                     },
                     "shim.js": Object {
-                      "offset": "115237",
+                      "offset": "95236",
                       "size": 4438,
                     },
                     "shim.js.map": Object {
-                      "offset": "119675",
+                      "offset": "99674",
                       "size": 6607,
                     },
                   },
                 },
                 "jest.config.js": Object {
-                  "offset": "72754",
+                  "offset": "106281",
                   "size": 265,
                 },
                 "package.json": Object {
-                  "offset": "73019",
+                  "offset": "106546",
                   "size": 705,
                 },
                 "src": Object {
                   "files": Object {
                     "domain.ts": Object {
-                      "offset": "74218",
+                      "offset": "107251",
                       "size": 630,
                     },
                     "global.ts": Object {
-                      "offset": "74848",
+                      "offset": "107881",
                       "size": 510,
                     },
                     "index.ts": Object {
-                      "offset": "75358",
+                      "offset": "108391",
                       "size": 421,
                     },
                     "interfaces.ts": Object {
-                      "offset": "75779",
+                      "offset": "108812",
                       "size": 352,
                     },
                     "models.ts": Object {
-                      "offset": "76131",
+                      "offset": "109164",
                       "size": 2213,
                     },
                     "sdk.ts": Object {
-                      "offset": "78344",
+                      "offset": "111377",
                       "size": 6858,
                     },
                     "shim.ts": Object {
-                      "offset": "85202",
+                      "offset": "118235",
                       "size": 3831,
                     },
                   },
                 },
                 "tsconfig.build.json": Object {
-                  "offset": "73724",
+                  "offset": "122066",
                   "size": 160,
                 },
                 "tsconfig.json": Object {
-                  "offset": "73884",
+                  "offset": "122226",
                   "size": 244,
                 },
                 "tslint.json": Object {
-                  "offset": "74128",
+                  "offset": "122470",
                   "size": 90,
                 },
               },
@@ -469,51 +469,51 @@ Object {
         "electron-log": Object {
           "files": Object {
             "LICENSE": Object {
-              "offset": "126282",
+              "offset": "122560",
               "size": 1082,
             },
             "index.js": Object {
-              "offset": "127364",
+              "offset": "123642",
               "size": 140,
             },
             "lib": Object {
               "files": Object {
                 "format.js": Object {
-                  "offset": "130570",
+                  "offset": "123782",
                   "size": 1021,
                 },
                 "log.js": Object {
-                  "offset": "131591",
+                  "offset": "124803",
                   "size": 877,
                 },
                 "transports": Object {
                   "files": Object {
                     "console.js": Object {
-                      "offset": "132468",
+                      "offset": "125680",
                       "size": 343,
                     },
                     "file": Object {
                       "files": Object {
                         "find-log-path.js": Object {
-                          "offset": "135106",
+                          "offset": "126023",
                           "size": 2078,
                         },
                         "get-app-name.js": Object {
-                          "offset": "137184",
+                          "offset": "128101",
                           "size": 1780,
                         },
                         "index.js": Object {
-                          "offset": "138964",
+                          "offset": "129881",
                           "size": 2068,
                         },
                       },
                     },
                     "log-s.js": Object {
-                      "offset": "132811",
+                      "offset": "131949",
                       "size": 1751,
                     },
                     "renderer-console.js": Object {
-                      "offset": "134562",
+                      "offset": "133700",
                       "size": 544,
                     },
                   },
@@ -521,15 +521,15 @@ Object {
               },
             },
             "main.js": Object {
-              "offset": "127504",
+              "offset": "134244",
               "size": 1343,
             },
             "package.json": Object {
-              "offset": "128847",
+              "offset": "135587",
               "size": 745,
             },
             "renderer.js": Object {
-              "offset": "129592",
+              "offset": "136332",
               "size": 978,
             },
           },
@@ -537,7 +537,7 @@ Object {
       },
     },
     "package.json": Object {
-      "offset": "3342",
+      "offset": "140652",
       "size": 380,
     },
   },

--- a/test/snapshots/globTest.js.snap
+++ b/test/snapshots/globTest.js.snap
@@ -9792,7 +9792,7 @@ Object {
 
 exports[`outside link 2`] = `
 Object {
-  "offset": "5281",
+  "offset": "5135",
   "size": "@size",
 }
 `;
@@ -9834,7 +9834,7 @@ Object {
                 "dir-3": Object {
                   "files": Object {
                     "file-in-asar": Object {
-                      "offset": "1937",
+                      "offset": "0",
                       "size": 2,
                     },
                   },
@@ -9848,27 +9848,27 @@ Object {
           "unpacked": true,
         },
         "must-be-not-unpacked": Object {
-          "offset": "1935",
+          "offset": "2",
           "size": 2,
         },
       },
     },
     "index.html": Object {
-      "offset": "0",
+      "offset": "4",
       "size": 378,
     },
     "index.js": Object {
-      "offset": "378",
+      "offset": "382",
       "size": 619,
     },
     "package.json": Object {
-      "offset": "997",
+      "offset": "1001",
       "size": 224,
     },
     "path": Object {
       "files": Object {
         "app.asar": Object {
-          "offset": "1221",
+          "offset": "1225",
           "size": 714,
         },
       },
@@ -9891,13 +9891,13 @@ Object {
         "package.json": Object {
           "files": Object {
             "readme.md": Object {
-              "offset": "5363",
+              "offset": "0",
               "size": 32,
             },
           },
         },
         "readme.md": Object {
-          "offset": "5285",
+          "offset": "32",
           "size": 78,
         },
       },
@@ -9930,7 +9930,7 @@ Object {
                 "dir-3": Object {
                   "files": Object {
                     "file-in-asar": Object {
-                      "offset": "5283",
+                      "offset": "110",
                       "size": 2,
                     },
                   },
@@ -9944,21 +9944,21 @@ Object {
           "unpacked": true,
         },
         "must-be-not-unpacked": Object {
-          "offset": "5281",
+          "offset": "112",
           "size": 2,
         },
       },
     },
     "index.html": Object {
-      "offset": "0",
+      "offset": "114",
       "size": 841,
     },
     "index.js": Object {
-      "offset": "841",
+      "offset": "955",
       "size": 4184,
     },
     "package.json": Object {
-      "offset": "5025",
+      "offset": "5139",
       "size": 256,
     },
   },


### PR DESCRIPTION
ASAR file begins with a header that list all files and an offset to each file in the rest of the file. When a file placed early in ASAR changes its length - it means that all subsequent file declarations in the header will have their offsets updated. While harmless by itself, this negatively affects the incremental download size as more of the installer binary is different from what it used to be.

In this change we order files in asar such that:

- Dependencies/node_modules come first (they change least often)
- Main app files come last (they change more frequently)

Additionally, files in asar are now ordered alphabetically within each fileset to guarantee stable output.

All of above results in 2x improvement of incremental download size for updates that don't change dependencies.