### PR TITLE
feat: unpacked native node file

### DIFF
--- a/.changeset/brown-singers-breathe.md
+++ b/.changeset/brown-singers-breathe.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Automatically place .node files into app.asar.unpack

--- a/packages/app-builder-lib/src/asar/unpackDetector.ts
+++ b/packages/app-builder-lib/src/asar/unpackDetector.ts
@@ -18,7 +18,7 @@ function addValue(map: Map<string, Array<string>>, key: string, value: string) {
 }
 
 export function isLibOrExe(file: string): boolean {
-  return file.endsWith(".dll") || file.endsWith(".exe") || file.endsWith(".dylib") || file.endsWith(".so")
+  return file.endsWith(".dll") || file.endsWith(".exe") || file.endsWith(".dylib") || file.endsWith(".so") || file.endsWith(".node")
 }
 
 /** @internal */

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -907,16 +907,18 @@ Object {
           "files": Object {
             "LICENSE.md": Object {
               "size": "<size>",
+              "unpacked": true,
             },
             "build": Object {
               "files": Object {
                 "Release": Object {
                   "files": Object {
                     "keytar.node": Object {
-                      "executable": true,
                       "size": "<size>",
+                      "unpacked": true,
                     },
                   },
+                  "unpacked": true,
                 },
               },
             },
@@ -924,13 +926,17 @@ Object {
               "files": Object {
                 "keytar.js": Object {
                   "size": "<size>",
+                  "unpacked": true,
                 },
               },
+              "unpacked": true,
             },
             "package.json": Object {
               "size": "<size>",
+              "unpacked": true,
             },
           },
+          "unpacked": true,
         },
         "mimic-response": Object {
           "files": Object {
@@ -4853,6 +4859,54 @@ Object {
 exports[`posix smart unpack 4`] = `
 Array [
   "app.asar",
+  "app.asar.unpacked/node_modules/keytar/LICENSE.md",
+  Object {
+    "content": "{
+  \\"main\\": \\"./lib/keytar.js\\",
+  \\"typings\\": \\"keytar.d.ts\\",
+  \\"name\\": \\"keytar\\",
+  \\"description\\": \\"Bindings to native Mac/Linux/Windows password APIs\\",
+  \\"version\\": \\"7.9.0\\",
+  \\"license\\": \\"MIT\\",
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"https://github.com/atom/node-keytar.git\\"
+  },
+  \\"homepage\\": \\"http://atom.github.io/node-keytar\\",
+  \\"files\\": [
+    \\"lib\\",
+    \\"src\\",
+    \\"binding.gyp\\",
+    \\"keytar.d.ts\\"
+  ],
+  \\"types\\": \\"./keytar.d.ts\\",
+  \\"devDependencies\\": {
+    \\"babel-core\\": \\"^6.26.3\\",
+    \\"babel-plugin-transform-async-to-generator\\": \\"^6.24.1\\",
+    \\"chai\\": \\"^4.2.0\\",
+    \\"mocha\\": \\"^9.2.0\\",
+    \\"node-cpplint\\": \\"~0.4.0\\",
+    \\"node-gyp\\": \\"^8.4.1\\",
+    \\"prebuild\\": \\"^11.0.2\\"
+  },
+  \\"dependencies\\": {
+    \\"node-addon-api\\": \\"^4.3.0\\",
+    \\"prebuild-install\\": \\"^7.0.1\\"
+  },
+  \\"binary\\": {
+    \\"napi_versions\\": [
+      3
+    ]
+  },
+  \\"config\\": {
+    \\"runtime\\": \\"napi\\",
+    \\"target\\": 3
+  }
+}",
+    "name": "app.asar.unpacked/node_modules/keytar/package.json",
+  },
+  "app.asar.unpacked/node_modules/keytar/lib/keytar.js",
+  "app.asar.unpacked/node_modules/keytar/build/Release/keytar.node",
 ]
 `;
 


### PR DESCRIPTION
All npm C++ native modules generate a file ending in .node, which is an executable file. Currently, it is default practice to place these inside app.asar, which seems problematic for several reasons:

1. .node files are executables that need to be signed. If packed directly into app.asar, they cannot be signed.
2. According to official documentation, placing .node files inside app.asar can lead to performance issues and file not found errors.
 https://www.electronjs.org/docs/latest/tutorial/asar-archives
![image](https://github.com/user-attachments/assets/b5e33dcd-cfc2-40a2-8a73-8024ca2ba835)

4. Looking at applications like VSCode and Slack, they currently default to placing .node files in app.asar.unpack.

Therefore, I suggest that during the smart unpack process, we automatically detect files ending in .node and place them in the unpack directory.