### PR TITLE
fix: add quotes to surround file path during azure signing to handle files with spaces

### DIFF
--- a/.changeset/sixty-dogs-deliver.md
+++ b/.changeset/sixty-dogs-deliver.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add quotes to surround file path during azure signing to handle files with spaces

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -86,7 +86,7 @@ export class WindowsSignAzureManager {
       Endpoint: endpoint,
       CertificateProfileName: certificateProfileName,
       CodeSigningAccountName: codeSigningAccountName,
-      Files: options.path,
+      Files: `"${options.path}"`,
     }
     const paramsString = Object.entries(params)
       .reduce((res, [field, value]) => {


### PR DESCRIPTION
Fixes: #8600