### PR TITLE
fix: fix the main matcher patterns for !node_modules/@test/xxxx

### DIFF
--- a/.changeset/three-fans-worry.md
+++ b/.changeset/three-fans-worry.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix the main matcher patterns for !node_modules/xxxx

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -206,7 +206,7 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
     return path.dirname(parentDir)
   }
 
-  const collectNodeModules = async (dep: NodeModuleInfo,realSource:string, destination: string) => {
+  const collectNodeModules = async (dep: NodeModuleInfo, realSource: string, destination: string) => {
     const source = dep.dir
     const matcher = new FileMatcher(realSource, destination, mainMatcher.macroExpander, mainMatcher.patterns)
     const copier = new NodeModuleCopyHelper(matcher, platformPackager.info)
@@ -223,7 +223,7 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
   for (const dep of deps) {
     const destination = path.join(mainMatcher.to, NODE_MODULES, dep.name)
     const realSource = getRealSource(dep.name, dep.dir)
-    await collectNodeModules(dep,realSource, destination)
+    await collectNodeModules(dep, realSource, destination)
   }
 
   return result

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -201,23 +201,23 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
     return path.dirname(path.normalize(parentPath))
   }
 
-  const collectNodeModules = async (dep: NodeModuleInfo, source: string, destination: string) => {
-    const matcher = new FileMatcher(source, destination, mainMatcher.macroExpander, mainMatcher.patterns)
+  const collectNodeModules = async (dep: NodeModuleInfo, destination: string) => {
+    const source = dep.dir
+    const matcher = new FileMatcher(getRealSource(dep.name, source), destination, mainMatcher.macroExpander, mainMatcher.patterns)
     const copier = new NodeModuleCopyHelper(matcher, platformPackager.info)
     const files = await copier.collectNodeModules(dep, nodeModuleExcludedExts)
     result[index++] = validateFileSet({ src: source, destination, files, metadata: copier.metadata })
 
     if (dep.conflictDependency) {
       for (const c of dep.conflictDependency) {
-        await collectNodeModules(c, source, path.join(destination, NODE_MODULES, c.name))
+        await collectNodeModules(c, path.join(destination, NODE_MODULES, c.name))
       }
     }
   }
 
   for (const dep of deps) {
     const destination = path.join(mainMatcher.to, NODE_MODULES, dep.name)
-    const source = getRealSource(dep.name, dep.dir)
-    await collectNodeModules(dep, source, destination)
+    await collectNodeModules(dep, destination)
   }
 
   return result

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -190,14 +190,12 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
   const NODE_MODULES = "node_modules"
   const getRealSource = (name: string, source: string) => {
     const normalizedPath = source.split(path.sep).join("/")
-    const normalizedName = name.split("/").join("/")
 
-    if (!normalizedPath.endsWith(normalizedName)) {
+    if (!normalizedPath.endsWith(name)) {
       throw new Error("Path does not end with the package name")
     }
-
-    const parentDir = path.normalize(normalizedPath.slice(0, -normalizedName.length - 1))
-
+    const parentDir = path.normalize(normalizedPath.slice(0, -name.length - 1))
+    
     // for the local node modules which is not in node modules
     if (!parentDir.endsWith(path.sep + NODE_MODULES)) {
       return parentDir

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -194,7 +194,7 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
       throw new Error("Path does not end with the package name")
     }
 
-    // get the parent dir of the node moudle, input: /root/path/node_modules/@electron/remote, output: /root/path/node_modules
+    // get the parent dir of the package, input: /root/path/node_modules/@electron/remote, output: /root/path/node_modules
     const parentDir = source.slice(0, -normalizedName.length - 1)
 
     // for the local node modules which is not in node modules

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -195,7 +195,7 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
       throw new Error("Path does not end with the package name")
     }
     const parentDir = path.normalize(normalizedPath.slice(0, -name.length - 1))
-    
+
     // for the local node modules which is not in node modules
     if (!parentDir.endsWith(path.sep + NODE_MODULES)) {
       return parentDir

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -189,18 +189,20 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
   let index = 0
   const NODE_MODULES = "node_modules"
   const getRealSource = (name: string, source: string) => {
-    const normalizedPath = source.split(path.sep).join("/")
-
-    if (!normalizedPath.endsWith(name)) {
+    const normalizedName = name.split("/").join(path.sep)
+    if (!source.endsWith(normalizedName)) {
       throw new Error("Path does not end with the package name")
     }
-    const parentDir = path.normalize(normalizedPath.slice(0, -name.length - 1))
+
+    // get the parent dir of the node moudle, input: /root/path/node_modules/@electron/remote, output: /root/path/node_modules
+    const parentDir = source.slice(0, -normalizedName.length - 1)
 
     // for the local node modules which is not in node modules
     if (!parentDir.endsWith(path.sep + NODE_MODULES)) {
       return parentDir
     }
-    // use main matcher patterns, so, user can exclude some files !node_modules/xxxx
+
+    // use main matcher patterns,return parent dir of the node_modules, so user can exclude some files !node_modules/xxxx
     return path.dirname(parentDir)
   }
 

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -168,6 +168,7 @@ test.ifAll.ifDevOrLinuxCi("ignore node_modules", () => {
           //noinspection SpellCheckingInspection
           data.dependencies = {
             "ci-info": "2.0.0",
+            "@electron/remote": "2.1.2",
           }
         }),
       packed: context => {


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8460

Reproducible demo
```
{
  "name": "TestApp",
  "productName": "Test App ßW",
  "description": "My Electron application description",
  "keywords": [],
  "main": "./main.js",
  "version": "1.0.0",
  "author": "beyondkmp",
  "scripts": {
    "start": "electron .",
    "dist": "electron-builder"
  },
  "license": "MIT",
  "build": {
    "appId": "electron-blog-example",
       "files": [
        "!node_modules/@electron/remote/*"
       ],
    "win": {
      "target": "nsis"
    }
  },
  "devDependencies": {
    "electron": "32.1.0",
    "electron-builder": "25.1.6"
  },
  "dependencies": {
     "tar": "7.4.3",
     "@electron/remote": "2.1.2"
  }
}
```