### PR TITLE
chore: re-enable CI tests in FilesTest

### DIFF
--- a/test/src/filesTest.ts
+++ b/test/src/filesTest.ts
@@ -1,5 +1,5 @@
 import { DIR_TARGET, Platform } from "electron-builder"
-import { TmpDir } from "builder-util"
+import { TmpDir, archFromString } from "builder-util"
 import { copyDir } from "builder-util/out/fs"
 import { outputFile } from "fs-extra"
 import * as fs from "fs/promises"
@@ -103,7 +103,7 @@ test.ifDevOrLinuxCi(
     {
       projectDirCreated: projectDir => Promise.all([outputFile(path.join(projectDir, "foo", "old"), "data"), outputFile(path.join(projectDir, "license.txt"), "data")]),
       packed: context => {
-        const resources = path.join(context.getResources(Platform.LINUX))
+        const resources = context.getResources(Platform.LINUX)
         return Promise.all([
           assertThat(path.join(resources, "app", "foo", "old")).doesNotExist(),
           assertThat(path.join(resources, "foo", "new")).isFile(),
@@ -116,7 +116,6 @@ test.ifDevOrLinuxCi(
 
 async function doExtraResourcesTest(platform: Platform) {
   const osName = platform.buildConfigurationKey
-  //noinspection SpellCheckingInspection
   await assertPack(
     "test-app-one",
     {
@@ -131,33 +130,28 @@ async function doExtraResourcesTest(platform: Platform) {
       },
     },
     {
-      projectDirCreated: projectDir => {
+      projectDirCreated: async projectDir => {
         return Promise.all([
-          outputFile(path.join(projectDir, "foo/nameWithoutDot"), "nameWithoutDot"),
-          outputFile(path.join(projectDir, "bar/hello.txt"), "data"),
-          outputFile(path.join(projectDir, "dir-relative/f.txt"), "data"),
-          outputFile(path.join(projectDir, `bar/${process.arch}.txt`), "data"),
-          outputFile(path.join(projectDir, `${osName}/${process.arch}.txt`), "data"),
-          outputFile(path.join(projectDir, "platformSpecificR"), "platformSpecificR"),
-          outputFile(path.join(projectDir, "ignoreMe.txt"), "ignoreMe"),
+          outputFile(path.resolve(projectDir, "foo/nameWithoutDot"), "nameWithoutDot"),
+          outputFile(path.resolve(projectDir, "bar/hello.txt"), "data"),
+          outputFile(path.resolve(projectDir, "dir-relative/f.txt"), "data"),
+          outputFile(path.resolve(projectDir, `bar/${process.arch}.txt`), "data"),
+          outputFile(path.resolve(projectDir, `${osName}/${process.arch}.txt`), "data"),
+          outputFile(path.resolve(projectDir, "platformSpecificR"), "platformSpecificR"),
+          outputFile(path.resolve(projectDir, "ignoreMe.txt"), "ignoreMe"),
         ])
       },
-      packed: context => {
-        const base = path.join(context.outDir, `${platform.buildConfigurationKey}${platform === Platform.MAC ? "" : "-unpacked"}`)
-        let resourcesDir = path.join(base, "resources")
-        if (platform === Platform.MAC) {
-          resourcesDir = path.join(base, `${context.packager.appInfo.productFilename}.app`, "Contents", "Resources")
-        }
-
+      packed: async context => {
+        const resourcesDir = context.getResources(platform, archFromString(process.arch))
         return Promise.all([
-          assertThat(path.join(resourcesDir, "foo")).isDirectory(),
-          assertThat(path.join(resourcesDir, "foo", "nameWithoutDot")).isFile(),
-          assertThat(path.join(resourcesDir, "bar", "hello.txt")).isFile(),
-          assertThat(path.join(resourcesDir, "dir-relative", "f.txt")).isFile(),
-          assertThat(path.join(resourcesDir, "bar", `${process.arch}.txt`)).isFile(),
-          assertThat(path.join(resourcesDir, osName, `${process.arch}.txt`)).isFile(),
-          assertThat(path.join(resourcesDir, "platformSpecificR")).isFile(),
-          assertThat(path.join(resourcesDir, "ignoreMe.txt")).doesNotExist(),
+          assertThat(path.resolve(resourcesDir, "foo")).isDirectory(),
+          assertThat(path.resolve(resourcesDir, "foo", "nameWithoutDot")).isFile(),
+          assertThat(path.resolve(resourcesDir, "bar", "hello.txt")).isFile(),
+          assertThat(path.resolve(resourcesDir, "dir-relative", "f.txt")).isFile(),
+          assertThat(path.resolve(resourcesDir, "bar", `${process.arch}.txt`)).isFile(),
+          assertThat(path.resolve(resourcesDir, osName, `${process.arch}.txt`)).isFile(),
+          assertThat(path.resolve(resourcesDir, "platformSpecificR")).isFile(),
+          assertThat(path.resolve(resourcesDir, "ignoreMe.txt")).doesNotExist(),
         ])
       },
     }
@@ -168,14 +162,11 @@ test.ifDevOrLinuxCi("extraResources on Linux", () => doExtraResourcesTest(Platfo
 
 // Squirrel.Windows is not supported on macOS anymore (32-bit)
 // Skipped due to bug in rimraf on Windows: `at fixWinEPERM (../node_modules/.pnpm/fs-extra@8.1.0/node_modules/fs-extra/lib/remove/rimraf.js:117:5)`
-test.skip.ifNotMac.ifDevOrWinCi("extraResources on Windows", () => doExtraResourcesTest(Platform.WINDOWS))
+test.ifNotMac.ifDevOrWinCi("extraResources on Windows", () => doExtraResourcesTest(Platform.WINDOWS))
 
-// TODO FIX ME
-test.skip.ifMac("extraResources on macOS", async () => {
-  await doExtraResourcesTest(Platform.MAC)
-})
+test.ifMac("extraResources on macOS", () => doExtraResourcesTest(Platform.MAC))
 
-test.skip.ifNotWindows.ifNotCiWin("extraResources - two-package", () => {
+test.ifNotWindows.ifNotCiWin("extraResources - two-package", () => {
   const platform = Platform.LINUX
   const osName = platform.buildConfigurationKey
 
@@ -208,11 +199,7 @@ test.skip.ifNotWindows.ifNotCiWin("extraResources - two-package", () => {
         ])
       },
       packed: async context => {
-        const base = path.join(context.outDir, `${platform.buildConfigurationKey}-unpacked`)
-        let resourcesDir = path.join(base, "resources")
-        if (platform === Platform.MAC) {
-          resourcesDir = path.join(base, "TestApp.app", "Contents", "Resources")
-        }
+        const resourcesDir = context.getResources(platform, archFromString(process.arch))
         const appDir = path.join(resourcesDir, "app")
 
         await Promise.all([

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -142,7 +142,7 @@ export async function assertPack(fixtureName: string, packagerOptions: PackagerO
         const base = function (platform: Platform, arch?: Arch): string {
           return path.join(
             outDir,
-            `${platform.buildConfigurationKey}${getArchSuffix(arch == null ? Arch.x64 : arch)}${platform === Platform.MAC ? "" : "-unpacked"}`,
+            `${platform.buildConfigurationKey}${getArchSuffix(arch ?? Arch.x64)}${platform === Platform.MAC ? "" : "-unpacked"}`,
             platform === Platform.MAC ? `${packager.appInfo.productFilename}.app/Contents` : ""
           )
         }


### PR DESCRIPTION
Re-enabling extra resources and files tests now that the arch-specific build machines have been identified as the core reason for the flakiness. (Likely due to the new rollout of arm64 mac machines on Github Runners?)