### PR TITLE
chore(deps): update dependency app-builder-bin to 5.0.0-alpha.10

### DIFF
--- a/.changeset/silly-cooks-allow.md
+++ b/.changeset/silly-cooks-allow.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+chore(deps): update dependency app-builder-bin to 5.0.0-alpha.10

--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "7zip-bin": "~5.2.0",
     "@types/debug": "^4.1.6",
-    "app-builder-bin": "5.0.0-alpha.9",
+    "app-builder-bin": "5.0.0-alpha.10",
     "bluebird-lst": "^1.0.9",
     "builder-util-runtime": "workspace:*",
     "chalk": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ importers:
         specifier: ^4.1.6
         version: 4.1.7
       app-builder-bin:
-        specifier: 5.0.0-alpha.9
-        version: 5.0.0-alpha.9
+        specifier: 5.0.0-alpha.10
+        version: 5.0.0-alpha.10
       bluebird-lst:
         specifier: ^1.0.9
         version: 1.0.9
@@ -2630,8 +2630,8 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  app-builder-bin@5.0.0-alpha.9:
-    resolution: {integrity: sha512-c/wOXdITW80MGUV2PECWuxB49MIm44latbuoWGjq0i89lmA9ZB8jcvuF1pStu3wrxStYVjYpPD3/NgQDWSHohA==}
+  app-builder-bin@5.0.0-alpha.10:
+    resolution: {integrity: sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==}
 
   aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
@@ -9380,7 +9380,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-bin@5.0.0-alpha.9: {}
+  app-builder-bin@5.0.0-alpha.10: {}
 
   aproba@2.0.0: {}
 


### PR DESCRIPTION
Try to fix  
https://github.com/electron-userland/electron-builder/issues/8493
https://github.com/electron-userland/electron-builder/issues/8519
https://github.com/electron-userland/electron-builder/issues/8503

In app-builder-bin(https://github.com/develar/app-builder/pull/138), if using pnpm, it will employ the simplest hoisting algorithm, which only elevates packages to higher levels (if possible) to reduce duplicate packages. This approach also ensures no other anomalies occur. For yarn/npm/pnpm with hoisting, it'll continue using the original algorithm, only reading the dependency tree from node modules without performing any hoisting.
