### PR TITLE
fix: install all dependencies to fix building within NPM workspaces

### DIFF
--- a/.changeset/small-windows-leave.md
+++ b/.changeset/small-windows-leave.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: does not work with NPM workspaces

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -100,7 +100,6 @@ async function installDependencies(config: Configuration, appDir: string, option
     if (process.env.NPM_NO_BIN_LINKS === "true") {
       execArgs.push("--no-bin-links")
     }
-    execArgs.push("--production")
   }
 
   if (!isRunningYarn(execPath)) {


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/7103.

If node_modules doesn't exist at all, I think we can directly install all packages, not just the production ones. Even if we  reinstall all packages under the workspace again, it shouldn't cause any issues. 

At most, this approach would just take some extra time but won't lead to any problems.