### PR TITLE
fix: adding additional logging when importing/requiring a hook script

### DIFF
--- a/.changeset/polite-impalas-shout.md
+++ b/.changeset/polite-impalas-shout.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: adding additional logging when importing/requiring a module in case the hook script is invalid or unable to be executed

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -778,10 +778,15 @@ async function resolveModule<T>(type: string | undefined, name: string): Promise
       const fileUrl = pathToFileURL(name).href
       return await eval("import('" + fileUrl + "')")
     }
-  } catch (error) {
-    log.debug({ moduleName: name }, "Unable to dynamically import hook, falling back to `require`")
+  } catch (error: any) {
+    log.debug({ moduleName: name, message: error.message ?? error.stack }, "Unable to dynamically import hook, falling back to `require`")
   }
-  return require(name)
+  try {
+    return require(name)
+  } catch (error: any) {
+    log.error({ moduleName: name, message: error.message ?? error.stack }, "Unable to `require` hook")
+    throw new Error(error.message ?? error.stack)
+  }
 }
 
 export async function resolveFunction<T>(type: string | undefined, executor: T | string, name: string): Promise<T> {


### PR DESCRIPTION
fix: adding additional logging when importing/requiring a module in case the hook script is invalid or unable to be executed