### PR TITLE
feat(mac): support macos signature additionalArguments parameter 

### DIFF
--- a/.changeset/four-taxis-doubt.md
+++ b/.changeset/four-taxis-doubt.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat(mac): support macos signature `additionalArguments` parameter

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -147,6 +147,7 @@ Env file `electron-builder.env` in the current dir ([example](https://github.com
 <li><code id="Configuration-launchUiVersion">launchUiVersion</code> Boolean | String | “undefined” - <em>libui-based frameworks only</em> The version of LaunchUI you are packaging for. Applicable for Windows only. Defaults to version suitable for used framework version.</li>
 <li><code id="Configuration-framework">framework</code> String | “undefined” - The framework name. One of <code>electron</code>, <code>proton</code>, <code>libui</code>. Defaults to <code>electron</code>.</li>
 <li><code id="Configuration-beforePack">beforePack</code> module:app-builder-lib/out/configuration.__type | String | “undefined” - The function (or path to file or module id) to be <a href="#beforepack">run before pack</a></li>
+<li><code id="Configuration-afterExtract">afterExtract</code> module:app-builder-lib/out/configuration.__type | String | “undefined” - The function (or path to file or module id) to be <a href="#afterextract">run after the prebuilt Electron binary has been extracted to the output directory</a></li>
 </ul>
 <hr>
 <ul>

--- a/docs/configuration/mac.md
+++ b/docs/configuration/mac.md
@@ -110,6 +110,10 @@ The top-level [mac](configuration.md#Configuration-mac) key contains set of opti
 <p>This option has no effect unless building for “universal” arch and applies only if <code>mergeASARs</code> is <code>true</code>.</p>
 </li>
 <li>
+<p><code id="MacConfiguration-additionalArguments">additionalArguments</code> Array&lt;String&gt; | “undefined” - Array of strings specifying additional arguments to pass to the <code>codesign</code> command used to sign a specific file.</p>
+<p>Some subresources that you may include in your Electron app may need to be signed with --deep, this is not typically safe to apply to the entire Electron app and therefore should be applied to just your file. Usage Example: <code>['--deep']</code></p>
+</li>
+<li>
 <p><code id="MacConfiguration-notarize">notarize</code> <a href="#NotarizeLegacyOptions">NotarizeLegacyOptions</a> | <a href="#NotarizeNotaryOptions">NotarizeNotaryOptions</a> | Boolean | “undefined” - Options to use for @electron/notarize (ref: <a href="https://github.com/electron/notarize">https://github.com/electron/notarize</a>). Use <code>false</code> to explicitly disable</p>
 <p>Note: In order to activate the notarization step You MUST specify one of the following via environment variables: 1. <code>APPLE_API_KEY</code>, <code>APPLE_API_KEY_ID</code> and <code>APPLE_API_ISSUER</code>. 2. <code>APPLE_ID</code>, <code>APPLE_APP_SPECIFIC_PASSWORD</code>, and <code>APPLE_TEAM_ID</code> 3. <code>APPLE_KEYCHAIN</code> and <code>APPLE_KEYCHAIN_PROFILE</code></p>
 <p>For security reasons it is recommended to use the first option (see <a href="https://github.com/electron-userland/electron-builder/issues/7859">https://github.com/electron-userland/electron-builder/issues/7859</a>)</p>

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@develar/schema-utils": "~2.6.5",
     "@electron/notarize": "2.3.0",
-    "@electron/osx-sign": "1.0.5",
+    "@electron/osx-sign": "1.3.0",
     "@electron/rebuild": "3.6.0",
     "@electron/universal": "2.0.1",
     "@malept/flatpak-bundler": "^0.4.0",

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2125,6 +2125,20 @@
     "MacConfiguration": {
       "additionalProperties": false,
       "properties": {
+        "additionalArguments": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Array of strings specifying additional arguments to pass to the `codesign` command used to sign a specific file.\n\nSome subresources that you may include in your Electron app may need to be signed with --deep, this is not typically safe to apply to the entire Electron app and therefore should be applied to just your file.\nUsage Example: `['--deep']`"
+        },
         "appId": {
           "default": "com.electron.${name}",
           "description": "The application id. Used as [CFBundleIdentifier](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070) for MacOS and as\n[Application User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx) for Windows (NSIS target only, Squirrel.Windows not supported). It is strongly recommended that an explicit ID is set.",
@@ -2744,6 +2758,20 @@
     "MasConfiguration": {
       "additionalProperties": false,
       "properties": {
+        "additionalArguments": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Array of strings specifying additional arguments to pass to the `codesign` command used to sign a specific file.\n\nSome subresources that you may include in your Electron app may need to be signed with --deep, this is not typically safe to apply to the entire Electron app and therefore should be applied to just your file.\nUsage Example: `['--deep']`"
+        },
         "appId": {
           "default": "com.electron.${name}",
           "description": "The application id. Used as [CFBundleIdentifier](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070) for MacOS and as\n[Application User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx) for Windows (NSIS target only, Squirrel.Windows not supported). It is strongly recommended that an explicit ID is set.",

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -378,6 +378,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
         hardenedRuntime: hardenedRuntime ?? undefined,
         timestamp: customSignOptions.timestamp || undefined,
         requirements: requirements || undefined,
+        additionalArguments: customSignOptions.additionalArguments || [],
       }
       log.debug({ file: log.filePath(filePath), ...args }, "selecting signing options")
       return args

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -213,6 +213,14 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   readonly x64ArchFiles?: string | null
 
   /**
+   * Array of strings specifying additional arguments to pass to the `codesign` command used to sign a specific file.
+   *
+   * Some subresources that you may include in your Electron app may need to be signed with --deep, this is not typically safe to apply to the entire Electron app and therefore should be applied to just your file.
+   * Usage Example: `['--deep']`
+   */
+  readonly additionalArguments?: Array<string> | null
+
+  /**
    * Options to use for @electron/notarize (ref: https://github.com/electron/notarize).
    * Use `false` to explicitly disable
    *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: 2.3.0
         version: 2.3.0
       '@electron/osx-sign':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.3.0
+        version: 1.3.0
       '@electron/rebuild':
         specifier: 3.6.0
         version: 3.6.0
@@ -2311,6 +2311,21 @@ packages:
 
   /@electron/osx-sign@1.0.5:
     resolution: {integrity: sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      compare-version: 0.1.2
+      debug: 4.3.4
+      fs-extra: 10.1.0
+      isbinaryfile: 4.0.10
+      minimist: 1.2.8
+      plist: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@electron/osx-sign@1.3.0:
+    resolution: {integrity: sha512-TEXhxlYSDRr9JWK5nWdOv5MtuUdaZ412uxIIEQ0hLt80o0HYWtQJBlW5QmrQDMtebzATaOjKG9UfCzLyA90zWQ==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Update [electron/osx-sign](https://github.com/electron/osx-sign), add macos signing option `additionalArguments`.
https://github.com/electron/osx-sign/pull/316
https://github.com/electron/osx-sign?tab=readme-ov-file#signing-with---deep

@develar @mmaietta TBR;