### PR TITLE
chore: update GHA actions/cache to v4.2.0

### DIFF
--- a/.github/actions/pretest/action.yml
+++ b/.github/actions/pretest/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
 
     - name: Cache Electron
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      uses: actions/cache@v4.2.0
       with:
         path: ${{ inputs.cache-path }}
         key: ${{ inputs.cache-key }}


### PR DESCRIPTION
Resolves:
<img width="1327" alt="Screenshot 2025-01-15 at 11 23 03 PM" src="https://github.com/user-attachments/assets/dcbb8a8a-8b77-4e11-86e1-6bf9ff1bc091" />
