### PR TITLE
Update deprecated `archiver` package in electron-builder-squirrel-windows

### DIFF
--- a/packages/electron-builder-squirrel-windows/package.json
+++ b/packages/electron-builder-squirrel-windows/package.json
@@ -16,12 +16,12 @@
   ],
   "dependencies": {
     "app-builder-lib": "workspace:*",
-    "archiver": "^5.3.1",
+    "archiver": "^7.0.1",
     "builder-util": "workspace:*",
     "fs-extra": "^10.1.0"
   },
   "devDependencies": {
-    "@types/archiver": "5.3.1",
+    "@types/archiver": "6.0.2",
     "@types/fs-extra": "9.0.13"
   },
   "types": "./out/SquirrelWindowsTarget.d.ts"


### PR DESCRIPTION
Node versions below 12 are no longer supported and several subdependencies are deprecated