### PR TITLE
chore: Remove informal Russian messages in the NSIS installer

### DIFF
--- a/.changeset/six-tips-play.md
+++ b/.changeset/six-tips-play.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: Remove informal Russian messages in the NSIS installer

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -139,7 +139,7 @@ export class AsarPackager {
       links.push({ file: destination, link })
     }
 
-    for await (const fileSet of fileSets) {
+    for (const fileSet of fileSets) {
       if (this.config.options.smartUnpack !== false) {
         detectUnpackedDirs(fileSet, unpackedPaths)
       }

--- a/packages/app-builder-lib/templates/nsis/assistedMessages.yml
+++ b/packages/app-builder-lib/templates/nsis/assistedMessages.yml
@@ -90,7 +90,7 @@ whoShouldThisApplicationBeInstalledFor:
 selectUserMode:
   en: Please select whether you wish to make this software available to all users or just yourself
   de: Bitte wählen Sie, ob Sie die Anwendung nur für sich oder für alle Benutzer installieren möchten.
-  ru: Выбери, хочешь ли ты сделать эту программу доступной для всех пользователей или только для себя
+  ru: Выберите, хотите ли Вы сделать эту программу доступной для всех пользователей, или только для себя
   sk: Prosím vyberte či sa ma tento softvér inštalovať len pre Vás alebo pre všetkých uživateľov
   cs: Prosím vyberte, zda se má tento software instalovat jen pro Vás, nebo pro všechny uživatele
   fr: "Choisis pour qui ce logiciel doit être accessible : pour tous les utilisateurs ou juste pour toi ?"
@@ -112,7 +112,7 @@ selectUserMode:
 whichInstallationRemove:
   en: This software is installed both per-machine (all users) and per-user.\nWhich installation you wish to remove?
   de: Die Anwendung wurde für alle Benutzer und pro Benutzer installiert.\nWelche Installation möchten Sie entfernen?
-  ru: Эта программа установлена для всего компьютера (для всех пользователей) и для отдельного пользователя.\nКакую из установленных программ ты хочешь удалить?
+  ru: Эта программа установлена для всего компьютера (для всех пользователей) и для отдельного пользователя.\nКакую из установленных программ Вы хотите удалить?
   sk: Tento softvér je nainštalovaný pre Vás a súčasne pre všetkých uživateľov.\nKtorú inštaláciu si želáte odstraniť?
   cs: Tento software je nainstalovaný pro Vás a současně pro všechny uživatele.\nKterou instalaci si přejete odstranit?
   fr: Ce logiciel est installé à la fois par machine (tous les utilisateurs) et par utilisateur.\nQuelle installation veux-tu supprimer ?
@@ -134,7 +134,7 @@ whichInstallationRemove:
 freshInstallForAll:
   en: Fresh install for all users. (will prompt for admin credentials)
   de: Neuinstallation für alle Benutzer durchführen. (Administratorrechte benötigt)
-  ru: Новая установка для всех пользователей. (потребуются права администратора)
+  ru: Новая установка для всех пользователей. (Потребуются права администратора)
   sk: Nová inštalácia pre všetkých uživateľov. (Bude potrebovať prihlásenie administrátora)
   cs: Nová instalace pro všechny uživatele. (Bude vyžadovat přihlášení administrátora)
   fr: Nouvelle installation pour tous les utilisateurs. (demandera les identifiants administrateur)
@@ -221,7 +221,7 @@ forAll:
 loginWithAdminAccount:
   en: You need to login with an account that is a member of the admin group to continue...
   de: Um die Installation fortzusetzen müssen Sie sich mit einem Administrator-Account anmelden...
-  ru: Чтобы продолжить, тебе нужно войти в учетную запись, которая входит в группу администраторов...
+  ru: Чтобы продолжить, Вам необходимо войти в учетную запись, которая входит в группу администраторов...
   sk: Pre pokračovanie sa musíte zalogovať s účtom ktorý patrí do skupiny adminstrátorov...
   cs: Pro pokračování se musíte přihlásit účtem, který patří do skupiny administrátorů...
   fr: Tu dois te connecter avec un compte ayant des droits d'administrateur pour continuer...


### PR DESCRIPTION
## Background
The assisted installer currently uses informal language that may not be appropriate for all users. This pull request updates the messages to use formal language to improve clarity and professionalism.