### PR TITLE
chore: Rename `vmRequired` variable to `useVmIfNotOnWin`

### DIFF
--- a/.changeset/shy-pumas-attack.md
+++ b/.changeset/shy-pumas-attack.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: Rename `vmRequired` variable to `useVmIfNotOnWin`

--- a/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
@@ -438,11 +438,11 @@ export class WindowsSignToolManager implements SignManager {
     let args: Array<string>
     let env = process.env
     let vm: VmManager
-    const winRequired = configuration.path.endsWith(".appx") || !("file" in configuration.cscInfo!) /* certificateSubjectName and other such options */
-    const isWin = process.platform === "win32" || winRequired
+    const useVmIfNotOnWin = configuration.path.endsWith(".appx") || !("file" in configuration.cscInfo!) /* certificateSubjectName and other such options */
+    const isWin = process.platform === "win32" || useVmIfNotOnWin
     const toolInfo = await this.getToolPath(isWin)
     const tool = toolInfo.path
-    if (winRequired) {
+    if (useVmIfNotOnWin) {
       vm = await packager.vm.value
       args = this.computeSignToolArgs(configuration, isWin, vm)
     } else {

--- a/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
@@ -438,11 +438,11 @@ export class WindowsSignToolManager implements SignManager {
     let args: Array<string>
     let env = process.env
     let vm: VmManager
-    const vmRequired = configuration.path.endsWith(".appx") || !("file" in configuration.cscInfo!) /* certificateSubjectName and other such options */
-    const isWin = process.platform === "win32" || vmRequired
+    const winRequired = configuration.path.endsWith(".appx") || !("file" in configuration.cscInfo!) /* certificateSubjectName and other such options */
+    const isWin = process.platform === "win32" || winRequired
     const toolInfo = await this.getToolPath(isWin)
     const tool = toolInfo.path
-    if (vmRequired) {
+    if (winRequired) {
       vm = await packager.vm.value
       args = this.computeSignToolArgs(configuration, isWin, vm)
     } else {


### PR DESCRIPTION
While working on learning how to set up code signing customization, the name `vmRequired` confused me a good bit, since it seemed to imply that a VM was required even when running on Windows.