### PR TITLE
feat: Add Support for a separate Github release token to the auto-update token

### DIFF
--- a/.changeset/serious-pumpkins-suffer.md
+++ b/.changeset/serious-pumpkins-suffer.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": minor
+---
+
+feat: Support for a separate Github publish token to the auto-update token

--- a/docs/configuration/publish.md
+++ b/docs/configuration/publish.md
@@ -9,6 +9,12 @@ If `GH_TOKEN` or `GITHUB_TOKEN` is defined — defaults to `[{provider: "github"
 
 If `KEYGEN_TOKEN` is defined and `GH_TOKEN` or `GITHUB_TOKEN` is not — defaults to `[{provider: "keygen"}]`.
 
+If `GITHUB_RELEASE_TOKEN` is defined, it will be used instead of (`GH_TOKEN` or `GITHUB_TOKEN`) to publish your release.
+- e.g. mac: ``` export GITHUB_RELEASE_TOKEN=<my token> ```
+- the `GITHUB_TOKEN` will still be used when your app checks for updates, etc.
+- you could make your `GITHUB_TOKEN` "Read-only" when creating a fine-grained personal access token, and "Read and write" for the `GITHUB_RELEASE_TOKEN`.
+- "Contents" fine-grained permission was sufficient. (at time of writing - Apr 2024)
+
 !!! info "Snap store"
     `snap` target by default publishes to snap store (the app store for Linux). To force publishing to another providers, explicitly specify publish configuration for `snap`. 
 

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -46,8 +46,8 @@ export class GitHubPublisher extends HttpPublisher {
     super(context, true)
 
     let token = info.token
-    if (isEmptyOrSpaces(token)) {
-      token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+    if (isEmptyOrSpaces(token) || process.env.GITHUB_RELEASE_TOKEN) {
+      token = process.env.GITHUB_RELEASE_TOKEN ? process.env.GITHUB_RELEASE_TOKEN : (process.env.GH_TOKEN || process.env.GITHUB_TOKEN)
       if (isEmptyOrSpaces(token)) {
         throw new InvalidConfigurationError(`GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"`)
       }


### PR DESCRIPTION

Reference: https://github.com/electron-userland/electron-builder/issues/5688 - Discussion about keeping two separate tokens; one for publishing to Github releases and the other used by the app to make requests for auto-update updates.

Now you can set a release token that has write permissions to publish your release.

The release token will be used instead of a GH_TOKEN || GITHUB_TOKEN ONLY during publishing.

The Github token defined via the Github options or environment variable will still be used as normal.

mac: ``` export GITHUB_RELEASE_TOKEN=<my token> ```

I used the Contents permission for a New fine-grained personal access token with "Read and write". "Read-only" for the usual app-update token.

So even if the app-update token is inside your app-update.yml its only read-only, yay! (Mac: you can find the app-update.yml by right-click > Show Package Contents > Contents > Resources)