### PR TITLE
fix: Remove path from published binaries

### DIFF
--- a/.changeset/wet-hats-drum.md
+++ b/.changeset/wet-hats-drum.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: Remove path from published binaries

--- a/packages/electron-publish/src/httpPublisher.ts
+++ b/packages/electron-publish/src/httpPublisher.ts
@@ -1,7 +1,7 @@
 import { Arch } from "builder-util"
 import { stat } from "fs-extra"
 import { ClientRequest } from "http"
-import { basename } from "path/posix"
+import { basename } from "path"
 import { Publisher } from "./publisher"
 import { PublishContext, UploadTask } from "."
 


### PR DESCRIPTION
During refactoring #8596, the `basename` import was changed from "path" to "path/posix", which doesn't properly reduce to the base name.
This caused some filenames to contain the absolute path after publishing.
