### PR TITLE
feat(updater): allow usage of `autoRunAppAfterInstall` with mac updater

### DIFF
--- a/.changeset/new-zoos-repair.md
+++ b/.changeset/new-zoos-repair.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": minor
+---
+
+feat(updater): allow usage of `autoRunAppAfterInstall` on mac updater

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -52,16 +52,18 @@ export type AppUpdaterEvents = {
 export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter<AppUpdaterEvents>) {
   /**
    * Whether to automatically download an update when it is found.
+   * @default true
    */
   autoDownload = true
 
   /**
    * Whether to automatically install a downloaded update on app quit (if `quitAndInstall` was not called before).
+   * @default true
    */
   autoInstallOnAppQuit = true
 
   /**
-   * *windows-only* Whether to run the app after finish install when run the installer NOT in silent mode.
+   * Whether to run the app after finish install when run the installer is NOT in silent mode.
    * @default true
    */
   autoRunAppAfterInstall = true

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -253,17 +253,22 @@ export class MacUpdater extends AppUpdater {
     })
   }
 
+  private handleUpdateDownloaded() {
+    if (this.autoRunAppAfterInstall) {
+      this.nativeUpdater.quitAndInstall()
+    } else {
+      this.app.quit()
+    }
+    this.closeServerIfExists()
+  }
+
   quitAndInstall(): void {
     if (this.squirrelDownloadedUpdate) {
       // update already fetched by Squirrel, it's ready to install
-      this.nativeUpdater.quitAndInstall()
-      this.closeServerIfExists()
+      this.handleUpdateDownloaded()
     } else {
       // Quit and install as soon as Squirrel get the update
-      this.nativeUpdater.on("update-downloaded", () => {
-        this.nativeUpdater.quitAndInstall()
-        this.closeServerIfExists()
-      })
+      this.nativeUpdater.on("update-downloaded", () => this.handleUpdateDownloaded())
 
       if (!this.autoInstallOnAppQuit) {
         /**


### PR DESCRIPTION
Looks like only MacUpdater is the only updater that doesn't utilize the property. The code docs weren't updated when the auto-install-relaunch logic was added for Linux.

Fixes: https://github.com/electron-userland/electron-builder/issues/8630

Credit to @toddsouthenbentley for the code