### PR TITLE
fix: cscIKeyPassword must support empty string arguments

### DIFF
--- a/.changeset/fresh-camels-smash.md
+++ b/.changeset/fresh-camels-smash.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: cscIKeyPassword must support empty string arguments

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -198,7 +198,7 @@ export async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink
     BluebirdPromise.mapSeries(securityCommands, it => exec("/usr/bin/security", it)),
   ])
   const cscPasswords: Array<string> = [cscKeyPassword]
-  if (cscIKeyPassword) {
+  if (cscIKeyPassword != null) {
     cscPasswords.push(cscIKeyPassword)
   }
   return await importCerts(keychainFile, certPaths, cscPasswords)


### PR DESCRIPTION
Related to this issue: https://github.com/electron-userland/electron-builder/issues/8647.

Thank you!