### PR TITLE
chore: moving `verifyUpdateCodeSignature` to within `signtoolOptions`

### DIFF
--- a/.changeset/twenty-gifts-lay.md
+++ b/.changeset/twenty-gifts-lay.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: moving `verifyUpdateCodeSignature` to `signtoolOptions` since publisher name can only be pulled from certificate used by signtool

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6200,7 +6200,7 @@
               "type": "null"
             }
           ],
-          "description": "Options for usage of Azure Trusted Signing (beta)"
+          "description": "Options for usage of Azure Trusted Signing (beta)\nCannot be used in conjunction with `signtoolOptions`, signing will default to Azure Trusted Signing"
         },
         "certificateFile": {
           "description": "The path to the *.pfx certificate you want to sign with. Please use it only if you cannot use env variable `CSC_LINK` (`WIN_CSC_LINK`) for some reason.\nPlease see [Code Signing](./code-signing.md).",
@@ -6589,7 +6589,7 @@
               "type": "null"
             }
           ],
-          "description": "Options for usage with signtool.exe"
+          "description": "Options for usage with signtool.exe\nCannot be used in conjunction with `azureSignOptions`, signing will default to Azure Trusted Signing"
         },
         "target": {
           "anyOf": [

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6629,7 +6629,7 @@
         },
         "verifyUpdateCodeSignature": {
           "default": true,
-          "description": "Whether to verify the signature of an available update before installation.\nThe [publisher name](#publisherName) will be used for the signature verification.",
+          "description": "Whether to verify the signature of an available update before installation.\nThe [publisher name](#publisherName) will be used for the signature verification.\n(Only applicable to signtool, not usable for Azure Trusted Signing since there's no local certificate to pull the publisher name from)",
           "type": "boolean"
         }
       },
@@ -6738,6 +6738,11 @@
             "null",
             "string"
           ]
+        },
+        "verifyUpdateCodeSignature": {
+          "default": true,
+          "description": "Whether to verify the signature of an available update before installation.\nThe [publisher name](#publisherName) will be used for the signature verification.",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -82,11 +82,13 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
 
   /**
    * Options for usage with signtool.exe
+   * Cannot be used in conjunction with `azureSignOptions`, signing will default to Azure Trusted Signing
    */
   readonly signtoolOptions?: WindowsSigntoolConfiguration | null
 
   /**
    * Options for usage of Azure Trusted Signing (beta)
+   * Cannot be used in conjunction with `signtoolOptions`, signing will default to Azure Trusted Signing
    */
   readonly azureSignOptions?: WindowsAzureSigningConfiguration | null
 

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -93,8 +93,10 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   /**
    * Whether to verify the signature of an available update before installation.
    * The [publisher name](#publisherName) will be used for the signature verification.
+   * (Only applicable to signtool, not usable for Azure Trusted Signing since there's no local certificate to pull the publisher name from)
    *
    * @default true
+   * @deprecated Please use {@link signtoolOptions}: {@link WindowsSigntoolConfiguration.verifyUpdateCodeSignature}
    */
   readonly verifyUpdateCodeSignature?: boolean
 
@@ -185,6 +187,14 @@ export interface WindowsSigntoolConfiguration {
    * Defaults to common name from your code signing certificate.
    */
   readonly publisherName?: string | Array<string> | null
+
+  /**
+   * Whether to verify the signature of an available update before installation.
+   * The [publisher name](#publisherName) will be used for the signature verification.
+   *
+   * @default true
+   */
+  readonly verifyUpdateCodeSignature?: boolean
 }
 
 // https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -39,7 +39,12 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   )
 
   get isForceCodeSigningVerification(): boolean {
-    return this.platformSpecificBuildOptions.verifyUpdateCodeSignature !== false
+    const signtoolWasUsed = this.platformSpecificBuildOptions.azureSignOptions == null
+    const shouldVerifySigntoolPublisher = chooseNotNull(
+      this.platformSpecificBuildOptions.signtoolOptions?.verifyUpdateCodeSignature,
+      this.platformSpecificBuildOptions.verifyUpdateCodeSignature
+    )
+    return signtoolWasUsed && shouldVerifySigntoolPublisher !== false
   }
 
   constructor(info: Packager) {


### PR DESCRIPTION
Moving `verifyUpdateCodeSignature` to `signtoolOptions` since publisher name can only be pulled from certificate used by signtool. We want to avoid having both signtool and Azure Trusted Signing accidentally being used at the same time as Azure Trusted Signing doesn't have a publisher name accessible at the time of `app-update.yml` being created