### PR TITLE
fix: enhance and fix deb and rpm updaters

### DIFF
--- a/.changeset/pretty-seals-appear.md
+++ b/.changeset/pretty-seals-appear.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: enhance and fix deb and rpm updaters

--- a/packages/electron-updater/src/DebUpdater.ts
+++ b/packages/electron-updater/src/DebUpdater.ts
@@ -31,7 +31,7 @@ export class DebUpdater extends BaseUpdater {
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
-    const cmd = ["dpkg", "-i", options.installerPath, "||", "apt-get", "install", "-f", "-y"]
+    const cmd = ["dpkg", "-i", options.installerPath]
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {
       this.app.relaunch()

--- a/packages/electron-updater/src/RpmUpdater.ts
+++ b/packages/electron-updater/src/RpmUpdater.ts
@@ -28,35 +28,10 @@ export class RpmUpdater extends BaseUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const upgradePath = options.installerPath
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
-    const packageManager = this.spawnSyncLog("which zypper")
-    let cmd: string[]
-    if (!packageManager) {
-      const packageManager = this.spawnSyncLog("which dnf || which yum")
-      cmd = [packageManager, "-y", "remove", `'${this.app.name}'`, ";", packageManager, "-y", "install", upgradePath]
-    } else {
-      cmd = [
-        packageManager,
-        "remove",
-        "-y",
-        `'${this.app.name}'`,
-        ";",
-        packageManager,
-        "clean",
-        "--all",
-        ";",
-        packageManager,
-        "--no-refresh",
-        "install",
-        "--allow-unsigned-rpm",
-        "-y",
-        "-f",
-        upgradePath,
-      ]
-    }
+    const cmd = ["rpm", "-U", options.installerPath]
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {
       this.app.relaunch()


### PR DESCRIPTION
Changes on this PR:

Fix rpm updater by using the rpm tool instead of package managers.
Simplify the deb updater by removing the apt-get part as it is useless.