### PR TITLE
add more extra component packages for macos archive

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5144,6 +5144,27 @@
             "null",
             "string"
           ]
+        },
+        "extraPkgsDir": {
+          "description": "Add extra component packages for MacOs product archive.\nThe extra component packages directory, relative to `build` (build resources directory).\nExample: `pkg-components`.",
+            "type": [
+              "null",
+              "string"
+            ]
+        },
+        "extraPkgs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The list of extra component packages, relative to `extraPkgsDir`.\nExample: `['virtual-audio-driver.pkg', 'obs-lib.pkg']`."
         }
       },
       "type": "object"

--- a/packages/app-builder-lib/src/options/pkgOptions.ts
+++ b/packages/app-builder-lib/src/options/pkgOptions.ts
@@ -126,6 +126,19 @@ export interface PkgOptions extends TargetSpecificOptions {
    * @default upgrade
    */
   readonly overwriteAction?: "upgrade" | "update" | null
+
+  /**
+  * Add extra component packages for MacOs product archive.
+  * The extra component packages directory, relative to `build` (build resources directory).
+  * Example: `pkg-components`.
+  */
+  readonly extraPkgsDir?: string | null
+
+  /**
+  * The list of extra component packages, relative to `extraPkgsDir`.
+  * Example: `['virtual-audio-driver.pkg', 'obs-lib.pkg']`.
+  */
+  readonly extraPkgs?: Array<string> | null
 }
 
 /**


### PR DESCRIPTION
Dear maintainer!

The product archive of macos is supported more component packages.
I add this option to the pkg builder.

Thanks for your supporting!