### PR TITLE
fix: should not chmod for 7za when process.env.USE_SYSTEM_7ZA is true

### DIFF
--- a/.changeset/selfish-experts-wonder.md
+++ b/.changeset/selfish-experts-wonder.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+should not chmod for 7za when process.env.USE_SYSTEM_7ZA is true

--- a/packages/builder-util/src/7za.ts
+++ b/packages/builder-util/src/7za.ts
@@ -1,8 +1,11 @@
 import { path7x, path7za } from "7zip-bin"
 import { chmod } from "fs-extra"
+import * as fs from "fs"
 
 export async function getPath7za(): Promise<string> {
-  await chmod(path7za, 0o755)
+  if (fs.existsSync(path7za)) {
+    await chmod(path7za, 0o755)
+  }
   return path7za
 }
 


### PR DESCRIPTION
fix #8151 