### PR TITLE
fix: don't log ignored error when requiring custom publisher

### DIFF
--- a/.changeset/spotty-timers-shave.md
+++ b/.changeset/spotty-timers-shave.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: don't log ignored error when requiring custom publisher

--- a/packages/app-builder-lib/src/publish/PublishManager.ts
+++ b/packages/app-builder-lib/src/publish/PublishManager.ts
@@ -346,7 +346,7 @@ function requireProviderClass(provider: string, packager: Packager): any | null 
       try {
         module = require(path.join(packager.buildResourcesDir, name + ".js"))
       } catch (ignored) {
-        console.log(ignored)
+        log.debug({ path: path.join(packager.buildResourcesDir, name + ".js") }, "Unable to find publish provider in build resources")
       }
 
       if (module == null) {


### PR DESCRIPTION
When using a custom publish provider, it is first attempted to be imported from the build resources, then if that fails, it attempts to import it from node_modules.

Currently, if the first attempted path fails, it logs the error to the console.

![image](https://github.com/electron-userland/electron-builder/assets/11861797/f4efea01-6495-43d3-bb50-03f6b557cfa9)

This happens multiple times per publish, and adds a lot of noise to the output.

Considering it's a (possibly) expected error, it would be better to move this to a debug log, with explanation.