### PR TITLE
fix(win): add mandatory `publisherName` field to Azure Trusted Signing

### DIFF
--- a/.changeset/dull-eyes-check.md
+++ b/.changeset/dull-eyes-check.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(win): add required `publisherName` field to Azure Trusted Signing

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6116,6 +6116,10 @@
           "description": "The File Digest for signing each file. Translates to field: FileDigest",
           "type": "string"
         },
+        "publisherName": {
+          "description": "[The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.",
+          "type": "string"
+        },
         "timestampDigest": {
           "default": "SHA256",
           "description": "The Timestamp Digest. Translates to field: TimestampDigest",
@@ -6130,7 +6134,8 @@
       "required": [
         "certificateProfileName",
         "codeSigningAccountName",
-        "endpoint"
+        "endpoint",
+        "publisherName"
       ],
       "type": "object"
     },

--- a/packages/app-builder-lib/src/codeSign/signManager.ts
+++ b/packages/app-builder-lib/src/codeSign/signManager.ts
@@ -1,10 +1,14 @@
-import { Lazy } from "lazy-val";
-import { WindowsSignOptions } from "./windowsCodeSign";
-import { Target } from "../core";
+import { Lazy } from "lazy-val"
+import { WindowsSignOptions } from "./windowsCodeSign"
+import { Target } from "../core"
+import { MemoLazy } from "builder-util-runtime"
+import { FileCodeSigningInfo, CertificateFromStoreInfo } from "./windowsSignToolManager"
+import { WindowsConfiguration } from "../options/winOptions"
 
 export interface SignManager {
   readonly computedPublisherName: Lazy<Array<string> | null>
+  readonly cscInfo: MemoLazy<WindowsConfiguration, FileCodeSigningInfo | CertificateFromStoreInfo | null>
   computePublisherName(target: Target, publisherName: string | null | undefined): Promise<string>
-  initializeProviderModules(): Promise<void>
+  initialize(): Promise<void>
   signFile(options: WindowsSignOptions): Promise<boolean>
 }

--- a/packages/app-builder-lib/src/codeSign/signManager.ts
+++ b/packages/app-builder-lib/src/codeSign/signManager.ts
@@ -1,0 +1,10 @@
+import { Lazy } from "lazy-val";
+import { WindowsSignOptions } from "./windowsCodeSign";
+import { Target } from "../core";
+
+export interface SignManager {
+  readonly computedPublisherName: Lazy<Array<string> | null>
+  computePublisherName(target: Target, publisherName: string | null | undefined): Promise<string>
+  initializeProviderModules(): Promise<void>
+  signFile(options: WindowsSignOptions): Promise<boolean>
+}

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -9,34 +9,36 @@ export interface WindowsSignOptions {
 }
 
 export async function signWindows(options: WindowsSignOptions, packager: WinPackager): Promise<boolean> {
+  const packageManager = await packager.signingManager.value
   if (options.options.azureSignOptions) {
+    if (options.options.signtoolOptions) {
+      log.warn(null, "ignoring signtool options, using Azure Trusted Signing; please only configure one")
+    }
     log.info({ path: log.filePath(options.path) }, "signing with Azure Trusted Signing (beta)")
-    const packageManager = await packager.azureSignManager.value
-    return signWithRetry(async () => packageManager.signUsingAzureTrustedSigning(options))
+  } else {
+    log.info({ path: log.filePath(options.path) }, "signing with signtool.exe")
+    const deprecatedFields = {
+      sign: options.options.sign,
+      signDlls: options.options.signDlls,
+      signingHashAlgorithms: options.options.signingHashAlgorithms,
+      certificateFile: options.options.certificateFile,
+      certificatePassword: options.options.certificatePassword,
+      certificateSha1: options.options.certificateSha1,
+      certificateSubjectName: options.options.certificateSubjectName,
+      additionalCertificateFile: options.options.additionalCertificateFile,
+      rfc3161TimeStampServer: options.options.rfc3161TimeStampServer,
+      timeStampServer: options.options.timeStampServer,
+      publisherName: options.options.publisherName,
+    }
+    const fields = Object.entries(deprecatedFields)
+      .filter(([, value]) => !!value)
+      .map(([field]) => field)
+    if (fields.length) {
+      log.warn({ fields, reason: "please move to win.signtoolOptions.<field_name>" }, `deprecated field`)
+    }
   }
 
-  log.info({ path: log.filePath(options.path) }, "signing with signtool.exe")
-  const deprecatedFields = {
-    sign: options.options.sign,
-    signDlls: options.options.signDlls,
-    signingHashAlgorithms: options.options.signingHashAlgorithms,
-    certificateFile: options.options.certificateFile,
-    certificatePassword: options.options.certificatePassword,
-    certificateSha1: options.options.certificateSha1,
-    certificateSubjectName: options.options.certificateSubjectName,
-    additionalCertificateFile: options.options.additionalCertificateFile,
-    rfc3161TimeStampServer: options.options.rfc3161TimeStampServer,
-    timeStampServer: options.options.timeStampServer,
-    publisherName: options.options.publisherName,
-  }
-  const fields = Object.entries(deprecatedFields)
-    .filter(([, value]) => !!value)
-    .map(([field]) => field)
-  if (fields.length) {
-    log.warn({ fields, reason: "please move to win.signtoolOptions.<field_name>" }, `deprecated field`)
-  }
-  const packageManager = await packager.signtoolManager.value
-  return signWithRetry(async () => packageManager.signUsingSigntool(options))
+  return signWithRetry(async () => packageManager.signFile(options))
 }
 
 function signWithRetry(signer: () => Promise<boolean>): Promise<boolean> {

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -4,6 +4,8 @@ import { WinPackager } from "../winPackager"
 import { getPSCmd, WindowsSignOptions } from "./windowsCodeSign"
 import { Lazy } from "lazy-val"
 import { SignManager } from "./signManager"
+import { MemoLazy } from "builder-util-runtime"
+import { CertificateFromStoreInfo, FileCodeSigningInfo } from "./windowsSignToolManager"
 
 export class WindowsSignAzureManager implements SignManager {
   private readonly platformSpecificBuildOptions: WindowsConfiguration
@@ -25,7 +27,7 @@ export class WindowsSignAzureManager implements SignManager {
     this.platformSpecificBuildOptions = packager.platformSpecificBuildOptions
   }
 
-  async initializeProviderModules() {
+  async initialize() {
     const vm = await this.packager.vm.value
     const ps = await getPSCmd(vm)
 
@@ -96,6 +98,10 @@ export class WindowsSignAzureManager implements SignManager {
   computePublisherName(): Promise<string> {
     return Promise.resolve(this.packager.platformSpecificBuildOptions.azureSignOptions!.publisherName)
   }
+  readonly cscInfo = new MemoLazy<WindowsConfiguration, FileCodeSigningInfo | CertificateFromStoreInfo | null>(
+    () => this.packager.platformSpecificBuildOptions,
+    _selected => Promise.resolve(null)
+  )
   // prerequisite: requires `initializeProviderModules` to already have been executed
   async signFile(options: WindowsSignOptions): Promise<boolean> {
     const vm = await this.packager.vm.value

--- a/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
@@ -16,6 +16,9 @@ import { getPSCmd } from "./windowsCodeSign"
 import { MemoLazy, parseDn } from "builder-util-runtime"
 import { Lazy } from "lazy-val"
 import { importCertificate } from "./codesign"
+import { SignManager } from "./signManager"
+import { Target } from "../core"
+import AppXTarget from "../targets/AppxTarget"
 
 export function getSignVendorPath() {
   return getBin("winCodeSign")
@@ -65,7 +68,7 @@ interface CertInfo {
   PSParentPath: string
 }
 
-export class WindowsSignToolManager {
+export class WindowsSignToolManager implements SignManager {
   private readonly platformSpecificBuildOptions: WindowsConfiguration
 
   constructor(private readonly packager: WinPackager) {
@@ -161,7 +164,26 @@ export class WindowsSignToolManager {
     }
   )
 
-  async signUsingSigntool(options: WindowsSignOptions): Promise<boolean> {
+  initializeProviderModules(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  // https://github.com/electron-userland/electron-builder/issues/2108#issuecomment-333200711
+  async computePublisherName(target: Target, publisherName: string) {
+    if (target instanceof AppXTarget && (await this.cscInfo.value) == null) {
+      log.info({ reason: "Windows Store only build" }, "AppX is not signed")
+      return publisherName || "CN=ms"
+    }
+
+    const certInfo = await this.lazyCertInfo.value
+    const publisher = publisherName || (certInfo == null ? null : certInfo.bloodyMicrosoftSubjectDn)
+    if (publisher == null) {
+      throw new Error("Internal error: cannot compute subject using certificate info")
+    }
+    return publisher
+  }
+
+  async signFile(options: WindowsSignOptions): Promise<boolean> {
     let hashes = chooseNotNull(options.options.signtoolOptions?.signingHashAlgorithms, options.options.signingHashAlgorithms)
     // msi does not support dual-signing
     if (options.path.endsWith(".msi")) {

--- a/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
@@ -164,7 +164,7 @@ export class WindowsSignToolManager implements SignManager {
     }
   )
 
-  initializeProviderModules(): Promise<void> {
+  initialize(): Promise<void> {
     return Promise.resolve()
   }
 

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -190,6 +190,10 @@ export interface WindowsSigntoolConfiguration {
 // https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations
 export interface WindowsAzureSigningConfiguration {
   /**
+   * [The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.
+   */
+  readonly publisherName: string
+  /**
    * The Trusted Signing Account endpoint. The URI value must have a URI that aligns to the
    * region your Trusted Signing Account and Certificate Profile you are specifying were created
    * in during the setup of these resources.

--- a/packages/app-builder-lib/src/publish/PublishManager.ts
+++ b/packages/app-builder-lib/src/publish/PublishManager.ts
@@ -263,7 +263,7 @@ export async function getAppUpdatePublishConfiguration(packager: PlatformPackage
 
   if (packager.platform === Platform.WINDOWS && publishConfig.publisherName == null) {
     const winPackager = packager as WinPackager
-    const publisherName = winPackager.isForceCodeSigningVerification ? await (await winPackager.signtoolManager.value).computedPublisherName.value : undefined
+    const publisherName = winPackager.isForceCodeSigningVerification ? await (await winPackager.signingManager.value).computedPublisherName.value : undefined
     if (publisherName != null) {
       publishConfig.publisherName = publisherName
     }

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -186,18 +186,8 @@ export default class AppXTarget extends Target {
 
   // https://github.com/electron-userland/electron-builder/issues/2108#issuecomment-333200711
   private async computePublisherName() {
-    const signtoolManager = await this.packager.signtoolManager.value
-    if ((await signtoolManager.cscInfo.value) == null) {
-      log.info({ reason: "Windows Store only build" }, "AppX is not signed")
-      return this.options.publisher || "CN=ms"
-    }
-
-    const certInfo = await signtoolManager.lazyCertInfo.value
-    const publisher = this.options.publisher || (certInfo == null ? null : certInfo.bloodyMicrosoftSubjectDn)
-    if (publisher == null) {
-      throw new Error("Internal error: cannot compute subject using certificate info")
-    }
-    return publisher
+    const signtoolManager = await this.packager.signingManager.value
+    return signtoolManager.computePublisherName(this, this.options.publisher)
   }
 
   private async writeManifest(outFile: string, arch: Arch, publisher: string, userAssets: Array<string>) {

--- a/test/src/windows/winCodeSignTest.ts
+++ b/test/src/windows/winCodeSignTest.ts
@@ -121,6 +121,7 @@ test.ifAll.ifNotCiMac(
       forceCodeSigning: true,
       win: {
         azureSignOptions: {
+          publisherName: "test",
           endpoint: "https://weu.codesigning.azure.net/",
           certificateProfileName: "profilenamehere",
           codeSigningAccountName: "codesigningnamehere",


### PR DESCRIPTION
In order to support signature verification during auto-update flow with Azure Trusted Signing, a `publisherName` field must be added (mirrors that of signtool, except that one is optional).

Previously, the `publisherName` could be read from local signing certificate automatically, but we want to avoid having both signtool and Azure Trusted Signing accidentally being used at the same time as Azure Trusted Signing doesn't have a publisher name accessible at the time of app-update.yml being created. (app-update.yml creation is during `afterPack` stage, as opposed to `afterSign`)