### PR TITLE
chore: remove deprecated fields from `winOptions` and `macOptions` to clean up configuration (BREAKING CHANGE)

### DIFF
--- a/.changeset/purple-sheep-share.md
+++ b/.changeset/purple-sheep-share.md
@@ -1,0 +1,8 @@
+---
+"app-builder-lib": major
+---
+
+chore: remove deprecated fields from `winOptions` and `macOptions`
+
+For `winOptions` signing configuration, it has been moved to `win.signtoolOptions` in order to support `azureOptions` as a separate field and avoid bloating `win` configuration object
+For `macOptions`, notarize options has been deprecated in favor of env vars for quite some time. Env vars are much more secure

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2622,18 +2622,11 @@
           ]
         },
         "notarize": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NotarizeNotaryOptions"
-            },
-            {
-              "type": [
-                "null",
-                "boolean"
-              ]
-            }
-          ],
-          "description": "Options to use for"
+          "description": "Whether to disable electron-builder's [@electron/notarize](https://github.com/electron/notarize) integration.\n\nNote: In order to activate the notarization step You MUST specify one of the following via environment variables:\n1. `APPLE_API_KEY`, `APPLE_API_KEY_ID` and `APPLE_API_ISSUER`.\n2. `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`\n3. `APPLE_KEYCHAIN` and `APPLE_KEYCHAIN_PROFILE`\n\nFor security reasons it is recommended to use the first option (see https://github.com/electron-userland/electron-builder/issues/7859)",
+          "type": [
+            "null",
+            "boolean"
+          ]
         },
         "preAutoEntitlements": {
           "default": true,
@@ -3263,18 +3256,11 @@
           ]
         },
         "notarize": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NotarizeNotaryOptions"
-            },
-            {
-              "type": [
-                "null",
-                "boolean"
-              ]
-            }
-          ],
-          "description": "Options to use for"
+          "description": "Whether to disable electron-builder's [@electron/notarize](https://github.com/electron/notarize) integration.\n\nNote: In order to activate the notarization step You MUST specify one of the following via environment variables:\n1. `APPLE_API_KEY`, `APPLE_API_KEY_ID` and `APPLE_API_ISSUER`.\n2. `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`\n3. `APPLE_KEYCHAIN` and `APPLE_KEYCHAIN_PROFILE`\n\nFor security reasons it is recommended to use the first option (see https://github.com/electron-userland/electron-builder/issues/7859)",
+          "type": [
+            "null",
+            "boolean"
+          ]
         },
         "preAutoEntitlements": {
           "default": true,
@@ -3779,16 +3765,6 @@
             "null",
             "string"
           ]
-        }
-      },
-      "type": "object"
-    },
-    "NotarizeNotaryOptions": {
-      "additionalProperties": false,
-      "properties": {
-        "teamId": {
-          "description": "The team ID you want to notarize under for when using `notarytool`",
-          "type": "string"
         }
       },
       "type": "object"
@@ -6073,13 +6049,6 @@
     "WindowsConfiguration": {
       "additionalProperties": false,
       "properties": {
-        "additionalCertificateFile": {
-          "description": "The path to an additional certificate file you want to add to the signature block.",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
         "appId": {
           "default": "com.electron.${name}",
           "description": "The application id. Used as [CFBundleIdentifier](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070) for MacOS and as\n[Application User Model ID](https://msdn.microsoft.com/en-us/library/windows/desktop/dd378459(v=vs.85).aspx) for Windows (NSIS target only, Squirrel.Windows not supported). It is strongly recommended that an explicit ID is set.",
@@ -6137,34 +6106,6 @@
             }
           ],
           "description": "Options for usage of Azure Trusted Signing (beta)"
-        },
-        "certificateFile": {
-          "description": "The path to the *.pfx certificate you want to sign with. Please use it only if you cannot use env variable `CSC_LINK` (`WIN_CSC_LINK`) for some reason.\nPlease see [Code Signing](./code-signing.md).",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "certificatePassword": {
-          "description": "The password to the certificate provided in `certificateFile`. Please use it only if you cannot use env variable `CSC_KEY_PASSWORD` (`WIN_CSC_KEY_PASSWORD`) for some reason.\nPlease see [Code Signing](./code-signing.md).",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "certificateSha1": {
-          "description": "The SHA1 hash of the signing certificate. The SHA1 hash is commonly specified when multiple certificates satisfy the criteria specified by the remaining switches. Works only on Windows (or on macOS if [Parallels Desktop](https://www.parallels.com/products/desktop/) Windows 10 virtual machines exits).",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "certificateSubjectName": {
-          "description": "The name of the subject of the signing certificate, which is often labeled with the field name `issued to`. Required only for EV Code Signing and works only on Windows (or on macOS if [Parallels Desktop](https://www.parallels.com/products/desktop/) Windows 10 virtual machines exits).",
-          "type": [
-            "null",
-            "string"
-          ]
         },
         "compression": {
           "anyOf": [
@@ -6412,23 +6353,6 @@
             }
           ]
         },
-        "publisherName": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          ],
-          "description": "[The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.\nDefaults to common name from your code signing certificate."
-        },
         "releaseInfo": {
           "$ref": "#/definitions/ReleaseInfo",
           "description": "The release info. Intended for command line usage:\n\n```\n-c.releaseInfo.releaseNotes=\"new features\"\n```"
@@ -6450,36 +6374,9 @@
           "default": "asInvoker",
           "description": "The [security level](https://msdn.microsoft.com/en-us/library/6ad1fshk.aspx#Anchor_9) at which the application requests to be executed.\nCannot be specified per target, allowed only in the `win`."
         },
-        "rfc3161TimeStampServer": {
-          "default": "http://timestamp.digicert.com",
-          "description": "The URL of the RFC 3161 time stamp server.",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "sign": {
-          "anyOf": [
-            {
-              "typeof": "function"
-            },
-            {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          ],
-          "description": "The custom function (or path to file or module id) to sign Windows executables"
-        },
         "signAndEditExecutable": {
           "default": true,
           "description": "Whether to sign and add metadata to executable. Advanced option.",
-          "type": "boolean"
-        },
-        "signDlls": {
-          "default": false,
-          "description": "Whether to sign DLL files. Advanced option.",
           "type": "boolean"
         },
         "signExts": {
@@ -6496,24 +6393,6 @@
           ],
           "default": null,
           "description": "Explicit file extensions to also sign. Advanced option."
-        },
-        "signingHashAlgorithms": {
-          "anyOf": [
-            {
-              "items": {
-                "enum": [
-                  "sha1",
-                  "sha256"
-                ],
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Array of signing algorithms used. For AppX `sha256` is always used."
         },
         "signtoolOptions": {
           "anyOf": [
@@ -6553,14 +6432,6 @@
           ],
           "default": "nsis",
           "description": "The target package type: list of `nsis`, `nsis-web` (Web installer), `portable` ([portable]./nsis.md#portable) app without installation), `appx`, `msi`, `msi-wrapped`, `squirrel`, `7z`, `zip`, `tar.xz`, `tar.lz`, `tar.gz`, `tar.bz2`, `dir`.\nAppX package can be built only on Windows 10.\n\nTo use Squirrel.Windows please install `electron-builder-squirrel-windows` dependency."
-        },
-        "timeStampServer": {
-          "default": "http://timestamp.digicert.com",
-          "description": "The URL of the time stamp server.",
-          "type": [
-            "null",
-            "string"
-          ]
         },
         "verifyUpdateCodeSignature": {
           "default": true,

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -15,25 +15,6 @@ export async function signWindows(options: WindowsSignOptions, packager: WinPack
   }
 
   log.info({ path: log.filePath(options.path) }, "signing with signtool.exe")
-  const deprecatedFields = {
-    sign: options.options.sign,
-    signDlls: options.options.signDlls,
-    signingHashAlgorithms: options.options.signingHashAlgorithms,
-    certificateFile: options.options.certificateFile,
-    certificatePassword: options.options.certificatePassword,
-    certificateSha1: options.options.certificateSha1,
-    certificateSubjectName: options.options.certificateSubjectName,
-    additionalCertificateFile: options.options.additionalCertificateFile,
-    rfc3161TimeStampServer: options.options.rfc3161TimeStampServer,
-    timeStampServer: options.options.timeStampServer,
-    publisherName: options.options.publisherName,
-  }
-  const fields = Object.entries(deprecatedFields)
-    .filter(([, value]) => !!value)
-    .map(([field]) => field)
-  if (fields.length) {
-    log.warn({ fields, reason: "please move to win.signtoolOptions.<field_name>" }, `deprecated field`)
-  }
   return (await packager.signtoolManager.value).signUsingSigntool(options)
 }
 

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -25,7 +25,7 @@ export { CommonConfiguration, Configuration, AfterPackContext, MetadataDirectori
 export { ElectronBrandingOptions, ElectronDownloadOptions, ElectronPlatformName } from "./electron/ElectronFramework"
 export { PlatformSpecificBuildOptions, AsarOptions, FileSet, Protocol, ReleaseInfo, FilesBuildOptions } from "./options/PlatformSpecificBuildOptions"
 export { FileAssociation } from "./options/FileAssociation"
-export { MacConfiguration, DmgOptions, MasConfiguration, MacOsTargetName, DmgContent, DmgWindow, NotarizeNotaryOptions } from "./options/macOptions"
+export { MacConfiguration, DmgOptions, MasConfiguration, MacOsTargetName, DmgContent, DmgWindow } from "./options/macOptions"
 export { PkgOptions, PkgBackgroundOptions, BackgroundAlignment, BackgroundScaling } from "./options/pkgOptions"
 export { WindowsConfiguration, WindowsAzureSigningConfiguration, WindowsSigntoolConfiguration } from "./options/winOptions"
 export { AppXOptions } from "./options/AppXOptions"

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -8,7 +8,7 @@ import { AppInfo } from "./appInfo"
 import { CertType, CodeSigningInfo, createKeychain, CreateKeychainOptions, findIdentity, Identity, isSignAllowed, removeKeychain, reportError, sign } from "./codeSign/macCodeSign"
 import { DIR_TARGET, Platform, Target } from "./core"
 import { AfterPackContext, ElectronPlatformName } from "./index"
-import { MacConfiguration, MasConfiguration, NotarizeNotaryOptions } from "./options/macOptions"
+import { MacConfiguration, MasConfiguration } from "./options/macOptions"
 import { Packager } from "./packager"
 import { chooseNotNull, PlatformPackager } from "./platformPackager"
 import { ArchiveTarget } from "./targets/ArchiveTarget"
@@ -530,17 +530,10 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
   }
 
   private getNotarizeOptions(appPath: string): NotarizeOptionsNotaryTool | undefined {
-    let teamId = process.env.APPLE_TEAM_ID
+    const teamId = process.env.APPLE_TEAM_ID
     const appleId = process.env.APPLE_ID
     const appleIdPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD
-    const options = this.platformSpecificBuildOptions.notarize
     const tool = "notarytool"
-
-    const optionsTeamId = (options as NotarizeNotaryOptions)?.teamId
-    if (optionsTeamId) {
-      log.warn(null, "Please specify notarization Team ID in the `APPLE_TEAM_ID` env var instead of `notarize.teamId`")
-      teamId = optionsTeamId
-    }
 
     // option 1: app specific password
     if (appleId || appleIdPassword) {

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -221,8 +221,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   readonly additionalArguments?: Array<string> | null
 
   /**
-   * Options to use for @electron/notarize (ref: https://github.com/electron/notarize).
-   * Use `false` to explicitly disable
+   * Whether to disable electron-builder's [@electron/notarize](https://github.com/electron/notarize) integration.
    *
    * Note: In order to activate the notarization step You MUST specify one of the following via environment variables:
    * 1. `APPLE_API_KEY`, `APPLE_API_KEY_ID` and `APPLE_API_ISSUER`.
@@ -231,15 +230,7 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
    *
    * For security reasons it is recommended to use the first option (see https://github.com/electron-userland/electron-builder/issues/7859)
    */
-  readonly notarize?: NotarizeNotaryOptions | boolean | null
-}
-
-export interface NotarizeNotaryOptions {
-  /**
-   * The team ID you want to notarize under for when using `notarytool`
-   * @deprecated Set the `APPLE_TEAM_ID` environment variable instead
-   */
-  readonly teamId?: string
+  readonly notarize?: boolean | null
 }
 
 export interface DmgOptions extends TargetSpecificOptions {

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -24,63 +24,6 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   readonly legalTrademarks?: string | null
 
   /**
-   * Array of signing algorithms used. For AppX `sha256` is always used.
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.signingHashAlgorithms}
-   */
-  readonly signingHashAlgorithms?: Array<"sha1" | "sha256"> | null
-  /**
-   * The custom function (or path to file or module id) to sign Windows executables
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.sign}
-   */
-  readonly sign?: CustomWindowsSign | string | null
-  /**
-   * The path to the *.pfx certificate you want to sign with. Please use it only if you cannot use env variable `CSC_LINK` (`WIN_CSC_LINK`) for some reason.
-   * Please see [Code Signing](./code-signing.md).
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.certificateFile}
-   */
-  readonly certificateFile?: string | null
-  /**
-   * The password to the certificate provided in `certificateFile`. Please use it only if you cannot use env variable `CSC_KEY_PASSWORD` (`WIN_CSC_KEY_PASSWORD`) for some reason.
-   * Please see [Code Signing](./code-signing.md).
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.certificatePassword}
-   */
-  readonly certificatePassword?: string | null
-  /**
-   * The name of the subject of the signing certificate, which is often labeled with the field name `issued to`. Required only for EV Code Signing and works only on Windows (or on macOS if [Parallels Desktop](https://www.parallels.com/products/desktop/) Windows 10 virtual machines exits).
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.certificateSubjectName}
-   */
-  readonly certificateSubjectName?: string | null
-  /**
-   * The SHA1 hash of the signing certificate. The SHA1 hash is commonly specified when multiple certificates satisfy the criteria specified by the remaining switches. Works only on Windows (or on macOS if [Parallels Desktop](https://www.parallels.com/products/desktop/) Windows 10 virtual machines exits).
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.certificateSha1}
-   */
-  readonly certificateSha1?: string | null
-  /**
-   * The path to an additional certificate file you want to add to the signature block.
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.additionalCertificateFile}
-   */
-  readonly additionalCertificateFile?: string | null
-  /**
-   * The URL of the RFC 3161 time stamp server.
-   * @default http://timestamp.digicert.com
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.rfc3161TimeStampServer}
-   */
-  readonly rfc3161TimeStampServer?: string | null
-  /**
-   * The URL of the time stamp server.
-   * @default http://timestamp.digicert.com
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.timeStampServer}
-   */
-  readonly timeStampServer?: string | null
-
-  /**
-   * [The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.
-   * Defaults to common name from your code signing certificate.
-   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.publisherName}
-   */
-  readonly publisherName?: string | Array<string> | null
-
-  /**
    * Options for usage with signtool.exe
    */
   readonly signtoolOptions?: WindowsSigntoolConfiguration | null
@@ -110,14 +53,6 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
    * @default true
    */
   readonly signAndEditExecutable?: boolean
-
-  /**
-   * Whether to sign DLL files. Advanced option.
-   * @see https://github.com/electron-userland/electron-builder/issues/3101#issuecomment-404212384
-   * @default false
-   * @deprecated Use {@link signExts} instead for more explicit control
-   */
-  readonly signDlls?: boolean
 
   /**
    * Explicit file extensions to also sign. Advanced option.

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -21,7 +21,8 @@ const excludedFiles = new Set(
     "binding.gyp",
     ".npmignore",
     "node_gyp_bins",
-  ].concat(excludedNames.split(",")))
+  ].concat(excludedNames.split(","))
+)
 
 const topLevelExcludedFiles = new Set([
   "karma.conf.js",

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -113,13 +113,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   }
 
   doGetCscPassword(): string | undefined | null {
-    return chooseNotNull(
-      chooseNotNull(
-        chooseNotNull(this.platformSpecificBuildOptions.signtoolOptions?.certificatePassword, this.platformSpecificBuildOptions.certificatePassword),
-        process.env.WIN_CSC_KEY_PASSWORD
-      ),
-      super.doGetCscPassword()
-    )
+    return chooseNotNull(chooseNotNull(this.platformSpecificBuildOptions.signtoolOptions?.certificatePassword, process.env.WIN_CSC_KEY_PASSWORD), super.doGetCscPassword())
   }
 
   async sign(file: string): Promise<boolean> {
@@ -209,10 +203,8 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       hash.update(config.electronVersion || "no electronVersion")
       hash.update(JSON.stringify(this.platformSpecificBuildOptions))
       hash.update(JSON.stringify(args))
-      hash.update(chooseNotNull(this.platformSpecificBuildOptions.signtoolOptions?.certificateSha1, this.platformSpecificBuildOptions.certificateSha1) || "no certificateSha1")
-      hash.update(
-        chooseNotNull(this.platformSpecificBuildOptions.signtoolOptions?.certificateSubjectName, this.platformSpecificBuildOptions.certificateSubjectName) || "no subjectName"
-      )
+      hash.update(this.platformSpecificBuildOptions.signtoolOptions?.certificateSha1 || "no certificateSha1")
+      hash.update(this.platformSpecificBuildOptions.signtoolOptions?.certificateSubjectName || "no subjectName")
 
       buildCacheManager = new BuildCacheManager(outDir, file, arch)
       if (await buildCacheManager.copyIfValid(await digest(hash, files))) {
@@ -240,9 +232,8 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   }
 
   private shouldSignFile(file: string): boolean {
-    const shouldSignDll = this.platformSpecificBuildOptions.signDlls === true && file.endsWith(".dll")
     const shouldSignExplicit = !!this.platformSpecificBuildOptions.signExts?.some(ext => file.endsWith(ext))
-    return shouldSignDll || shouldSignExplicit || file.endsWith(".exe")
+    return shouldSignExplicit || file.endsWith(".exe")
   }
 
   protected createTransformerForExtraFiles(packContext: AfterPackContext): FileTransformer | null {

--- a/pages/mac.md
+++ b/pages/mac.md
@@ -3,7 +3,3 @@ The top-level [mac](configuration.md#mac) key contains set of options instructin
 ## Configuration
 
 {!./app-builder-lib.Interface.MacConfiguration.md!}
-
-## Notarize Configuration
-
-{!./app-builder-lib.Interface.NotarizeNotaryOptions.md!}

--- a/pages/win.md
+++ b/pages/win.md
@@ -9,7 +9,9 @@ Use [sign](app-builder-lib.Interface.WindowsSigntoolConfiguration.md#sign) optio
 
 ```json
 "win": {
-  "sign": "./customSign.js"
+  "signtoolOptions": {
+    "sign": "./customSign.js"
+  }
 }
 ```
 


### PR DESCRIPTION
For `winOptions` signing configuration, it has been moved to `win.signtoolOptions` in order to support `azureOptions` as a separate field and avoid bloating `win` configuration object
For `macOptions`, notarize options has been deprecated in favor of env vars for quite some time. Env vars are much more secure