### PR TITLE
fix: Path does not end with the package name 

### DIFF
--- a/.changeset/swift-apricots-explode.md
+++ b/.changeset/swift-apricots-explode.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Path does not end with the package name

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -189,11 +189,12 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
   let index = 0
   const NODE_MODULES = "node_modules"
   const getRealSource = (name: string, source: string) => {
-    const scopeDepth = name.split("/").length
     let parentDir = path.dirname(source)
+
+    const scopeDepth = name.split("/").length
     // get the parent dir of the package, input: /root/path/node_modules/@electron/remote, output: /root/path/node_modules
     for (let i = 0; i < scopeDepth - 1; i++) {
-      parentDir = path.dirname(source)
+      parentDir = path.dirname(parentDir)
     }
 
     // for the local node modules which is not in node modules

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -193,7 +193,7 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
     let parentDir = path.dirname(source)
     // get the parent dir of the package, input: /root/path/node_modules/@electron/remote, output: /root/path/node_modules
     for (let i = 0; i < scopeDepth - 1; i++) {
-       parentDir = path.dirname(source)
+      parentDir = path.dirname(source)
     }
 
     // for the local node modules which is not in node modules

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -189,13 +189,12 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
   let index = 0
   const NODE_MODULES = "node_modules"
   const getRealSource = (name: string, source: string) => {
-    const normalizedName = name.split("/").join(path.sep)
-    if (!source.endsWith(normalizedName)) {
-      throw new Error("Path does not end with the package name")
-    }
-
+    const scopeDepth = name.split("/").length
+    let parentDir = path.dirname(source)
     // get the parent dir of the package, input: /root/path/node_modules/@electron/remote, output: /root/path/node_modules
-    const parentDir = source.slice(0, -normalizedName.length - 1)
+    for (let i = 0; i < scopeDepth - 1; i++) {
+       parentDir = path.dirname(source)
+    }
 
     // for the local node modules which is not in node modules
     if (!parentDir.endsWith(path.sep + NODE_MODULES)) {

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -168,7 +168,8 @@ test.ifAll.ifDevOrLinuxCi("ignore node_modules", () => {
           //noinspection SpellCheckingInspection
           data.dependencies = {
             "ci-info": "2.0.0",
-            "@electron/remote": "2.1.2",
+            "@types/node": "14.17.0",
+            "string-width-cjs": "4.2.3",
           }
         }),
       packed: context => {

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -169,7 +169,8 @@ test.ifAll.ifDevOrLinuxCi("ignore node_modules", () => {
           data.dependencies = {
             "ci-info": "2.0.0",
             "@types/node": "14.17.0",
-            "string-width-cjs": "4.2.3",
+            // this contains string-width-cjs 4.2.3
+            "@isaacs/cliui":"8.0.2"
           }
         }),
       packed: context => {


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8558

The @isaacs/cliui package depends on string-width-cjs@4.2.3, but the package that's actually downloaded is string-width@4.2.3. The name in the path doesn't match the original name, which is causing an error.
Fix solution: Truncate based on scope depth, not by name.

```
"string-width-cjs": {
          "from": "string-width",
          "version": "4.2.3",
          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
          "description": "Get the visual width of a string - the number of columns required to display it",
          "license": "MIT",
          "author": {
            "name": "Sindre Sorhus",
            "email": "sindresorhus@gmail.com",
            "url": "sindresorhus.com"
          },
          "homepage": "https://github.com/sindresorhus/string-width#readme",
          "repository": "git+https://github.com/sindresorhus/string-width.git",
          "path": "/Users/beyondkmp/Code/deepFocus/node_modules/.pnpm/string-width@4.2.3/node_modules/string-width",
}                 
                             
```