### PR TITLE
fix: windows signature verification special chars

### DIFF
--- a/.changeset/proud-cats-try.md
+++ b/.changeset/proud-cats-try.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: windows signature verification special chars

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -33,8 +33,10 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
     // https://github.com/electron-userland/electron-builder/issues/2421
     // https://github.com/electron-userland/electron-builder/issues/2535
     // Resetting PSModulePath is necessary https://github.com/electron-userland/electron-builder/issues/7127
+    // semicolon wont terminate the set command and run chcp thus leading to verification errors on certificats with special chars like german umlauts, so rather 
+    //   join commands using & https://github.com/electron-userland/electron-builder/issues/8162 
     execFile(
-      `set "PSModulePath="; chcp 65001 >NUL & powershell.exe`,
+      `set "PSModulePath=" & chcp 65001 >NUL & powershell.exe`,
       ["-NoProfile", "-NonInteractive", "-InputFormat", "None", "-Command", `"Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress"`],
       {
         shell: true,


### PR DESCRIPTION
by applying #8051 and noted in #8162 win signature verification of signatures created using
certificates including special chars like german
umlauts got broken in electron-updater >= 1.6.9
issue at hand is that the windows set command does not terminate when reading semicolon;
setting %PATH% is a good example for this
c.f. https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490998(v=technet.10) so instead commands should be concatenated using &

Closes #8162