### PR TITLE
fix: handle spaces in artifact name for all linux platforms instead of only .deb

### DIFF
--- a/.changeset/old-ducks-cry.md
+++ b/.changeset/old-ducks-cry.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": minor
+---
+
+Handle spaces for all linux package managers

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -48,7 +48,20 @@ export abstract class BaseUpdater extends AppUpdater {
     }
 
     const downloadedUpdateHelper = this.downloadedUpdateHelper
-    const installerPath = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.file
+    
+    // Get the installer path, ensuring spaces are escaped on Linux
+    // 1. Check if downloadedUpdateHelper is not null
+    // 2. Check if downloadedUpdateHelper.file is not null
+    // 3. If both checks pass:
+    //    a. If the platform is Linux, replace spaces with '\ ' for shell compatibility
+    //    b. If the platform is not Linux, use the original path
+    // 4. If any check fails, set installerPath to null
+    const installerPath = downloadedUpdateHelper && downloadedUpdateHelper.file 
+      ? (process.platform === 'linux' 
+        ? downloadedUpdateHelper.file.replace(/ /g, '\\ ') 
+        : downloadedUpdateHelper.file) 
+      : null;
+
     const downloadedFileInfo = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.downloadedFileInfo
     if (installerPath == null || downloadedFileInfo == null) {
       this.dispatchError(new Error("No valid update available, can't quit and install"))

--- a/packages/electron-updater/src/DebUpdater.ts
+++ b/packages/electron-updater/src/DebUpdater.ts
@@ -31,10 +31,7 @@ export class DebUpdater extends BaseUpdater {
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
-    // application artifact names may include spaces in their name which leads
-    // to an error when the install command is executed
-    const installerPath = options.installerPath.replace(/ /g, "\\ ")
-    const cmd = ["dpkg", "-i", installerPath, "||", "apt-get", "install", "-f", "-y"]
+    const cmd = ["dpkg", "-i", options.installerPath, "||", "apt-get", "install", "-f", "-y"]
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {
       this.app.relaunch()


### PR DESCRIPTION
So @Ryan432 just discovered an amazing bug (and made a PR for the fix #8400) that produces problems with the auto updates when an application has spaces in the artifact name. However, it was only implemented for .deb specifically and the same issues exists with other package managers. 

So I moved the handling of spaces in installer paths to the point where the installerPath is generated, before the `doInstall` function is called so it's pre-formatted.

To address this, I updated the logic for managing installer paths to ensure compatibility across various Linux package managers:
- **Linux:** Spaces in paths are now escaped with `\ ` to ensure proper handling in shell commands.

This fix ensures that auto-updates work seamlessly regardless of whether the artifact name includes spaces.