### PR TITLE
fix: cancellation token management for packager and retry logic

### DIFF
--- a/.changeset/silly-impalas-relax.md
+++ b/.changeset/silly-impalas-relax.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+---
+
+fix: checking cancellation token during pack and any retry tasks to exit early on process "cancel"

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -125,9 +125,19 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
         const x64Arch = Arch.x64
         const x64AppOutDir = outDirName(x64Arch)
         await super.doPack(outDir, x64AppOutDir, platformName, x64Arch, platformSpecificBuildOptions, targets, false, true)
+
+        if (this.info.cancellationToken.cancelled) {
+          return
+        }
+
         const arm64Arch = Arch.arm64
         const arm64AppOutPath = outDirName(arm64Arch)
         await super.doPack(outDir, arm64AppOutPath, platformName, arm64Arch, platformSpecificBuildOptions, targets, false, true)
+
+        if (this.info.cancellationToken.cancelled) {
+          return
+        }
+
         const framework = this.info.framework
         log.info(
           {
@@ -162,6 +172,10 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
           electronPlatformName: platformName,
         }
         await this.info.afterPack(packContext)
+
+        if (this.info.cancellationToken.cancelled) {
+          return
+        }
 
         await this.doSignAfterPack(outDir, appOutDir, platformName, arch, platformSpecificBuildOptions, targets)
         break

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -152,7 +152,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       await subTaskManager.awaitTasks()
 
       for (const target of targets) {
-        if (!target.isAsyncSupported) {
+        if (!target.isAsyncSupported && !this.info.cancellationToken.cancelled) {
           await target.build(appOutDir, arch)
         }
       }

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -1,5 +1,5 @@
 import { appBuilderPath } from "app-builder-bin"
-import { safeStringifyJson } from "builder-util-runtime"
+import { CancellationToken, safeStringifyJson } from "builder-util-runtime"
 import * as chalk from "chalk"
 import { ChildProcess, execFile, ExecFileOptions, SpawnOptions } from "child_process"
 import { spawn as _spawn } from "cross-spawn"
@@ -408,11 +408,12 @@ export async function executeAppBuilder(
 }
 
 export async function retry<T>(task: () => Promise<T>, retryCount: number, interval: number, backoff = 0, attempt = 0, shouldRetry?: (e: any) => boolean): Promise<T> {
+  const cancellationToken = new CancellationToken()
   try {
     return await task()
   } catch (error: any) {
     log.info(`Above command failed, retrying ${retryCount} more times`)
-    if ((shouldRetry?.(error) ?? true) && retryCount > 0) {
+    if ((shouldRetry?.(error) ?? true) && retryCount > 0 && !cancellationToken.cancelled) {
       await new Promise(resolve => setTimeout(resolve, interval + backoff * attempt))
       return await retry(task, retryCount - 1, interval, backoff, attempt + 1, shouldRetry)
     } else {


### PR DESCRIPTION
Checking cancellation token during synchronous `build`, `universal` mac packaging, and any retry tasks to exit early on process "cancel" Ctrl+C