### PR TITLE
fix(win): corrupt asar integrity file path on crossplatform build

### DIFF
--- a/.changeset/thirty-colts-march.md
+++ b/.changeset/thirty-colts-march.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(win): corrupt asar integrity file path on crossplatform build

--- a/packages/app-builder-lib/src/electron/electronWin.ts
+++ b/packages/app-builder-lib/src/electron/electronWin.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "fs/promises"
 import { log } from "builder-util"
 import { NtExecutable, NtExecutableResource, Resource } from "resedit"
+import * as path from "path"
 import { AsarIntegrity } from "../asar/integrity"
 
 /** @internal */
@@ -21,7 +22,7 @@ export async function addWinAsarIntegrity(executablePath: string, asarIntegrity:
 
   // See: https://github.com/electron/packager/blob/00d20b99cf4aa4621103dbbd09ff7de7d2f7f539/src/resedit.ts#L124
   const integrityList = Array.from(Object.entries(asarIntegrity)).map(([file, { algorithm: alg, hash: value }]) => ({
-    file,
+    file: path.win32.normalize(file),
     alg,
     value,
   }))


### PR DESCRIPTION
Fix asar integrity info in `.exe` binary built from Linux by normalizing the file path using `path.win32`

Resolves https://github.com/electron-userland/electron-builder/issues/8690

I tested locally with the app in [issue reproduction gist](https://gist.github.com/Lemonexe/0f4b098febc1595914c1636e83b8c774) by compiling the local fix and linking it there.

I confirmed with `strings ./release/win-unpacked/asar-demo.exe | grep '"alg":"SHA256"'`
that it contains `resources\\app.asar` :heavy_check_mark: 
And running `wine ./release/win-unpacked/asar-demo.exe` no longer crashes :heavy_check_mark: 