### PR TITLE
chore(deps): upgrade semver to latest to resolve CVE

### DIFF
--- a/.changeset/chatty-mayflies-argue.md
+++ b/.changeset/chatty-mayflies-argue.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+update semver to latest

--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -22,7 +22,7 @@
     "lazy-val": "^1.0.5",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.isequal": "^4.5.0",
-    "semver": "^7.3.8",
+    "semver": "^7.6.3",
     "tiny-typed-emitter": "^2.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,8 +533,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       semver:
-        specifier: ^7.3.8
-        version: 7.6.0
+        specifier: ^7.6.3
+        version: 7.6.3
       tiny-typed-emitter:
         specifier: ^2.1.0
         version: 2.1.0
@@ -11116,7 +11116,7 @@ snapshots:
       resolve: 1.22.8
       sass: 1.71.1
       scss-parser: 1.0.6
-      semver: 7.6.0
+      semver: 7.6.3
       yargs: 16.2.0
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
fix https://nvd.nist.gov/vuln/detail/CVE-2022-25883