### PR TITLE
Treat cscLink empty same as absent

### DIFF
--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -63,7 +63,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     }
 
     const cscLink = this.getCscLink("WIN_CSC_LINK")
-    if (cscLink == null) {
+    if (cscLink == null || cscLink === '') {
       return Promise.resolve(null)
     }
 


### PR DESCRIPTION
I think this is expected with env variables that empty string means disabled.

currently if set to empty string it crashes with:
Error: Env WIN_CSC_LINK is not correct, cannot resolve: D:\a\path\to\project not a file