### PR TITLE
fix: ignore symlink file if it links outside module

### DIFF
--- a/.changeset/heavy-buses-unite.md
+++ b/.changeset/heavy-buses-unite.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+delete symlink file if it links outside node_modules

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -160,8 +160,8 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
       const resolvedPath = realpathSync(file)
       const absolutePath = path.resolve(resolvedPath)
       if (!absolutePath.startsWith(path.resolve(tmpPath))) {
-        // delete symlink file if it links outside node_modules (e.g.
-        log.debug({ file: file, module_path: tmpPath, resolvedPath: resolvedPath }, `deleting symlink outside node_modules`)
+        // delete symlink file if it links outside module (e.g.
+        log.debug({ module: moduleName, file: file, resolvedPath: resolvedPath }, `deleting symlink outside module`)
         result[index] = undefined
       }
 

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -1,5 +1,5 @@
 import BluebirdPromise from "bluebird-lst"
-import { CONCURRENCY } from "builder-util"
+import { log, CONCURRENCY } from "builder-util"
 import { lstat, readdir, lstatSync } from "fs-extra"
 import * as path from "path"
 import { excludedNames, FileMatcher } from "../fileMatcher"
@@ -158,6 +158,13 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
     for (const [file, index] of symlinkFiles) {
       const resolvedPath = realpathSync(file)
+      const absolutePath = path.resolve(resolvedPath)
+      if (!absolutePath.startsWith(path.resolve(tmpPath))) {
+        // delete symlink file if it links outside node_modules (e.g.
+        log.debug({ file: file, module_path: tmpPath, resolvedPath: resolvedPath }, `deleting symlink outside node_modules`)
+        result[index] = undefined
+      }
+
       if (emptyDirs.has(resolvedPath)) {
         // delete symlink file if target is a empty dir
         result[index] = undefined

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -160,7 +160,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
       const resolvedPath = realpathSync(file)
       if (!isSubPath(tmpPath, resolvedPath)) {
         // delete symlink file if it links outside module (e.g.
-        log.debug({ module: moduleName, file: file, resolvedPath: resolvedPath }, `deleting symlink outside module`)
+        log.warn({ module: moduleName, file: file, resolvedPath: resolvedPath }, `deleting symlink outside module`)
         result[index] = undefined
       }
 

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -110,8 +110,8 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
             if (stat.isSymbolicLink()) {
               const resolvedLinkTarget = realpathSync(filePath)
-              if (!isSubPath(tmpPath, resolvedLinkTarget)) {
-                // delete symlink file if it links outside module 
+              if (!isSubPath(resolvedLinkTarget, tmpPath)) {
+                // delete symlink file if it links outside module
                 log.warn({ module: moduleName, file: filePath, resolvedLinkTarget }, `deleting symlink outside module`)
                 return null
               }

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -1,5 +1,5 @@
 import BluebirdPromise from "bluebird-lst"
-import { log, CONCURRENCY } from "builder-util"
+import { log, CONCURRENCY, isSubPath } from "builder-util"
 import { lstat, readdir, lstatSync } from "fs-extra"
 import * as path from "path"
 import { excludedNames, FileMatcher } from "../fileMatcher"
@@ -158,8 +158,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
     for (const [file, index] of symlinkFiles) {
       const resolvedPath = realpathSync(file)
-      const absolutePath = path.resolve(resolvedPath)
-      if (!absolutePath.startsWith(path.resolve(tmpPath))) {
+      if (!isSubPath(tmpPath, resolvedPath)) {
         // delete symlink file if it links outside module (e.g.
         log.debug({ module: moduleName, file: file, resolvedPath: resolvedPath }, `deleting symlink outside module`)
         result[index] = undefined

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -108,6 +108,15 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
               return null
             }
 
+      if (stat.isSymbolicLink()) {
+        const resolvedLinkTarget =  realpathSync(filePath)
+        if(!isSubPath(tmpPath, resolvedLinkTarget)) {
+        // delete symlink file if it links outside module 
+        log.warn({ module: moduleName, file: filePath, resolvedLinkTarget }, `deleting symlink outside module`)
+        return null
+        }
+      }
+
             if (!stat.isDirectory()) {
               metadata.set(filePath, stat)
             }
@@ -158,11 +167,6 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
     for (const [file, index] of symlinkFiles) {
       const resolvedPath = realpathSync(file)
-      if (!isSubPath(tmpPath, resolvedPath)) {
-        // delete symlink file if it links outside module (e.g.
-        log.warn({ module: moduleName, file: file, resolvedPath: resolvedPath }, `deleting symlink outside module`)
-        result[index] = undefined
-      }
 
       if (emptyDirs.has(resolvedPath)) {
         // delete symlink file if target is a empty dir

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -108,14 +108,14 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
               return null
             }
 
-      if (stat.isSymbolicLink()) {
-        const resolvedLinkTarget =  realpathSync(filePath)
-        if(!isSubPath(tmpPath, resolvedLinkTarget)) {
-        // delete symlink file if it links outside module 
-        log.warn({ module: moduleName, file: filePath, resolvedLinkTarget }, `deleting symlink outside module`)
-        return null
-        }
-      }
+            if (stat.isSymbolicLink()) {
+              const resolvedLinkTarget = realpathSync(filePath)
+              if (!isSubPath(tmpPath, resolvedLinkTarget)) {
+                // delete symlink file if it links outside module 
+                log.warn({ module: moduleName, file: filePath, resolvedLinkTarget }, `deleting symlink outside module`)
+                return null
+              }
+            }
 
             if (!stat.isDirectory()) {
               metadata.set(filePath, stat)
@@ -167,7 +167,6 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
     for (const [file, index] of symlinkFiles) {
       const resolvedPath = realpathSync(file)
-
       if (emptyDirs.has(resolvedPath)) {
         // delete symlink file if target is a empty dir
         result[index] = undefined

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -330,7 +330,7 @@ export async function dirSize(dirPath: string): Promise<number> {
   return (await Promise.all(entrySizes)).reduce((entrySize, totalSize) => entrySize + totalSize, 0)
 }
 
-export function isSubPath(parent: string, child: string) {
+export function isSubPath(child: string, parent: string) {
   const parentPath = path.resolve(parent)
   const childPath = path.resolve(child)
   const relativePath = path.relative(parentPath, childPath)

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -330,6 +330,13 @@ export async function dirSize(dirPath: string): Promise<number> {
   return (await Promise.all(entrySizes)).reduce((entrySize, totalSize) => entrySize + totalSize, 0)
 }
 
+export function isSubPath(parent: string, child: string) {
+  const parentPath = path.resolve(parent)
+  const childPath = path.resolve(child)
+  const relativePath = path.relative(parentPath, childPath)
+  return !relativePath.startsWith("..")
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const DO_NOT_USE_HARD_LINKS = (file: string) => false
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -368,15 +368,6 @@ Object {
                   },
                   "unpacked": true,
                 },
-                "node_gyp_bins": Object {
-                  "files": Object {
-                    "python3": Object {
-                      "size": 5490456,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
               },
             },
             "deps": Object {

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -671,14 +671,6 @@ Object {
                     },
                   },
                 },
-                "node_gyp_bins": Object {
-                  "files": Object {
-                    "python3": Object {
-                      "size": "<size>",
-                      "unpacked": true,
-                    },
-                  },
-                },
               },
             },
             "index.js": Object {
@@ -771,14 +763,6 @@ Object {
                       "unpacked": true,
                     },
                     "spawn-helper": Object {
-                      "size": "<size>",
-                      "unpacked": true,
-                    },
-                  },
-                },
-                "node_gyp_bins": Object {
-                  "files": Object {
-                    "python3": Object {
                       "size": "<size>",
                       "unpacked": true,
                     },

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -1672,7 +1672,6 @@ Array [
   "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/MinimumWindowWidths.txt",
   "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/Results.txt",
   "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/Windows10SetFontBugginess.txt",
-  "app.asar.unpacked/node_modules/node-pty/build/node_gyp_bins/python3",
   "app.asar.unpacked/node_modules/node-pty/build/Release/pty.node",
   "app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper",
   "app.asar.unpacked/node_modules/node-mac-permissions/LICENSE",
@@ -1719,7 +1718,6 @@ Array [
     "name": "app.asar.unpacked/node_modules/node-mac-permissions/package.json",
   },
   "app.asar.unpacked/node_modules/node-mac-permissions/permissions.mm",
-  "app.asar.unpacked/node_modules/node-mac-permissions/build/node_gyp_bins/python3",
   "app.asar.unpacked/node_modules/node-mac-permissions/build/Release/permissions.node",
 ]
 `;

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -9,7 +9,6 @@ import { app, appTwo, appTwoThrows, assertPack, linuxDirTarget, modifyPackageJso
 import { ELECTRON_VERSION } from "./helpers/testConfig"
 import { verifySmartUnpack } from "./helpers/verifySmartUnpack"
 import { AsarFilesystem } from "app-builder-lib/src/asar/asar"
-import { outputFile } from "fs-extra"
 
 test("cli", async () => {
   // because these methods are internal

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -9,6 +9,7 @@ import { app, appTwo, appTwoThrows, assertPack, linuxDirTarget, modifyPackageJso
 import { ELECTRON_VERSION } from "./helpers/testConfig"
 import { verifySmartUnpack } from "./helpers/verifySmartUnpack"
 import { AsarFilesystem } from "app-builder-lib/src/asar/asar"
+import { outputFile } from "fs-extra"
 
 test("cli", async () => {
   // because these methods are internal

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -120,15 +120,15 @@ export async function assertPack(fixtureName: string, packagerOptions: PackagerO
         await projectDirCreated(projectDir, tmpDir)
       }
 
-      if(beforePack != null) {
-        await beforePack(projectDir, tmpDir)
-      }
-
       if (checkOptions.isInstallDepsBefore) {
         // bin links required (e.g. for node-pre-gyp - if package refers to it in the install script)
         await spawn(process.platform === "win32" ? "npm.cmd" : "npm", ["install", "--production", "--legacy-peer-deps"], {
           cwd: projectDir,
         })
+      }
+
+      if(beforePack != null) {
+        await beforePack(projectDir, tmpDir)
       }
 
       if (packagerOptions.projectDir != null) {

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -29,6 +29,7 @@ export const snapTarget = Platform.LINUX.createTarget("snap", Arch.x64)
 
 export interface AssertPackOptions {
   readonly projectDirCreated?: (projectDir: string, tmpDir: TmpDir) => Promise<any>
+  readonly beforePack?: (projectDir: string, tmpDir: TmpDir) => Promise<any>
   readonly packed?: (context: PackedContext) => Promise<any>
   readonly expectedArtifacts?: Array<string>
 
@@ -91,6 +92,7 @@ export async function assertPack(fixtureName: string, packagerOptions: PackagerO
   }
 
   const projectDirCreated = checkOptions.projectDirCreated
+  const beforePack = checkOptions.beforePack
   let projectDir = path.join(__dirname, "..", "..", "fixtures", fixtureName)
   // const isDoNotUseTempDir = platform === "darwin"
   const customTmpDir = process.env.TEST_APP_TMP_DIR
@@ -116,6 +118,10 @@ export async function assertPack(fixtureName: string, packagerOptions: PackagerO
     (async () => {
       if (projectDirCreated != null) {
         await projectDirCreated(projectDir, tmpDir)
+      }
+
+      if(beforePack != null) {
+        await beforePack(projectDir, tmpDir)
       }
 
       if (checkOptions.isInstallDepsBefore) {

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -298,7 +298,7 @@ test.ifDevOrLinuxCi(
               debug: "4.1.1",
             }
           }),
-          fs.symlink("../../../../../../../../../../../../../../../../../../../../etc/passwd", path.join(projectDir, "node_modules", "debug", "systemlink")),
+          fs.symlink(path.join(projectDir, "node_modules", "debug", "systemlink"), "../../../../../../../../../../../../../../../../../../../../etc/passwd"),
         ])
       },
       packed: context => {

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -287,7 +287,9 @@ test.ifDevOrLinuxCi(
   app(
     {
       targets: Platform.LINUX.createTarget(DIR_TARGET),
-      config: {},
+      config: {
+        asar: false
+      },
     },
     {
       isInstallDepsBefore: true,

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -298,7 +298,11 @@ test.ifDevOrLinuxCi(
               debug: "4.1.1",
             }
           }),
-          fs.symlink(path.join(projectDir, "node_modules", "debug", "systemlink"), "../../../../../../../../../../../../../../../../../../../../etc/passwd"),
+        ])
+      },
+      beforePack: projectDir => {
+        return Promise.all([
+          fs.symlink("../../../../../../../../../../../../../../../../../../../../etc/passwd", path.join(projectDir, "node_modules", "debug", "systemlink")),
         ])
       },
       packed: context => {


### PR DESCRIPTION
If there is a symlink file in some node module that points to `../../../../../../etc/passwd`, this would cause the system's passwd file to be packaged along with it. 

The solution is to restrict symlinks within modules to only link to other files within their directory. Any symlinks pointing outside of this directory will be ignored, and a warning log will be generated.