### PR TITLE
chore: update test snapshot and improve file path logging

### DIFF
--- a/.changeset/shy-cobras-smell.md
+++ b/.changeset/shy-cobras-smell.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: improving file path logging to be relative paths when within process.cwd()

--- a/packages/app-builder-lib/src/electron/electronWin.ts
+++ b/packages/app-builder-lib/src/electron/electronWin.ts
@@ -37,5 +37,5 @@ export async function addWinAsarIntegrity(executablePath: string, asarIntegrity:
   resource.outputResource(executable)
 
   await writeFile(executablePath, Buffer.from(executable.generate()))
-  log.info({ executablePath }, "updating asar integrity executable resource")
+  log.info({ executablePath: log.filePath(executablePath) }, "updating asar integrity executable resource")
 }

--- a/packages/app-builder-lib/src/electron/injectFFMPEG.ts
+++ b/packages/app-builder-lib/src/electron/injectFFMPEG.ts
@@ -25,7 +25,7 @@ const copyFFMPEG = (targetPath: string, platform: ElectronPlatformName) => (sour
 
   const libPath = path.resolve(sourcePath, fileName)
   const libTargetPath = path.resolve(targetPath, fileName)
-  log.info({ lib: libPath, target: libTargetPath }, "copying non-proprietary FFMPEG")
+  log.info({ lib: log.filePath(libPath), target: log.filePath(libTargetPath) }, "copying non-proprietary FFMPEG")
 
   // If the source doesn't exist we have a problem
   if (!fs.existsSync(libPath)) {

--- a/packages/app-builder-lib/src/publish/PublishManager.ts
+++ b/packages/app-builder-lib/src/publish/PublishManager.ts
@@ -152,7 +152,7 @@ export class PublishManager implements PublishContext {
     if (publisher == null) {
       log.debug(
         {
-          file: event.file,
+          file: log.filePath(event.file),
           reason: "publisher is null",
           publishConfig: safeStringifyJson(publishConfig),
         },
@@ -163,7 +163,7 @@ export class PublishManager implements PublishContext {
 
     const providerName = publisher.providerName
     if (this.publishOptions.publish === "onTagOrDraft" && getCiTag() == null && providerName !== "bitbucket" && providerName !== "github") {
-      log.info({ file: event.file, reason: "current build is not for a git tag", publishPolicy: "onTagOrDraft" }, `not published to ${providerName}`)
+      log.info({ file: log.filePath(event.file), reason: "current build is not for a git tag", publishPolicy: "onTagOrDraft" }, `not published to ${providerName}`)
       return
     }
 

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -137,7 +137,7 @@ export default class FpmTarget extends Target {
     if (publishConfig != null) {
       const linuxDistType = this.packager.packagerOptions.prepackaged || path.join(this.outDir, `linux${getArchSuffix(arch)}-unpacked`)
       const resourceDir = packager.getResourcesDir(linuxDistType)
-      log.info({ resourceDir }, `adding autoupdate files for: ${target}. (Beta feature)`)
+      log.info({ resourceDir: log.filePath(resourceDir) }, `adding autoupdate files for: ${target}. (Beta feature)`)
       await outputFile(path.join(resourceDir, "app-update.yml"), serializeToYaml(publishConfig))
       // Extra file needed for auto-updater to detect installation method
       await outputFile(path.join(resourceDir, "package-type"), target)

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -1128,6 +1128,9 @@ Object {
             "LICENSE": Object {
               "size": "<size>",
             },
+            "SECURITY.md": Object {
+              "size": "<size>",
+            },
             "index.js": Object {
               "size": "<size>",
             },


### PR DESCRIPTION
chore: improving file path logging to be relative paths when within process.cwd()

Also updates BuildTest snapshot due to new SECURITY.md file in the `pump` npm package -> (asar file tree verification in `posix smart unpack` test detected this npm package change)