### PR TITLE
fix(docs): get rid of typo in default glob pattern

### DIFF
--- a/docs/configuration/contents.md
+++ b/docs/configuration/contents.md
@@ -67,7 +67,7 @@ The destination path relative to and defaults to:
 
 `Array<String> | String`
 
-The [glob patterns](../file-patterns.md). Defaults to `*/**`.
+The [glob patterns](../file-patterns.md). Defaults to `**/*`.
 
 ## extraResources
 


### PR DESCRIPTION
If I assume correctly, the order has accidentally been reversed, as `*/**` doesn't seem to make much sense to me.