### PR TITLE
feat: Make notarization with Apple ID more usable

### DIFF
--- a/.changeset/moody-years-poke.md
+++ b/.changeset/moody-years-poke.md
@@ -1,0 +1,7 @@
+---
+"app-builder-lib": minor
+"electron-builder": minor
+---
+
+Use `APPLE_TEAM_ID` env var when using notarizing with `APPLE_ID`.
+Deprecate legacy (`altool`) notarization API.

--- a/docs/configuration/mac.md
+++ b/docs/configuration/mac.md
@@ -110,8 +110,8 @@ The top-level [mac](configuration.md#Configuration-mac) key contains set of opti
 <p>This option has no effect unless building for “universal” arch and applies only if <code>mergeASARs</code> is <code>true</code>.</p>
 </li>
 <li>
-<p><code id="MacConfiguration-notarize">notarize</code> <a href="#NotarizeLegacyOptions">NotarizeLegacyOptions</a> | <a href="#NotarizeNotaryOptions">NotarizeNotaryOptions</a> | Boolean | “undefined” - Options to use for @electron/notarize (ref: <a href="https://github.com/electron/notarize">https://github.com/electron/notarize</a>). Supports both <code>legacy</code> and <code>notarytool</code> notarization tools. Use <code>false</code> to explicitly disable</p>
-<p>Note: In order to activate the notarization step You MUST specify one of the following via environment variables: 1. <code>APPLE_API_KEY</code>, <code>APPLE_API_KEY_ID</code> and <code>APPLE_API_ISSUER</code>. 2. <code>APPLE_ID</code> and <code>APPLE_APP_SPECIFIC_PASSWORD</code> 3. <code>APPLE_KEYCHAIN</code> and <code>APPLE_KEYCHAIN_PROFILE</code></p>
+<p><code id="MacConfiguration-notarize">notarize</code> <a href="#NotarizeLegacyOptions">NotarizeLegacyOptions</a> | <a href="#NotarizeNotaryOptions">NotarizeNotaryOptions</a> | Boolean | “undefined” - Options to use for @electron/notarize (ref: <a href="https://github.com/electron/notarize">https://github.com/electron/notarize</a>). Use <code>false</code> to explicitly disable</p>
+<p>Note: In order to activate the notarization step You MUST specify one of the following via environment variables: 1. <code>APPLE_API_KEY</code>, <code>APPLE_API_KEY_ID</code> and <code>APPLE_API_ISSUER</code>. 2. <code>APPLE_ID</code>, <code>APPLE_APP_SPECIFIC_PASSWORD</code>, and <code>APPLE_TEAM_ID</code> 3. <code>APPLE_KEYCHAIN</code> and <code>APPLE_KEYCHAIN_PROFILE</code></p>
 <p>For security reasons it is recommended to use the first option (see <a href="https://github.com/electron-userland/electron-builder/issues/7859">https://github.com/electron-userland/electron-builder/issues/7859</a>)</p>
 </li>
 </ul>
@@ -124,7 +124,7 @@ The top-level [mac](configuration.md#Configuration-mac) key contains set of opti
 <h2 id="notarizenotaryoptions">NotarizeNotaryOptions</h2>
 <p>undefined</p>
 <ul>
-<li><strong><code id="NotarizeNotaryOptions-teamId">teamId</code></strong> String - The team ID you want to notarize under for when using <code>notarytool</code></li>
+<li tag.description=""><code id="NotarizeNotaryOptions-teamId">teamId</code> String - The team ID you want to notarize under for when using <code>notarytool</code> Deprecated:</li>
 </ul>
 
 <!-- end of generated block -->

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -3687,9 +3687,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "teamId"
-      ],
       "type": "object"
     },
     "NsisOptions": {

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -214,11 +214,11 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
 
   /**
    * Options to use for @electron/notarize (ref: https://github.com/electron/notarize).
-   * Supports both `legacy` and `notarytool` notarization tools. Use `false` to explicitly disable
+   * Use `false` to explicitly disable
    *
    * Note: In order to activate the notarization step You MUST specify one of the following via environment variables:
    * 1. `APPLE_API_KEY`, `APPLE_API_KEY_ID` and `APPLE_API_ISSUER`.
-   * 2. `APPLE_ID` and `APPLE_APP_SPECIFIC_PASSWORD`
+   * 2. `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`
    * 3. `APPLE_KEYCHAIN` and `APPLE_KEYCHAIN_PROFILE`
    *
    * For security reasons it is recommended to use the first option (see https://github.com/electron-userland/electron-builder/issues/7859)
@@ -226,6 +226,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   readonly notarize?: NotarizeLegacyOptions | NotarizeNotaryOptions | boolean | null
 }
 
+/** @deprecated */
 export interface NotarizeLegacyOptions {
   /**
    * The app bundle identifier your Electron app is using. E.g. com.github.electron. Useful if notarization ID differs from app ID (unlikely).
@@ -242,8 +243,9 @@ export interface NotarizeLegacyOptions {
 export interface NotarizeNotaryOptions {
   /**
    * The team ID you want to notarize under for when using `notarytool`
+   * @deprecated Set the `APPLE_TEAM_ID` environment variable instead
    */
-  readonly teamId: string
+  readonly teamId?: string
 }
 
 export interface DmgOptions extends TargetSpecificOptions {


### PR DESCRIPTION
Previously, we supported notarizing with the legacy `altool` or the new `notarytool` API. The legacy tool has since been decommissioned.
1. Look at `APPLE_TEAM_ID` environment variable for getting the team to notarize as. Previously, when authenticating with an Apple ID, this property was used to determine whether to notarize with the old or new API. It's confusing to have the authentication split across these two places.
2. Mark legacy notarize API as deprecated and remove old validation.

Fixes https://github.com/electron-userland/electron-builder/issues/7812