### PR TITLE
fix: Folder's named "constructor" not being included in asar 

### DIFF
--- a/.changeset/lazy-buttons-hunt.md
+++ b/.changeset/lazy-buttons-hunt.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix Folder's named "constructor" not being included in asar

--- a/packages/app-builder-lib/src/asar/asar.ts
+++ b/packages/app-builder-lib/src/asar/asar.ts
@@ -40,7 +40,7 @@ export class AsarFilesystem {
     readonly headerSize: number = -1
   ) {
     if (this.header.files == null) {
-      this.header.files = {}
+      this.header.files = Object.create(null) as { [key: string]: Node }
     }
   }
 
@@ -54,7 +54,7 @@ export class AsarFilesystem {
             return null
           }
           child = new Node()
-          child.files = {}
+          child.files = Object.create(null) as { [key: string]: Node }
           node.files![dir] = child
         }
         node = child
@@ -71,7 +71,7 @@ export class AsarFilesystem {
     const name = path.basename(p)
     const dirNode = this.searchNodeFromDirectory(path.dirname(p), true)!
     if (dirNode.files == null) {
-      dirNode.files = {}
+      dirNode.files = Object.create(null) as { [key: string]: Node }
     }
 
     let result = dirNode.files[name]
@@ -105,7 +105,7 @@ export class AsarFilesystem {
 
     let children = dirNode.files
     if (children == null) {
-      children = {}
+      children = Object.create(null) as { [key: string]: Node }
       dirNode.files = children
     }
     children[path.basename(file)] = node


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8284

Refers to https://github.com/electron/asar/pull/253