### PR TITLE
Add nodejs 20 (lts iron) based images

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -8,6 +8,13 @@ docker build -t electronuserland/builder:base -t "electronuserland/builder:base-
 
 ## NOTE: Order the latest to oldest versions. The most recent node LTS should be tagged as the latest image
 
+# Node 20
+docker build --build-arg NODE_VERSION=20.15.1 --build-arg IMAGE_VERSION=base-$DATE -t electronuserland/builder:20 -t "electronuserland/builder:20-$DATE" -t electronuserland/builder:latest docker/node
+
+docker build --build-arg IMAGE_VERSION=20-$DATE -t electronuserland/builder:20-wine -t "electronuserland/builder:20-wine-$DATE" -t electronuserland/builder:wine docker/wine
+docker build --build-arg IMAGE_VERSION=20-wine-$DATE -t electronuserland/builder:20-wine-mono -t "electronuserland/builder:20-wine-mono-$DATE" -t electronuserland/builder:wine-mono docker/wine-mono
+docker build --build-arg IMAGE_VERSION=20-wine-$DATE -t electronuserland/builder:20-wine-chrome -t "electronuserland/builder:20-wine-chrome-$DATE" -t electronuserland/builder:wine-chrome docker/wine-chrome
+
 # Node 18
 docker build --build-arg NODE_VERSION=18.18.2 --build-arg IMAGE_VERSION=base-$DATE -t electronuserland/builder:18 -t "electronuserland/builder:18-$DATE" -t electronuserland/builder:latest docker/node
 


### PR DESCRIPTION
Add NodeJS 20 (LTS Iron) based images, as that is the version used in Electron releases 29, 30 and 31 . 

I could not find an existing issue / pull request, so if it is a duplicate, just close this one. I hope I dit not miss anything, that needs changing.

Thanks your work!

