### PR TITLE
fix: change abort to aborted event

### DIFF
--- a/.changeset/strong-spiders-grab.md
+++ b/.changeset/strong-spiders-grab.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix aborted event

--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -233,10 +233,6 @@ export abstract class DifferentialDownloader {
 
         const request = this.httpExecutor.createRequest(requestOptions, response => {
           response.on("error", reject)
-          // for old nodejs:https://nodejs.org/docs/latest-v16.x/api/http.html#event-abort
-          response.on("abort", () => {
-            reject(new Error("response has been abort by the server"))
-          })
           response.on("aborted", () => {
             reject(new Error("response has been aborted by the server"))
           })

--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -296,10 +296,6 @@ export abstract class DifferentialDownloader {
         }
 
         response.on("error", reject)
-        // for old nodejs:https://nodejs.org/docs/latest-v16.x/api/http.html#event-abort
-        response.on("abort", () => {
-          reject(new Error("response has been abort by the server"))
-        })
         response.on("aborted", () => {
           reject(new Error("response has been aborted by the server"))
         })

--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -233,6 +233,10 @@ export abstract class DifferentialDownloader {
 
         const request = this.httpExecutor.createRequest(requestOptions, response => {
           response.on("error", reject)
+          // for old nodejs:https://nodejs.org/docs/latest-v16.x/api/http.html#event-abort
+          response.on("abort", () => {
+            reject(new Error("response has been abort by the server"))
+          })
           response.on("aborted", () => {
             reject(new Error("response has been aborted by the server"))
           })
@@ -294,6 +298,15 @@ export abstract class DifferentialDownloader {
         if (!checkIsRangesSupported(response, reject)) {
           return
         }
+
+        response.on("error", reject)
+        // for old nodejs:https://nodejs.org/docs/latest-v16.x/api/http.html#event-abort
+        response.on("abort", () => {
+          reject(new Error("response has been abort by the server"))
+        })
+        response.on("aborted", () => {
+          reject(new Error("response has been aborted by the server"))
+        })
 
         response.on("data", dataHandler)
         response.on("end", () => resolve())

--- a/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/DifferentialDownloader.ts
@@ -233,7 +233,7 @@ export abstract class DifferentialDownloader {
 
         const request = this.httpExecutor.createRequest(requestOptions, response => {
           response.on("error", reject)
-          response.on("abort", () => {
+          response.on("aborted", () => {
             reject(new Error("response has been aborted by the server"))
           })
           // Electron net handles redirects automatically, our NodeJS test server doesn't use redirects - so, we don't check 3xx codes.


### PR DESCRIPTION
There are many SimpleURLLoaderWrapper server error in sentrty, I think they might be caused by this event.

Here's a simple example:
```javascript
// test.js
'use strict';

// The same issue occurs with `http`, too.
const https = require('https');

const req = https.request('https://nodejs.org/dist/v13.7.0/node-v13.7.0.tar.gz');
req.on('response', (res) => {
  res
    .on('end', () => console.log('end'))
    .on('close', () => console.log('close'))
    .on('aborted', () => console.log('aborted'))
    .on('error', (err) => console.log(err));

  setTimeout(() => {
    console.log('start');
    req.abort();
  }, 500);
});
req.end();
```

