### PR TITLE
fix: add `CodeSigningAccountName` as required prop in Azure Signing Options

### DIFF
--- a/.changeset/real-otters-sparkle.md
+++ b/.changeset/real-otters-sparkle.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add `CodeSigningAccountName` as required prop in Azure Signing Options

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5977,6 +5977,10 @@
           "description": "The Certificate Profile name. Translates to field: CertificateProfileName",
           "type": "string"
         },
+        "codeSigningAccountName": {
+          "description": "The Code Signing Signing Account name. Translates to field: CodeSigningAccountName",
+          "type": "string"
+        },
         "endpoint": {
           "description": "The Trusted Signing Account endpoint. The URI value must have a URI that aligns to the\nregion your Trusted Signing Account and Certificate Profile you are specifying were created\nin during the setup of these resources.\n\nTranslates to field: Endpoint\n\nRequires one of environment variable configurations for authenticating to Microsoft Entra ID per [Microsoft's documentation](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet#definition)",
           "type": "string"
@@ -5984,6 +5988,7 @@
       },
       "required": [
         "certificateProfileName",
+        "codeSigningAccountName",
         "endpoint"
       ],
       "type": "object"

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -79,12 +79,13 @@ export class WindowsSignAzureManager {
     const vm = await this.packager.vm.value
     const ps = await getPSCmd(vm)
 
-    const { endpoint, certificateProfileName, ...extraSigningArgs }: WindowsAzureSigningConfiguration = options.options.azureSignOptions!
+    const { endpoint, certificateProfileName, codeSigningAccountName, ...extraSigningArgs }: WindowsAzureSigningConfiguration = options.options.azureSignOptions!
     const params = {
       FileDigest: "SHA256",
       ...extraSigningArgs, // allows overriding FileDigest if provided in config
       Endpoint: endpoint,
       CertificateProfileName: certificateProfileName,
+      CodeSigningAccountName: codeSigningAccountName,
       Files: options.path,
     }
     const paramsString = Object.entries(params)

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -204,6 +204,10 @@ export interface WindowsAzureSigningConfiguration {
    */
   readonly certificateProfileName: string
   /**
+   * The Code Signing Signing Account name. Translates to field: CodeSigningAccountName
+   */
+  readonly codeSigningAccountName: string
+  /**
    * Allow other CLI parameters (verbatim case-sensitive) to `Invoke-TrustedSigning`
    */
   [k: string]: string

--- a/test/src/windows/winCodeSignTest.ts
+++ b/test/src/windows/winCodeSignTest.ts
@@ -123,6 +123,7 @@ test.ifAll.ifNotCiMac(
         azureSignOptions: {
           endpoint: "https://weu.codesigning.azure.net/",
           certificateProfileName: "profilenamehere",
+          codeSigningAccountName: "codesigningnamehere"
         },
       },
     },


### PR DESCRIPTION
Ref: https://github.com/electron-userland/electron-builder/issues/8276#issuecomment-2371920176