### PR TITLE
refactor: builder-util-runtime, separate newError to eliminate circular dependency

### DIFF
--- a/.changeset/quiet-jars-leave.md
+++ b/.changeset/quiet-jars-leave.md
@@ -1,0 +1,5 @@
+---
+"builder-util-runtime": patch
+---
+
+Refactored to resolve circular dependency, eliminating warnings from tools such as Rollup

--- a/packages/builder-util-runtime/src/error.ts
+++ b/packages/builder-util-runtime/src/error.ts
@@ -1,0 +1,5 @@
+export function newError(message: string, code: string) {
+  const error = new Error(message)
+  ;(error as NodeJS.ErrnoException).code = code
+  return error
+}

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -6,7 +6,7 @@ import { Socket } from "net"
 import { Transform } from "stream"
 import { URL } from "url"
 import { CancellationToken } from "./CancellationToken"
-import { newError } from "./index"
+import { newError } from "./error"
 import { ProgressCallbackTransform, ProgressInfo } from "./ProgressCallbackTransform"
 
 const debug = _debug("electron-builder")

--- a/packages/builder-util-runtime/src/index.ts
+++ b/packages/builder-util-runtime/src/index.ts
@@ -35,6 +35,7 @@ export { UUID } from "./uuid"
 export { ProgressCallbackTransform, ProgressInfo } from "./ProgressCallbackTransform"
 export { parseXml, XElement } from "./xml"
 export { BlockMap } from "./blockMapApi"
+export { newError } from "./error"
 
 // nsis
 export const CURRENT_APP_INSTALLER_FILE_NAME = "installer.exe"
@@ -49,10 +50,4 @@ export function asArray<T>(v: null | undefined | T | Array<T>): Array<T> {
   } else {
     return [v]
   }
-}
-
-export function newError(message: string, code: string) {
-  const error = new Error(message)
-  ;(error as NodeJS.ErrnoException).code = code
-  return error
 }

--- a/packages/builder-util-runtime/src/uuid.ts
+++ b/packages/builder-util-runtime/src/uuid.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "crypto"
-import { newError } from "./index"
+import { newError } from "./error"
 
 const invalidName = "options.name must be either a string or a Buffer"
 

--- a/packages/builder-util-runtime/src/xml.ts
+++ b/packages/builder-util-runtime/src/xml.ts
@@ -1,5 +1,5 @@
 import * as sax from "sax"
-import { newError } from "./index"
+import { newError } from "./error"
 
 export class XElement {
   value = ""


### PR DESCRIPTION
After importing `electron-updater`, Rollup would log this warning:
```
(!) Circular dependencies
../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/index.js -> ../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/httpExecutor.js -> ../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/index.js
../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/index.js -> ../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/uuid.js -> ../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/index.js
../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/index.js -> ../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/xml.js -> ../../node_modules/.pnpm/builder-util-runtime@9.2.5-alpha.2/node_modules/builder-util-runtime/out/index.js
...and 6 more
```

This is because builder-util-runtime/src/index.ts exports from many other modules, and several of those modules import from it with `import { newError } from './index`.

This PR removes the circular dependency by extracting `newError` to `error.ts` and importing it from there.