### PR TITLE
fix: correct native dependency tree mismatch in app-builder rebuild

### DIFF
--- a/.changeset/chatty-rice-hunt.md
+++ b/.changeset/chatty-rice-hunt.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"electron-builder": patch
+---
+
+fix: correct native dependency tree mismatch in app-builder rebuild

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -132,8 +132,8 @@ export class Packager {
 
   private nodeDependencyInfo = new Map<string, Lazy<Array<any>>>()
 
-  getNodeDependencyInfo(platform: Platform | null): Lazy<Array<NodeModuleInfo | NodeModuleDirInfo>> {
-    let key = ""
+  getNodeDependencyInfo<T extends boolean>(platform: Platform | null, flatten: T): Lazy<Array<T extends true ? NodeModuleInfo : NodeModuleDirInfo>> {
+    let key = "" + flatten.toString()
     let excludedDependencies: Array<string> | null = null
     if (platform != null && this.framework.getExcludedDependencies != null) {
       excludedDependencies = this.framework.getExcludedDependencies(platform)
@@ -144,7 +144,7 @@ export class Packager {
 
     let result = this.nodeDependencyInfo.get(key)
     if (result == null) {
-      result = createLazyProductionDeps(this.appDir, excludedDependencies)
+      result = createLazyProductionDeps(this.appDir, excludedDependencies, flatten)
       this.nodeDependencyInfo.set(key, result)
     }
     return result
@@ -542,7 +542,7 @@ export class Packager {
         frameworkInfo,
         platform: platform.nodeName,
         arch: Arch[arch],
-        productionDeps: this.getNodeDependencyInfo(null) as Lazy<Array<NodeModuleDirInfo>>,
+        productionDeps: this.getNodeDependencyInfo(null, false),
       })
     }
   }

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -132,7 +132,7 @@ export class Packager {
 
   private nodeDependencyInfo = new Map<string, Lazy<Array<any>>>()
 
-  getNodeDependencyInfo<T extends boolean>(platform: Platform | null, flatten: T): Lazy<Array<T extends true ? NodeModuleInfo : NodeModuleDirInfo>> {
+  getNodeDependencyInfo(platform: Platform | null, flatten: boolean = true): Lazy<Array<NodeModuleInfo | NodeModuleDirInfo>> {
     let key = "" + flatten.toString()
     let excludedDependencies: Array<string> | null = null
     if (platform != null && this.framework.getExcludedDependencies != null) {
@@ -542,7 +542,7 @@ export class Packager {
         frameworkInfo,
         platform: platform.nodeName,
         arch: Arch[arch],
-        productionDeps: this.getNodeDependencyInfo(null, false),
+        productionDeps: this.getNodeDependencyInfo(null, false) as Lazy<Array<NodeModuleDirInfo>>,
       })
     }
   }

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -12,7 +12,6 @@ import { Packager } from "../packager"
 import { PlatformPackager } from "../platformPackager"
 import { AppFileWalker } from "./AppFileWalker"
 import { NodeModuleCopyHelper } from "./NodeModuleCopyHelper"
-import { NodeModuleInfo } from "./packageDependencies"
 
 const BOWER_COMPONENTS_PATTERN = `${path.sep}bower_components${path.sep}`
 /** @internal */
@@ -181,7 +180,7 @@ function validateFileSet(fileSet: ResolvedFileSet): ResolvedFileSet {
 
 /** @internal */
 export async function computeNodeModuleFileSets(platformPackager: PlatformPackager<any>, mainMatcher: FileMatcher): Promise<Array<ResolvedFileSet>> {
-  const deps = (await platformPackager.info.getNodeDependencyInfo(platformPackager.platform).value) as Array<NodeModuleInfo>
+  const deps = await platformPackager.info.getNodeDependencyInfo(platformPackager.platform, true).value
 
   const nodeModuleExcludedExts = getNodeModuleExcludedExts(platformPackager)
   // serial execution because copyNodeModules is concurrent and so, no need to increase queue/pressure

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -12,6 +12,7 @@ import { Packager } from "../packager"
 import { PlatformPackager } from "../platformPackager"
 import { AppFileWalker } from "./AppFileWalker"
 import { NodeModuleCopyHelper } from "./NodeModuleCopyHelper"
+import { NodeModuleInfo } from "./packageDependencies"
 
 const BOWER_COMPONENTS_PATTERN = `${path.sep}bower_components${path.sep}`
 /** @internal */
@@ -180,7 +181,7 @@ function validateFileSet(fileSet: ResolvedFileSet): ResolvedFileSet {
 
 /** @internal */
 export async function computeNodeModuleFileSets(platformPackager: PlatformPackager<any>, mainMatcher: FileMatcher): Promise<Array<ResolvedFileSet>> {
-  const deps = await platformPackager.info.getNodeDependencyInfo(platformPackager.platform, true).value
+  const deps = (await platformPackager.info.getNodeDependencyInfo(platformPackager.platform).value) as Array<NodeModuleInfo>
 
   const nodeModuleExcludedExts = getNodeModuleExcludedExts(platformPackager)
   // serial execution because copyNodeModules is concurrent and so, no need to increase queue/pressure

--- a/packages/app-builder-lib/src/util/packageDependencies.ts
+++ b/packages/app-builder-lib/src/util/packageDependencies.ts
@@ -1,15 +1,16 @@
 import { Lazy } from "lazy-val"
 import { executeAppBuilderAsJson } from "./appBuilder"
 
-export function createLazyProductionDeps(projectDir: string, excludedDependencies: Array<string> | null) {
+export function createLazyProductionDeps<T extends boolean>(projectDir: string, excludedDependencies: Array<string> | null, flatten: T) {
   return new Lazy(async () => {
-    const args = ["node-dep-tree", "--flatten", "--dir", projectDir]
+    const args = ["node-dep-tree", "--dir", projectDir]
+    if (flatten) args.push("--flatten")
     if (excludedDependencies != null) {
       for (const name of excludedDependencies) {
         args.push("--exclude-dep", name)
       }
     }
-    return executeAppBuilderAsJson<Array<any>>(args)
+    return executeAppBuilderAsJson<Array<T extends true ? NodeModuleInfo : NodeModuleDirInfo>>(args)
   })
 }
 

--- a/packages/electron-builder/src/cli/install-app-deps.ts
+++ b/packages/electron-builder/src/cli/install-app-deps.ts
@@ -62,7 +62,7 @@ export async function installAppDeps(args: any) {
       frameworkInfo: { version, useCustomDist: true },
       platform: args.platform,
       arch: args.arch,
-      productionDeps: createLazyProductionDeps(appDir, null),
+      productionDeps: createLazyProductionDeps(appDir, null, false),
     },
     appDir !== projectDir
   )


### PR DESCRIPTION
This PR fixes the mismatch in the dependency tree structure provided by the rebuild-node-modules command in the app-builder binary.