### PR TITLE
feat(linux): add music mac to linux category

### DIFF
--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -207,4 +207,5 @@ const macToLinuxCategory: any = {
   "public.app-category.utilities": "Utility",
   "public.app-category.social-networking": "Network;Chat",
   "public.app-category.finance": "Office;Finance",
+  "public.app-category.music": "Audio;AudioVideo",
 }


### PR DESCRIPTION
Add new category when converting mac categories to linux equivalent. This is probably just an oversight, as it's obvious what categories music should be.