### PR TITLE
feat: add `afterExtract` hook

### DIFF
--- a/.changeset/tough-clouds-think.md
+++ b/.changeset/tough-clouds-think.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: add `afterExtract` hook to build process with the same payload interface as `beforePack` and `afterPack`

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6418,6 +6418,20 @@
       ],
       "description": "The function (or path to file or module id) to be [run after all artifacts are build](#afterAllArtifactBuild)."
     },
+    "afterExtract": {
+      "anyOf": [
+        {
+          "typeof": "function"
+        },
+        {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      ],
+      "description": "The function (or path to file or module id) to be [run after the prebuilt Electron binary has been extracted to the output directory](#afterextract)"
+    },
     "afterPack": {
       "anyOf": [
         {

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -221,6 +221,11 @@ export interface Configuration extends PlatformSpecificBuildOptions {
   readonly beforePack?: ((context: BeforePackContext) => Promise<any> | any) | string | null
 
   /**
+   * The function (or path to file or module id) to be [run after the prebuilt Electron binary has been extracted to the output directory](#afterextract)
+   */
+  readonly afterExtract?: ((context: AfterExtractContext) => Promise<any> | any) | string | null
+
+  /**
    * The function (or path to file or module id) to be [run after pack](#afterpack) (but before pack into distributable format and sign).
    */
   readonly afterPack?: ((context: AfterPackContext) => Promise<any> | any) | string | null
@@ -297,6 +302,7 @@ interface PackContext {
 }
 export type AfterPackContext = PackContext
 export type BeforePackContext = PackContext
+export type AfterExtractContext = PackContext
 
 export interface MetadataDirectories {
   /**

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -245,6 +245,18 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       version: framework.version,
     })
 
+    const afterExtract = await resolveFunction(this.appInfo.type, this.config.afterExtract, "afterExtract")
+    if (afterExtract != null) {
+      await afterExtract({
+        appOutDir,
+        outDir,
+        arch,
+        targets,
+        packager: this,
+        electronPlatformName: platformName,
+      })
+    }
+
     const excludePatterns: Array<Minimatch> = []
 
     const computeParsedPatterns = (patterns: Array<FileMatcher> | null) => {


### PR DESCRIPTION
Add a hook that triggers after the prebuilt Electron binary has been extracted to the output directory.

What I was looking for is a `beforeAsar` (or `afterCopy`) hook, but looks like the file copying function is tightly coupled with asar transformation, this is the next best option.

Partially solves https://github.com/electron-userland/electron-builder/issues/8188 + https://github.com/electron-userland/electron-builder/issues/5619 + https://github.com/electron-userland/electron-builder/issues/4422 + https://github.com/electron-userland/electron-builder/issues/5709