### PR TITLE
fix(linux): Don't setuid chrome-sandbox when not required

### DIFF
--- a/.changeset/purple-terms-sing.md
+++ b/.changeset/purple-terms-sing.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: don't setuid chrome-sandbox when not required

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -10,8 +10,13 @@ else
     ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 fi
 
-# SUID chrome-sandbox for Electron 5+
-chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+# Check if user namespaces are supported by the kernel and working with a quick test:
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces:
+    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+else
+    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+fi
 
 if hash update-mime-database 2>/dev/null; then
     update-mime-database /usr/share/mime || true

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -530,8 +530,12 @@ else
     ln -sf '/opt/foo/Boo' '/usr/bin/Boo'
 fi
 
-# SUID chrome-sandbox for Electron 5+
-chmod 4755 '/opt/foo/chrome-sandbox' || true
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces:
+    chmod 4755 '/opt/foo/chrome-sandbox' || true
+else
+    chmod 0755 '/opt/foo/chrome-sandbox' || true
+fi
 
 if hash update-mime-database 2>/dev/null; then
     update-mime-database /usr/share/mime || true

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -530,6 +530,7 @@ else
     ln -sf '/opt/foo/Boo' '/usr/bin/Boo'
 fi
 
+# Check if user namespaces are supported by the kernel and working with a quick test:
 if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
     # Use SUID chrome-sandbox only on systems without user namespaces:
     chmod 4755 '/opt/foo/chrome-sandbox' || true


### PR DESCRIPTION
Fix #7545 (already closed but as stale, not actually fixed)

Setuid for chrome-sandbox is not needed on the vast majority of systems where user namespaces are available, as this more secure mechanism is used for sandboxing instead. Root setuid binaries like this are a general security risk, and appear to cause specific problems in various cases today (e.g. making a deb package unusable on Ubuntu 24.04: https://github.com/httptoolkit/httptoolkit/issues/602, making rpm packages fail validation on Fedora: https://github.com/bitwarden/clients/issues/5153)

User namespaces were implemented in 2013 (kernel 3.8), and have been enabled by default widely for many years. Chrome themselves stopped setting this in 2016, describing it as unnecessary on all supported Linux platforms: https://issues.chromium.org/issues/40462640.

The only other case I'm aware of where setuid is required despite user namespace support is Electron <5. This electron version has been end-of-life since 2019 (more than 4 years ago) so hopefully that's not a concern, but if Electron Builder supports very old electron versions then this may be a breaking change.

This PR checks whether they're supported (i.e. `/proc/self/ns/user` is a symlink) and briefly tests that they work correctly (running `true` in a separate user namespace), and then sets the setuid bit _only_ if that fails. This is the same test approach as used to detect sandboxing support in Nix: https://github.com/NixOS/nix/blob/40f80e1b5cf2bebb6d1d8c9efac1d982a540d555/tests/functional/common/vars-and-functions.sh#L180-L182