### PR TITLE
docs: channel works with Github

### DIFF
--- a/.changeset/selfish-turtles-fold.md
+++ b/.changeset/selfish-turtles-fold.md
@@ -1,0 +1,13 @@
+---
+"app-builder-lib": patch
+"dmg-builder": patch
+"electron-builder": patch
+"electron-builder-squirrel-windows": patch
+"electron-forge-maker-appimage": patch
+"electron-forge-maker-nsis": patch
+"electron-forge-maker-nsis-web": patch
+"electron-forge-maker-snap": patch
+"electron-updater": patch
+---
+
+fix(docs): update autoupdate docs noting that channels work with Github

--- a/docs/api/electron-builder.md
+++ b/docs/api/electron-builder.md
@@ -3397,7 +3397,7 @@ return await getCertInfo(cscFile, cscInfo.password || “”)
 <p><code id="AppUpdater-currentVersion">currentVersion</code> SemVer - The current application version.</p>
 </li>
 <li>
-<p><strong><code id="AppUpdater-channel">channel</code></strong> String | “undefined” - Get the update channel. Not applicable for GitHub. Doesn’t return <code>channel</code> from the update configuration, only if was previously set.</p>
+<p><strong><code id="AppUpdater-channel">channel</code></strong> String | “undefined” - Get the update channel. Doesn’t return <code>channel</code> from the update configuration, only if was previously set.</p>
 </li>
 <li>
 <p><strong><code id="AppUpdater-requestHeaders">requestHeaders</code></strong> [key: string]: string | “undefined” - The request headers.</p>

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -123,14 +123,14 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
   protected downloadedUpdateHelper: DownloadedUpdateHelper | null = null
 
   /**
-   * Get the update channel. Not applicable for GitHub. Doesn't return `channel` from the update configuration, only if was previously set.
+   * Get the update channel. Doesn't return `channel` from the update configuration, only if was previously set.
    */
   get channel(): string | null {
     return this._channel
   }
 
   /**
-   * Set the update channel. Not applicable for GitHub. Overrides `channel` in the update configuration.
+   * Set the update channel. Overrides `channel` in the update configuration.
    *
    * `allowDowngrade` will be automatically set to `true`. If this behavior is not suitable for you, simple set `allowDowngrade` explicitly after.
    */


### PR DESCRIPTION
The `channel` option was documented as not working with GitHub, but it *does* work. Updated docs accordingly.