### PR TITLE
docs: Fix a broken link formatting in the docs

### DIFF
--- a/packages/app-builder-lib/src/options/linuxOptions.ts
+++ b/packages/app-builder-lib/src/options/linuxOptions.ts
@@ -108,7 +108,7 @@ export interface DebOptions extends LinuxTargetSpecificOptions {
   /**
    * Package dependencies. Defaults to `["gconf2", "gconf-service", "libnotify4", "libappindicator1", "libxtst6", "libnss3"]`.
    * If need to support Debian, `libappindicator1` should be removed, it is [deprecated in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037).
-   * If need to support KDE, `gconf2` and `gconf-service` should be removed as it's no longer used by GNOME](https://packages.debian.org/bullseye/gconf2).
+   * If need to support KDE, `gconf2` and `gconf-service` should be removed as it's no longer used [by GNOME](https://packages.debian.org/bullseye/gconf2).
    */
   readonly depends?: Array<string> | null
 


### PR DESCRIPTION
Noticed that while browsing the docs. Seemed easy to fix and contribute back a little 🙇‍♂️

![image](https://github.com/user-attachments/assets/11ac318b-44c6-4500-85e3-c1a6f3638e67)


---

By the way, the reason I was looking at the docs is because [some users of Simplenote Electron are reproting issues installing due to `gconf2`](https://github.com/Automattic/simplenote-electron/issues/3241). Any ideas how to work around it? Thanks!