### PR TITLE
Support completely custom AppxManifest.xml

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -183,6 +183,13 @@
           "description": "Relative path to custom extensions xml to be included in an `appmanifest.xml`.",
           "type": "string"
         },
+        "customManifestPath": {
+          "description": "Path to custom AppxManifest.xml",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "displayName": {
           "description": "A friendly name that can be displayed to users. Corresponds to [Properties.DisplayName](https://msdn.microsoft.com/en-us/library/windows/apps/br211432.aspx).\nDefaults to the application product name.",
           "type": [

--- a/packages/app-builder-lib/src/options/AppXOptions.ts
+++ b/packages/app-builder-lib/src/options/AppXOptions.ts
@@ -51,6 +51,11 @@ export interface AppXOptions extends TargetSpecificOptions {
    */
   readonly customExtensionsPath?: string
 
+    /**
+   * Path to custom `AppxManifest.xml`.
+   */
+  readonly customManifestPath?: string
+
   /**
    * Whether to overlay the app's name on top of tile images on the Start screen. Defaults to `false`. (https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-shownameontiles) in the dependencies.
    * @default false

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -98,8 +98,13 @@ export default class AppXTarget extends Target {
     const assetInfo = await AppXTarget.computeUserAssets(vm, vendorPath, userAssetDir)
     const userAssets = assetInfo.userAssets
 
-    const manifestFile = stageDir.getTempFile("AppxManifest.xml")
-    await this.writeManifest(manifestFile, arch, await this.computePublisherName(), userAssets)
+    const manifestFile = this.options.customManifestPath || stageDir.getTempFile("AppxManifest.xml")
+    if (this.options.customManifestPath) {
+      log.info({ reason: "Custom manifest path provided" }, "Manifest writing skipped")
+    } else {
+      await this.writeManifest(manifestFile, arch, await this.computePublisherName(), userAssets)
+    }
+
     await packager.info.callAppxManifestCreated(manifestFile)
     mappingList.push(assetInfo.mappings)
     mappingList.push([`"${vm.toVmFile(manifestFile)}" "AppxManifest.xml"`])


### PR DESCRIPTION
PR tries to give total control over the manifest to the users.

To provide mitigation for issues like

- https://github.com/electron-userland/electron-builder/issues/3072
- https://github.com/electron-userland/electron-builder/issues/3501
- https://github.com/electron-userland/electron-builder/issues/6745
