### PR TITLE
feat(appx): Update identityName for windows 10

### DIFF
--- a/.changeset/gentle-bags-thank.md
+++ b/.changeset/gentle-bags-thank.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+feat(appx): Update identityName for windows 10

--- a/docs/configuration/appx.md
+++ b/docs/configuration/appx.md
@@ -4,7 +4,7 @@ All options are optional. All required for AppX configuration is inferred and co
 
 <!-- do not edit. start of generated block -->
 <ul>
-<li><code id="AppXOptions-applicationId">applicationId</code> String - The application id. Defaults to <code>identityName</code>.</li>
+<li><code id="AppXOptions-applicationId">applicationId</code> String - The application id. Defaults to <code>identityName</code>. This string contains alpha-numeric fields separated by periods. Each field must begin with an ASCII alphabetic character.</li>
 <li><code id="AppXOptions-backgroundColor">backgroundColor</code> = <code>#464646</code> String | “undefined” - The background color of the app tile. See <a href="https://msdn.microsoft.com/en-us/library/windows/apps/br211471.aspx">Visual Elements</a>.</li>
 <li><code id="AppXOptions-displayName">displayName</code> String | “undefined” - A friendly name that can be displayed to users. Corresponds to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/br211432.aspx">Properties.DisplayName</a>. Defaults to the application product name.</li>
 <li><code id="AppXOptions-identityName">identityName</code> String | “undefined” - The name. Corresponds to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx">Identity.Name</a>. Defaults to the <a href="/configuration/configuration#Metadata-name">application name</a>.</li>

--- a/docs/configuration/appx.md
+++ b/docs/configuration/appx.md
@@ -4,7 +4,7 @@ All options are optional. All required for AppX configuration is inferred and co
 
 <!-- do not edit. start of generated block -->
 <ul>
-<li><code id="AppXOptions-applicationId">applicationId</code> String - The application id. Defaults to <code>identityName</code>. Can’t start with numbers.</li>
+<li><code id="AppXOptions-applicationId">applicationId</code> String - The application id. Defaults to <code>identityName</code>.</li>
 <li><code id="AppXOptions-backgroundColor">backgroundColor</code> = <code>#464646</code> String | “undefined” - The background color of the app tile. See <a href="https://msdn.microsoft.com/en-us/library/windows/apps/br211471.aspx">Visual Elements</a>.</li>
 <li><code id="AppXOptions-displayName">displayName</code> String | “undefined” - A friendly name that can be displayed to users. Corresponds to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/br211432.aspx">Properties.DisplayName</a>. Defaults to the application product name.</li>
 <li><code id="AppXOptions-identityName">identityName</code> String | “undefined” - The name. Corresponds to <a href="https://msdn.microsoft.com/en-us/library/windows/apps/br211441.aspx">Identity.Name</a>. Defaults to the <a href="/configuration/configuration#Metadata-name">application name</a>.</li>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -153,7 +153,7 @@
           "type": "boolean"
         },
         "applicationId": {
-          "description": "The application id. Defaults to `identityName`. Can’t start with numbers.",
+          "description": "The application id. Defaults to `identityName`.",
           "type": "string"
         },
         "artifactName": {

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -153,7 +153,7 @@
           "type": "boolean"
         },
         "applicationId": {
-          "description": "The application id. Defaults to `identityName`. This string contains alpha-numeric fields separated by periods. Each field must begin with an ASCII alphabetic character",
+          "description": "The application id. Defaults to `identityName`. This string contains alpha-numeric fields separated by periods. Each field must begin with an ASCII alphabetic character.",
           "type": "string"
         },
         "artifactName": {

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -153,7 +153,7 @@
           "type": "boolean"
         },
         "applicationId": {
-          "description": "The application id. Defaults to `identityName`.",
+          "description": "The application id. Defaults to `identityName`. This string contains alpha-numeric fields separated by periods. Each field must begin with an ASCII alphabetic character",
           "type": "string"
         },
         "artifactName": {

--- a/packages/app-builder-lib/src/options/AppXOptions.ts
+++ b/packages/app-builder-lib/src/options/AppXOptions.ts
@@ -2,7 +2,7 @@ import { TargetSpecificOptions } from "../core"
 
 export interface AppXOptions extends TargetSpecificOptions {
   /**
-   * The application id. Defaults to `identityName`.
+   * The application id. Defaults to `identityName` This string contains alpha-numeric fields separated by periods. Each field must begin with an ASCII alphabetic character.
    */
   readonly applicationId?: string
 

--- a/packages/app-builder-lib/src/options/AppXOptions.ts
+++ b/packages/app-builder-lib/src/options/AppXOptions.ts
@@ -2,7 +2,7 @@ import { TargetSpecificOptions } from "../core"
 
 export interface AppXOptions extends TargetSpecificOptions {
   /**
-   * The application id. Defaults to `identityName` This string contains alpha-numeric fields separated by periods. Each field must begin with an ASCII alphabetic character.
+   * The application id. Defaults to `identityName`. This string contains alpha-numeric fields separated by periods. Each field must begin with an ASCII alphabetic character.
    */
   readonly applicationId?: string
 

--- a/packages/app-builder-lib/src/options/AppXOptions.ts
+++ b/packages/app-builder-lib/src/options/AppXOptions.ts
@@ -2,7 +2,7 @@ import { TargetSpecificOptions } from "../core"
 
 export interface AppXOptions extends TargetSpecificOptions {
   /**
-   * The application id. Defaults to `identityName`. Can’t start with numbers.
+   * The application id. Defaults to `identityName`.
    */
   readonly applicationId?: string
 

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -224,13 +224,13 @@ export default class AppXTarget extends Target {
           return appInfo.getVersionInWeirdWindowsForm(options.setBuildNumber === true)
 
         case "applicationId": {
-          const result = options.applicationId || options.identityName || appInfo.name
           const validCharactersRegex = /^([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*$/
-          const identitynumber = parseInt(result, 10)
-          if (!isNaN(identitynumber)) {
+          const identitynumber =  parseInt(options.identityName as string, 10) || NaN
+          const result = (!isNaN(identitynumber) && options.identityName !== null && options.identityName !== undefined) ? options.identityName.replace(identitynumber.toString(),'') : options.applicationId || options.identityName || appInfo.name
+
+          if (!isNaN(identitynumber) ) {
             log.warn(`Remove the ${identitynumber}`)
-            result = result.replace(identitynumber,'')
-          }
+          }			
 
           if (result.length < 1 || result.length > 64) {
             const message = `Appx Application.Id with a value between 1 and 64 characters in length`

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -235,10 +235,10 @@ export default class AppXTarget extends Target {
             const message = `Appx Application.Id with a value between 1 and 64 characters in length`
             throw new InvalidConfigurationError(message)
           } else if (!validCharactersRegex.test(result)) {
-            const message = `AppX Application.Id cat be consists of alpha-numeric and period"`
+            const message = `AppX Application.Id can not be consists of alpha-numeric and period"`
             throw new InvalidConfigurationError(message)
           } else if (restrictedApplicationIdValues.includes(result.toUpperCase())) {
-            const message = `AppX Application.Id cannot be some values`
+            const message = `AppX Application.Id can not be some values`
             throw new InvalidConfigurationError(message)
           } else if (result == null && options.applicationId == null) {
             const message = `Please set appx.applicationId (or correct appx.identityName or name)`
@@ -258,7 +258,7 @@ export default class AppXTarget extends Target {
             const message = `AppX identityName.Id cat be consists of alpha-numeric, period, and dash characters"`
             throw new InvalidConfigurationError(message)
           } else if (restrictedApplicationIdValues.includes(result.toUpperCase())) {
-            const message = `AppX identityName.Id cannot be some values`
+            const message = `AppX identityName.Id can not be some values`
             throw new InvalidConfigurationError(message)
           } else if (result == null && options.identityName == null) {
             const message = `Please set appx.identityName or name`

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -226,11 +226,10 @@ export default class AppXTarget extends Target {
         case "applicationId": {
           const validCharactersRegex = /^([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*$/
           const identitynumber =  parseInt(options.identityName as string, 10) || NaN
-          const result = (!isNaN(identitynumber) && options.identityName !== null && options.identityName !== undefined) ? options.identityName.replace(identitynumber.toString(),'') : options.applicationId || options.identityName || appInfo.name
-
+          const result = isNaN(identitynumber) ? options.applicationId || (options.identityName !== null && options.identityName !== undefined) || appInfo.name: options.identityName.replace(identitynumber.toString(), '')
           if (!isNaN(identitynumber) ) {
             log.warn(`Remove the ${identitynumber}`)
-          }			
+          }
 
           if (result.length < 1 || result.length > 64) {
             const message = `Appx Application.Id with a value between 1 and 64 characters in length`
@@ -250,7 +249,7 @@ export default class AppXTarget extends Target {
         }
 
         case "identityName": {
-		  const result = options.identityName || appInfo.name
+          const result = options.identityName || appInfo.name
           const validCharactersRegex = /^[a-zA-Z0-9.-]+$/
           if (result.length < 3 || result.length > 50) {
             const message = `Appx identityName.Id with a value between 3 and 50 characters in length`

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -226,7 +226,7 @@ export default class AppXTarget extends Target {
         case "applicationId": {
           const validCharactersRegex = /^([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*$/
           const identitynumber = parseInt(options.identityName as string, 10) || NaN
-		  let result
+		  let result:string
           if (!isNaN(identitynumber) && options.identityName !== null && options.identityName !== undefined) {
             if (options.identityName[0] === "0") {
               log.warn(`Remove the 0${identitynumber}`)

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -20,6 +20,31 @@ const vendorAssetsForDefaultAssets: { [key: string]: string } = {
   "Wide310x150Logo.png": "SampleAppx.310x150.png",
 }
 
+const restrictedApplicationIdValues = [
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  "COM1",
+  "COM2",
+  "COM3",
+  "COM4",
+  "COM5",
+  "COM6",
+  "COM7",
+  "COM8",
+  "COM9",
+  "LPT1",
+  "LPT2",
+  "LPT3",
+  "LPT4",
+  "LPT5",
+  "LPT6",
+  "LPT7",
+  "LPT8",
+  "LPT9",
+]
+
 const DEFAULT_RESOURCE_LANG = "en-US"
 
 export default class AppXTarget extends Target {
@@ -200,29 +225,21 @@ export default class AppXTarget extends Target {
 
         case "applicationId": {
           const result = options.applicationId || options.identityName || appInfo.name
+          const validCharactersRegex = /^[a-zA-Z0-9.-]+$/
           if (result.length < 3 || result.length > 50) {
-            let message = `Appx Application.Id with a value between 3 and 50 characters in length`
+            const message = `Appx Application.Id with a value between 3 and 50 characters in length`
+            throw new InvalidConfigurationError(message)
+          } else if (!validCharactersRegex.test(result)) {
+            const message = `AppX Application.Id cat be consists of alpha-numeric, period, and dash characters"`
+            throw new InvalidConfigurationError(message)
+          } else if (restrictedApplicationIdValues.includes(result.toUpperCase())) {
+            const message = `AppX Application.Id cannot be some values`
+            throw new InvalidConfigurationError(message)
+          } else if (options.applicationId == null) {
+            const message = `Please set appx.applicationId (or correct appx.identityName or name)`
             throw new InvalidConfigurationError(message)
           }
-          const validCharactersRegex = /^[a-zA-Z0-9.-]+$/;
-          else if (!validCharactersRegex.test(result)) {
-            let message = `AppX Application.Id cat be consists of alpha-numeric, period, and dash characters"`
-            throw new InvalidConfigurationError(message)
-          }
-          const restrictedValues = [
-                  'CON', 'PRN', 'AUX', 'NUL',
-                  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
-                  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
-          ];
-          else if (restrictedValues.includes(result.toUpperCase())) {
-            let message = `AppX Application.Id cannot be some values`
-            throw new InvalidConfigurationError(message)
-          }
-          else if (options.applicationId == null) {
-            let message = `Please set appx.applicationId (or correct appx.identityName or name)`
-            throw new InvalidConfigurationError(message)
-          }
-          
+
           return result
         }
 

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -226,11 +226,17 @@ export default class AppXTarget extends Target {
         case "applicationId": {
           const result = options.applicationId || options.identityName || appInfo.name
           const validCharactersRegex = /^[a-zA-Z0-9.-]+$/
-          if (result.length < 3 || result.length > 50) {
-            const message = `Appx Application.Id with a value between 3 and 50 characters in length`
+		  const identitynumber = parseInt(result, 10)
+          if (!isNaN(identitynumber)) {
+            log.warn(`Remove the ${identitynumber}`)
+            result = result.replace(identitynumber,'')
+          }
+
+          if (result.length < 1 || result.length > 64) {
+            const message = `Appx Application.Id with a value between 1 and 64 characters in length`
             throw new InvalidConfigurationError(message)
           } else if (!validCharactersRegex.test(result)) {
-            const message = `AppX Application.Id cat be consists of alpha-numeric, period, and dash characters"`
+            const message = `AppX Application.Id cat be consists of alpha-numeric and period"`
             throw new InvalidConfigurationError(message)
           } else if (restrictedApplicationIdValues.includes(result.toUpperCase())) {
             const message = `AppX Application.Id cannot be some values`
@@ -243,8 +249,25 @@ export default class AppXTarget extends Target {
           return result
         }
 
-        case "identityName":
-          return options.identityName || appInfo.name
+        case "identityName": {
+		  const result = options.identityName || appInfo.name
+          const validCharactersRegex = /^[a-zA-Z0-9.-]+$/
+          if (result.length < 3 || result.length > 50) {
+            const message = `Appx identityName.Id with a value between 3 and 50 characters in length`
+            throw new InvalidConfigurationError(message)
+          } else if (!validCharactersRegex.test(result)) {
+            const message = `AppX identityName.Id cat be consists of alpha-numeric, period, and dash characters"`
+            throw new InvalidConfigurationError(message)
+          } else if (restrictedApplicationIdValues.includes(result.toUpperCase())) {
+            const message = `AppX identityName.Id cannot be some values`
+            throw new InvalidConfigurationError(message)
+          } else if (result == null && options.identityName == null) {
+            const message = `Please set appx.identityName or name`
+            throw new InvalidConfigurationError(message)
+          }
+
+          return result
+        }
 
         case "executable":
           return executable

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -226,11 +226,11 @@ export default class AppXTarget extends Target {
         case "applicationId": {
           const validCharactersRegex = /^([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*$/
           const identitynumber = parseInt(options.identityName as string, 10) || NaN
-		  let result:string
+          let result: string
           if (!isNaN(identitynumber) && options.identityName !== null && options.identityName !== undefined) {
             if (options.identityName[0] === "0") {
               log.warn(`Remove the 0${identitynumber}`)
-              result = options.identityName.replace("0"+identitynumber.toString(), "")
+              result = options.identityName.replace("0" + identitynumber.toString(), "")
             } else {
               log.warn(`Remove the ${identitynumber}`)
               result = options.identityName.replace(identitynumber.toString(), "")
@@ -246,7 +246,7 @@ export default class AppXTarget extends Target {
             const message = `AppX Application.Id can not be consists of alpha-numeric and period"`
             throw new InvalidConfigurationError(message)
           } else if (restrictedApplicationIdValues.includes(result.toUpperCase())) {
-            const message = `AppX Application.Id can not be some values`
+            const message = `AppX identityName.Id can not include restricted values: ${JSON.stringify(restrictedApplicationIdValues)}`
             throw new InvalidConfigurationError(message)
           } else if (result == null && options.applicationId == null) {
             const message = `Please set appx.applicationId (or correct appx.identityName or name)`

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -227,7 +227,7 @@ export default class AppXTarget extends Target {
           const validCharactersRegex = /^([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*$/
           const identitynumber = parseInt(options.identityName as string, 10) || NaN
 		  let result
-          if (!isNaN(identitynumber)) {
+          if (!isNaN(identitynumber) && options.identityName !== null && options.identityName !== undefined) {
             if (options.identityName[0] === "0") {
               log.warn(`Remove the 0${identitynumber}`)
               result = options.identityName.replace("0"+identitynumber.toString(), "")

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -225,10 +225,18 @@ export default class AppXTarget extends Target {
 
         case "applicationId": {
           const validCharactersRegex = /^([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*$/
-          const identitynumber =  parseInt(options.identityName as string, 10) || NaN
-          const result = isNaN(identitynumber) ? options.applicationId || (options.identityName !== null && options.identityName !== undefined) || appInfo.name: options.identityName.replace(identitynumber.toString(), '')
-          if (!isNaN(identitynumber) ) {
-            log.warn(`Remove the ${identitynumber}`)
+          const identitynumber = parseInt(options.identityName as string, 10) || NaN
+		  let result
+          if (!isNaN(identitynumber)) {
+            if (options.identityName[0] === "0") {
+              log.warn(`Remove the 0${identitynumber}`)
+              result = options.identityName.replace("0"+identitynumber.toString(), "")
+            } else {
+              log.warn(`Remove the ${identitynumber}`)
+              result = options.identityName.replace(identitynumber.toString(), "")
+            }
+          } else {
+            result = options.applicationId || (options.identityName !== null && options.identityName !== undefined) || appInfo.name
           }
 
           if (result.length < 1 || result.length > 64) {

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -225,8 +225,8 @@ export default class AppXTarget extends Target {
 
         case "applicationId": {
           const result = options.applicationId || options.identityName || appInfo.name
-          const validCharactersRegex = /^[a-zA-Z0-9.-]+$/
-		  const identitynumber = parseInt(result, 10)
+          const validCharactersRegex = /^([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*$/
+          const identitynumber = parseInt(result, 10)
           if (!isNaN(identitynumber)) {
             log.warn(`Remove the ${identitynumber}`)
             result = result.replace(identitynumber,'')

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -200,13 +200,29 @@ export default class AppXTarget extends Target {
 
         case "applicationId": {
           const result = options.applicationId || options.identityName || appInfo.name
-          if (!isNaN(parseInt(result[0], 10))) {
-            let message = `AppX Application.Id can’t start with numbers: "${result}"`
-            if (options.applicationId == null) {
-              message += `\nPlease set appx.applicationId (or correct appx.identityName or name)`
-            }
+          if (result.length < 3 || result.length > 50) {
+            let message = `Appx Application.Id with a value between 3 and 50 characters in length`
             throw new InvalidConfigurationError(message)
           }
+          const validCharactersRegex = /^[a-zA-Z0-9.-]+$/;
+          else if (!validCharactersRegex.test(result)) {
+            let message = `AppX Application.Id cat be consists of alpha-numeric, period, and dash characters"`
+            throw new InvalidConfigurationError(message)
+          }
+          const restrictedValues = [
+                  'CON', 'PRN', 'AUX', 'NUL',
+                  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+                  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
+          ];
+          else if (restrictedValues.includes(result.toUpperCase())) {
+            let message = `AppX Application.Id cannot be some values`
+            throw new InvalidConfigurationError(message)
+          }
+          else if (options.applicationId == null) {
+            let message = `Please set appx.applicationId (or correct appx.identityName or name)`
+            throw new InvalidConfigurationError(message)
+          }
+          
           return result
         }
 

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -236,7 +236,7 @@ export default class AppXTarget extends Target {
               result = options.identityName.replace(identitynumber.toString(), "")
             }
           } else {
-            result = options.applicationId || (options.identityName !== null && options.identityName !== undefined) || appInfo.name
+            result = options.applicationId || options.identityName || appInfo.name
           }
 
           if (result.length < 1 || result.length > 64) {

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -235,7 +235,7 @@ export default class AppXTarget extends Target {
           } else if (restrictedApplicationIdValues.includes(result.toUpperCase())) {
             const message = `AppX Application.Id cannot be some values`
             throw new InvalidConfigurationError(message)
-          } else if (options.applicationId == null) {
+          } else if (result == null && options.applicationId == null) {
             const message = `Please set appx.applicationId (or correct appx.identityName or name)`
             throw new InvalidConfigurationError(message)
           }

--- a/test/src/windows/appxTest.ts
+++ b/test/src/windows/appxTest.ts
@@ -49,6 +49,8 @@ it.ifDevOrWinCi(
     {
       targets: Platform.WINDOWS.createTarget(["appx"], Arch.x64),
       config: {
+        cscLink: protectedCscLink,
+        cscKeyPassword: "test",
         appx: {
           identityName: "01234Test.ApplicationDataSample",
         },

--- a/test/src/windows/appxTest.ts
+++ b/test/src/windows/appxTest.ts
@@ -42,6 +42,22 @@ it.ifDevOrWinCi(
   )
 )
 
+// use identityName and same setting for applicationId
+it.ifDevOrWinCi(
+  "application id",
+  app(
+    {
+      targets: Platform.WINDOWS.createTarget(["appx"], Arch.x64),
+      config: {
+        appx: {
+          identityName: "01234Test.ApplicationDataSample",
+        },
+      },
+    },
+    {}
+  )
+)
+
 const it2 = isEnvTrue(process.env.DO_APPX_CERT_STORE_AWARE_TEST) ? test : test.skip
 it2.ifNotCi(
   "certificateSubjectName",


### PR DESCRIPTION
- Split the [applicationid](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-application) and [identityname](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-identity) detect function
- Add auto remove the identityname in Microsoft store has some number in first