### PR TITLE
fix(deps): Update notarize tool

### DIFF
--- a/.changeset/tender-countries-drive.md
+++ b/.changeset/tender-countries-drive.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: update @electron/notarize to latest version

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/electron-userland/electron-builder",
   "dependencies": {
     "@develar/schema-utils": "~2.6.5",
-    "@electron/notarize": "2.3.0",
+    "@electron/notarize": "2.3.2",
     "@electron/osx-sign": "1.3.0",
     "@electron/rebuild": "3.6.0",
     "@electron/universal": "2.0.1",

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -26,7 +26,7 @@ export { Configuration, AfterPackContext, MetadataDirectories } from "./configur
 export { ElectronBrandingOptions, ElectronDownloadOptions, ElectronPlatformName } from "./electron/ElectronFramework"
 export { PlatformSpecificBuildOptions, AsarOptions, FileSet, Protocol, ReleaseInfo } from "./options/PlatformSpecificBuildOptions"
 export { FileAssociation } from "./options/FileAssociation"
-export { MacConfiguration, DmgOptions, MasConfiguration, MacOsTargetName, DmgContent, DmgWindow, NotarizeLegacyOptions, NotarizeNotaryOptions } from "./options/macOptions"
+export { MacConfiguration, DmgOptions, MasConfiguration, MacOsTargetName, DmgContent, DmgWindow, NotarizeNotaryOptions } from "./options/macOptions"
 export { PkgOptions, PkgBackgroundOptions, BackgroundAlignment, BackgroundScaling } from "./options/pkgOptions"
 export { WindowsConfiguration } from "./options/winOptions"
 export { AppXOptions } from "./options/AppXOptions"

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -19,8 +19,8 @@ import { createCommonTarget, NoOpTarget } from "./targets/targetFactory"
 import { isMacOsHighSierra } from "./util/macosVersion"
 import { getTemplatePath } from "./util/pathManager"
 import * as fs from "fs/promises"
-import { notarize, NotarizeOptions } from "@electron/notarize"
-import { NotaryToolKeychainCredentials } from "@electron/notarize/lib/types"
+import { notarize } from "@electron/notarize"
+import { NotarizeOptionsNotaryTool, NotaryToolKeychainCredentials } from "@electron/notarize/lib/types"
 
 export type CustomMacSignOptions = SignOptions
 export type CustomMacSign = (configuration: CustomMacSignOptions, packager: MacPackager) => Promise<void>
@@ -505,7 +505,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
     log.info(null, "notarization successful")
   }
 
-  private getNotarizeOptions(appPath: string): NotarizeOptions | undefined {
+  private getNotarizeOptions(appPath: string): NotarizeOptionsNotaryTool | undefined {
     let teamId = process.env.APPLE_TEAM_ID
     const appleId = process.env.APPLE_ID
     const appleIdPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -231,21 +231,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    *
    * For security reasons it is recommended to use the first option (see https://github.com/electron-userland/electron-builder/issues/7859)
    */
-  readonly notarize?: NotarizeLegacyOptions | NotarizeNotaryOptions | boolean | null
-}
-
-/** @deprecated */
-export interface NotarizeLegacyOptions {
-  /**
-   * The app bundle identifier your Electron app is using. E.g. com.github.electron. Useful if notarization ID differs from app ID (unlikely).
-   * Only used by `legacy` notarization tool
-   */
-  readonly appBundleId?: string | null
-
-  /**
-   * Your Team Short Name. Only used by `legacy` notarization tool
-   */
-  readonly ascProvider?: string | null
+  readonly notarize?: NotarizeNotaryOptions | boolean | null
 }
 
 export interface NotarizeNotaryOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
         specifier: ~2.6.5
         version: 2.6.5
       '@electron/notarize':
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.3.2
+        version: 2.3.2
       '@electron/osx-sign':
         specifier: 1.3.0
         version: 1.3.0
@@ -2301,8 +2301,8 @@ packages:
       minimatch: 3.1.2
     dev: false
 
-  /@electron/notarize@2.3.0:
-    resolution: {integrity: sha512-EiTBU0BwE7HZZjAG1fFWQaiQpCuPrVGn7jPss1kUjD6eTTdXXd29RiZqEqkgN7xqt/Pgn4g3I7Saqovanrfj3w==}
+  /@electron/notarize@2.3.2:
+    resolution: {integrity: sha512-zfayxCe19euNwRycCty1C7lF7snk9YwfRpB5M8GLr1a4ICH63znxaPNAubrMvj0yDvVozqfgsdYpXVUnpWBDpg==}
     engines: {node: '>= 10.0.0'}
     dependencies:
       debug: 4.3.4


### PR DESCRIPTION
Updates @electron/notarize to v2.3.2 which should fix the issue with parsing errors created by `notarytool`

https://github.com/electron/notarize/pull/191