### PR TITLE
fix: adding retries to account for dmg `hdiutil` flakiness 

### DIFF
--- a/.changeset/fast-maps-dress.md
+++ b/.changeset/fast-maps-dress.md
@@ -1,0 +1,11 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+"dmg-builder": patch
+"electron-builder": patch
+"electron-builder-squirrel-windows": patch
+"electron-publish": patch
+"electron-updater": patch
+---
+
+fix: unstable hdiutil retry mechanism

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -404,14 +404,14 @@ export async function executeAppBuilder(
   }
 }
 
-export async function retry<T>(task: () => Promise<T>, retriesLeft: number, interval: number, backoff = 0, attempt = 0): Promise<T> {
+export async function retry<T>(task: () => Promise<T>, retryCount: number, interval: number, backoff = 0, attempt = 0, shouldRetry?: (e: any) => boolean): Promise<T> {
   try {
     return await task()
   } catch (error: any) {
-    log.info(`Above command failed, retrying ${retriesLeft} more times`)
-    if (retriesLeft > 0) {
+    log.info(`Above command failed, retrying ${retryCount} more times`)
+    if ((shouldRetry?.(error) ?? true) && retryCount > 0) {
       await new Promise(resolve => setTimeout(resolve, interval + backoff * attempt))
-      return await retry(task, retriesLeft - 1, interval, backoff, attempt + 1)
+      return await retry(task, retryCount - 1, interval, backoff, attempt + 1, shouldRetry)
     } else {
       throw error
     }

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -1,7 +1,7 @@
-import { exec, retry } from "builder-util"
 import { PlatformPackager } from "app-builder-lib"
 import { executeFinally } from "builder-util/out/promise"
 import * as path from "path"
+import { hdiUtil } from "./hdiuil"
 
 export { DmgTarget } from "./dmg"
 
@@ -23,7 +23,7 @@ export async function attachAndExecute(dmgPath: string, readWrite: boolean, task
   }
 
   args.push(dmgPath)
-  const attachResult = await exec("hdiutil", args)
+  const attachResult = await hdiUtil(args)
   const deviceResult = attachResult == null ? null : /^(\/dev\/\w+)/.exec(attachResult)
   const device = deviceResult == null || deviceResult.length !== 2 ? null : deviceResult[1]
   if (device == null) {
@@ -34,11 +34,7 @@ export async function attachAndExecute(dmgPath: string, readWrite: boolean, task
 }
 
 export async function detach(name: string) {
-  try {
-    await exec("hdiutil", ["detach", "-quiet", name])
-  } catch (e: any) {
-    await retry(() => exec("hdiutil", ["detach", "-force", "-debug", name]), 5, 1000, 500)
-  }
+  return hdiUtil(["detach", "-quiet", name])
 }
 
 export async function computeBackground(packager: PlatformPackager<any>): Promise<string> {

--- a/packages/dmg-builder/src/hdiuil.ts
+++ b/packages/dmg-builder/src/hdiuil.ts
@@ -1,0 +1,15 @@
+import { exec, log, retry } from "builder-util"
+
+export async function hdiUtil(args: string[]) {
+  return retry(
+    () => exec("hdiutil", args),
+    5,
+    1000,
+    2000,
+    0,
+    (error: any) => {
+      log.error({ args, code: error.code, error: (error.message || error).toString() }, "unable to execute hdiutil")
+      return true
+    }
+  )
+}


### PR DESCRIPTION
attempting to wrap all hdiutil's in a common retry mechanism for CI stability