### PR TITLE
fix(linux): continue update process even if AppImage is not available

### DIFF
--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -80,8 +80,12 @@ export class AppImageUpdater extends BaseUpdater {
     }
 
     // https://stackoverflow.com/a/1712051/1910191
-    unlinkSync(appImageFile)
-
+    try {
+      unlinkSync(appImageFile)
+    } catch(e: any) {
+      this._logger.warn("Previous version of AppImage is not available");
+    }
+  
     let destination: string
     const existingBaseName = path.basename(appImageFile)
     // https://github.com/electron-userland/electron-builder/issues/2964


### PR DESCRIPTION
### Situation
To update the AppImage, current (now running) version of AppImage must had to be on path that declared in code. (process.env.APPIMAGE)
If not, downloaded new version of AppImage disappers and current version app restarts.

### Fix
Fixed to continue the update process even if the previous version of AppImage is not available in APPIMAGE env path.