### PR TITLE
feat: write asar integrity resource on windows

### DIFF
--- a/.changeset/thick-flies-carry.md
+++ b/.changeset/thick-flies-carry.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+write asar integrity resource on windows

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -70,7 +70,7 @@
     "lazy-val": "^1.0.5",
     "minimatch": "^5.1.1",
     "read-config-file": "6.4.0",
-    "resedit": "^2.0.2",
+    "resedit": "^1.7.0",
     "sanitize-filename": "^1.6.3",
     "semver": "^7.3.8",
     "tar": "^6.1.12",

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -70,6 +70,7 @@
     "lazy-val": "^1.0.5",
     "minimatch": "^5.1.1",
     "read-config-file": "6.4.0",
+    "resedit": "^2.0.2",
     "sanitize-filename": "^1.6.3",
     "semver": "^7.3.8",
     "tar": "^6.1.12",

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -10,6 +10,7 @@ import { LinuxPackager } from "../linuxPackager"
 import { MacPackager } from "../macPackager"
 import { getTemplatePath } from "../util/pathManager"
 import { createMacApp } from "./electronMac"
+import { addWinAsarIntegrity } from "./electronWin"
 import { computeElectronVersion, getElectronVersionFromInstalled } from "./electronVersion"
 import * as fs from "fs/promises"
 import injectFFMPEG from "./injectFFMPEG"
@@ -78,6 +79,9 @@ async function beforeCopyExtraFiles(options: BeforeCopyExtraFilesOptions) {
   } else if (packager.platform === Platform.WINDOWS) {
     const executable = path.join(appOutDir, `${packager.appInfo.productFilename}.exe`)
     await rename(path.join(appOutDir, `${electronBranding.projectName}.exe`), executable)
+    if (options.asarIntegrity) {
+      await addWinAsarIntegrity(executable, options.asarIntegrity)
+    }
   } else {
     await createMacApp(packager as MacPackager, appOutDir, options.asarIntegrity, (options.platformName as ElectronPlatformName) === "mas")
   }

--- a/packages/app-builder-lib/src/electron/electronWin.ts
+++ b/packages/app-builder-lib/src/electron/electronWin.ts
@@ -1,0 +1,42 @@
+import { readFile, writeFile } from "fs/promises"
+import { log } from "builder-util"
+import { AsarIntegrity } from "../asar/integrity"
+
+/** @internal */
+export async function addWinAsarIntegrity(executablePath: string, asarIntegrity: AsarIntegrity) {
+  const { NtExecutable, NtExecutableResource, Resource } = await import("resedit")
+
+  const buffer = await readFile(executablePath)
+  const executable = NtExecutable.from(buffer)
+  const resource = NtExecutableResource.from(executable)
+
+  const versionInfo = Resource.VersionInfo.fromEntries(resource.entries)
+  if (versionInfo.length !== 1) {
+    throw new Error(`Failed to parse version info in ${executablePath}`)
+  }
+
+  const languages = versionInfo[0].getAllLanguagesForStringValues()
+  if (languages.length !== 1) {
+    throw new Error(`Failed to locate languages in ${executablePath}`)
+  }
+
+  // See: https://github.com/electron/packager/blob/00d20b99cf4aa4621103dbbd09ff7de7d2f7f539/src/resedit.ts#L124
+  const integrityList = Array.from(Object.entries(asarIntegrity)).map(([file, { algorithm: alg, hash: value }]) => ({
+    file,
+    alg,
+    value,
+  }))
+
+  resource.entries.push({
+    type: "INTEGRITY",
+    id: "ELECTRONASAR",
+    bin: Buffer.from(JSON.stringify(integrityList)),
+    lang: languages[0].lang,
+    codepage: languages[0].codepage,
+  })
+
+  resource.outputResource(executable)
+
+  await writeFile(executablePath, Buffer.from(executable.generate()))
+  log.info({ executablePath }, "updating asar integrity executable resource")
+}

--- a/packages/app-builder-lib/src/electron/electronWin.ts
+++ b/packages/app-builder-lib/src/electron/electronWin.ts
@@ -1,11 +1,10 @@
 import { readFile, writeFile } from "fs/promises"
 import { log } from "builder-util"
+import { NtExecutable, NtExecutableResource, Resource } from "resedit"
 import { AsarIntegrity } from "../asar/integrity"
 
 /** @internal */
 export async function addWinAsarIntegrity(executablePath: string, asarIntegrity: AsarIntegrity) {
-  const { NtExecutable, NtExecutableResource, Resource } = await import("resedit")
-
   const buffer = await readFile(executablePath)
   const executable = NtExecutable.from(buffer)
   const resource = NtExecutableResource.from(executable)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       resedit:
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^1.7.0
+        version: 1.7.0
       sanitize-filename:
         specifier: ^1.6.3
         version: 1.6.3
@@ -9490,9 +9490,9 @@ packages:
       util: 0.10.4
     dev: true
 
-  /pe-library@1.0.1:
-    resolution: {integrity: sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==}
-    engines: {node: '>=14', npm: '>=7'}
+  /pe-library@0.4.0:
+    resolution: {integrity: sha512-JAmVv2jGxmczplhHO7UoFGJ+pM/yMBpny3vNjwNFuaeQfzKlekQidZ8Ss8EJ0qee8wEQN4lY2IwtWx2oRfMsag==}
+    engines: {node: '>=12', npm: '>=6'}
     dev: false
 
   /pend@1.2.0:
@@ -10007,11 +10007,11 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /resedit@2.0.2:
-    resolution: {integrity: sha512-UKTnq602iVe+W5SyRAQx/WdWMnlDiONfXBLFg/ur4QE4EQQ8eP7Jgm5mNXdK12kKawk1vvXPja2iXKqZiGDW6Q==}
-    engines: {node: '>=14', npm: '>=7'}
+  /resedit@1.7.0:
+    resolution: {integrity: sha512-dbsZ0gk5opWPFlKMqvxCrLCuMZUVmsW3yTPT0tT4mYwo5fjQM8c4HMN9ZJt6dRDqDV/78m9SU4rv24PN4NiYaA==}
+    engines: {node: '>=12', npm: '>=6'}
     dependencies:
-      pe-library: 1.0.1
+      pe-library: 0.4.0
     dev: false
 
   /resolve-alpn@1.2.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       read-config-file:
         specifier: 6.4.0
         version: 6.4.0
+      resedit:
+        specifier: ^2.0.2
+        version: 2.0.2
       sanitize-filename:
         specifier: ^1.6.3
         version: 1.6.3
@@ -9487,6 +9490,11 @@ packages:
       util: 0.10.4
     dev: true
 
+  /pe-library@1.0.1:
+    resolution: {integrity: sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==}
+    engines: {node: '>=14', npm: '>=7'}
+    dev: false
+
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
     dev: true
@@ -9998,6 +10006,13 @@ packages:
     dependencies:
       lodash: 4.17.21
     dev: true
+
+  /resedit@2.0.2:
+    resolution: {integrity: sha512-UKTnq602iVe+W5SyRAQx/WdWMnlDiONfXBLFg/ur4QE4EQQ8eP7Jgm5mNXdK12kKawk1vvXPja2iXKqZiGDW6Q==}
+    engines: {node: '>=14', npm: '>=7'}
+    dependencies:
+      pe-library: 1.0.1
+    dev: false
 
   /resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}


### PR DESCRIPTION
Electron 30-x-y added support for ASAR integrity fuse on Windows. When enabled the app would fetch the ELECTRONASAR resource out of the executable file and use it to verify the integrity of the ASAR when reading the data from it.