### PR TITLE
fix: keep the dispatch timing of update-downloaded events consistent with nativeUpdater

### DIFF
--- a/.changeset/spotty-toys-ring.md
+++ b/.changeset/spotty-toys-ring.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: keep the dispatch timing of update-downloaded events consistent with nativeUpdater

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -14,6 +14,8 @@ import { randomBytes } from "crypto"
 export class MacUpdater extends AppUpdater {
   private readonly nativeUpdater: AutoUpdater = require("electron").autoUpdater
 
+  private updateInfoForPendingUpdateDownloadedEvent: UpdateDownloadedEvent | null = null
+
   private squirrelDownloadedUpdate = false
 
   private server?: Server
@@ -27,6 +29,9 @@ export class MacUpdater extends AppUpdater {
     })
     this.nativeUpdater.on("update-downloaded", () => {
       this.squirrelDownloadedUpdate = true
+      const updateInfo = this.updateInfoForPendingUpdateDownloadedEvent
+      this.updateInfoForPendingUpdateDownloadedEvent = null
+      this.dispatchUpdateDownloaded(updateInfo!)
       this.debug("nativeUpdater.update-downloaded")
     })
   }
@@ -239,8 +244,7 @@ export class MacUpdater extends AppUpdater {
           },
         })
 
-        // The update has been downloaded and is ready to be served to Squirrel
-        this.dispatchUpdateDownloaded(event)
+        this.updateInfoForPendingUpdateDownloadedEvent = event
 
         if (this.autoInstallOnAppQuit) {
           this.nativeUpdater.once("error", reject)


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8651