### PR TITLE
fix: Add global download promise to limit concurrent downloads to 1

### DIFF
--- a/.changeset/green-brooms-mix.md
+++ b/.changeset/green-brooms-mix.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+Limit concurrent downloads to 1

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -521,24 +521,21 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       return e
     }
 
-    try {
-      this.downloadPromise = this.doDownloadUpdate({
-        updateInfoAndProvider,
-        requestHeaders: this.computeRequestHeaders(updateInfoAndProvider.provider),
-        cancellationToken,
-        disableWebInstaller: this.disableWebInstaller,
-        disableDifferentialDownload: this.disableDifferentialDownload,
+    this.downloadPromise = this.doDownloadUpdate({
+      updateInfoAndProvider,
+      requestHeaders: this.computeRequestHeaders(updateInfoAndProvider.provider),
+      cancellationToken,
+      disableWebInstaller: this.disableWebInstaller,
+      disableDifferentialDownload: this.disableDifferentialDownload,
+    })
+      .catch((e: any) => {
+        throw errorHandler(e)
       })
-        .catch((e: any) => {
-          throw errorHandler(e)
-        })
-        .finally(() => {
-          this.downloadPromise = null
-        })
-      return this.downloadPromise
-    } catch (e: any) {
-      return Promise.reject(errorHandler(e))
-    }
+      .finally(() => {
+        this.downloadPromise = null
+      })
+
+    return this.downloadPromise
   }
 
   protected dispatchError(e: Error): void {

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -209,6 +209,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
   configOnDisk = new Lazy<any>(() => this.loadUpdateConfig())
 
   private checkForUpdatesPromise: Promise<UpdateCheckResult> | null = null
+  private downloadPromise: Promise<Array<string>> | null = null
 
   protected readonly app: AppAdapter
 
@@ -452,7 +453,9 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
     const updateInfo = result.info
     if (!(await this.isUpdateAvailable(updateInfo))) {
       this._logger.info(
-        `Update for version ${this.currentVersion.format()} is not available (latest version: ${updateInfo.version}, downgrade is ${this.allowDowngrade ? "allowed" : "disallowed"}).`
+        `Update for version ${this.currentVersion.format()} is not available (latest version: ${updateInfo.version}, downgrade is ${
+          this.allowDowngrade ? "allowed" : "disallowed"
+        }).`
       )
       this.emit("update-not-available", updateInfo)
       return {
@@ -495,6 +498,11 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       return Promise.reject(error)
     }
 
+    if (this.downloadPromise != null) {
+      this._logger.info("Downloading update (already in progress)")
+      return this.downloadPromise
+    }
+
     this._logger.info(
       `Downloading update from ${asArray(updateInfoAndProvider.info.files)
         .map(it => it.url)
@@ -514,15 +522,20 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
     }
 
     try {
-      return this.doDownloadUpdate({
+      this.downloadPromise = this.doDownloadUpdate({
         updateInfoAndProvider,
         requestHeaders: this.computeRequestHeaders(updateInfoAndProvider.provider),
         cancellationToken,
         disableWebInstaller: this.disableWebInstaller,
         disableDifferentialDownload: this.disableDifferentialDownload,
-      }).catch((e: any) => {
-        throw errorHandler(e)
       })
+        .catch((e: any) => {
+          throw errorHandler(e)
+        })
+        .finally(() => {
+          this.downloadPromise = null
+        })
+      return this.downloadPromise
     } catch (e: any) {
       return Promise.reject(errorHandler(e))
     }


### PR DESCRIPTION
Calling `autoUpdater.checkForUpdates()` twice initiates two download processes that conflict and results in update failure. This PR adds a global download promise limiting the download processes to 1.

Fixes: https://github.com/electron-userland/electron-builder/issues/7063