### PR TITLE
fix: check relative path in `asarUtil` without path separator

### DIFF
--- a/.changeset/slimy-chairs-buy.md
+++ b/.changeset/slimy-chairs-buy.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: checking relative path without separator as that doesn't work on Windows

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -102,7 +102,7 @@ export class AsarPackager {
 
       const realPathRelative = path.relative(this.config.appDir, realPathFile)
       const symlinkTarget = path.resolve(this.rootForAppFilesWithoutAsar, realPathRelative)
-      const isOutsidePackage = realPathRelative.startsWith("../")
+      const isOutsidePackage = realPathRelative.startsWith("..")
       if (isOutsidePackage) {
         log.error({ source: log.filePath(source), realPathFile: log.filePath(realPathFile) }, `unable to copy, file is symlinked outside the package`)
         throw new Error(


### PR DESCRIPTION
fix: checking relative path without separator as that doesn't work on Windows