### PR TITLE
fix(win): Revert "fix(win): use appInfo description as primary entry for FileDescription"

### DIFF
--- a/.changeset/stupid-buses-compete.md
+++ b/.changeset/stupid-buses-compete.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Revert "fix(win): use appInfo description as primary entry for FileDescription" to resolve https://github.com/electron-userland/electron-builder/issues/8599

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -165,7 +165,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       file,
       "--set-version-string",
       "FileDescription",
-      appInfo.description || appInfo.productName,
+      appInfo.productName,
       "--set-version-string",
       "ProductName",
       appInfo.productName,


### PR DESCRIPTION
Reverts electron-userland/electron-builder#8125
The PR caused a regression where task manager shows the app description instead of the app name for the running process

Fixes: https://github.com/electron-userland/electron-builder/issues/8599