### PR TITLE
fix: Revert "feat: allow `riscv64` support via custom electron dist"

### DIFF
--- a/.changeset/stupid-avocados-appear.md
+++ b/.changeset/stupid-avocados-appear.md
@@ -1,7 +1,0 @@
----
-"app-builder-lib": minor
-"builder-util": minor
-"electron-builder": minor
----
-
-feat: support riscv64 architecture for electron-builder (requires custom prebuilt artifact via `electronDist`)

--- a/docs/api/electron-builder.md
+++ b/docs/api/electron-builder.md
@@ -36,7 +36,6 @@ Developer API only. See [Configuration](../configuration/configuration.md) for u
 <li><strong><code id="Arch-armv7l">armv7l</code></strong></li>
 <li><strong><code id="Arch-arm64">arm64</code></strong></li>
 <li><strong><code id="Arch-universal">universal</code></strong></li>
-<li><strong><code id="Arch-riscv64">riscv64</code></strong></li>
 </ul>
 <p><a name="module_electron-builder.build"></a></p>
 <h2 id="electron-builder.build(rawoptions)-%E2%87%92-promise%3Carray%3Cstring%3E%3E"><code>electron-builder.build(rawOptions)</code> ⇒ <code>Promise&lt;Array&lt;String&gt;&gt;</code></h2>

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -311,7 +311,6 @@
         "arm64",
         "armv7l",
         "ia32",
-        "riscv64",
         "universal",
         "x64"
       ],
@@ -5942,7 +5941,6 @@
                 "arm64",
                 "armv7l",
                 "ia32",
-                "riscv64",
                 "universal",
                 "x64"
               ],

--- a/packages/app-builder-lib/src/linuxPackager.ts
+++ b/packages/app-builder-lib/src/linuxPackager.ts
@@ -81,8 +81,6 @@ export function toAppImageOrSnapArch(arch: Arch): string {
       return "arm"
     case Arch.arm64:
       return "arm_aarch64"
-    case Arch.riscv64:
-      return "riscv64"
 
     default:
       throw new Error(`Unsupported arch ${arch}`)

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -328,8 +328,6 @@ function archNameToTriplet(arch: Arch): string {
       return "arm-linux-gnueabihf"
     case Arch.arm64:
       return "aarch64-linux-gnu"
-    case Arch.riscv64:
-      return "riscv64-linux-gnu"
 
     default:
       throw new Error(`Unsupported arch ${arch}`)

--- a/packages/builder-util/src/arch.ts
+++ b/packages/builder-util/src/arch.ts
@@ -4,10 +4,9 @@ export enum Arch {
   armv7l,
   arm64,
   universal,
-  riscv64,
 }
 
-export type ArchType = "x64" | "ia32" | "armv7l" | "arm64" | "universal" | "riscv64"
+export type ArchType = "x64" | "ia32" | "armv7l" | "arm64" | "universal"
 
 export function toLinuxArchString(arch: Arch, targetName: string): string {
   switch (arch) {
@@ -19,15 +18,14 @@ export function toLinuxArchString(arch: Arch, targetName: string): string {
       return targetName === "snap" || targetName === "deb" ? "armhf" : targetName === "flatpak" ? "arm" : "armv7l"
     case Arch.arm64:
       return targetName === "pacman" || targetName === "rpm" || targetName === "flatpak" ? "aarch64" : "arm64"
-    case Arch.riscv64:
-      return "riscv64"
+
     default:
       throw new Error(`Unsupported arch ${arch}`)
   }
 }
 
 export function getArchCliNames(): Array<string> {
-  return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64], Arch[Arch.riscv64]]
+  return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64]]
 }
 
 export function getArchSuffix(arch: Arch, defaultArch?: string): string {
@@ -47,8 +45,6 @@ export function archFromString(name: string): Arch {
       return Arch.armv7l
     case "universal":
       return Arch.universal
-    case "riscv64":
-      return Arch.riscv64
     default:
       throw new Error(`Unsupported arch ${name}`)
   }

--- a/packages/electron-builder/src/builder.ts
+++ b/packages/electron-builder/src/builder.ts
@@ -18,7 +18,6 @@ export interface CliOptions extends PackagerOptions, PublishOptions {
   armv7l?: boolean
   arm64?: boolean
   universal?: boolean
-  riscv64?: boolean
 
   dir?: boolean
 }
@@ -48,9 +47,6 @@ export function normalizeOptions(args: CliOptions): BuildOptions {
       }
       if (args.universal) {
         result.push(Arch.universal)
-      }
-      if (args.riscv64) {
-        result.push(Arch.riscv64)
       }
 
       return result.length === 0 && currentIfNotSpecified ? [archFromString(process.arch)] : result

--- a/test/src/helpers/downloadElectron.ts
+++ b/test/src/helpers/downloadElectron.ts
@@ -42,17 +42,13 @@ export function downloadAllRequiredElectronVersions(): Promise<any> {
 
   const versions: Array<any> = []
   for (const platform of platforms) {
-    const archs =
+    const archs: string[] =
       platform === "mas" || platform === "darwin"
         ? ["x64"]
         : platform === "win32"
           ? ["ia32", "x64"]
           : require(`${path.join(__dirname, "../../..")}/packages/builder-util/out/util`).getArchCliNames()
     for (const arch of archs) {
-      if (arch === "riscv64") {
-        // No prebuilt electron for riscv64
-        continue
-      }
       if (gte(ELECTRON_VERSION, "19.0.0") && platform === "linux" && arch === "ia32") {
         // Chromium dropped support for ia32 linux binaries in 102.0.4999.0
         // https://www.electronjs.org/docs/latest/breaking-changes#removed-ia32-linux-binaries


### PR DESCRIPTION
Reverts electron-userland/electron-builder#8143