### PR TITLE
fix: support including node_modules in other subdirectories

### DIFF
--- a/.changeset/tricky-files-speak.md
+++ b/.changeset/tricky-files-speak.md
@@ -1,6 +1,6 @@
 ---
-"app-builder-lib": patch
-"builder-util": patch
+"app-builder-lib": major 
+"builder-util": major 
 ---
 
 support including node_modules in other subdirectories

--- a/.changeset/tricky-files-speak.md
+++ b/.changeset/tricky-files-speak.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+---
+
+support including node_modules in other subdirectories

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -7142,11 +7142,6 @@
       "description": "Whether to include PDB files.",
       "type": "boolean"
     },
-    "includeSubNodeModules": {
-      "default": false,
-      "description": "Whether to include *all* of the submodules node_modules directories",
-      "type": "boolean"
-    },
     "launchUiVersion": {
       "description": "*libui-based frameworks only* The version of LaunchUI you are packaging for. Applicable for Windows only. Defaults to version suitable for used framework version.",
       "type": [

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -184,12 +184,6 @@ export interface CommonConfiguration {
 }
 export interface Configuration extends CommonConfiguration, PlatformSpecificBuildOptions, Hooks {
   /**
-   * Whether to include *all* of the submodules node_modules directories
-   * @default false
-   */
-  includeSubNodeModules?: boolean
-
-  /**
    * Whether to use [electron-compile](http://github.com/electron/electron-compile) to compile app. Defaults to `true` if `electron-compile` in the dependencies. And `false` if in the `devDependencies` or doesn't specified.
    */
   readonly electronCompile?: boolean

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -163,8 +163,6 @@ export function getMainFileMatchers(
     patterns.push("package.json")
   }
 
-  customFirstPatterns.push("!**/node_modules")
-
   // https://github.com/electron-userland/electron-builder/issues/1482
   const relativeBuildResourceDir = path.relative(matcher.from, buildResourceDir)
   if (relativeBuildResourceDir.length !== 0 && !relativeBuildResourceDir.startsWith(".")) {

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -163,6 +163,20 @@ export function getMainFileMatchers(
     patterns.push("package.json")
   }
 
+  let insertExculdeNodeModulesIndex = -1
+  for (let i = 0; i < patterns.length; i++) {
+    if (!patterns[i].startsWith("!") && (patterns[i].includes("/node_modules") || patterns[i].includes("node_modules/"))) {
+      insertExculdeNodeModulesIndex = i
+      break
+    }
+  }
+
+  if (insertExculdeNodeModulesIndex !== -1) {
+    patterns.splice(insertExculdeNodeModulesIndex, 0, ...["!**/node_modules"])
+  } else {
+    customFirstPatterns.push("!**/node_modules")
+  }
+
   // https://github.com/electron-userland/electron-builder/issues/1482
   const relativeBuildResourceDir = path.relative(matcher.from, buildResourceDir)
   if (relativeBuildResourceDir.length !== 0 && !relativeBuildResourceDir.startsWith(".")) {
@@ -182,7 +196,6 @@ export function getMainFileMatchers(
       break
     }
   }
-  patterns.unshift("!**/node_modules")
   patterns.splice(insertIndex, 0, ...customFirstPatterns)
 
   patterns.push(`!**/*.{${excludedExts}${packager.config.includePdb === true ? "" : ",pdb"}}`)

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -172,9 +172,9 @@ export function getMainFileMatchers(
   }
 
   if (insertExculdeNodeModulesIndex !== -1) {
-    patterns.splice(insertExculdeNodeModulesIndex, 0, ...["!**/node_modules"])
+    patterns.splice(insertExculdeNodeModulesIndex, 0, ...["!**/node_modules/**"])
   } else {
-    customFirstPatterns.push("!**/node_modules")
+    customFirstPatterns.push("!**/node_modules/**")
   }
 
   // https://github.com/electron-userland/electron-builder/issues/1482

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -182,6 +182,7 @@ export function getMainFileMatchers(
       break
     }
   }
+  patterns.unshift("!**/node_modules")
   patterns.splice(insertIndex, 0, ...customFirstPatterns)
 
   patterns.push(`!**/*.{${excludedExts}${packager.config.includePdb === true ? "" : ",pdb"}}`)

--- a/packages/app-builder-lib/src/util/AppFileWalker.ts
+++ b/packages/app-builder-lib/src/util/AppFileWalker.ts
@@ -18,7 +18,7 @@ export abstract class FileCopyHelper {
     protected readonly matcher: FileMatcher,
     readonly filter: Filter | null,
     protected readonly packager: Packager
-  ) { }
+  ) {}
 
   protected handleFile(file: string, parent: string, fileStat: Stats): Promise<Stats | null> | null {
     if (!fileStat.isSymbolicLink()) {

--- a/packages/app-builder-lib/src/util/AppFileWalker.ts
+++ b/packages/app-builder-lib/src/util/AppFileWalker.ts
@@ -18,7 +18,7 @@ export abstract class FileCopyHelper {
     protected readonly matcher: FileMatcher,
     readonly filter: Filter | null,
     protected readonly packager: Packager
-  ) {}
+  ) { }
 
   protected handleFile(file: string, parent: string, fileStat: Stats): Promise<Stats | null> | null {
     if (!fileStat.isSymbolicLink()) {
@@ -68,8 +68,8 @@ export class AppFileWalker extends FileCopyHelper implements FileConsumer {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   consume(file: string, fileStat: Stats, parent: string, siblingNames: Array<string>): any {
     if (fileStat.isDirectory()) {
-          const matchesFilter = this.matcherFilter(file, fileStat)
-          return !matchesFilter
+      const matchesFilter = this.matcherFilter(file, fileStat)
+      return !matchesFilter
     } else {
       // save memory - no need to store stat for directory
       this.metadata.set(file, fileStat)

--- a/packages/app-builder-lib/src/util/AppFileWalker.ts
+++ b/packages/app-builder-lib/src/util/AppFileWalker.ts
@@ -4,8 +4,6 @@ import { FileMatcher } from "../fileMatcher"
 import { Packager } from "../packager"
 import * as path from "path"
 
-const nodeModulesSystemDependentSuffix = `${path.sep}node_modules`
-
 function addAllPatternIfNeed(matcher: FileMatcher) {
   if (!matcher.isSpecifiedAsEmptyArray && (matcher.isEmpty() || matcher.containsOnlyIgnore())) {
     matcher.prependPattern("**/*")
@@ -55,22 +53,7 @@ function createAppFilter(matcher: FileMatcher, packager: Packager): Filter | nul
   if (packager.areNodeModulesHandledExternally) {
     return matcher.isEmpty() ? null : matcher.createFilter()
   }
-
-  const nodeModulesFilter: Filter = (file, fileStat) => {
-    return !(fileStat.isDirectory() && file.endsWith(nodeModulesSystemDependentSuffix))
-  }
-
-  if (matcher.isEmpty()) {
-    return nodeModulesFilter
-  }
-
-  const filter = matcher.createFilter()
-  return (file, fileStat) => {
-    if (!nodeModulesFilter(file, fileStat)) {
-      return !!packager.config.includeSubNodeModules
-    }
-    return filter(file, fileStat)
-  }
+  return matcher.createFilter()
 }
 
 /** @internal */
@@ -85,18 +68,8 @@ export class AppFileWalker extends FileCopyHelper implements FileConsumer {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   consume(file: string, fileStat: Stats, parent: string, siblingNames: Array<string>): any {
     if (fileStat.isDirectory()) {
-      // https://github.com/electron-userland/electron-builder/issues/1539
-      // but do not filter if we inside node_modules dir
-      // update: solution disabled, node module resolver should support such setup
-      if (file.endsWith(nodeModulesSystemDependentSuffix)) {
-        if (!this.packager.config.includeSubNodeModules) {
           const matchesFilter = this.matcherFilter(file, fileStat)
-          if (!matchesFilter) {
-            // Skip the file
-            return false
-          }
-        }
-      }
+          return !matchesFilter
     } else {
       // save memory - no need to store stat for directory
       this.metadata.set(file, fileStat)

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -54,7 +54,7 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
       return true
     }
 
-    let relative = getRelativePath(file, srcWithEndSlash)
+    const relative = getRelativePath(file, srcWithEndSlash)
 
     // filter the root node_modules, but not a subnode_modules (like /appDir/others/foo/node_modules/blah)
     if (relative === "node_modules") {

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -61,10 +61,6 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
       return false
     }
 
-    if (stat.isDirectory()) {
-      relative += "/"
-    }
-
     // https://github.com/electron-userland/electron-builder/issues/867
     return minimatchAll(relative, patterns, stat) && (excludePatterns == null || stat.isDirectory() || !minimatchAll(relative, excludePatterns, stat))
   }

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -54,11 +54,15 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
       return true
     }
 
-    const relative = getRelativePath(file, srcWithEndSlash)
+    let relative = getRelativePath(file, srcWithEndSlash)
 
     // filter the root node_modules, but not a subnode_modules (like /appDir/others/foo/node_modules/blah)
     if (relative === "node_modules") {
       return false
+    }
+
+    if(stat.isDirectory()) {
+      relative += "/"
     }
 
     // https://github.com/electron-userland/electron-builder/issues/867

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -57,7 +57,7 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
     const relative = getRelativePath(file, srcWithEndSlash)
 
     // filter the root node_modules, but not a subnode_modules (like /appDir/others/foo/node_modules/blah)
-    if(relative === "node_modules") {
+    if (relative === "node_modules") {
       return false
     }
 

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -61,7 +61,7 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
       return false
     }
 
-    if(stat.isDirectory()) {
+    if (stat.isDirectory()) {
       relative += "/"
     }
 

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -54,11 +54,15 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
       return true
     }
 
-    const relative = getRelativePath(file, srcWithEndSlash)
+    let relative = getRelativePath(file, srcWithEndSlash)
 
     // filter the root node_modules, but not a subnode_modules (like /appDir/others/foo/node_modules/blah)
     if (relative === "node_modules") {
       return false
+    }
+
+    if (relative.endsWith("node_modules")) {
+      relative += "/"
     }
 
     // https://github.com/electron-userland/electron-builder/issues/867

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -59,9 +59,7 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
     // filter the root node_modules, but not a subnode_modules (like /appDir/others/foo/node_modules/blah)
     if (relative === "node_modules") {
       return false
-    }
-
-    if (relative.endsWith("node_modules")) {
+    } else if (relative.endsWith("/node_modules")) {
       relative += "/"
     }
 

--- a/packages/app-builder-lib/src/util/filter.ts
+++ b/packages/app-builder-lib/src/util/filter.ts
@@ -55,6 +55,12 @@ export function createFilter(src: string, patterns: Array<Minimatch>, excludePat
     }
 
     const relative = getRelativePath(file, srcWithEndSlash)
+
+    // filter the root node_modules, but not a subnode_modules (like /appDir/others/foo/node_modules/blah)
+    if(relative === "node_modules") {
+      return false
+    }
+
     // https://github.com/electron-userland/electron-builder/issues/867
     return minimatchAll(relative, patterns, stat) && (excludePatterns == null || stat.isDirectory() || !minimatchAll(relative, excludePatterns, stat))
   }

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -88,9 +88,9 @@ export async function walk(initialDirPath: string, filter?: Filter | null, consu
           }
 
           const consumerResult = consumer == null ? null : consumer.consume(filePath, stat, dirPath, childNames)
-          if (consumerResult === false) {
+          if (consumerResult === true) {
             return null
-          } else if (consumerResult == null || !("then" in consumerResult)) {
+          } else if (consumerResult=== false || consumerResult == null || !("then" in consumerResult)) {
             if (stat.isDirectory()) {
               dirs.push(name)
               return null

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -15,7 +15,7 @@ export const CONCURRENCY = { concurrency: MAX_FILE_REQUESTS }
 export type AfterCopyFileTransformer = (file: string) => Promise<boolean>
 
 export class CopyFileTransformer {
-  constructor(public readonly afterCopyTransformer: AfterCopyFileTransformer) { }
+  constructor(public readonly afterCopyTransformer: AfterCopyFileTransformer) {}
 }
 
 export type FileTransformer = (file: string) => Promise<null | string | Buffer | CopyFileTransformer> | null | string | Buffer | CopyFileTransformer
@@ -251,14 +251,14 @@ export class FileCopier {
       isUseHardLink,
       isUseHardLink
         ? () => {
-          // files are copied concurrently, so, we must not check here currentIsUseHardLink — our code can be executed after that other handler will set currentIsUseHardLink to false
-          if (this.isUseHardLink) {
-            this.isUseHardLink = false
-            return true
-          } else {
-            return false
+            // files are copied concurrently, so, we must not check here currentIsUseHardLink — our code can be executed after that other handler will set currentIsUseHardLink to false
+            if (this.isUseHardLink) {
+              this.isUseHardLink = false
+              return true
+            } else {
+              return false
+            }
           }
-        }
         : null
     )
 

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -15,7 +15,7 @@ export const CONCURRENCY = { concurrency: MAX_FILE_REQUESTS }
 export type AfterCopyFileTransformer = (file: string) => Promise<boolean>
 
 export class CopyFileTransformer {
-  constructor(public readonly afterCopyTransformer: AfterCopyFileTransformer) {}
+  constructor(public readonly afterCopyTransformer: AfterCopyFileTransformer) { }
 }
 
 export type FileTransformer = (file: string) => Promise<null | string | Buffer | CopyFileTransformer> | null | string | Buffer | CopyFileTransformer
@@ -90,7 +90,7 @@ export async function walk(initialDirPath: string, filter?: Filter | null, consu
           const consumerResult = consumer == null ? null : consumer.consume(filePath, stat, dirPath, childNames)
           if (consumerResult === true) {
             return null
-          } else if (consumerResult=== false || consumerResult == null || !("then" in consumerResult)) {
+          } else if (consumerResult === false || consumerResult == null || !("then" in consumerResult)) {
             if (stat.isDirectory()) {
               dirs.push(name)
               return null
@@ -251,14 +251,14 @@ export class FileCopier {
       isUseHardLink,
       isUseHardLink
         ? () => {
-            // files are copied concurrently, so, we must not check here currentIsUseHardLink — our code can be executed after that other handler will set currentIsUseHardLink to false
-            if (this.isUseHardLink) {
-              this.isUseHardLink = false
-              return true
-            } else {
-              return false
-            }
+          // files are copied concurrently, so, we must not check here currentIsUseHardLink — our code can be executed after that other handler will set currentIsUseHardLink to false
+          if (this.isUseHardLink) {
+            this.isUseHardLink = false
+            return true
+          } else {
+            return false
           }
+        }
         : null
     )
 

--- a/test/snapshots/ignoreTest.js.snap
+++ b/test/snapshots/ignoreTest.js.snap
@@ -6,18 +6,6 @@ Object {
 }
 `;
 
-exports[`copied all submodule node_modules 1`] = `
-Object {
-  "linux": Array [],
-}
-`;
-
-exports[`copied no submodule node_modules 1`] = `
-Object {
-  "linux": Array [],
-}
-`;
-
 exports[`copied select submodule node_modules 1`] = `
 Object {
   "linux": Array [],

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -86,21 +86,20 @@ test.ifNotCiMac(
       },
     },
     {
+      isInstallDepsBefore: true,
       projectDirCreated: projectDir => {
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.devDependencies = {
-              "@electron/osx-sign": "*",
+              "semver": "6.3.1",
               ...data.devDependencies,
             }
           }),
-          outputFile(path.join(projectDir, "node_modules", "@electron/osx-sign", "package.json"), "{}"),
         ])
       },
       packed: context => {
         return Promise.all([
-          assertThat(path.join(context.getResources(Platform.LINUX), "app", "node_modules", "@electron/osx-sign")).doesNotExist(),
-          assertThat(path.join(context.getResources(Platform.LINUX), "app", "ignoreMe")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX), "app", "node_modules", "semver")).doesNotExist(),
         ])
       },
     }
@@ -117,12 +116,13 @@ test.ifDevOrLinuxCi(
       },
     },
     {
+      isInstallDepsBefore: true,
       projectDirCreated: projectDir => {
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.dependencies = {
-              "@types/node": "22.7.4",
-              "undici-types": "5.25.1",
+              "electron-updater": "6.3.9",
+              "semver":"6.3.1",
               ...data.dependencies,
             }
           }),
@@ -130,7 +130,7 @@ test.ifDevOrLinuxCi(
       },
       packed: context => {
         return Promise.all([
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "@types/node", "node_modules")).isDirectory(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "electron-updater", "node_modules")).isDirectory(),
         ])
       },
     }

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -122,7 +122,7 @@ test.ifDevOrLinuxCi(
           modifyPackageJson(projectDir, data => {
             data.dependencies = {
               "@types/node": "22.7.4",
-              "undici-types":"5.25.1",
+              "undici-types": "5.25.1",
               ...data.dependencies,
             }
           }),
@@ -154,8 +154,8 @@ test.ifDevOrLinuxCi(
               ...data.dependencies,
             }
           }),
-          outputFile(path.join(projectDir, "others", "node_modules","package.json"), "{}"),
-          outputFile(path.join(projectDir, "others", "test1","package.json"), "{}"),
+          outputFile(path.join(projectDir, "others", "node_modules", "package.json"), "{}"),
+          outputFile(path.join(projectDir, "others", "test1", "package.json"), "{}"),
           outputFile(path.join(projectDir, "others", "submodule-2-test", "node_modules", "package.json"), "{}"),
           outputFile(path.join(projectDir, "others", "submodule-2-test", "test2", "package.json"), "{}"),
         ])
@@ -205,7 +205,7 @@ test.ifDevOrLinuxCi(
           assertThat(
             path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules", "package.json")
           ).isFile(),
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app","submodule-2-test", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-2-test", "node_modules")).doesNotExist(),
         ])
       },
     }
@@ -237,7 +237,7 @@ test.ifDevOrLinuxCi(
       packed: context => {
         return Promise.all([
           assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules")).doesNotExist(),
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app","submodule-2-test", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-2-test", "node_modules")).doesNotExist(),
         ])
       },
     }

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -108,13 +108,12 @@ test.ifNotCiMac(
 )
 
 test.ifDevOrLinuxCi(
-  "copied no submodule node_modules",
+  "copied sub node_modules of the rootDir/node_modules",
   app(
     {
       targets: Platform.LINUX.createTarget(DIR_TARGET),
       config: {
         asar: false,
-        includeSubNodeModules: false,
       },
     },
     {
@@ -122,19 +121,16 @@ test.ifDevOrLinuxCi(
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.dependencies = {
-              "submodule-1-test": "*",
-              "submodule-2-test": "*",
+              "@types/node": "22.7.4",
+              "undici-types":"5.25.1",
               ...data.dependencies,
             }
           }),
-          outputFile(path.join(projectDir, "node_modules", "submodule-1-test", "node_modules", "package.json"), "{}"),
-          outputFile(path.join(projectDir, "node_modules", "submodule-2-test", "node_modules", "package.json"), "{}"),
         ])
       },
       packed: context => {
         return Promise.all([
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "submodule-1-test", "node_modules")).doesNotExist(),
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "submodule-2-test", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "@types/node", "node_modules")).isDirectory(),
         ])
       },
     }
@@ -142,13 +138,12 @@ test.ifDevOrLinuxCi(
 )
 
 test.ifDevOrLinuxCi(
-  "copied all submodule node_modules",
+  "Don't copy sub node_modules of the other dir instead of rootDir",
   app(
     {
       targets: Platform.LINUX.createTarget(DIR_TARGET),
       config: {
         asar: false,
-        includeSubNodeModules: true,
       },
     },
     {
@@ -156,27 +151,69 @@ test.ifDevOrLinuxCi(
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.dependencies = {
-              "submodule-1-test": "*",
-              "submodule-2-test": "*",
               ...data.dependencies,
             }
           }),
-          outputFile(path.join(projectDir, "node_modules", "submodule-1-test", "node_modules", "package.json"), "{}"),
-          outputFile(path.join(projectDir, "node_modules", "submodule-2-test", "node_modules", "package.json"), "{}"),
+          outputFile(path.join(projectDir, "others", "node_modules","package.json"), "{}"),
+          outputFile(path.join(projectDir, "others", "test1","package.json"), "{}"),
+          outputFile(path.join(projectDir, "others", "submodule-2-test", "node_modules", "package.json"), "{}"),
+          outputFile(path.join(projectDir, "others", "submodule-2-test", "test2", "package.json"), "{}"),
         ])
       },
       packed: context => {
         return Promise.all([
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "submodule-1-test", "node_modules")).isDirectory(),
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "submodule-2-test", "node_modules")).isDirectory(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "others", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "others", "test1")).isDirectory(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "others", "test1", "package.json")).isFile(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "others", "submodule-2-test", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "others", "submodule-2-test", "test2")).isDirectory(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "others", "submodule-2-test", "test2", "package.json")).isFile(),
         ])
       },
     }
   )
 )
 
-test.skip.ifDevOrLinuxCi(
+test.ifDevOrLinuxCi(
   "copied select submodule node_modules",
+  app(
+    {
+      targets: Platform.LINUX.createTarget(DIR_TARGET),
+      config: {
+        asar: false,
+        // should use **/ instead of */, 
+        // we use the related path to match, so the relative path is submodule-1-test/node_modules
+        // */ will not match submodule-1-test/node_modules 
+        files: ["**/*", "**/submodule-1-test/node_modules/**"],
+      },
+    },
+    {
+      projectDirCreated: projectDir => {
+        return Promise.all([
+          modifyPackageJson(projectDir, data => {
+            data.dependencies = {
+              ...data.dependencies,
+            }
+          }),
+          outputFile(path.join(projectDir, "submodule-1-test", "node_modules", "package.json"), "{}"),
+          outputFile(path.join(projectDir, "submodule-2-test", "node_modules", "package.json"), "{}"),
+        ])
+      },
+      packed: context => {
+        return Promise.all([
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules")).isDirectory(),
+          assertThat(
+            path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules", "package.json")
+          ).isFile(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app","submodule-2-test", "node_modules")).doesNotExist(),
+        ])
+      },
+    }
+  )
+)
+
+test.ifDevOrLinuxCi(
+  "cannot copied select submodule node_modules by */",
   app(
     {
       targets: Platform.LINUX.createTarget(DIR_TARGET),
@@ -190,22 +227,17 @@ test.skip.ifDevOrLinuxCi(
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.dependencies = {
-              "submodule-1-test": "*",
-              "submodule-2-test": "*",
               ...data.dependencies,
             }
           }),
-          outputFile(path.join(projectDir, "node_modules", "submodule-1-test", "node_modules", "package.json"), "{}"),
-          outputFile(path.join(projectDir, "node_modules", "submodule-2-test", "node_modules", "package.json"), "{}"),
+          outputFile(path.join(projectDir, "submodule-1-test", "node_modules", "package.json"), "{}"),
+          outputFile(path.join(projectDir, "submodule-2-test", "node_modules", "package.json"), "{}"),
         ])
       },
       packed: context => {
         return Promise.all([
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "submodule-1-test", "node_modules")).isDirectory(),
-          assertThat(
-            path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "submodule-1-test", "node_modules", "package.json")
-          ).isFile(),
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "submodule-2-test", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app","submodule-2-test", "node_modules")).doesNotExist(),
         ])
       },
     }

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -240,13 +240,41 @@ test.ifDevOrLinuxCi(
             }
           }),
           outputFile(path.join(projectDir, "submodule-1-test", "node_modules", "package.json"), "{}"),
-          outputFile(path.join(projectDir, "submodule-2-test", "node_modules", "package.json"), "{}"),
         ])
       },
       packed: context => {
         return Promise.all([
           assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules")).doesNotExist(),
-          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-2-test", "node_modules")).doesNotExist(),
+        ])
+      },
+    }
+  )
+)
+
+test.ifDevOrLinuxCi(
+  "cannot copied select submodule node_modules by **/submodule-1-test/node_modules",
+  app(
+    {
+      targets: Platform.LINUX.createTarget(DIR_TARGET),
+      config: {
+        asar: false,
+        files: ["**/*", "**/submodule-1-test/node_modules"],
+      },
+    },
+    {
+      projectDirCreated: projectDir => {
+        return Promise.all([
+          modifyPackageJson(projectDir, data => {
+            data.dependencies = {
+              ...data.dependencies,
+            }
+          }),
+          outputFile(path.join(projectDir, "submodule-1-test", "node_modules", "package.json"), "{}"),
+        ])
+      },
+      packed: context => {
+        return Promise.all([
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules")).doesNotExist(),
         ])
       },
     }

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -83,6 +83,7 @@ test.ifNotCiMac(
       targets: Platform.LINUX.createTarget(DIR_TARGET),
       config: {
         asar: false,
+        files: ["**/*", "**/submodule-1-test/node_modules/**"],
       },
     },
     {

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -113,6 +113,7 @@ test.ifDevOrLinuxCi(
       targets: Platform.LINUX.createTarget(DIR_TARGET),
       config: {
         asar: false,
+        files: ["**/*", "**/submodule-1-test/node_modules/**"],
       },
     },
     {
@@ -126,11 +127,18 @@ test.ifDevOrLinuxCi(
               ...data.dependencies,
             }
           }),
+          outputFile(path.join(projectDir, "submodule-1-test", "node_modules", "package.json"), "{}"),
+          outputFile(path.join(projectDir, "others", "node_modules", "package.json"), "{}"),
         ])
       },
       packed: context => {
         return Promise.all([
           assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "node_modules", "electron-updater", "node_modules")).isDirectory(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "others", "node_modules")).doesNotExist(),
+          assertThat(path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules")).isDirectory(),
+          assertThat(
+            path.join(context.getResources(Platform.LINUX, archFromString(process.arch)), "app", "submodule-1-test", "node_modules", "package.json")
+          ).isFile(),
         ])
       },
     }


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/pull/6080  and support including node_modules in other subdirectories

**How to fix**

1. No file patterns

    -  The final File patterns are `["**/*", "!**/node_modules/**", "!dist{,/**/*}", ...] `

2. File patterns with other sub node_modules `["/*", "**/sub/node_modules/**"]`

   - File patterns are `["**/*", "!**/node_modules/**", "**/sub/node_modules/**", "!dist{,/**/*}", ...]`

3. File patterns without sub node_modules

   -  The final File patterns are `["**/*", "!**/node_modules/**", "!dist{,/**/*}", ...]`

The final patterns above all filter out the node_modules in the app root directory. In filter.ts, we handle this by returning false by default if relative === 'node_modules', so it won't be filtered out. 

https://github.com/electron-userland/electron-builder/blob/e2c79819751454dbd1a939610d66e940b5dfb73d/packages/app-builder-lib/src/util/filter.ts#L60-L62

However, if you really want to filter out the node_modules in the app directory, you can use `["!node_modules/**/*"]` to filter it.

**Two points to note**

1. Now `["**/*", "**/sub/node_modules"]` cannot match. Only `["**/*", "**/sub/node_modules/**"]` will match. 

   For a relative path of` sub/node_modules`, if  don't add a `/ ` at the end, we can only use `**/sub/node_module` to match. If  add a `/` at the end, we can only use `**/sub/node_module/**` to match.
   
   **I currently prefer that `**/sub/node_modules/**` matches, as this aligns more with conventional usage.**

2. `*/sub/node_modules/**`  cannot match because the relative path is `sub/node_modules`, and there's no extra directory at the beginning.