### PR TITLE
chore(deps): update fast-xml-parser to 4.4.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,8 +658,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0(esbuild@0.12.29)
       fast-xml-parser:
-        specifier: ^4.0.15
-        version: 4.3.5
+        specifier: 4.4.1
+        version: 4.4.1
 
 packages:
 
@@ -3746,8 +3746,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-parser@4.3.5:
-    resolution: {integrity: sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==}
+  fast-xml-parser@4.4.1:
+    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
 
   fastq@1.17.1:
@@ -10576,7 +10576,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-parser@4.3.5:
+  fast-xml-parser@4.4.1:
     dependencies:
       strnum: 1.0.5
 

--- a/test/package.json
+++ b/test/package.json
@@ -40,7 +40,7 @@
     "babel-jest": "^29.7.0",
     "esbuild": "^0.12.14",
     "esbuild-jest": "^0.5.0",
-    "fast-xml-parser": "^4.0.15"
+    "fast-xml-parser": "4.4.1"
   },
   "jest": {
     "snapshotResolver": "<rootDir>/snapshotResolver.js",


### PR DESCRIPTION
chore(deps): update fast-xml-parser to 4.4.1 to fix https://github.com/electron-userland/electron-builder/security/dependabot/31