### PR TITLE
fix: setting `disablePreGypCopy: true` and updating unit test with `node-pty` native module

### DIFF
--- a/.changeset/brave-bottles-sell.md
+++ b/.changeset/brave-bottles-sell.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): `disablePreGypCopy: true` to handle mac universal builds (fixes #8347)

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -206,9 +206,8 @@ export async function rebuild(config: Configuration, appDir: string, options: Re
     debug: log.isDebugEnabled,
     projectRootPath: await getProjectRootPath(appDir),
     mode: (config.nativeRebuilder as RebuildMode) || "sequential",
-  }
-  if (buildFromSource) {
-    rebuildOptions.prebuildTagPrefix = "totally-not-a-real-prefix-to-force-rebuild"
+    buildFromSource: buildFromSource,
+    disablePreGypCopy: true,
   }
   return remoteRebuild(rebuildOptions)
 }

--- a/test/fixtures/test-app-two-native-modules/app/package.json
+++ b/test/fixtures/test-app-two-native-modules/app/package.json
@@ -3,7 +3,8 @@
   "main": "index.js",
   "version": "1.1.1",
   "dependencies": {
-    "debug": "4.1.1"
+    "debug": "4.1.1",
+    "node-pty": "1.1.0-beta14"
   },
   "optionalDependencies": {
     "node-mac-permissions": "2.3.0"

--- a/test/fixtures/test-app-two-native-modules/app/package.json
+++ b/test/fixtures/test-app-two-native-modules/app/package.json
@@ -4,7 +4,8 @@
   "version": "1.1.1",
   "dependencies": {
     "debug": "4.1.1",
-    "node-pty": "1.1.0-beta14"
+    "node-pty": "1.1.0-beta14",
+    "node-addon-api": "7.1.1"
   },
   "optionalDependencies": {
     "node-mac-permissions": "2.3.0"

--- a/test/fixtures/test-app-two-native-modules/app/yarn.lock
+++ b/test/fixtures/test-app-two-native-modules/app/yarn.lock
@@ -26,6 +26,11 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+node-addon-api@7.1.1, node-addon-api@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
+
 node-addon-api@^3.0.2:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
@@ -38,3 +43,10 @@ node-mac-permissions@2.3.0:
   dependencies:
     bindings "^1.5.0"
     node-addon-api "^3.0.2"
+
+node-pty@1.1.0-beta14:
+  version "1.1.0-beta14"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta14.tgz#e6e9eeb3ac7186144d17902977f9da011e513563"
+  integrity sha512-w/o/q6UL95azHQhrKvMnIojs1AGiqxnjNgcH3138H/RIRkIpE8S5GvT4dpvQT+ZVbTJxoBFt/DnaBAT1PAN7WQ==
+  dependencies:
+    node-addon-api "^7.1.0"

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -352,6 +352,15 @@ Object {
               "files": Object {
                 "Release": Object {
                   "files": Object {
+                    "node-addon-api": Object {
+                      "files": Object {
+                        "node_addon_api_except.stamp": Object {
+                          "size": 0,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
                     "pty.node": Object {
                       "size": 72880,
                       "unpacked": true,
@@ -948,6 +957,15 @@ Object {
               },
               "unpacked": true,
             },
+            "node-addon-api": Object {
+              "files": Object {
+                "node_addon_api.Makefile": Object {
+                  "size": 159,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
             "package.json": Object {
               "size": 884,
               "unpacked": true,
@@ -1076,7 +1094,7 @@ Object {
     },
     "package.json": Object {
       "offset": "426524",
-      "size": 235,
+      "size": 266,
     },
   },
 }

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -196,11 +196,11 @@ exports[`yarn two package.json w/ native module 2`] = `
 Object {
   "files": Object {
     "index.html": Object {
-      "offset": "50776",
+      "offset": "423182",
       "size": 841,
     },
     "index.js": Object {
-      "offset": "51617",
+      "offset": "424023",
       "size": 2501,
     },
     "node_modules": Object {
@@ -261,11 +261,822 @@ Object {
             },
           },
         },
+        "node-addon-api": Object {
+          "files": Object {
+            "LICENSE.md": Object {
+              "offset": "50776",
+              "size": 1150,
+            },
+            "common.gypi": Object {
+              "offset": "51926",
+              "size": 724,
+            },
+            "except.gypi": Object {
+              "offset": "52650",
+              "size": 560,
+            },
+            "index.js": Object {
+              "offset": "53210",
+              "size": 377,
+            },
+            "napi-inl.deprecated.h": Object {
+              "offset": "53587",
+              "size": 6323,
+            },
+            "napi-inl.h": Object {
+              "offset": "59910",
+              "size": 219411,
+            },
+            "napi.h": Object {
+              "offset": "279321",
+              "size": 115423,
+            },
+            "node_addon_api.gyp": Object {
+              "offset": "394744",
+              "size": 793,
+            },
+            "node_api.gyp": Object {
+              "offset": "395537",
+              "size": 132,
+            },
+            "noexcept.gypi": Object {
+              "offset": "395669",
+              "size": 639,
+            },
+            "nothing.c": Object {
+              "offset": "396308",
+              "size": 0,
+            },
+            "package-support.json": Object {
+              "offset": "396308",
+              "size": 467,
+            },
+            "package.json": Object {
+              "offset": "396775",
+              "size": 928,
+            },
+            "tools": Object {
+              "files": Object {
+                "README.md": Object {
+                  "offset": "397703",
+                  "size": 3217,
+                },
+                "check-napi.js": Object {
+                  "offset": "400920",
+                  "size": 3176,
+                },
+                "clang-format.js": Object {
+                  "offset": "404096",
+                  "size": 2002,
+                },
+                "conversion.js": Object {
+                  "executable": true,
+                  "offset": "406098",
+                  "size": 15013,
+                },
+                "eslint-format.js": Object {
+                  "offset": "421111",
+                  "size": 2071,
+                },
+              },
+            },
+          },
+        },
+        "node-pty": Object {
+          "files": Object {
+            "LICENSE": Object {
+              "size": 3326,
+              "unpacked": true,
+            },
+            "build": Object {
+              "files": Object {
+                "Release": Object {
+                  "files": Object {
+                    "pty.node": Object {
+                      "size": 72880,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "node_gyp_bins": Object {
+                  "files": Object {
+                    "python3": Object {
+                      "size": 5490456,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+            },
+            "deps": Object {
+              "files": Object {
+                ".editorconfig": Object {
+                  "size": 55,
+                  "unpacked": true,
+                },
+                "winpty": Object {
+                  "files": Object {
+                    ".drone.yml": Object {
+                      "size": 439,
+                      "unpacked": true,
+                    },
+                    "LICENSE": Object {
+                      "size": 1085,
+                      "unpacked": true,
+                    },
+                    "Makefile": Object {
+                      "size": 4722,
+                      "unpacked": true,
+                    },
+                    "README.md": Object {
+                      "size": 5551,
+                      "unpacked": true,
+                    },
+                    "RELEASES.md": Object {
+                      "size": 13667,
+                      "unpacked": true,
+                    },
+                    "VERSION.txt": Object {
+                      "size": 10,
+                      "unpacked": true,
+                    },
+                    "configure": Object {
+                      "size": 6478,
+                      "unpacked": true,
+                    },
+                    "misc": Object {
+                      "files": Object {
+                        "ConinMode.ps1": Object {
+                          "size": 3228,
+                          "unpacked": true,
+                        },
+                        "DebugClient.py": Object {
+                          "size": 1558,
+                          "unpacked": true,
+                        },
+                        "DebugServer.py": Object {
+                          "size": 2396,
+                          "unpacked": true,
+                        },
+                        "DumpLines.py": Object {
+                          "size": 97,
+                          "unpacked": true,
+                        },
+                        "EnableExtendedFlags.txt": Object {
+                          "size": 1974,
+                          "unpacked": true,
+                        },
+                        "Font-Report-June2016": Object {
+                          "files": Object {
+                            "CP437-Consolas.txt": Object {
+                              "size": 16408,
+                              "unpacked": true,
+                            },
+                            "CP437-Lucida.txt": Object {
+                              "size": 19641,
+                              "unpacked": true,
+                            },
+                            "CP932.txt": Object {
+                              "size": 19593,
+                              "unpacked": true,
+                            },
+                            "CP936.txt": Object {
+                              "size": 19650,
+                              "unpacked": true,
+                            },
+                            "CP949.txt": Object {
+                              "size": 19588,
+                              "unpacked": true,
+                            },
+                            "CP950.txt": Object {
+                              "size": 19656,
+                              "unpacked": true,
+                            },
+                            "MinimumWindowWidths.txt": Object {
+                              "size": 870,
+                              "unpacked": true,
+                            },
+                            "Results.txt": Object {
+                              "size": 147,
+                              "unpacked": true,
+                            },
+                            "Windows10SetFontBugginess.txt": Object {
+                              "size": 7851,
+                              "unpacked": true,
+                            },
+                          },
+                          "unpacked": true,
+                        },
+                        "FormatChar.h": Object {
+                          "size": 529,
+                          "unpacked": true,
+                        },
+                        "IdentifyConsoleWindow.ps1": Object {
+                          "size": 1952,
+                          "unpacked": true,
+                        },
+                        "MouseInputNotes.txt": Object {
+                          "size": 4325,
+                          "unpacked": true,
+                        },
+                        "Notes.txt": Object {
+                          "size": 9856,
+                          "unpacked": true,
+                        },
+                        "Spew.py": Object {
+                          "size": 65,
+                          "unpacked": true,
+                        },
+                        "build32.sh": Object {
+                          "size": 213,
+                          "unpacked": true,
+                        },
+                        "build64.sh": Object {
+                          "size": 217,
+                          "unpacked": true,
+                        },
+                        "color-test.sh": Object {
+                          "size": 6068,
+                          "unpacked": true,
+                        },
+                        "font-notes.txt": Object {
+                          "size": 14988,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                    "ship": Object {
+                      "files": Object {
+                        "build-pty4j-libpty.bat": Object {
+                          "size": 1230,
+                          "unpacked": true,
+                        },
+                        "common_ship.py": Object {
+                          "size": 1698,
+                          "unpacked": true,
+                        },
+                        "make_msvc_package.py": Object {
+                          "size": 5415,
+                          "unpacked": true,
+                        },
+                        "ship.py": Object {
+                          "size": 4022,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                    "src": Object {
+                      "files": Object {
+                        "agent": Object {
+                          "files": Object {
+                            "Agent.h": Object {
+                              "size": 3520,
+                              "unpacked": true,
+                            },
+                            "AgentCreateDesktop.h": Object {
+                              "size": 1283,
+                              "unpacked": true,
+                            },
+                            "ConsoleFont.h": Object {
+                              "size": 1266,
+                              "unpacked": true,
+                            },
+                            "ConsoleInput.h": Object {
+                              "size": 3950,
+                              "unpacked": true,
+                            },
+                            "ConsoleInputReencoding.h": Object {
+                              "size": 1444,
+                              "unpacked": true,
+                            },
+                            "ConsoleLine.h": Object {
+                              "size": 1524,
+                              "unpacked": true,
+                            },
+                            "Coord.h": Object {
+                              "size": 2204,
+                              "unpacked": true,
+                            },
+                            "DebugShowInput.h": Object {
+                              "size": 1434,
+                              "unpacked": true,
+                            },
+                            "DefaultInputMap.h": Object {
+                              "size": 1271,
+                              "unpacked": true,
+                            },
+                            "DsrSender.h": Object {
+                              "size": 1242,
+                              "unpacked": true,
+                            },
+                            "EventLoop.h": Object {
+                              "size": 1603,
+                              "unpacked": true,
+                            },
+                            "InputMap.h": Object {
+                              "size": 3369,
+                              "unpacked": true,
+                            },
+                            "LargeConsoleRead.h": Object {
+                              "size": 2411,
+                              "unpacked": true,
+                            },
+                            "NamedPipe.h": Object {
+                              "size": 4130,
+                              "unpacked": true,
+                            },
+                            "Scraper.h": Object {
+                              "size": 3760,
+                              "unpacked": true,
+                            },
+                            "SimplePool.h": Object {
+                              "size": 2365,
+                              "unpacked": true,
+                            },
+                            "SmallRect.h": Object {
+                              "size": 4437,
+                              "unpacked": true,
+                            },
+                            "Terminal.h": Object {
+                              "size": 2262,
+                              "unpacked": true,
+                            },
+                            "UnicodeEncoding.h": Object {
+                              "size": 5298,
+                              "unpacked": true,
+                            },
+                            "Win32Console.h": Object {
+                              "size": 2347,
+                              "unpacked": true,
+                            },
+                            "Win32ConsoleBuffer.h": Object {
+                              "size": 3244,
+                              "unpacked": true,
+                            },
+                          },
+                          "unpacked": true,
+                        },
+                        "configurations.gypi": Object {
+                          "size": 2378,
+                          "unpacked": true,
+                        },
+                        "include": Object {
+                          "files": Object {
+                            "winpty.h": Object {
+                              "size": 9420,
+                              "unpacked": true,
+                            },
+                            "winpty_constants.h": Object {
+                              "size": 5697,
+                              "unpacked": true,
+                            },
+                          },
+                          "unpacked": true,
+                        },
+                        "libwinpty": Object {
+                          "files": Object {
+                            "AgentLocation.h": Object {
+                              "size": 1278,
+                              "unpacked": true,
+                            },
+                            "LibWinptyException.h": Object {
+                              "size": 1961,
+                              "unpacked": true,
+                            },
+                            "WinptyInternal.h": Object {
+                              "size": 2379,
+                              "unpacked": true,
+                            },
+                          },
+                          "unpacked": true,
+                        },
+                        "shared": Object {
+                          "files": Object {
+                            "AgentMsg.h": Object {
+                              "size": 1418,
+                              "unpacked": true,
+                            },
+                            "BackgroundDesktop.h": Object {
+                              "size": 2836,
+                              "unpacked": true,
+                            },
+                            "Buffer.h": Object {
+                              "size": 3376,
+                              "unpacked": true,
+                            },
+                            "DebugClient.h": Object {
+                              "size": 1696,
+                              "unpacked": true,
+                            },
+                            "GenRandom.h": Object {
+                              "size": 2015,
+                              "unpacked": true,
+                            },
+                            "GetCommitHash.bat": Object {
+                              "size": 274,
+                              "unpacked": true,
+                            },
+                            "Mutex.h": Object {
+                              "size": 2183,
+                              "unpacked": true,
+                            },
+                            "OsModule.h": Object {
+                              "size": 2282,
+                              "unpacked": true,
+                            },
+                            "OwnedHandle.h": Object {
+                              "size": 1870,
+                              "unpacked": true,
+                            },
+                            "PrecompiledHeader.h": Object {
+                              "size": 1528,
+                              "unpacked": true,
+                            },
+                            "StringBuilder.h": Object {
+                              "size": 8506,
+                              "unpacked": true,
+                            },
+                            "StringUtil.h": Object {
+                              "size": 2677,
+                              "unpacked": true,
+                            },
+                            "TimeMeasurement.h": Object {
+                              "size": 2171,
+                              "unpacked": true,
+                            },
+                            "UnixCtrlChars.h": Object {
+                              "size": 2019,
+                              "unpacked": true,
+                            },
+                            "UpdateGenVersion.bat": Object {
+                              "size": 578,
+                              "unpacked": true,
+                            },
+                            "WindowsSecurity.h": Object {
+                              "size": 3465,
+                              "unpacked": true,
+                            },
+                            "WindowsVersion.h": Object {
+                              "size": 1345,
+                              "unpacked": true,
+                            },
+                            "WinptyAssert.h": Object {
+                              "size": 2829,
+                              "unpacked": true,
+                            },
+                            "WinptyException.h": Object {
+                              "size": 1643,
+                              "unpacked": true,
+                            },
+                            "WinptyVersion.h": Object {
+                              "size": 1246,
+                              "unpacked": true,
+                            },
+                            "winpty_snprintf.h": Object {
+                              "size": 3668,
+                              "unpacked": true,
+                            },
+                          },
+                          "unpacked": true,
+                        },
+                        "unix-adapter": Object {
+                          "files": Object {
+                            "InputHandler.h": Object {
+                              "size": 2058,
+                              "unpacked": true,
+                            },
+                            "OutputHandler.h": Object {
+                              "size": 1943,
+                              "unpacked": true,
+                            },
+                            "Util.h": Object {
+                              "size": 1410,
+                              "unpacked": true,
+                            },
+                            "WakeupFd.h": Object {
+                              "size": 1549,
+                              "unpacked": true,
+                            },
+                          },
+                          "unpacked": true,
+                        },
+                        "winpty.gyp": Object {
+                          "size": 7684,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                    "vcbuild.bat": Object {
+                      "size": 2425,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "lib": Object {
+              "files": Object {
+                "conpty_console_list_agent.js": Object {
+                  "size": 775,
+                  "unpacked": true,
+                },
+                "conpty_console_list_agent.js.map": Object {
+                  "size": 564,
+                  "unpacked": true,
+                },
+                "eventEmitter2.js": Object {
+                  "size": 1600,
+                  "unpacked": true,
+                },
+                "eventEmitter2.js.map": Object {
+                  "size": 1155,
+                  "unpacked": true,
+                },
+                "eventEmitter2.test.js": Object {
+                  "size": 1266,
+                  "unpacked": true,
+                },
+                "eventEmitter2.test.js.map": Object {
+                  "size": 1396,
+                  "unpacked": true,
+                },
+                "index.js": Object {
+                  "size": 1972,
+                  "unpacked": true,
+                },
+                "index.js.map": Object {
+                  "size": 964,
+                  "unpacked": true,
+                },
+                "interfaces.js": Object {
+                  "size": 233,
+                  "unpacked": true,
+                },
+                "interfaces.js.map": Object {
+                  "size": 124,
+                  "unpacked": true,
+                },
+                "shared": Object {
+                  "files": Object {
+                    "conout.js": Object {
+                      "size": 348,
+                      "unpacked": true,
+                    },
+                    "conout.js.map": Object {
+                      "size": 204,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "terminal.js": Object {
+                  "size": 7454,
+                  "unpacked": true,
+                },
+                "terminal.js.map": Object {
+                  "size": 5844,
+                  "unpacked": true,
+                },
+                "terminal.test.js": Object {
+                  "size": 6250,
+                  "unpacked": true,
+                },
+                "terminal.test.js.map": Object {
+                  "size": 4150,
+                  "unpacked": true,
+                },
+                "testUtils.test.js": Object {
+                  "size": 807,
+                  "unpacked": true,
+                },
+                "testUtils.test.js.map": Object {
+                  "size": 622,
+                  "unpacked": true,
+                },
+                "types.js": Object {
+                  "size": 228,
+                  "unpacked": true,
+                },
+                "types.js.map": Object {
+                  "size": 114,
+                  "unpacked": true,
+                },
+                "unixTerminal.js": Object {
+                  "size": 10231,
+                  "unpacked": true,
+                },
+                "unixTerminal.js.map": Object {
+                  "size": 7978,
+                  "unpacked": true,
+                },
+                "unixTerminal.test.js": Object {
+                  "size": 19444,
+                  "unpacked": true,
+                },
+                "unixTerminal.test.js.map": Object {
+                  "size": 11472,
+                  "unpacked": true,
+                },
+                "utils.js": Object {
+                  "size": 580,
+                  "unpacked": true,
+                },
+                "utils.js.map": Object {
+                  "size": 443,
+                  "unpacked": true,
+                },
+                "windowsConoutConnection.js": Object {
+                  "size": 6017,
+                  "unpacked": true,
+                },
+                "windowsConoutConnection.js.map": Object {
+                  "size": 1593,
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.js": Object {
+                  "size": 12461,
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.js.map": Object {
+                  "size": 8889,
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.test.js": Object {
+                  "size": 4147,
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.test.js.map": Object {
+                  "size": 2951,
+                  "unpacked": true,
+                },
+                "windowsTerminal.js": Object {
+                  "size": 7988,
+                  "unpacked": true,
+                },
+                "windowsTerminal.js.map": Object {
+                  "size": 5127,
+                  "unpacked": true,
+                },
+                "windowsTerminal.test.js": Object {
+                  "size": 9832,
+                  "unpacked": true,
+                },
+                "windowsTerminal.test.js.map": Object {
+                  "size": 8006,
+                  "unpacked": true,
+                },
+                "worker": Object {
+                  "files": Object {
+                    "conoutSocketWorker.js": Object {
+                      "size": 848,
+                      "unpacked": true,
+                    },
+                    "conoutSocketWorker.js.map": Object {
+                      "size": 638,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "package.json": Object {
+              "size": 884,
+              "unpacked": true,
+            },
+            "scripts": Object {
+              "files": Object {
+                "post-install.js": Object {
+                  "size": 1213,
+                  "unpacked": true,
+                },
+                "publish.js": Object {
+                  "size": 2369,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "src": Object {
+              "files": Object {
+                "conpty_console_list_agent.ts": Object {
+                  "size": 696,
+                  "unpacked": true,
+                },
+                "eventEmitter2.test.ts": Object {
+                  "size": 975,
+                  "unpacked": true,
+                },
+                "eventEmitter2.ts": Object {
+                  "size": 1111,
+                  "unpacked": true,
+                },
+                "index.ts": Object {
+                  "size": 2115,
+                  "unpacked": true,
+                },
+                "interfaces.ts": Object {
+                  "size": 2845,
+                  "unpacked": true,
+                },
+                "shared": Object {
+                  "files": Object {
+                    "conout.ts": Object {
+                      "size": 291,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "terminal.test.ts": Object {
+                  "size": 4346,
+                  "unpacked": true,
+                },
+                "terminal.ts": Object {
+                  "size": 6665,
+                  "unpacked": true,
+                },
+                "testUtils.test.ts": Object {
+                  "size": 567,
+                  "unpacked": true,
+                },
+                "tsconfig.json": Object {
+                  "size": 323,
+                  "unpacked": true,
+                },
+                "types.ts": Object {
+                  "size": 306,
+                  "unpacked": true,
+                },
+                "unixTerminal.test.ts": Object {
+                  "size": 13205,
+                  "unpacked": true,
+                },
+                "unixTerminal.ts": Object {
+                  "size": 8195,
+                  "unpacked": true,
+                },
+                "utils.ts": Object {
+                  "size": 292,
+                  "unpacked": true,
+                },
+                "win": Object {
+                  "files": Object {
+                    "path_util.h": Object {
+                      "size": 695,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "windowsConoutConnection.ts": Object {
+                  "size": 2683,
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.test.ts": Object {
+                  "size": 3419,
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.ts": Object {
+                  "size": 10359,
+                  "unpacked": true,
+                },
+                "windowsTerminal.test.ts": Object {
+                  "size": 7551,
+                  "unpacked": true,
+                },
+                "windowsTerminal.ts": Object {
+                  "size": 5784,
+                  "unpacked": true,
+                },
+                "worker": Object {
+                  "files": Object {
+                    "conoutSocketWorker.ts": Object {
+                      "size": 724,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+          },
+          "unpacked": true,
+        },
       },
     },
     "package.json": Object {
-      "offset": "54118",
-      "size": 203,
+      "offset": "426524",
+      "size": 235,
     },
   },
 }

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -611,6 +611,9 @@ Object {
             "napi.h": Object {
               "size": "<size>",
             },
+            "node_addon_api.gyp": Object {
+              "size": "<size>",
+            },
             "node_api.gyp": Object {
               "size": "<size>",
             },
@@ -639,6 +642,9 @@ Object {
                 },
                 "conversion.js": Object {
                   "executable": true,
+                  "size": "<size>",
+                },
+                "eslint-format.js": Object {
                   "size": "<size>",
                 },
               },
@@ -679,6 +685,67 @@ Object {
               "size": "<size>",
               "unpacked": true,
             },
+            "node_modules": Object {
+              "files": Object {
+                "node-addon-api": Object {
+                  "files": Object {
+                    "LICENSE.md": Object {
+                      "size": "<size>",
+                    },
+                    "common.gypi": Object {
+                      "size": "<size>",
+                    },
+                    "except.gypi": Object {
+                      "size": "<size>",
+                    },
+                    "index.js": Object {
+                      "size": "<size>",
+                    },
+                    "napi-inl.deprecated.h": Object {
+                      "size": "<size>",
+                    },
+                    "napi-inl.h": Object {
+                      "size": "<size>",
+                    },
+                    "napi.h": Object {
+                      "size": "<size>",
+                    },
+                    "node_api.gyp": Object {
+                      "size": "<size>",
+                    },
+                    "noexcept.gypi": Object {
+                      "size": "<size>",
+                    },
+                    "nothing.c": Object {
+                      "size": "<size>",
+                    },
+                    "package-support.json": Object {
+                      "size": "<size>",
+                    },
+                    "package.json": Object {
+                      "size": "<size>",
+                    },
+                    "tools": Object {
+                      "files": Object {
+                        "README.md": Object {
+                          "size": "<size>",
+                        },
+                        "check-napi.js": Object {
+                          "size": "<size>",
+                        },
+                        "clang-format.js": Object {
+                          "size": "<size>",
+                        },
+                        "conversion.js": Object {
+                          "executable": true,
+                          "size": "<size>",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
             "package.json": Object {
               "size": "<size>",
               "unpacked": true,
@@ -686,6 +753,718 @@ Object {
             "permissions.mm": Object {
               "size": "<size>",
               "unpacked": true,
+            },
+          },
+        },
+        "node-pty": Object {
+          "files": Object {
+            "LICENSE": Object {
+              "size": "<size>",
+              "unpacked": true,
+            },
+            "build": Object {
+              "files": Object {
+                "Release": Object {
+                  "files": Object {
+                    "pty.node": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "spawn-helper": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+                "node_gyp_bins": Object {
+                  "files": Object {
+                    "python3": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+              },
+            },
+            "deps": Object {
+              "files": Object {
+                ".editorconfig": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "winpty": Object {
+                  "files": Object {
+                    ".drone.yml": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "LICENSE": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "Makefile": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "README.md": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "RELEASES.md": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "VERSION.txt": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "configure": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "misc": Object {
+                      "files": Object {
+                        "ConinMode.ps1": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "DebugClient.py": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "DebugServer.py": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "DumpLines.py": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "EnableExtendedFlags.txt": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "Font-Report-June2016": Object {
+                          "files": Object {
+                            "CP437-Consolas.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "CP437-Lucida.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "CP932.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "CP936.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "CP949.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "CP950.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "MinimumWindowWidths.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Results.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Windows10SetFontBugginess.txt": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                          },
+                        },
+                        "FormatChar.h": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "IdentifyConsoleWindow.ps1": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "MouseInputNotes.txt": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "Notes.txt": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "Spew.py": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "build32.sh": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "build64.sh": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "color-test.sh": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "font-notes.txt": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                      },
+                    },
+                    "ship": Object {
+                      "files": Object {
+                        "build-pty4j-libpty.bat": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "common_ship.py": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "make_msvc_package.py": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "ship.py": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                      },
+                    },
+                    "src": Object {
+                      "files": Object {
+                        "agent": Object {
+                          "files": Object {
+                            "Agent.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "AgentCreateDesktop.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "ConsoleFont.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "ConsoleInput.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "ConsoleInputReencoding.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "ConsoleLine.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Coord.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "DebugShowInput.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "DefaultInputMap.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "DsrSender.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "EventLoop.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "InputMap.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "LargeConsoleRead.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "NamedPipe.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Scraper.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "SimplePool.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "SmallRect.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Terminal.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "UnicodeEncoding.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Win32Console.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Win32ConsoleBuffer.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                          },
+                        },
+                        "configurations.gypi": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "include": Object {
+                          "files": Object {
+                            "winpty.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "winpty_constants.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                          },
+                        },
+                        "libwinpty": Object {
+                          "files": Object {
+                            "AgentLocation.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "LibWinptyException.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "WinptyInternal.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                          },
+                        },
+                        "shared": Object {
+                          "files": Object {
+                            "AgentMsg.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "BackgroundDesktop.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Buffer.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "DebugClient.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "GenRandom.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "GetCommitHash.bat": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Mutex.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "OsModule.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "OwnedHandle.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "PrecompiledHeader.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "StringBuilder.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "StringUtil.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "TimeMeasurement.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "UnixCtrlChars.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "UpdateGenVersion.bat": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "WindowsSecurity.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "WindowsVersion.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "WinptyAssert.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "WinptyException.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "WinptyVersion.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "winpty_snprintf.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                          },
+                        },
+                        "unix-adapter": Object {
+                          "files": Object {
+                            "InputHandler.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "OutputHandler.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "Util.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                            "WakeupFd.h": Object {
+                              "size": "<size>",
+                              "unpacked": true,
+                            },
+                          },
+                        },
+                        "winpty.gyp": Object {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                      },
+                    },
+                    "vcbuild.bat": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+              },
+            },
+            "lib": Object {
+              "files": Object {
+                "conpty_console_list_agent.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "conpty_console_list_agent.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "eventEmitter2.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "eventEmitter2.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "eventEmitter2.test.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "eventEmitter2.test.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "index.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "index.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "interfaces.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "interfaces.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "shared": Object {
+                  "files": Object {
+                    "conout.js": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "conout.js.map": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+                "terminal.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "terminal.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "terminal.test.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "terminal.test.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "testUtils.test.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "testUtils.test.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "types.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "types.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "unixTerminal.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "unixTerminal.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "unixTerminal.test.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "unixTerminal.test.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "utils.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "utils.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsConoutConnection.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsConoutConnection.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.test.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.test.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsTerminal.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsTerminal.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsTerminal.test.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsTerminal.test.js.map": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "worker": Object {
+                  "files": Object {
+                    "conoutSocketWorker.js": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                    "conoutSocketWorker.js.map": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+              },
+            },
+            "package.json": Object {
+              "size": "<size>",
+              "unpacked": true,
+            },
+            "scripts": Object {
+              "files": Object {
+                "post-install.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "publish.js": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+              },
+            },
+            "src": Object {
+              "files": Object {
+                "conpty_console_list_agent.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "eventEmitter2.test.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "eventEmitter2.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "index.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "interfaces.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "shared": Object {
+                  "files": Object {
+                    "conout.ts": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+                "terminal.test.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "terminal.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "testUtils.test.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "tsconfig.json": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "types.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "unixTerminal.test.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "unixTerminal.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "utils.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "win": Object {
+                  "files": Object {
+                    "path_util.h": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+                "windowsConoutConnection.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.test.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsPtyAgent.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsTerminal.test.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "windowsTerminal.ts": Object {
+                  "size": "<size>",
+                  "unpacked": true,
+                },
+                "worker": Object {
+                  "files": Object {
+                    "conoutSocketWorker.ts": Object {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                },
+              },
             },
           },
         },
@@ -702,6 +1481,200 @@ exports[`yarn two package.json w/ native module 4`] = `
 Array [
   "app.asar",
   "electron.icns",
+  "app.asar.unpacked/node_modules/node-pty/LICENSE",
+  Object {
+    "content": "{
+  \\"name\\": \\"node-pty\\",
+  \\"description\\": \\"Fork pseudoterminals in Node.JS\\",
+  \\"author\\": {
+    \\"name\\": \\"Microsoft Corporation\\"
+  },
+  \\"version\\": \\"1.1.0-beta9\\",
+  \\"license\\": \\"MIT\\",
+  \\"main\\": \\"./lib/index.js\\",
+  \\"types\\": \\"./typings/node-pty.d.ts\\",
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"git://github.com/microsoft/node-pty.git\\"
+  },
+  \\"files\\": [
+    \\"binding.gyp\\",
+    \\"lib/\\",
+    \\"scripts/\\",
+    \\"src/\\",
+    \\"deps/\\",
+    \\"typings/\\"
+  ],
+  \\"homepage\\": \\"https://github.com/microsoft/node-pty\\",
+  \\"dependencies\\": {
+    \\"node-addon-api\\": \\"^7.1.0\\"
+  },
+  \\"devDependencies\\": {
+    \\"@types/mocha\\": \\"^7.0.2\\",
+    \\"@types/node\\": \\"12\\",
+    \\"@typescript-eslint/eslint-plugin\\": \\"^2.27.0\\",
+    \\"@typescript-eslint/parser\\": \\"^2.27.0\\",
+    \\"cross-env\\": \\"^5.1.4\\",
+    \\"eslint\\": \\"^6.8.0\\",
+    \\"mocha\\": \\"10\\",
+    \\"node-gyp\\": \\"^9.4.0\\",
+    \\"ps-list\\": \\"^6.0.0\\",
+    \\"typescript\\": \\"^3.8.3\\"
+  }
+}",
+    "name": "app.asar.unpacked/node_modules/node-pty/package.json",
+  },
+  "app.asar.unpacked/node_modules/node-pty/src/conpty_console_list_agent.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/eventEmitter2.test.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/eventEmitter2.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/index.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/interfaces.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/terminal.test.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/terminal.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/testUtils.test.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/tsconfig.json",
+  "app.asar.unpacked/node_modules/node-pty/src/types.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/unixTerminal.test.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/unixTerminal.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/utils.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/windowsConoutConnection.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/windowsPtyAgent.test.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/windowsPtyAgent.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/windowsTerminal.test.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/windowsTerminal.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/worker/conoutSocketWorker.ts",
+  "app.asar.unpacked/node_modules/node-pty/src/win/path_util.h",
+  "app.asar.unpacked/node_modules/node-pty/src/shared/conout.ts",
+  "app.asar.unpacked/node_modules/node-pty/scripts/post-install.js",
+  "app.asar.unpacked/node_modules/node-pty/scripts/publish.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/conpty_console_list_agent.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/conpty_console_list_agent.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/eventEmitter2.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/eventEmitter2.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/eventEmitter2.test.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/eventEmitter2.test.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/index.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/index.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/interfaces.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/interfaces.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/terminal.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/terminal.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/terminal.test.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/terminal.test.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/testUtils.test.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/testUtils.test.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/types.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/types.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/unixTerminal.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/unixTerminal.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/unixTerminal.test.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/unixTerminal.test.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/utils.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/utils.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsConoutConnection.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsConoutConnection.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsPtyAgent.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsPtyAgent.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsPtyAgent.test.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsPtyAgent.test.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsTerminal.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsTerminal.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsTerminal.test.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/windowsTerminal.test.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/worker/conoutSocketWorker.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/worker/conoutSocketWorker.js.map",
+  "app.asar.unpacked/node_modules/node-pty/lib/shared/conout.js",
+  "app.asar.unpacked/node_modules/node-pty/lib/shared/conout.js.map",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/LICENSE",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/Makefile",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/README.md",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/RELEASES.md",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/VERSION.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/configure",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/vcbuild.bat",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/configurations.gypi",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/winpty.gyp",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/unix-adapter/InputHandler.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/unix-adapter/OutputHandler.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/unix-adapter/Util.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/unix-adapter/WakeupFd.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/AgentMsg.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/BackgroundDesktop.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/Buffer.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/DebugClient.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/GenRandom.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/GetCommitHash.bat",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/Mutex.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/OsModule.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/OwnedHandle.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/PrecompiledHeader.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/StringBuilder.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/StringUtil.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/TimeMeasurement.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/UnixCtrlChars.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/UpdateGenVersion.bat",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/WindowsSecurity.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/WindowsVersion.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/WinptyAssert.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/WinptyException.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/WinptyVersion.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/shared/winpty_snprintf.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/libwinpty/AgentLocation.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/libwinpty/LibWinptyException.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/libwinpty/WinptyInternal.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/include/winpty.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/include/winpty_constants.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/Agent.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/AgentCreateDesktop.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/ConsoleFont.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/ConsoleInput.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/ConsoleInputReencoding.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/ConsoleLine.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/Coord.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/DebugShowInput.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/DefaultInputMap.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/DsrSender.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/EventLoop.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/InputMap.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/LargeConsoleRead.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/NamedPipe.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/Scraper.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/SimplePool.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/SmallRect.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/Terminal.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/UnicodeEncoding.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/Win32Console.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/src/agent/Win32ConsoleBuffer.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/ship/build-pty4j-libpty.bat",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/ship/common_ship.py",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/ship/make_msvc_package.py",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/ship/ship.py",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/ConinMode.ps1",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/DebugClient.py",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/DebugServer.py",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/DumpLines.py",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/EnableExtendedFlags.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/FormatChar.h",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/IdentifyConsoleWindow.ps1",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/MouseInputNotes.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Notes.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Spew.py",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/build32.sh",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/build64.sh",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/color-test.sh",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/font-notes.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/CP437-Consolas.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/CP437-Lucida.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/CP932.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/CP936.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/CP949.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/CP950.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/MinimumWindowWidths.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/Results.txt",
+  "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/Windows10SetFontBugginess.txt",
+  "app.asar.unpacked/node_modules/node-pty/build/node_gyp_bins/python3",
+  "app.asar.unpacked/node_modules/node-pty/build/Release/pty.node",
+  "app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper",
   "app.asar.unpacked/node_modules/node-mac-permissions/LICENSE",
   "app.asar.unpacked/node_modules/node-mac-permissions/index.js",
   Object {

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -1489,7 +1489,7 @@ Array [
   \\"author\\": {
     \\"name\\": \\"Microsoft Corporation\\"
   },
-  \\"version\\": \\"1.1.0-beta9\\",
+  \\"version\\": \\"1.1.0-beta14\\",
   \\"license\\": \\"MIT\\",
   \\"main\\": \\"./lib/index.js\\",
   \\"types\\": \\"./typings/node-pty.d.ts\\",
@@ -1517,7 +1517,7 @@ Array [
     \\"cross-env\\": \\"^5.1.4\\",
     \\"eslint\\": \\"^6.8.0\\",
     \\"mocha\\": \\"10\\",
-    \\"node-gyp\\": \\"^9.4.0\\",
+    \\"node-gyp\\": \\"^10.0.1\\",
     \\"ps-list\\": \\"^6.0.0\\",
     \\"typescript\\": \\"^3.8.3\\"
   }

--- a/test/src/helpers/verifySmartUnpack.ts
+++ b/test/src/helpers/verifySmartUnpack.ts
@@ -28,9 +28,10 @@ export async function verifySmartUnpack(resourceDir: string, additionalVerificat
   expect(await asarFs.readJson(`node_modules${path.sep}debug${path.sep}package.json`)).toMatchObject({
     name: "debug",
   })
-  if (additionalVerifications) {
-    await additionalVerifications(asarFs)
-  }
+
+  // For verifying additional files within the Asar Filesystem
+  await additionalVerifications?.(asarFs)
+
   expect(removeUnstableProperties(asarFs.header)).toMatchSnapshot()
 
   const files = (await walk(resourceDir, file => !path.basename(file).startsWith(".") && !file.endsWith(`resources${path.sep}inspector`))).map(it => {

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -103,7 +103,7 @@ test.ifMac(
   )
 )
 
-test.only("yarn two package.json w/ native module", () =>
+test.ifMac("yarn two package.json w/ native module", () =>
   assertPack(
     "test-app-two-native-modules",
     {

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -103,7 +103,7 @@ test.ifMac(
   )
 )
 
-test.ifMac("yarn two package.json w/ native module", () =>
+test.only("yarn two package.json w/ native module", () =>
   assertPack(
     "test-app-two-native-modules",
     {


### PR DESCRIPTION
Setting `disablePreGypCopy: true` to handle mac universal builds (fixes #8347)