### PR TITLE
fix: check if the file already starts with a UTF-8 BOM

### DIFF
--- a/.changeset/six-spoons-heal.md
+++ b/.changeset/six-spoons-heal.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Check if the file already starts with a UTF-8 BOM

--- a/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
@@ -8,7 +8,6 @@ import { NsisScriptGenerator } from "./nsisScriptGenerator"
 import { nsisTemplatesDir } from "./nsisUtil"
 import * as fs from "fs"
 
-
 function convertFileToUtf8WithBOMSync(filePath: string): boolean {
   try {
     const UTF8_BOM_HEADER = Buffer.from([0xef, 0xbb, 0xbf])
@@ -18,7 +17,7 @@ function convertFileToUtf8WithBOMSync(filePath: string): boolean {
     log.debug({ file: log.filePath(filePath) }, "checking file for BOM header")
     if (data.length >= UTF8_BOM_HEADER.length && data.subarray(0, UTF8_BOM_HEADER.length).equals(UTF8_BOM_HEADER)) {
       log.debug({ file: log.filePath(filePath) }, "file is already in BOM format, skipping conversion.")
-      return true;
+      return true
     }
 
     // If not, add the BOM

--- a/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
@@ -1,3 +1,4 @@
+import { log } from "builder-util"
 import { lcid } from "../../util/langs"
 import { getLicenseFiles, getNotLocalizedLicenseFile } from "../../util/license"
 import * as path from "path"
@@ -9,17 +10,26 @@ import * as fs from "fs"
 
 function convertFileToUtf8WithBOMSync(filePath: string): boolean {
   try {
-    const data = fs.readFileSync(filePath)
-    // UTF-8 BOM is EF BB BF
-    const BOM = Buffer.from([0xef, 0xbb, 0xbf])
-    const dataWithBOM = Buffer.concat([BOM, data])
-    fs.writeFileSync(filePath, dataWithBOM)
-    return true
-  } catch (err) {
-    console.error("Failed to convert file to UTF-8 with BOM: ", err)
-    return false
+    const data = fs.readFileSync(filePath);
+    const BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+    // Check if the file already starts with a UTF-8 BOM
+    if (data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf) {
+      log.info("File is already in UTF-8 with BOM format");
+      return true;
+    }
+
+    // If not, add the BOM
+    const dataWithBOM = Buffer.concat([BOM, data]);
+    fs.writeFileSync(filePath, dataWithBOM);
+    log.info("File successfully converted to UTF-8 with BOM");
+    return true;
+  } catch (err: any) {
+    log.error("Failed to convert file to UTF-8 with BOM: ", err.toString());
+    return false;
   }
 }
+
 export async function computeLicensePage(packager: WinPackager, options: NsisOptions, scriptGenerator: NsisScriptGenerator, languages: Array<string>): Promise<void> {
   const license = await getNotLocalizedLicenseFile(options.license, packager)
   if (license != null) {

--- a/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
@@ -10,23 +10,23 @@ import * as fs from "fs"
 
 function convertFileToUtf8WithBOMSync(filePath: string): boolean {
   try {
-    const data = fs.readFileSync(filePath);
-    const BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+    const data = fs.readFileSync(filePath)
+    const BOM = Buffer.from([0xef, 0xbb, 0xbf])
 
     // Check if the file already starts with a UTF-8 BOM
     if (data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf) {
-      log.info("File is already in UTF-8 with BOM format");
-      return true;
+      log.info("File is already in UTF-8 with BOM format")
+      return true
     }
 
     // If not, add the BOM
-    const dataWithBOM = Buffer.concat([BOM, data]);
-    fs.writeFileSync(filePath, dataWithBOM);
-    log.info("File successfully converted to UTF-8 with BOM");
-    return true;
+    const dataWithBOM = Buffer.concat([BOM, data])
+    fs.writeFileSync(filePath, dataWithBOM)
+    log.info("File successfully converted to UTF-8 with BOM")
+    return true
   } catch (err: any) {
-    log.error("Failed to convert file to UTF-8 with BOM: ", err.toString());
-    return false;
+    log.error("Failed to convert file to UTF-8 with BOM: ", err.toString())
+    return false
   }
 }
 

--- a/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisLicense.ts
@@ -8,24 +8,26 @@ import { NsisScriptGenerator } from "./nsisScriptGenerator"
 import { nsisTemplatesDir } from "./nsisUtil"
 import * as fs from "fs"
 
+
 function convertFileToUtf8WithBOMSync(filePath: string): boolean {
   try {
+    const UTF8_BOM_HEADER = Buffer.from([0xef, 0xbb, 0xbf])
     const data = fs.readFileSync(filePath)
-    const BOM = Buffer.from([0xef, 0xbb, 0xbf])
 
     // Check if the file already starts with a UTF-8 BOM
-    if (data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf) {
-      log.info("File is already in UTF-8 with BOM format")
-      return true
+    log.debug({ file: log.filePath(filePath) }, "checking file for BOM header")
+    if (data.length >= UTF8_BOM_HEADER.length && data.subarray(0, UTF8_BOM_HEADER.length).equals(UTF8_BOM_HEADER)) {
+      log.debug({ file: log.filePath(filePath) }, "file is already in BOM format, skipping conversion.")
+      return true;
     }
 
     // If not, add the BOM
-    const dataWithBOM = Buffer.concat([BOM, data])
+    const dataWithBOM = Buffer.concat([UTF8_BOM_HEADER, data])
     fs.writeFileSync(filePath, dataWithBOM)
-    log.info("File successfully converted to UTF-8 with BOM")
+    log.debug({ file: log.filePath(filePath) }, "file successfully converted to UTF-8 with BOM")
     return true
   } catch (err: any) {
-    log.error("Failed to convert file to UTF-8 with BOM: ", err.toString())
+    log.error({ file: log.filePath(filePath), message: err.message ?? err.stack }, "unable to convert file to UTF-8 with BOM")
     return false
   }
 }


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8512

If the file is already in UTF-8 BOM format, there's no need to convert it again. If it's converted again, it will result in garbled characters.