### PR TITLE
fix: delete the symlink file when the target is empty

### DIFF
--- a/.changeset/happy-monkeys-rule.md
+++ b/.changeset/happy-monkeys-rule.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+delete the symlink file when the target is empty

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -161,7 +161,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
         result[index] = undefined
       }
     }
-    const finalResult = result.filter(it => it !== undefined)
+    const finalResult: Array<string> = result.filter(it => it !== undefined)
     return finalResult
   }
 }

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -137,11 +137,16 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
       for (const child of sortedFilePaths) {
         if (child != null) {
           result.push(child)
-          this.metadata.get(child)?.isSymbolicLink() && symlinkFiles.set(child, result.length - 1)
+          if (this.metadata.get(child)?.isSymbolicLink()) {
+            symlinkFiles.set(child, result.length - 1)
+          }
           isEmpty = false
         }
       }
-      isEmpty && emptyDirs.add(dirPath)
+
+      if (isEmpty) {
+        emptyDirs.add(dirPath)
+      }
 
       dirs.sort()
       for (const child of dirs) {

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -161,6 +161,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
         result[index] = undefined
       }
     }
-    return result.filter(it => it !== undefined) as Array<string>
+    const finalResult = result.filter(it => it !== undefined)
+    return finalResult
   }
 }

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -45,7 +45,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
     const onNodeModuleFile = await resolveFunction(this.packager.appInfo.type, this.packager.config.onNodeModuleFile, "onNodeModuleFile")
 
-    const result: Array<string> = []
+    const result: Array<string | null> = []
     const queue: Array<string> = []
     const emptyDirs: Set<string> = new Set()
     const symlinkFiles: Map<string, number> = new Map()
@@ -158,9 +158,9 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
       const resolvedPath = realpathSync(file)
       if (emptyDirs.has(resolvedPath)) {
         // delete symlink file if target is a empty dir
-        result[index] = ""
+        result[index] = null
       }
     }
-    return result.filter(it => it !== "")
+    return result.filter(it => it !== null) as Array<string>
   }
 }

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -161,6 +161,6 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
         result[index] = undefined
       }
     }
-    return result.filter(it => it !== undefined)
+    return result.filter(it => it !== undefined) as Array<string>
   }
 }

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -161,7 +161,6 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
         result[index] = undefined
       }
     }
-    const finalResult: Array<string> = result.filter(it => it !== undefined)
-    return finalResult
+    return result.filter((it): it is string => it !== undefined)
   }
 }

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -45,7 +45,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
     const onNodeModuleFile = await resolveFunction(this.packager.appInfo.type, this.packager.config.onNodeModuleFile, "onNodeModuleFile")
 
-    const result: Array<string | null> = []
+    const result: Array<string | undefined> = []
     const queue: Array<string> = []
     const emptyDirs: Set<string> = new Set()
     const symlinkFiles: Map<string, number> = new Map()
@@ -158,9 +158,9 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
       const resolvedPath = realpathSync(file)
       if (emptyDirs.has(resolvedPath)) {
         // delete symlink file if target is a empty dir
-        result[index] = null
+        result[index] = undefined
       }
     }
-    return result.filter(it => it !== null) as Array<string>
+    return result.filter(it => it !== undefined)
   }
 }


### PR DESCRIPTION
Add the following filtering rule in the `files` section to exclude all files in the `headers` directory.
```
 "files": [
      "package.json",
      "!**/*.{h,cpp}"
    ]
```
![image](https://github.com/user-attachments/assets/56f61dc4-b8c4-4816-a477-b1163cf43777)


 This will result in an empty directory, which will not generate a corresponding empty directory in `app.asar.unpack`. However, the symbolic links for `headers` will still be present. This will cause an error during signing, stating that the corresponding files cannot be found.