### PR TITLE
fix: Unable to copy file for caching: ENOENT

### DIFF
--- a/.changeset/dry-rockets-pretend.md
+++ b/.changeset/dry-rockets-pretend.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: Unable to copy file for caching: ENOENT

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -94,13 +94,13 @@ export class MacUpdater extends AppUpdater {
 
     const provider = downloadUpdateOptions.updateInfoAndProvider.provider
     const CURRENT_MAC_APP_ZIP_FILE_NAME = "update.zip"
-    const cachedUpdateFilePath = path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_MAC_APP_ZIP_FILE_NAME)
 
     return this.executeDownload({
       fileExtension: "zip",
       fileInfo: zipFileInfo,
       downloadUpdateOptions,
       task: async (destinationFile, downloadOptions) => {
+        const cachedUpdateFilePath = path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_MAC_APP_ZIP_FILE_NAME)
         const canDifferentialDownload = () => {
           if (!pathExistsSync(cachedUpdateFilePath)) {
             log.info("Unable to locate previous update.zip for differential download (is this first install?), falling back to full download")
@@ -119,6 +119,7 @@ export class MacUpdater extends AppUpdater {
       },
       done: event => {
         try {
+          const cachedUpdateFilePath = path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_MAC_APP_ZIP_FILE_NAME)
           copyFileSync(event.downloadedFile, cachedUpdateFilePath)
         } catch (error: any) {
           this._logger.error(`Unable to copy file for caching: ${error.message}`)

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -94,16 +94,15 @@ export class MacUpdater extends AppUpdater {
 
     const provider = downloadUpdateOptions.updateInfoAndProvider.provider
     const CURRENT_MAC_APP_ZIP_FILE_NAME = "update.zip"
-    let cachedUpdateFile: string = ""
+    const cachedUpdateFilePath = path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_MAC_APP_ZIP_FILE_NAME)
 
     return this.executeDownload({
       fileExtension: "zip",
       fileInfo: zipFileInfo,
       downloadUpdateOptions,
       task: async (destinationFile, downloadOptions) => {
-        cachedUpdateFile = path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_MAC_APP_ZIP_FILE_NAME)
         const canDifferentialDownload = () => {
-          if (!pathExistsSync(cachedUpdateFile)) {
+          if (!pathExistsSync(cachedUpdateFilePath)) {
             log.info("Unable to locate previous update.zip for differential download (is this first install?), falling back to full download")
             return false
           }
@@ -120,7 +119,7 @@ export class MacUpdater extends AppUpdater {
       },
       done: event => {
         try {
-          copyFileSync(event.downloadedFile, cachedUpdateFile)
+          copyFileSync(event.downloadedFile, cachedUpdateFilePath)
         } catch (error: any) {
           this._logger.error(`Unable to copy file for caching: ${error.message}`)
         }

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -118,11 +118,13 @@ export class MacUpdater extends AppUpdater {
         }
       },
       done: event => {
-        try {
-          const cachedUpdateFilePath = path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_MAC_APP_ZIP_FILE_NAME)
-          copyFileSync(event.downloadedFile, cachedUpdateFilePath)
-        } catch (error: any) {
-          this._logger.error(`Unable to copy file for caching: ${error.message}`)
+        if (!downloadUpdateOptions.disableDifferentialDownload) {
+          try {
+            const cachedUpdateFilePath = path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_MAC_APP_ZIP_FILE_NAME)
+            copyFileSync(event.downloadedFile, cachedUpdateFilePath)
+          } catch (error: any) {
+            this._logger.warn(`Unable to copy file for caching for future differential downloads: ${error.message}`)
+          }
         }
         return this.updateDownloaded(zipFileInfo, event)
       },


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8507

https://github.com/electron-userland/electron-builder/blob/3b03f27245458a0b595b7a65c8634f184d32f2fa/packages/electron-updater/src/AppUpdater.ts#L698-L702
The problem lies here. If cachedUpdateFile already exists, the task function won't run; instead, the done function will be executed directly.