### PR TITLE
fix(win): add rfc3161 timestamp entry as default for azure signing

### DIFF
--- a/.changeset/gold-parents-complain.md
+++ b/.changeset/gold-parents-complain.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add rfc3161 timestamp entry as default for azure signing to resolve Windows Defender alert

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6093,7 +6093,10 @@
     },
     "WindowsAzureSigningConfiguration": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "null",
+          "string"
+        ]
       },
       "properties": {
         "certificateProfileName": {
@@ -6106,6 +6109,16 @@
         },
         "endpoint": {
           "description": "The Trusted Signing Account endpoint. The URI value must have a URI that aligns to the\nregion your Trusted Signing Account and Certificate Profile you are specifying were created\nin during the setup of these resources.\n\nTranslates to field: Endpoint\n\nRequires one of environment variable configurations for authenticating to Microsoft Entra ID per [Microsoft's documentation](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet#definition)",
+          "type": "string"
+        },
+        "timestampDigest": {
+          "default": "SHA256",
+          "description": "The Timestamp Digest. Translates to field: TimestampDigest",
+          "type": "string"
+        },
+        "timestampRfc3161": {
+          "default": "http://timestamp.acs.microsoft.com",
+          "description": "The Timestamp rfc3161 server. Translates to field: TimestampRfc3161",
           "type": "string"
         }
       },

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6111,6 +6111,11 @@
           "description": "The Trusted Signing Account endpoint. The URI value must have a URI that aligns to the\nregion your Trusted Signing Account and Certificate Profile you are specifying were created\nin during the setup of these resources.\n\nTranslates to field: Endpoint\n\nRequires one of environment variable configurations for authenticating to Microsoft Entra ID per [Microsoft's documentation](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet#definition)",
           "type": "string"
         },
+        "fileDigest": {
+          "default": "SHA256",
+          "description": "The File Digest for signing each file. Translates to field: FileDigest",
+          "type": "string"
+        },
         "timestampDigest": {
           "default": "SHA256",
           "description": "The Timestamp Digest. Translates to field: TimestampDigest",

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -79,16 +79,16 @@ export class WindowsSignAzureManager {
     const vm = await this.packager.vm.value
     const ps = await getPSCmd(vm)
 
-    const { endpoint, certificateProfileName, codeSigningAccountName, timestampRfc3161, timestampDigest, ...extraSigningArgs }: WindowsAzureSigningConfiguration =
+    const { endpoint, certificateProfileName, codeSigningAccountName, fileDigest, timestampRfc3161, timestampDigest, ...extraSigningArgs }: WindowsAzureSigningConfiguration =
       options.options.azureSignOptions!
     const params = {
-      FileDigest: "SHA256",
-      ...extraSigningArgs, // allows overriding FileDigest if provided in config
+      ...extraSigningArgs,
       Endpoint: endpoint,
       CertificateProfileName: certificateProfileName,
       CodeSigningAccountName: codeSigningAccountName,
       TimestampRfc3161: timestampRfc3161 || "http://timestamp.acs.microsoft.com",
       TimestampDigest: timestampDigest || "SHA256",
+      FileDigest: fileDigest || "SHA256",
       Files: `"${options.path}"`,
     }
     const paramsString = Object.entries(params)

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -79,16 +79,20 @@ export class WindowsSignAzureManager {
     const vm = await this.packager.vm.value
     const ps = await getPSCmd(vm)
 
-    const { endpoint, certificateProfileName, codeSigningAccountName, ...extraSigningArgs }: WindowsAzureSigningConfiguration = options.options.azureSignOptions!
+    const { endpoint, certificateProfileName, codeSigningAccountName, timestampRfc3161, timestampDigest, ...extraSigningArgs }: WindowsAzureSigningConfiguration =
+      options.options.azureSignOptions!
     const params = {
       FileDigest: "SHA256",
       ...extraSigningArgs, // allows overriding FileDigest if provided in config
       Endpoint: endpoint,
       CertificateProfileName: certificateProfileName,
       CodeSigningAccountName: codeSigningAccountName,
+      TimestampRfc3161: timestampRfc3161 || "http://timestamp.acs.microsoft.com",
+      TimestampDigest: timestampDigest || "SHA256",
       Files: `"${options.path}"`,
     }
     const paramsString = Object.entries(params)
+      .filter(([_, value]) => value != null)
       .reduce((res, [field, value]) => {
         return [...res, `-${field}`, value]
       }, [] as string[])

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -208,7 +208,18 @@ export interface WindowsAzureSigningConfiguration {
    */
   readonly codeSigningAccountName: string
   /**
-   * Allow other CLI parameters (verbatim case-sensitive) to `Invoke-TrustedSigning`
+   * The Timestamp rfc3161 server. Translates to field: TimestampRfc3161
+   * @default http://timestamp.acs.microsoft.com
    */
-  [k: string]: string
+  readonly timestampRfc3161?: string
+  /**
+   * The Timestamp Digest. Translates to field: TimestampDigest
+   * @default SHA256
+   */
+  readonly timestampDigest?: string
+  /**
+   * Allow other CLI parameters (verbatim case-sensitive) to `Invoke-TrustedSigning`
+   * Note: Key-Value pairs with `undefined`/`null` value are filtered out of the command.
+   */
+  [k: string]: string | undefined | null
 }

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -208,6 +208,11 @@ export interface WindowsAzureSigningConfiguration {
    */
   readonly codeSigningAccountName: string
   /**
+   * The File Digest for signing each file. Translates to field: FileDigest
+   * @default SHA256
+   */
+  readonly fileDigest?: string
+  /**
    * The Timestamp rfc3161 server. Translates to field: TimestampRfc3161
    * @default http://timestamp.acs.microsoft.com
    */


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/8626