### PR TITLE
feat: add integration for `@electron/fuses`

### DIFF
--- a/.changeset/two-rice-wash.md
+++ b/.changeset/two-rice-wash.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: adding integration with @electron/fuses

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
       - Multi Platform Build: multi-platform-build.md
 
   - Tutorials:
+      - Configuring Electron Fuses: tutorials/adding-electron-fuses.md
       - Loading App Dependencies Manually: tutorials/loading-app-dependencies-manually.md
       - Two package.json Structure: tutorials/two-package-structure.md
       - macOS Kernel Extensions: tutorials/macos-kernel-extensions.md

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "docs:prebuild": "docker build -t mkdocs-dockerfile -f mkdocs-dockerfile . ",
     "docs:build": "pnpm compile && node scripts/renderer/out/typedoc2html.js",
     "docs:mkdocs": "docker run --rm -v ${PWD}:/docs -v ${PWD}/site:/site mkdocs-dockerfile build",
+    "docs:preview": "open ./site/index.html",
     "docs:all": "pnpm docs:prebuild && pnpm docs:build && pnpm docs:mkdocs",
     "prepare": "husky install"
   },

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/electron-userland/electron-builder",
   "dependencies": {
     "@develar/schema-utils": "~2.6.5",
+    "@electron/fuses": "^1.8.0",
     "@electron/notarize": "2.5.0",
     "@electron/osx-sign": "1.3.1",
     "@electron/rebuild": "3.7.0",

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1284,6 +1284,39 @@
       },
       "type": "object"
     },
+    "FuseOptionsV1": {
+      "additionalProperties": false,
+      "properties": {
+        "enableCookieEncryption": {
+          "type": "boolean"
+        },
+        "enableEmbeddedAsarIntegrityValidation": {
+          "type": "boolean"
+        },
+        "enableNodeCliInspectArguments": {
+          "type": "boolean"
+        },
+        "enableNodeOptionsEnvironmentVariable": {
+          "type": "boolean"
+        },
+        "grantFileProtocolExtraPrivileges": {
+          "type": "boolean"
+        },
+        "loadBrowserProcessSpecificV8Snapshot": {
+          "type": "boolean"
+        },
+        "onlyLoadAppFromAsar": {
+          "type": "boolean"
+        },
+        "resetAdHocDarwinSignature": {
+          "type": "boolean"
+        },
+        "runAsNode": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "GenericServerOptions": {
       "additionalProperties": false,
       "description": "Generic (any HTTP(S) server) options.\nIn all publish options [File Macros](./file-patterns.md#file-macros) are supported.",
@@ -7022,6 +7055,17 @@
     "electronDownload": {
       "$ref": "#/definitions/ElectronDownloadOptions",
       "description": "The [electron-download](https://github.com/electron-userland/electron-download#usage) options."
+    },
+    "electronFuses": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FuseOptionsV1"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Options to pass to `@electron/fuses`\nRef: https://github.com/electron/fuses"
     },
     "electronLanguages": {
       "anyOf": [

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1286,34 +1286,34 @@
     },
     "FuseOptionsV1": {
       "additionalProperties": false,
-      "description": "All options come from [@electron/fuses](https://github.com/electron/fuses)",
+      "description": "All options come from [@electron/fuses](https://github.com/electron/fuses)\nRef: https://raw.githubusercontent.com/electron/electron/refs/heads/main/docs/tutorial/fuses.md",
       "properties": {
         "enableCookieEncryption": {
-          "description": "Enables cookie encryption",
+          "description": "The cookieEncryption fuse toggles whether the cookie store on disk is encrypted using OS level cryptography keys.  By default the sqlite database that Chromium uses to store cookies stores the values in plaintext.  If you wish to ensure your apps cookies are encrypted in the same way Chrome does then you should enable this fuse.  Please note it is a one-way transition, if you enable this fuse existing unencrypted cookies will be encrypted-on-write but if you then disable the fuse again your cookie store will effectively be corrupt and useless.  Most apps can safely enable this fuse.",
           "type": "boolean"
         },
         "enableEmbeddedAsarIntegrityValidation": {
-          "description": "Enables validation of the app.asar archive on macOS",
+          "description": "The embeddedAsarIntegrityValidation fuse toggles an experimental feature on macOS that validates the content of the `app.asar` file when it is loaded.  This feature is designed to have a minimal performance impact but may marginally slow down file reads from inside the `app.asar` archive.\nCurrently, ASAR integrity checking is supported on:\n- macOS as of electron>=16.0.0\n- Windows as of electron>=30.0.0\nFor more information on how to use asar integrity validation please read the [Asar Integrity](https://github.com/electron/electron/blob/main/docs/tutorial/asar-integrity.md) documentation.",
           "type": "boolean"
         },
         "enableNodeCliInspectArguments": {
-          "description": "Disables the --inspect and --inspect-brk family of CLI options",
+          "description": "The nodeCliInspect fuse toggles whether the `--inspect`, `--inspect-brk`, etc. flags are respected or not.  When disabled it also ensures that `SIGUSR1` signal does not initialize the main process inspector.  Most apps can safely disable this fuse.",
           "type": "boolean"
         },
         "enableNodeOptionsEnvironmentVariable": {
-          "description": "Disables the NODE_OPTIONS environment variable",
+          "description": "The nodeOptions fuse toggles whether the [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#node_optionsoptions)  and [`NODE_EXTRA_CA_CERTS`](https://github.com/nodejs/node/blob/main/doc/api/cli.md#node_extra_ca_certsfile) environment variables are respected.  The `NODE_OPTIONS` environment variable can be used to pass all kinds of custom options to the Node.js runtime and isn't typically used by apps in production.  Most apps can safely disable this fuse.",
           "type": "boolean"
         },
         "grantFileProtocolExtraPrivileges": {
-          "description": "Grants the file protocol extra privileges",
+          "description": "The grantFileProtocolExtraPrivileges fuse changes whether pages loaded from the `file://` protocol are given privileges beyond what they would receive in a traditional web browser.  This behavior was core to Electron apps in original versions of Electron but is no longer required as apps should be [serving local files from custom protocols](https://github.com/electron/electron/blob/main/docs/tutorial/security.md#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols) now instead.  If you aren't serving pages from `file://` you should disable this fuse.\nThe extra privileges granted to the `file://` protocol by this fuse are incompletely documented below:\n- `file://` protocol pages can use `fetch` to load other assets over `file://`\n- `file://` protocol pages can use service workers\n- `file://` protocol pages have universal access granted to child frames also running on `file://` protocols regardless of sandbox settings",
           "type": "boolean"
         },
         "loadBrowserProcessSpecificV8Snapshot": {
-          "description": "Loads V8 Snapshot from `browser_v8_context_snapshot.bin` for the browser process",
+          "description": "The loadBrowserProcessSpecificV8Snapshot fuse changes which V8 snapshot file is used for the browser process.  By default Electron's processes will all use the same V8 snapshot file.  When this fuse is enabled the browser process uses the file called `browser_v8_context_snapshot.bin` for its V8 snapshot. The other processes will use the V8 snapshot file that they normally do.",
           "type": "boolean"
         },
         "onlyLoadAppFromAsar": {
-          "description": "Enforces that Electron will only load your app from \"app.asar\" instead of its normal search paths",
+          "description": "The onlyLoadAppFromAsar fuse changes the search system that Electron uses to locate your app code.  By default Electron will search in the following order `app.asar` -> `app` -> `default_app.asar`.  When this fuse is enabled the search order becomes a single entry `app.asar` thus ensuring that when combined with the `embeddedAsarIntegrityValidation` fuse it is impossible to load non-validated code.",
           "type": "boolean"
         },
         "resetAdHocDarwinSignature": {
@@ -1321,7 +1321,7 @@
           "type": "boolean"
         },
         "runAsNode": {
-          "description": "Disables ELECTRON_RUN_AS_NODE",
+          "description": "The runAsNode fuse toggles whether the `ELECTRON_RUN_AS_NODE` environment variable is respected or not.  Please note that if this fuse is disabled then `process.fork` in the main process will not function as expected as it depends on this environment variable to function. Instead, we recommend that you use [Utility Processes](https://github.com/electron/electron/blob/main/docs/api/utility-process.md), which work for many use cases where you need a standalone Node.js process (like a Sqlite server process or similar scenarios).",
           "type": "boolean"
         }
       },

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1286,32 +1286,42 @@
     },
     "FuseOptionsV1": {
       "additionalProperties": false,
+      "description": "All options come from [@electron/fuses](https://github.com/electron/fuses)",
       "properties": {
         "enableCookieEncryption": {
+          "description": "Enables cookie encryption",
           "type": "boolean"
         },
         "enableEmbeddedAsarIntegrityValidation": {
+          "description": "Enables validation of the app.asar archive on macOS",
           "type": "boolean"
         },
         "enableNodeCliInspectArguments": {
+          "description": "Disables the --inspect and --inspect-brk family of CLI options",
           "type": "boolean"
         },
         "enableNodeOptionsEnvironmentVariable": {
+          "description": "Disables the NODE_OPTIONS environment variable",
           "type": "boolean"
         },
         "grantFileProtocolExtraPrivileges": {
+          "description": "Grants the file protocol extra privileges",
           "type": "boolean"
         },
         "loadBrowserProcessSpecificV8Snapshot": {
+          "description": "Loads V8 Snapshot from `browser_v8_context_snapshot.bin` for the browser process",
           "type": "boolean"
         },
         "onlyLoadAppFromAsar": {
+          "description": "Enforces that Electron will only load your app from \"app.asar\" instead of its normal search paths",
           "type": "boolean"
         },
         "resetAdHocDarwinSignature": {
+          "description": "Resets the app signature, specifically used for macOS.\nNote: This should be unneeded since electron-builder signs the app directly after flipping the fuses.\nRef: https://github.com/electron/fuses?tab=readme-ov-file#apple-silicon",
           "type": "boolean"
         },
         "runAsNode": {
+          "description": "Disables ELECTRON_RUN_AS_NODE",
           "type": "boolean"
         }
       },

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -181,6 +181,12 @@ export interface CommonConfiguration {
    * @default true
    */
   readonly removePackageKeywords?: boolean
+
+  /**
+   * Options to pass to `@electron/fuses`
+   * Ref: https://github.com/electron/fuses
+   */
+  readonly electronFuses?: FuseOptionsV1 | null
 }
 export interface Configuration extends CommonConfiguration, PlatformSpecificBuildOptions, Hooks {
   /**
@@ -374,4 +380,16 @@ export interface MetadataDirectories {
    * The application directory (containing the application package.json), defaults to `app`, `www` or working directory.
    */
   readonly app?: string | null
+}
+
+export interface FuseOptionsV1 {
+  runAsNode?: boolean
+  enableCookieEncryption?: boolean
+  enableNodeOptionsEnvironmentVariable?: boolean
+  enableNodeCliInspectArguments?: boolean
+  enableEmbeddedAsarIntegrityValidation?: boolean
+  onlyLoadAppFromAsar?: boolean
+  loadBrowserProcessSpecificV8Snapshot?: boolean
+  grantFileProtocolExtraPrivileges?: boolean
+  resetAdHocDarwinSignature?: boolean
 }

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -382,14 +382,46 @@ export interface MetadataDirectories {
   readonly app?: string | null
 }
 
+/**
+ * All options come from [@electron/fuses](https://github.com/electron/fuses)
+ */
 export interface FuseOptionsV1 {
+  /**
+   * Disables ELECTRON_RUN_AS_NODE
+   */
   runAsNode?: boolean
+  /**
+   * Enables cookie encryption
+   */
   enableCookieEncryption?: boolean
+  /**
+   * Disables the NODE_OPTIONS environment variable
+   */
   enableNodeOptionsEnvironmentVariable?: boolean
+  /**
+   * Disables the --inspect and --inspect-brk family of CLI options
+   */
   enableNodeCliInspectArguments?: boolean
+  /**
+   * Enables validation of the app.asar archive on macOS
+   */
   enableEmbeddedAsarIntegrityValidation?: boolean
+  /**
+   * Enforces that Electron will only load your app from "app.asar" instead of its normal search paths
+   */
   onlyLoadAppFromAsar?: boolean
+  /**
+   * Loads V8 Snapshot from `browser_v8_context_snapshot.bin` for the browser process
+   */
   loadBrowserProcessSpecificV8Snapshot?: boolean
+  /**
+   * Grants the file protocol extra privileges
+   */
   grantFileProtocolExtraPrivileges?: boolean
+  /**
+   * Resets the app signature, specifically used for macOS.
+   * Note: This should be unneeded since electron-builder signs the app directly after flipping the fuses.
+   * Ref: https://github.com/electron/fuses?tab=readme-ov-file#apple-silicon
+   */
   resetAdHocDarwinSignature?: boolean
 }

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -384,38 +384,47 @@ export interface MetadataDirectories {
 
 /**
  * All options come from [@electron/fuses](https://github.com/electron/fuses)
+ * Ref: https://raw.githubusercontent.com/electron/electron/refs/heads/main/docs/tutorial/fuses.md
  */
 export interface FuseOptionsV1 {
   /**
-   * Disables ELECTRON_RUN_AS_NODE
+   *The runAsNode fuse toggles whether the `ELECTRON_RUN_AS_NODE` environment variable is respected or not.  Please note that if this fuse is disabled then `process.fork` in the main process will not function as expected as it depends on this environment variable to function. Instead, we recommend that you use [Utility Processes](https://github.com/electron/electron/blob/main/docs/api/utility-process.md), which work for many use cases where you need a standalone Node.js process (like a Sqlite server process or similar scenarios).
    */
   runAsNode?: boolean
   /**
-   * Enables cookie encryption
+   * The cookieEncryption fuse toggles whether the cookie store on disk is encrypted using OS level cryptography keys.  By default the sqlite database that Chromium uses to store cookies stores the values in plaintext.  If you wish to ensure your apps cookies are encrypted in the same way Chrome does then you should enable this fuse.  Please note it is a one-way transition, if you enable this fuse existing unencrypted cookies will be encrypted-on-write but if you then disable the fuse again your cookie store will effectively be corrupt and useless.  Most apps can safely enable this fuse.
    */
   enableCookieEncryption?: boolean
   /**
-   * Disables the NODE_OPTIONS environment variable
+   * The nodeOptions fuse toggles whether the [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#node_optionsoptions)  and [`NODE_EXTRA_CA_CERTS`](https://github.com/nodejs/node/blob/main/doc/api/cli.md#node_extra_ca_certsfile) environment variables are respected.  The `NODE_OPTIONS` environment variable can be used to pass all kinds of custom options to the Node.js runtime and isn't typically used by apps in production.  Most apps can safely disable this fuse.
    */
   enableNodeOptionsEnvironmentVariable?: boolean
   /**
-   * Disables the --inspect and --inspect-brk family of CLI options
+   * The nodeCliInspect fuse toggles whether the `--inspect`, `--inspect-brk`, etc. flags are respected or not.  When disabled it also ensures that `SIGUSR1` signal does not initialize the main process inspector.  Most apps can safely disable this fuse.
    */
   enableNodeCliInspectArguments?: boolean
   /**
-   * Enables validation of the app.asar archive on macOS
+   * The embeddedAsarIntegrityValidation fuse toggles an experimental feature on macOS that validates the content of the `app.asar` file when it is loaded.  This feature is designed to have a minimal performance impact but may marginally slow down file reads from inside the `app.asar` archive.
+   * Currently, ASAR integrity checking is supported on:
+   * - macOS as of electron>=16.0.0
+   * - Windows as of electron>=30.0.0
+   * For more information on how to use asar integrity validation please read the [Asar Integrity](https://github.com/electron/electron/blob/main/docs/tutorial/asar-integrity.md) documentation.
    */
   enableEmbeddedAsarIntegrityValidation?: boolean
   /**
-   * Enforces that Electron will only load your app from "app.asar" instead of its normal search paths
+   * The onlyLoadAppFromAsar fuse changes the search system that Electron uses to locate your app code.  By default Electron will search in the following order `app.asar` -> `app` -> `default_app.asar`.  When this fuse is enabled the search order becomes a single entry `app.asar` thus ensuring that when combined with the `embeddedAsarIntegrityValidation` fuse it is impossible to load non-validated code.
    */
   onlyLoadAppFromAsar?: boolean
   /**
-   * Loads V8 Snapshot from `browser_v8_context_snapshot.bin` for the browser process
+   * The loadBrowserProcessSpecificV8Snapshot fuse changes which V8 snapshot file is used for the browser process.  By default Electron's processes will all use the same V8 snapshot file.  When this fuse is enabled the browser process uses the file called `browser_v8_context_snapshot.bin` for its V8 snapshot. The other processes will use the V8 snapshot file that they normally do.
    */
   loadBrowserProcessSpecificV8Snapshot?: boolean
   /**
-   * Grants the file protocol extra privileges
+   * The grantFileProtocolExtraPrivileges fuse changes whether pages loaded from the `file://` protocol are given privileges beyond what they would receive in a traditional web browser.  This behavior was core to Electron apps in original versions of Electron but is no longer required as apps should be [serving local files from custom protocols](https://github.com/electron/electron/blob/main/docs/tutorial/security.md#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols) now instead.  If you aren't serving pages from `file://` you should disable this fuse.
+   * The extra privileges granted to the `file://` protocol by this fuse are incompletely documented below:
+   * - `file://` protocol pages can use `fetch` to load other assets over `file://`
+   * - `file://` protocol pages can use service workers
+   * - `file://` protocol pages have universal access granted to child frames also running on `file://` protocols regardless of sandbox settings
    */
   grantFileProtocolExtraPrivileges?: boolean
   /**

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -406,8 +406,10 @@ export interface FuseOptionsV1 {
   /**
    * The embeddedAsarIntegrityValidation fuse toggles an experimental feature on macOS that validates the content of the `app.asar` file when it is loaded.  This feature is designed to have a minimal performance impact but may marginally slow down file reads from inside the `app.asar` archive.
    * Currently, ASAR integrity checking is supported on:
-   * - macOS as of electron>=16.0.0
-   * - Windows as of electron>=30.0.0
+   *
+   *  - macOS as of electron>=16.0.0
+   *  - Windows as of electron>=30.0.0
+   *
    * For more information on how to use asar integrity validation please read the [Asar Integrity](https://github.com/electron/electron/blob/main/docs/tutorial/asar-integrity.md) documentation.
    */
   enableEmbeddedAsarIntegrityValidation?: boolean
@@ -422,9 +424,10 @@ export interface FuseOptionsV1 {
   /**
    * The grantFileProtocolExtraPrivileges fuse changes whether pages loaded from the `file://` protocol are given privileges beyond what they would receive in a traditional web browser.  This behavior was core to Electron apps in original versions of Electron but is no longer required as apps should be [serving local files from custom protocols](https://github.com/electron/electron/blob/main/docs/tutorial/security.md#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols) now instead.  If you aren't serving pages from `file://` you should disable this fuse.
    * The extra privileges granted to the `file://` protocol by this fuse are incompletely documented below:
-   * - `file://` protocol pages can use `fetch` to load other assets over `file://`
-   * - `file://` protocol pages can use service workers
-   * - `file://` protocol pages have universal access granted to child frames also running on `file://` protocols regardless of sandbox settings
+   *
+   *  - `file://` protocol pages can use `fetch` to load other assets over `file://`
+   *  - `file://` protocol pages can use service workers
+   *  - `file://` protocol pages have universal access granted to child frames also running on `file://` protocols regardless of sandbox settings
    */
   grantFileProtocolExtraPrivileges?: boolean
   /**

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -21,7 +21,18 @@ export {
   CompressionLevel,
 } from "./core"
 export { getArchSuffix, Arch, archFromString } from "builder-util"
-export { CommonConfiguration, Configuration, AfterPackContext, MetadataDirectories, BeforePackContext, AfterExtractContext, Hooks, Hook, PackContext } from "./configuration"
+export {
+  CommonConfiguration,
+  Configuration,
+  AfterPackContext,
+  MetadataDirectories,
+  BeforePackContext,
+  AfterExtractContext,
+  Hooks,
+  Hook,
+  PackContext,
+  FuseOptionsV1,
+} from "./configuration"
 export { ElectronBrandingOptions, ElectronDownloadOptions, ElectronPlatformName } from "./electron/ElectronFramework"
 export { PlatformSpecificBuildOptions, AsarOptions, FileSet, Protocol, ReleaseInfo, FilesBuildOptions } from "./options/PlatformSpecificBuildOptions"
 export { FileAssociation } from "./options/FileAssociation"

--- a/pages/tutorials/adding-electron-fuses.md
+++ b/pages/tutorials/adding-electron-fuses.md
@@ -13,9 +13,9 @@ Under-the-hood, electron-builder leverages the official [`@electron/fuses`](http
 
 ### Example
 !!! note
-  The true/false below are just an example, customize your configuration to your own requirements
+    The true/false below are just an example, customize your configuration to your own requirements
 
-```js
+```typescript
 electronFuses: {
   runAsNode: false,
   enableCookieEncryption: true,
@@ -34,17 +34,17 @@ This convience method was opened so that custom FuseConfig's could be provided, 
 !!! example "afterPack.ts"
 
 ```typescript
-    const { FuseConfig, FuseVersion } = require("@electron/fuses")
+const { FuseConfig, FuseVersion, FuseV1Options } = require("@electron/fuses")
 
-    exports.default = function (context: AfterPackContext) {
-      const fuses: FuseConfig = {
-        version: FuseVersion.V1,
-        strictlyRequireAllFuses: true,
-        [FuseV1Options.RunAsNode]: false,
-        ... // all other flags must be specified since `strictlyRequireAllFuses = true`
-      }
-      await context.packager.addElectronFuses(context, fuses)
-    }
+exports.default = function (context: AfterPackContext) {
+  const fuses: FuseConfig = {
+    version: FuseVersion.V1,
+    strictlyRequireAllFuses: true,
+    [FuseV1Options.RunAsNode]: false,
+    ... // all other flags must be specified since `strictlyRequireAllFuses = true`
+  }
+  await context.packager.addElectronFuses(context, fuses)
+}
 ```
 
 ## Validating Fuses
@@ -55,4 +55,5 @@ You can validate the fuses have been flipped or check the fuse status of an arbi
 npx @electron/fuses read --app /Applications/Foo.app
 ```
 
+## Typedoc
 {!./app-builder-lib.Interface.FuseOptionsV1.md!}

--- a/pages/tutorials/adding-electron-fuses.md
+++ b/pages/tutorials/adding-electron-fuses.md
@@ -1,0 +1,58 @@
+!!! note
+    Information below has been partially copied from integration with [@electron/fuses](https://github.com/electron/fuses) and [electron tutorial](https://raw.githubusercontent.com/electron/electron/refs/heads/main/docs/tutorial/fuses.md) for easier reading/access.
+
+## What are fuses?
+
+For a subset of Electron functionality it makes sense to disable certain features for an entire application.  For example, 99% of apps don't make use of `ELECTRON_RUN_AS_NODE`, these applications want to be able to ship a binary that is incapable of using that feature.  We also don't want Electron consumers building Electron from source as that is both a massive technical challenge and has a high cost of both time and money.
+
+Fuses are the solution to this problem, at a high level they are "magic bits" in the Electron binary that can be flipped when packaging your Electron app to enable / disable certain features / restrictions.  Because they are flipped at package time before you code sign your app the OS becomes responsible for ensuring those bits aren't flipped back via OS level code signing validation (Gatekeeper / App Locker).
+
+## How do I flip the fuses?
+
+Under-the-hood, electron-builder leverages the official [`@electron/fuses`](https://npmjs.com/package/@electron/fuses) module to make flipping these fuses easy. Previously, electron fuses could only be flipped within the `afterPack` hook (this is still a supported method). Now, you can instead set electron-builder configuration property `electronFuses: FuseOptionsV1` to activate electron-builder's integration.
+
+### Example
+!!! note
+  The true/false below are just an example, customize your configuration to your own requirements
+
+```js
+electronFuses: {
+  runAsNode: false,
+  enableCookieEncryption: true,
+  enableNodeOptionsEnvironmentVariable: false,
+  enableNodeCliInspectArguments: false,
+  enableEmbeddedAsarIntegrityValidation: true,
+  onlyLoadAppFromAsar: true,
+  loadBrowserProcessSpecificV8Snapshot: false,
+  grantFileProtocolExtraPrivileges: false
+}
+```
+
+It also is still possible to continue to keep your current logic flow in `afterPack` hook, so a convience method has been exposed in the `PlatformPackager` for easy customization of the flags on your own. It directly accepts an `AfterPackContext` and a `FuseConfig` object of [type](https://github.com/electron/fuses/blob/main/src/config.ts).
+This convience method was opened so that custom FuseConfig's could be provided, allow usage of `strictlyRequireAllFuses` to monitor your fuses and stay up-to-date with fuses as they're released, and/or force override the version of @electron/fuses in electron-builder if there's an update you'd like to leverage.
+
+!!! example "afterPack.ts"
+
+```typescript
+    const { FuseConfig, FuseVersion } = require("@electron/fuses")
+
+    exports.default = function (context: AfterPackContext) {
+      const fuses: FuseConfig = {
+        version: FuseVersion.V1,
+        strictlyRequireAllFuses: true,
+        [FuseV1Options.RunAsNode]: false,
+        ... // all other flags must be specified since `strictlyRequireAllFuses = true`
+      }
+      await context.packager.addElectronFuses(context, fuses)
+    }
+```
+
+## Validating Fuses
+
+You can validate the fuses have been flipped or check the fuse status of an arbitrary Electron app using the fuses CLI.
+
+```bash
+npx @electron/fuses read --app /Applications/Foo.app
+```
+
+{!./app-builder-lib.Interface.FuseOptionsV1.md!}

--- a/pages/tutorials/code-signing-windows-apps-on-unix.md
+++ b/pages/tutorials/code-signing-windows-apps-on-unix.md
@@ -109,7 +109,9 @@ package.json
 ...
     "win": {
       "target": "nsis",
-      "sign": "./sign.js"
+      "signtoolOptions": {
+        "sign": "./sign.js"
+      }
     },
 ...
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@develar/schema-utils':
         specifier: ~2.6.5
         version: 2.6.5
+      '@electron/fuses':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@electron/notarize':
         specifier: 2.5.0
         version: 2.5.0
@@ -1595,6 +1598,10 @@ packages:
   '@electron/asar@3.2.13':
     resolution: {integrity: sha512-pY5z2qQSwbFzJsBdgfJIzXf5ElHTVMutC2dxh0FD60njknMu3n1NnTABOcQwbb5/v5soqE79m9UjaJryBf3epg==}
     engines: {node: '>=10.12.0'}
+    hasBin: true
+
+  '@electron/fuses@1.8.0':
+    resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
   '@electron/get@2.0.3':
@@ -7433,6 +7440,12 @@ snapshots:
       commander: 5.1.0
       glob: 7.2.3
       minimatch: 3.1.2
+
+  '@electron/fuses@1.8.0':
+    dependencies:
+      chalk: 4.1.2
+      fs-extra: 9.1.0
+      minimist: 1.2.8
 
   '@electron/get@2.0.3':
     dependencies:

--- a/test/src/linux/debTest.ts
+++ b/test/src/linux/debTest.ts
@@ -22,6 +22,16 @@ test.ifNotWindows(
       deb: {
         depends: ["foo"],
       },
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
     },
   })
 )

--- a/test/src/linux/flatpakTest.ts
+++ b/test/src/linux/flatpakTest.ts
@@ -15,6 +15,18 @@ test.ifAll.ifDevOrLinuxCi(
   "flatpak",
   app({
     targets: Platform.LINUX.createTarget("flatpak"),
+    config: {
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
+    },
   })
 )
 

--- a/test/src/linux/fpmTest.ts
+++ b/test/src/linux/fpmTest.ts
@@ -9,8 +9,42 @@ if (process.platform === "win32") {
 }
 
 // "apk" is very slow, don't test for now
-test.ifAll.ifDevOrLinuxCi("targets", app({ targets: Platform.LINUX.createTarget(["sh", "freebsd", "pacman", "zip", "7z"]) }))
+test.ifAll.ifDevOrLinuxCi(
+  "targets",
+  app({
+    targets: Platform.LINUX.createTarget(["sh", "freebsd", "pacman", "zip", "7z"]),
+    config: {
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
+    },
+  })
+)
 
 // https://github.com/electron-userland/electron-builder/issues/460
 // for some reasons in parallel to fmp we cannot use tar
-test.ifAll.ifDevOrLinuxCi("rpm and tar.gz", app({ targets: Platform.LINUX.createTarget(["rpm", "tar.gz"]) }))
+test.ifAll.ifDevOrLinuxCi(
+  "rpm and tar.gz",
+  app({
+    targets: Platform.LINUX.createTarget(["rpm", "tar.gz"]),
+    config: {
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
+    },
+  })
+)

--- a/test/src/linux/linuxArchiveTest.ts
+++ b/test/src/linux/linuxArchiveTest.ts
@@ -1,4 +1,21 @@
 import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 
-test.ifAll.ifNotWindows.ifDevOrLinuxCi("tar", app({ targets: Platform.LINUX.createTarget(["tar.xz", "tar.lz", "tar.bz2"]) }))
+test.ifAll.ifNotWindows.ifDevOrLinuxCi(
+  "tar",
+  app({
+    targets: Platform.LINUX.createTarget(["tar.xz", "tar.lz", "tar.bz2"]),
+    config: {
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
+    },
+  })
+)

--- a/test/src/linux/linuxPackagerTest.ts
+++ b/test/src/linux/linuxPackagerTest.ts
@@ -34,8 +34,7 @@ test.ifNotWindows(
         enableEmbeddedAsarIntegrityValidation: true,
         onlyLoadAppFromAsar: true,
         loadBrowserProcessSpecificV8Snapshot: true,
-        // grantFileProtocolExtraPrivileges: true,
-        resetAdHocDarwinSignature: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
       }
     },
   })

--- a/test/src/linux/linuxPackagerTest.ts
+++ b/test/src/linux/linuxPackagerTest.ts
@@ -26,6 +26,17 @@ test.ifNotWindows(
       },
       downloadAlternateFFmpeg: true,
       publish: testPublishConfig,
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        // grantFileProtocolExtraPrivileges: true,
+        resetAdHocDarwinSignature: true,
+      }
     },
   })
 )

--- a/test/src/linux/linuxPackagerTest.ts
+++ b/test/src/linux/linuxPackagerTest.ts
@@ -35,7 +35,7 @@ test.ifNotWindows(
         onlyLoadAppFromAsar: true,
         loadBrowserProcessSpecificV8Snapshot: true,
         grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
-      }
+      },
     },
   })
 )
@@ -146,6 +146,16 @@ test.ifNotWindows.ifNotCiMac(
         appImage: {
           // tslint:disable-next-line:no-invalid-template-strings
           artifactName: "boo-${productName}",
+        },
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
         },
       },
       effectiveOptionComputed: async it => {

--- a/test/src/linux/snapHeavyTest.ts
+++ b/test/src/linux/snapHeavyTest.ts
@@ -21,6 +21,16 @@ test.ifAll(
       snap: {
         useTemplateApp: false,
       },
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
     },
   })
 )

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -20,6 +20,16 @@ test.ifAll.ifDevOrLinuxCi(
         name: "sep",
       },
       productName: "Sep",
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
     },
   })
 )

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -33,7 +33,7 @@ test.ifMac.ifAll("two-package", () =>
           onlyLoadAppFromAsar: true,
           loadBrowserProcessSpecificV8Snapshot: true,
           grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
-        }
+        },
       },
     },
     {

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -32,8 +32,7 @@ test.ifMac.ifAll("two-package", () =>
           enableEmbeddedAsarIntegrityValidation: true,
           onlyLoadAppFromAsar: true,
           loadBrowserProcessSpecificV8Snapshot: true,
-          // grantFileProtocolExtraPrivileges: true,
-          resetAdHocDarwinSignature: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
         }
       },
     },

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -24,6 +24,17 @@ test.ifMac.ifAll("two-package", () =>
         },
         //tslint:disable-next-line:no-invalid-template-strings
         artifactName: "${name}-${version}-${os}-${arch}.${ext}",
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          // grantFileProtocolExtraPrivileges: true,
+          resetAdHocDarwinSignature: true,
+        }
       },
     },
     {

--- a/test/src/windows/appxTest.ts
+++ b/test/src/windows/appxTest.ts
@@ -15,6 +15,18 @@ it.ifDevOrWinCi(
   app(
     {
       targets: Platform.WINDOWS.createTarget(["appx"], Arch.x64),
+      config: {
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+        },
+      },
     },
     {
       projectDirCreated: async projectDir => {

--- a/test/src/windows/assistedInstallerTest.ts
+++ b/test/src/windows/assistedInstallerTest.ts
@@ -19,6 +19,16 @@ test.ifNotCiMac(
         win: {
           legalTrademarks: "My Trademark",
         },
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+        },
       },
     },
     {

--- a/test/src/windows/msiTest.ts
+++ b/test/src/windows/msiTest.ts
@@ -13,6 +13,16 @@ test.ifAll.ifDevOrWinCi(
           // version: "1.0.0",
         },
         productName: "Test MSI",
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+        },
       },
     },
     {

--- a/test/src/windows/msiWrappedTest.ts
+++ b/test/src/windows/msiWrappedTest.ts
@@ -23,6 +23,16 @@ test.ifAll.ifDevOrWinCi(
         win: {
           target: ["msiWrapped"],
         },
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+        },
       },
     },
     {},

--- a/test/src/windows/oneClickInstallerTest.ts
+++ b/test/src/windows/oneClickInstallerTest.ts
@@ -43,6 +43,16 @@ test(
           deleteAppDataOnUninstall: true,
           packElevateHelper: false,
         },
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+        },
       },
     },
     {
@@ -331,6 +341,16 @@ test.skip.ifWindows(
       productName: "foo",
       win: {
         executableName: "Boo",
+      },
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
       },
     },
     effectiveOptionComputed: async it => {

--- a/test/src/windows/portableTest.ts
+++ b/test/src/windows/portableTest.ts
@@ -12,6 +12,16 @@ test.ifAll.ifNotCiMac(
       nsis: {
         differentialPackage: false,
       },
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
     },
   })
 )

--- a/test/src/windows/squirrelWindowsTest.ts
+++ b/test/src/windows/squirrelWindowsTest.ts
@@ -12,6 +12,17 @@ test.ifAll.ifNotCiMac(
         win: {
           compression: "normal",
         },
+        executableName: " test with spaces",
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+        },
       },
     },
     { signedWin: true }

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -13,6 +13,16 @@ test.ifNotCiMac(
         bucket: "develar",
         path: "test",
       },
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+      },
     },
   })
 )

--- a/test/src/windows/winPackagerTest.ts
+++ b/test/src/windows/winPackagerTest.ts
@@ -30,8 +30,7 @@ test.ifNotCiMac(
         enableEmbeddedAsarIntegrityValidation: true,
         onlyLoadAppFromAsar: true,
         loadBrowserProcessSpecificV8Snapshot: true,
-        // grantFileProtocolExtraPrivileges: true,
-        resetAdHocDarwinSignature: true,
+        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
       }
     },
   })

--- a/test/src/windows/winPackagerTest.ts
+++ b/test/src/windows/winPackagerTest.ts
@@ -22,6 +22,17 @@ test.ifNotCiMac(
     targets: Platform.WINDOWS.createTarget(["zip"], Arch.x64),
     config: {
       downloadAlternateFFmpeg: true,
+      electronFuses: {
+        runAsNode: true,
+        enableCookieEncryption: true,
+        enableNodeOptionsEnvironmentVariable: true,
+        enableNodeCliInspectArguments: true,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: true,
+        // grantFileProtocolExtraPrivileges: true,
+        resetAdHocDarwinSignature: true,
+      }
     },
   })
 )

--- a/test/src/windows/winPackagerTest.ts
+++ b/test/src/windows/winPackagerTest.ts
@@ -31,7 +31,7 @@ test.ifNotCiMac(
         onlyLoadAppFromAsar: true,
         loadBrowserProcessSpecificV8Snapshot: true,
         grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
-      }
+      },
     },
   })
 )


### PR DESCRIPTION
feat: adding hardcoded interface for [FuseV1Config](https://github.com/electron/fuses/blob/0cf2a177e70dd81cc74c4449847287cd65ea140b/src/config.ts#L19-L34) so that electron-builder can integrate [@electron/fuses](https://github.com/electron/fuses) while also allowing scheme.json to still generated correctly

Resolves: #6365

There will be a new configuration object `electronFuses: FuseOptionsV1` and it executes `@electron/fuses` directly before signing as is recommended on the repo instructions: https://github.com/electron/fuses?tab=readme-ov-file#apple-silicon

I've also opened it up as a convenience method should you want to keep custom logic in your `afterPack` method called via
```
await context.packager.addElectronFuses(context, { ... })
```

https://github.com/electron-userland/electron-builder/blob/f5cc9ed4352a9c42343d4e0fe4dde6067d33d952/packages/app-builder-lib/src/platformPackager.ts#L398
It allows you to pass a full `FuseConfig` into the method as opposed to having electron-builder parsing `electronFuses` config property.
Taking this ☝️  approach would also allow you to set `strictlyRequireAllFuses: true` should you so desire. (I couldn't pass any var of this in-code due to https://github.com/electron/fuses/blob/0cf2a177e70dd81cc74c4449847287cd65ea140b/src/config.ts#L31-L34)

The fuse `FuseV1Options.EnableEmbeddedAsarIntegrityValidation = true` is supported now as well.
Tested locally and app runs
```
npx @electron/fuses read --app dist/mac-universal/electron-quick-start-typescript.app
Analyzing app: electron-quick-start-typescript.app
Fuse Version: v1
  RunAsNode is Enabled
  EnableCookieEncryption is Disabled
  EnableNodeOptionsEnvironmentVariable is Enabled
  EnableNodeCliInspectArguments is Enabled
  EnableEmbeddedAsarIntegrityValidation is Enabled
  OnlyLoadAppFromAsar is Disabled
  LoadBrowserProcessSpecificV8Snapshot is Disabled
```