### PR TITLE
fix: pnpm prettier cannot work in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint-staged": "lint-staged",
     "lint-deps": "node ./test/out/helpers/checkDeps.js",
     "pretest": "pnpm lint-deps && pnpm lint",
-    "prettier": "prettier 'packages/**/*.{ts, js}' 'test/src/**/*.ts' --write",
+    "prettier": "prettier 'packages/**/*.{ts,js}' test/src/**/*.ts --write",
     "///": "Please see https://github.com/electron-userland/electron-builder/blob/master/CONTRIBUTING.md#run-test-using-cli how to run particular test instead full (and very slow) run",
     "test": "node ./test/out/helpers/runTests.js skipArtifactPublisher",
     "test-all": "pnpm compile && pnpm pretest && pnpm ci:test",

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -110,14 +110,14 @@ test.ifNotWindows(
   )
 )
 
-test.ifNotWindows(
-  "symlinks everywhere w/ static framework", () =>
-  assertPack("test-app-symlink-framework",
+test.ifNotWindows("symlinks everywhere w/ static framework", () =>
+  assertPack(
+    "test-app-symlink-framework",
     {
       targets: Platform.LINUX.createTarget(DIR_TARGET),
       config: {
-        files: ["!hello-world"]
-      }
+        files: ["!hello-world"],
+      },
     },
     {
       isInstallDepsBefore: true,
@@ -125,7 +125,7 @@ test.ifNotWindows(
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
             debug: "4.1.1",
-            ...data.dependencies
+            ...data.dependencies,
           }
         })
         return fs.symlink(path.join(projectDir, "index.js"), path.join(projectDir, "foo.js"))


### PR DESCRIPTION
**Error info**

```
> @electron-builder/monorepo@ prettier C:\Users\beyon\Code\electron-builder
> prettier 'packages/**/*.{ts, js}' 'test/src/**/*.ts' --write

[error] No files matching the pattern were found: "'packages/**/*.{ts,".
[error] No files matching the pattern were found: "js}'".
[error] No files matching the pattern were found: "'test/src/**/*.ts'".
 ELIFECYCLE  Command failed with exit code 2.
```
The modified command has been tested on Linux/Mac/Windows and is now working properly on all platforms.
