### PR TITLE
fix: add additional default exclusions to copy logic

### DIFF
--- a/.changeset/lucky-tigers-do.md
+++ b/.changeset/lucky-tigers-do.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add additional default exclusions to copy logic

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -15,13 +15,13 @@ export const excludedNames =
   ".git,.hg,.svn,CVS,RCS,SCCS," +
   "__pycache__,.DS_Store,thumbs.db,.gitignore,.gitkeep,.gitattributes,.npmignore," +
   ".idea,.vs,.flowconfig,.jshintrc,.eslintrc,.circleci," +
-  ".yarn-integrity,.yarn-metadata.json,yarn-error.log,yarn.lock,package-lock.json,npm-debug.log," +
+  ".yarn-integrity,.yarn-metadata.json,yarn-error.log,yarn.lock,package-lock.json,npm-debug.log,pnpm-lock.yaml," +
   "appveyor.yml,.travis.yml,circle.yml,.nyc_output,.husky,.github,electron-builder.env"
 
 export const excludedExts =
   "iml,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,suo,xproj,cc,d.ts," +
   // https://github.com/electron-userland/electron-builder/issues/7512
-  "mk,a,o,forge-meta"
+  "mk,a,o,obj,forge-meta"
 
 function ensureNoEndSlash(file: string): string {
   if (path.sep !== "/") {

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -10,10 +10,19 @@ import { NodeModuleInfo } from "./packageDependencies"
 import { realpathSync } from "fs"
 
 const excludedFiles = new Set(
-  [".DS_Store", "node_modules" /* already in the queue */, "CHANGELOG.md", "ChangeLog", "changelog.md", "Changelog.md", "Changelog", "binding.gyp", ".npmignore"].concat(
-    excludedNames.split(",")
-  )
-)
+  [
+    ".DS_Store",
+    "node_modules" /* already in the queue */,
+    "CHANGELOG.md",
+    "ChangeLog",
+    "changelog.md",
+    "Changelog.md",
+    "Changelog",
+    "binding.gyp",
+    ".npmignore",
+    "node_gyp_bins",
+  ].concat(excludedNames.split(",")))
+
 const topLevelExcludedFiles = new Set([
   "karma.conf.js",
   ".coveralls.yml",

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -368,15 +368,6 @@ Object {
                   },
                   "unpacked": true,
                 },
-                "node_gyp_bins": Object {
-                  "files": Object {
-                    "python3": Object {
-                      "size": 5490456,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
               },
             },
             "deps": Object {

--- a/test/snapshots/globTest.js.snap
+++ b/test/snapshots/globTest.js.snap
@@ -9816,12 +9816,27 @@ Object {
   "files": Object {
     "assets": Object {
       "files": Object {
-        "file": Object {
+        "file-symlink2": Object {
+          "link": "assets/file2",
+        },
+        "file1": Object {
           "size": 4,
           "unpacked": true,
         },
-        "file-symlink": Object {
-          "link": "assets/file",
+        "file2": Object {
+          "size": 4,
+          "unpacked": true,
+        },
+        "subdir": Object {
+          "files": Object {
+            "file-symlink1": Object {
+              "link": "assets/file1",
+            },
+            "file3": Object {
+              "size": 4,
+              "unpacked": true,
+            },
+          },
         },
       },
     },
@@ -9860,6 +9875,9 @@ Object {
           "size": 2,
         },
       },
+    },
+    "file-symlink3": Object {
+      "link": "assets/subdir/file3",
     },
     "index.html": Object {
       "offset": "4",
@@ -9912,12 +9930,27 @@ Object {
     },
     "assets": Object {
       "files": Object {
-        "file": Object {
+        "file-symlink2": Object {
+          "link": "assets/file2",
+        },
+        "file1": Object {
           "size": 4,
           "unpacked": true,
         },
-        "file-symlink": Object {
-          "link": "assets/file",
+        "file2": Object {
+          "size": 4,
+          "unpacked": true,
+        },
+        "subdir": Object {
+          "files": Object {
+            "file-symlink1": Object {
+              "link": "assets/file1",
+            },
+            "file3": Object {
+              "size": 4,
+              "unpacked": true,
+            },
+          },
         },
       },
     },
@@ -9956,6 +9989,9 @@ Object {
           "size": 2,
         },
       },
+    },
+    "file-symlink3": Object {
+      "link": "assets/subdir/file3",
     },
     "index.html": Object {
       "offset": "114",

--- a/test/snapshots/ignoreTest.js.snap
+++ b/test/snapshots/ignoreTest.js.snap
@@ -6,7 +6,31 @@ Object {
 }
 `;
 
+exports[`Don't copy sub node_modules of the other dir instead of rootDir 1`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
+exports[`cannot copied select submodule node_modules by **/submodule-1-test/node_modules 1`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
+exports[`cannot copied select submodule node_modules by */ 1`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
 exports[`copied select submodule node_modules 1`] = `
+Object {
+  "linux": Array [],
+}
+`;
+
+exports[`copied sub node_modules of the rootDir/node_modules 1`] = `
 Object {
   "linux": Array [],
 }

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -671,14 +671,6 @@ Object {
                     },
                   },
                 },
-                "node_gyp_bins": Object {
-                  "files": Object {
-                    "python3": Object {
-                      "size": "<size>",
-                      "unpacked": true,
-                    },
-                  },
-                },
               },
             },
             "index.js": Object {
@@ -771,14 +763,6 @@ Object {
                       "unpacked": true,
                     },
                     "spawn-helper": Object {
-                      "size": "<size>",
-                      "unpacked": true,
-                    },
-                  },
-                },
-                "node_gyp_bins": Object {
-                  "files": Object {
-                    "python3": Object {
                       "size": "<size>",
                       "unpacked": true,
                     },
@@ -1672,7 +1656,6 @@ Array [
   "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/MinimumWindowWidths.txt",
   "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/Results.txt",
   "app.asar.unpacked/node_modules/node-pty/deps/winpty/misc/Font-Report-June2016/Windows10SetFontBugginess.txt",
-  "app.asar.unpacked/node_modules/node-pty/build/node_gyp_bins/python3",
   "app.asar.unpacked/node_modules/node-pty/build/Release/pty.node",
   "app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper",
   "app.asar.unpacked/node_modules/node-mac-permissions/LICENSE",
@@ -1719,7 +1702,6 @@ Array [
     "name": "app.asar.unpacked/node_modules/node-mac-permissions/package.json",
   },
   "app.asar.unpacked/node_modules/node-mac-permissions/permissions.mm",
-  "app.asar.unpacked/node_modules/node-mac-permissions/build/node_gyp_bins/python3",
   "app.asar.unpacked/node_modules/node-mac-permissions/build/Release/permissions.node",
 ]
 `;

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -9,7 +9,9 @@ import { verifySmartUnpack } from "./helpers/verifySmartUnpack"
 
 async function createFiles(appDir: string) {
   await Promise.all([
-    outputFile(path.join(appDir, "assets", "file"), "data"),
+    outputFile(path.join(appDir, "assets", "file1"), "data"),
+    outputFile(path.join(appDir, "assets", "file2"), "data"),
+    outputFile(path.join(appDir, "assets", "subdir", "file3"), "data"),
     outputFile(path.join(appDir, "b2", "file"), "data"),
     outputFile(path.join(appDir, "do-not-unpack-dir", "file.json"), "{}").then(() => fs.writeFile(path.join(appDir, "do-not-unpack-dir", "must-be-not-unpacked"), "{}")),
   ])
@@ -18,7 +20,9 @@ async function createFiles(appDir: string) {
   await fs.mkdir(dir, { recursive: true })
   await fs.writeFile(path.join(dir, "file-in-asar"), "{}")
 
-  await fs.symlink(path.join(appDir, "assets", "file"), path.join(appDir, "assets", "file-symlink"))
+  await fs.symlink(path.join(appDir, "assets", "file1"), path.join(appDir, "assets", "subdir", "file-symlink1")) // "reverse" symlink up one directory
+  await fs.symlink(path.join(appDir, "assets", "file2"), path.join(appDir, "assets", "file-symlink2")) // same dir symlink
+  await fs.symlink(path.join(appDir, "assets", "subdir", "file3"), path.join(appDir, "file-symlink3")) // symlink down
 }
 
 test.ifNotWindows.ifDevOrLinuxCi(


### PR DESCRIPTION
Adding `node_gyp_bins` to excluded directories and `pnpm-lock.yaml` & `.obj` to excluded files.
Adding additional symlinks "types" to globTest unit tests ("reverse" up one dir, same dir symlink, "downward" symlink)

The exclusions mirror the behavior that electron-forge's packager takes. For instance, `node_gyp_bins` directory commonly has extraneous symlinks for building (such as usually python3), but are not supposed to be in the final assets