### PR TITLE
fix: remove concurrency of windows codesign

### DIFF
--- a/.changeset/sour-points-refuse.md
+++ b/.changeset/sour-points-refuse.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: only sign concurrently when using local signtool. azure can't be in parallel due to resources being locked during usage

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -11,7 +11,8 @@ export interface WindowsSignOptions {
 export async function signWindows(options: WindowsSignOptions, packager: WinPackager): Promise<boolean> {
   if (options.options.azureSignOptions) {
     log.info({ path: log.filePath(options.path) }, "signing with Azure Trusted Signing (beta)")
-    return signWithRetry(async () => (await packager.azureSignManager.value).signUsingAzureTrustedSigning(options))
+    const packageManager = await packager.azureSignManager.value
+    return signWithRetry(async () => packageManager.signUsingAzureTrustedSigning(options))
   }
 
   log.info({ path: log.filePath(options.path) }, "signing with signtool.exe")
@@ -34,7 +35,8 @@ export async function signWindows(options: WindowsSignOptions, packager: WinPack
   if (fields.length) {
     log.warn({ fields, reason: "please move to win.signtoolOptions.<field_name>" }, `deprecated field`)
   }
-  return signWithRetry(async () => (await packager.signtoolManager.value).signUsingSigntool(options))
+  const packageManager = await packager.signtoolManager.value
+  return signWithRetry(async () => packageManager.signUsingSigntool(options))
 }
 
 function signWithRetry(signer: () => Promise<boolean>): Promise<boolean> {

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -1,4 +1,4 @@
-import { log } from "builder-util"
+import { log, retry } from "builder-util"
 import { WindowsConfiguration } from "../options/winOptions"
 import { VmManager } from "../vm/vm"
 import { WinPackager } from "../winPackager"
@@ -11,7 +11,8 @@ export interface WindowsSignOptions {
 export async function signWindows(options: WindowsSignOptions, packager: WinPackager): Promise<boolean> {
   if (options.options.azureSignOptions) {
     log.info({ path: log.filePath(options.path) }, "signing with Azure Trusted Signing (beta)")
-    return (await packager.azureSignManager.value).signUsingAzureTrustedSigning(options)
+    const packageManager = await packager.azureSignManager.value
+    return signWithRetry(async () => packageManager.signUsingAzureTrustedSigning(options))
   }
 
   log.info({ path: log.filePath(options.path) }, "signing with signtool.exe")
@@ -34,7 +35,24 @@ export async function signWindows(options: WindowsSignOptions, packager: WinPack
   if (fields.length) {
     log.warn({ fields, reason: "please move to win.signtoolOptions.<field_name>" }, `deprecated field`)
   }
-  return (await packager.signtoolManager.value).signUsingSigntool(options)
+  const packageManager = await packager.signtoolManager.value
+  return signWithRetry(async () => packageManager.signUsingSigntool(options))
+}
+
+function signWithRetry(signer: () => Promise<boolean>): Promise<boolean> {
+  return retry(signer, 3, 1000, 1000, 0, (e: any) => {
+    const message = e.message
+    if (
+      // https://github.com/electron-userland/electron-builder/issues/1414
+      message?.includes("Couldn't resolve host name") ||
+      // https://github.com/electron-userland/electron-builder/issues/8615
+      message?.includes("being used by another process.")
+    ) {
+      log.warn({ error: message }, "attempt to sign failed, another attempt will be made")
+      return true
+    }
+    return false
+  })
 }
 
 export async function getPSCmd(vm: VmManager): Promise<string> {

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -1,4 +1,4 @@
-import { log, retry } from "builder-util"
+import { log } from "builder-util"
 import { WindowsConfiguration } from "../options/winOptions"
 import { VmManager } from "../vm/vm"
 import { WinPackager } from "../winPackager"
@@ -11,8 +11,7 @@ export interface WindowsSignOptions {
 export async function signWindows(options: WindowsSignOptions, packager: WinPackager): Promise<boolean> {
   if (options.options.azureSignOptions) {
     log.info({ path: log.filePath(options.path) }, "signing with Azure Trusted Signing (beta)")
-    const packageManager = await packager.azureSignManager.value
-    return signWithRetry(async () => packageManager.signUsingAzureTrustedSigning(options))
+    return (await packager.azureSignManager.value).signUsingAzureTrustedSigning(options)
   }
 
   log.info({ path: log.filePath(options.path) }, "signing with signtool.exe")
@@ -35,24 +34,7 @@ export async function signWindows(options: WindowsSignOptions, packager: WinPack
   if (fields.length) {
     log.warn({ fields, reason: "please move to win.signtoolOptions.<field_name>" }, `deprecated field`)
   }
-  const packageManager = await packager.signtoolManager.value
-  return signWithRetry(async () => packageManager.signUsingSigntool(options))
-}
-
-function signWithRetry(signer: () => Promise<boolean>): Promise<boolean> {
-  return retry(signer, 3, 1000, 1000, 0, (e: any) => {
-    const message = e.message
-    if (
-      // https://github.com/electron-userland/electron-builder/issues/1414
-      message?.includes("Couldn't resolve host name") ||
-      // https://github.com/electron-userland/electron-builder/issues/8615
-      message?.includes("being used by another process.")
-    ) {
-      log.warn({ error: message }, "attempt to sign failed, another attempt will be made")
-      return true
-    }
-    return false
-  })
+  return (await packager.signtoolManager.value).signUsingSigntool(options)
 }
 
 export async function getPSCmd(vm: VmManager): Promise<string> {

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -1,5 +1,5 @@
 import BluebirdPromise from "bluebird-lst"
-import { Arch, InvalidConfigurationError, log, use, executeAppBuilder, CopyFileTransformer, FileTransformer, walk, retry } from "builder-util"
+import { Arch, InvalidConfigurationError, use, executeAppBuilder, CopyFileTransformer, FileTransformer, walk } from "builder-util"
 import { createHash } from "crypto"
 import { readdir } from "fs/promises"
 import * as isCI from "is-ci"

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -270,7 +270,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       return walk(outDir, (file, stat) => stat.isDirectory() || this.shouldSignFile(file))
     }
     const filesToSign = await Promise.all([filesPromise(["resources", "app.asar.unpacked"]), filesPromise(["swiftshader"])])
-    for await (const file of filesToSign.flat(1)) {
+    for (const file of filesToSign.flat(1)) {
       await this.sign(file)
     }
 

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -1,10 +1,11 @@
-import BluebirdPromise from "bluebird-lst"
-import { Arch, InvalidConfigurationError, use, executeAppBuilder, CopyFileTransformer, FileTransformer, walk } from "builder-util"
+import { Arch, CopyFileTransformer, executeAppBuilder, FileTransformer, InvalidConfigurationError, use, walk } from "builder-util"
 import { createHash } from "crypto"
 import { readdir } from "fs/promises"
 import * as isCI from "is-ci"
 import { Lazy } from "lazy-val"
 import * as path from "path"
+import { signWindows, WindowsSignOptions } from "./codeSign/windowsCodeSign"
+import { WindowsSignAzureManager } from "./codeSign/windowsSignAzureManager"
 import { FileCodeSigningInfo, getSignVendorPath, WindowsSignToolManager } from "./codeSign/windowsSignToolManager"
 import { AfterPackContext } from "./configuration"
 import { DIR_TARGET, Platform, Target } from "./core"
@@ -23,9 +24,6 @@ import { isBuildCacheEnabled } from "./util/flags"
 import { time } from "./util/timer"
 import { getWindowsVm, VmManager } from "./vm/vm"
 import { execWine } from "./wine"
-import { signWindows } from "./codeSign/windowsCodeSign"
-import { WindowsSignOptions } from "./codeSign/windowsCodeSign"
-import { WindowsSignAzureManager } from "./codeSign/windowsSignAzureManager"
 
 export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   _iconPath = new Lazy(() => this.getOrConvertIcon("ico"))

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -133,32 +133,13 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       options: this.platformSpecificBuildOptions,
     }
 
-    const didSignSuccessfully = await this.doSign(signOptions)
+    const didSignSuccessfully = await signWindows(signOptions, this)
     if (!didSignSuccessfully && this.forceCodeSigning) {
       throw new InvalidConfigurationError(
         `App is not signed and "forceCodeSigning" is set to true, please ensure that code signing configuration is correct, please see https://electron.build/code-signing`
       )
     }
     return didSignSuccessfully
-  }
-
-  private async doSign(options: WindowsSignOptions) {
-    return retry(
-      () => signWindows(options, this),
-      3,
-      500,
-      500,
-      0,
-      (e: any) => {
-        // https://github.com/electron-userland/electron-builder/issues/1414
-        const message = e.message
-        if (message != null && message.includes("Couldn't resolve host name")) {
-          log.warn({ error: message }, `cannot sign`)
-          return true
-        }
-        return false
-      }
-    )
   }
 
   async signAndEditResources(file: string, arch: Arch, outDir: string, internalName?: string | null, requestedExecutionLevel?: RequestedExecutionLevel | null) {

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -41,6 +41,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   )
 
   get canSignConcurrently(): boolean {
+    // https://github.com/electron-userland/electron-builder/issues/8615
     return this.platformSpecificBuildOptions.azureSignOptions == null
   }
 

--- a/test/src/windows/winCodeSignTest.ts
+++ b/test/src/windows/winCodeSignTest.ts
@@ -115,17 +115,24 @@ test.ifAll.ifNotCiMac(
 
 test.ifAll.ifNotCiMac(
   "azure signing without credentials",
-  appThrows({
-    targets: windowsDirTarget,
-    config: {
-      forceCodeSigning: true,
-      win: {
-        azureSignOptions: {
-          endpoint: "https://weu.codesigning.azure.net/",
-          certificateProfileName: "profilenamehere",
-          codeSigningAccountName: "codesigningnamehere",
+  appThrows(
+    {
+      targets: windowsDirTarget,
+      config: {
+        forceCodeSigning: true,
+        win: {
+          azureSignOptions: {
+            endpoint: "https://weu.codesigning.azure.net/",
+            certificateProfileName: "profilenamehere",
+            codeSigningAccountName: "codesigningnamehere",
+          },
         },
       },
     },
-  })
+    {},
+    error => {
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message.includes("Unable to find valid azure env field AZURE_TENANT_ID for signing.")).toBe(true)
+    }
+  )
 )

--- a/test/src/windows/winCodeSignTest.ts
+++ b/test/src/windows/winCodeSignTest.ts
@@ -115,24 +115,17 @@ test.ifAll.ifNotCiMac(
 
 test.ifAll.ifNotCiMac(
   "azure signing without credentials",
-  appThrows(
-    {
-      targets: windowsDirTarget,
-      config: {
-        forceCodeSigning: true,
-        win: {
-          azureSignOptions: {
-            endpoint: "https://weu.codesigning.azure.net/",
-            certificateProfileName: "profilenamehere",
-            codeSigningAccountName: "codesigningnamehere",
-          },
+  appThrows({
+    targets: windowsDirTarget,
+    config: {
+      forceCodeSigning: true,
+      win: {
+        azureSignOptions: {
+          endpoint: "https://weu.codesigning.azure.net/",
+          certificateProfileName: "profilenamehere",
+          codeSigningAccountName: "codesigningnamehere",
         },
       },
     },
-    {},
-    error => {
-      expect(error).toBeInstanceOf(Error)
-      expect(error.message.includes("Unable to find valid azure env field AZURE_TENANT_ID for signing.")).toBe(true)
-    }
-  )
+  })
 )


### PR DESCRIPTION
Removing Bluebird map w/ concurrency from signing flow as Azure Trusted Signing locks specific files each time it's being invoked.

Also adds retry functionality to the codesigning mechanism (already existed for signtool, added it for azure)

Fixes: https://github.com/electron-userland/electron-builder/issues/8615