### PR TITLE
fix: binary checking

### DIFF
--- a/.changeset/lovely-bottles-allow.md
+++ b/.changeset/lovely-bottles-allow.md
@@ -2,4 +2,4 @@
 "app-builder-lib": patch
 ---
 
-update binar checking
+update binary checking

--- a/.changeset/lovely-bottles-allow.md
+++ b/.changeset/lovely-bottles-allow.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+update binar checking

--- a/packages/app-builder-lib/src/asar/unpackDetector.ts
+++ b/packages/app-builder-lib/src/asar/unpackDetector.ts
@@ -82,7 +82,7 @@ export async function detectUnpackedDirs(fileSet: ResolvedFileSet, autoUnpackDir
     const moduleName = path.basename(packageDir)
     if (moduleName === "ffprobe-static" || moduleName === "ffmpeg-static" || isLibOrExe(file)) {
       shouldUnpack = true
-    } else if (!file.includes(".", nextSlashIndex)) {
+    } else {
       shouldUnpack = !!isBinaryFileSync(file)
     }
 

--- a/packages/app-builder-lib/src/asar/unpackDetector.ts
+++ b/packages/app-builder-lib/src/asar/unpackDetector.ts
@@ -82,7 +82,11 @@ export async function detectUnpackedDirs(fileSet: ResolvedFileSet, autoUnpackDir
     const moduleName = path.basename(packageDir)
     if (moduleName === "ffprobe-static" || moduleName === "ffmpeg-static" || isLibOrExe(file)) {
       shouldUnpack = true
-    } else {
+    }
+
+    const fileBaseName = path.basename(file)
+    const hasExtension = path.extname(fileBaseName)
+    if (!hasExtension) {
       shouldUnpack = !!isBinaryFileSync(file)
     }
 

--- a/packages/app-builder-lib/src/asar/unpackDetector.ts
+++ b/packages/app-builder-lib/src/asar/unpackDetector.ts
@@ -80,13 +80,11 @@ export async function detectUnpackedDirs(fileSet: ResolvedFileSet, autoUnpackDir
     let shouldUnpack = false
     // ffprobe-static and ffmpeg-static are known packages to always unpack
     const moduleName = path.basename(packageDir)
-    if (moduleName === "ffprobe-static" || moduleName === "ffmpeg-static" || isLibOrExe(file)) {
-      shouldUnpack = true
-    }
-
     const fileBaseName = path.basename(file)
     const hasExtension = path.extname(fileBaseName)
-    if (!hasExtension) {
+    if (moduleName === "ffprobe-static" || moduleName === "ffmpeg-static" || isLibOrExe(file)) {
+      shouldUnpack = true
+    } else if (!hasExtension) {
       shouldUnpack = !!isBinaryFileSync(file)
     }
 


### PR DESCRIPTION
If a module contains a folder with a name like `test.app` or `test.framework`, and there are binary files inside, it will be incorrectly processed and the module will be placed in `app.asar` instead of being smartly unpacked into `app.asar.unpacked`.