### PR TITLE
fix: always produce Release .node builds

### DIFF
--- a/.changeset/wise-turtles-heal.md
+++ b/.changeset/wise-turtles-heal.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: always produce Release .node builds

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -203,7 +203,6 @@ export async function rebuild(config: Configuration, appDir: string, options: Re
     buildPath: appDir,
     electronVersion,
     arch,
-    debug: log.isDebugEnabled,
     projectRootPath: await getProjectRootPath(appDir),
     mode: (config.nativeRebuilder as RebuildMode) || "sequential",
     buildFromSource: buildFromSource,


### PR DESCRIPTION
`debug` flag on electron-rebuild is for Release/Debug native rebuilds, not for logging

Fixes: https://github.com/electron-userland/electron-builder/issues/8529