### PR TITLE
chore: refactor docker build/test/deploy workflows

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,32 +1,76 @@
 name: Docker Deployment
 
 on:
-  # release: 
-  #   types: [published] 
- push:
-   tags:
-     - docker*
+  # release:
+  #   types: [published]
+  push:
+    tags:
+      - docker*
+  workflow_dispatch:
 
 permissions:
   contents: read
 
+env:
+  LATEST_IMAGE_NODE_MAJOR_VERSION: 20
+
 jobs:
+  run-docker-build-and-test:
+    uses: ./.github/workflows/test.yaml
+    with:
+      rebuild-docker-images: true
+
   deploy:
     name: Build and Push Docker
+    needs: run-docker-build-and-test
     runs-on: ubuntu-latest
-    
+
     steps:
-      - name: Checkout code repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      
+      - name: Download images artifact - node14
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-builder-all-14
+          path: ${{ runner.temp }}
+
+      - name: Download images artifact - node16
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-builder-all-16
+          path: ${{ runner.temp }}
+
+      - name: Download images artifact - node18
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-builder-all-18
+          path: ${{ runner.temp }}
+
+      - name: Download images artifact - node20
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-builder-all-20
+          path: ${{ runner.temp }}
+
+      - name: Load all images
+        run: find -type f -name "${{ runner.temp }}/electron-builder-all-*.tar" -exec docker image load --input "{}" \;
+
+      - name: Tag LTS images for electron-builder latest/wine/wine-chrome/wine-mono
+        run: |
+          docker image tag electronuserland/builder:${{ env.LATEST_IMAGE_NODE_MAJOR_VERSION }} electronuserland/builder:latest
+          docker image tag electronuserland/builder:${{ env.LATEST_IMAGE_NODE_MAJOR_VERSION }}-wine electronuserland/builder:wine
+          docker image tag electronuserland/builder:${{ env.LATEST_IMAGE_NODE_MAJOR_VERSION }}-wine-mono electronuserland/builder:wine-mono
+          docker image tag electronuserland/builder:${{ env.LATEST_IMAGE_NODE_MAJOR_VERSION }}-wine-chrome electronuserland/builder:wine-chrome
+
+      - name: List all images and tags
+        run: docker image ls -a
+
       - name: Login to DockerHub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3 
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build all Docker images
-        run: sh ./docker/build.sh
-
       - name: Push all Docker images
-        run: sh ./docker/push.sh
+        if: github.event_name != 'workflow_dispatch'
+        run: echo "TESTING step logic. (this will trigger docker push)"
+        # run: docker image push --all-tags electronuserland/builder
+

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,41 @@
+name: Build Docker Images
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-docker-images:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        nodeVersion: [
+          22.13.0,
+          20.18.1,
+          18.20.5,
+          16.20.2,
+          14.21.3
+        ]
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: Extract node major version to tag docker images
+        run: echo "NODE_TAG=$(cut -d '.' -f 1 <<< ${{ matrix.nodeVersion }})" >> $GITHUB_ENV
+
+      - name: Builds all images
+        shell: bash
+        run: |
+          bash docker/build.sh ${{ matrix.nodeVersion }}
+          docker images --filter=reference="electronuserland/builder:*"
+          docker save -o ${{ runner.temp }}/electron-builder-all-${{ env.NODE_TAG }}.tar electronuserland/builder
+
+      - name: Bundle all images
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-builder-all-${{ env.NODE_TAG }}
+          path: ${{ runner.temp }}/electron-builder-all-${{ env.NODE_TAG }}.tar
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         nodeVersion: [
-          22.13.0,
+          # 22.13.0,
           20.18.1,
           18.20.5,
           16.20.2,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,16 +5,62 @@ on:
     branches:
       master
   pull_request:
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
+    inputs:
+      rebuild-docker-images:
+        description: 'Rebuild all Docker images'
+        default: false
+        type: 'boolean'
+  workflow_call: # Allow this workflow to be called from other workflows
+    inputs:
+      rebuild-docker-images:
+        description: 'Rebuild all Docker images'
+        default: false
+        type: 'boolean'
 
 permissions:
   contents: read
 
+env:
+  TEST_IMAGE_NODE_MAJOR_VERSION: 20
+
 jobs:
+  check-if-docker-build:
+    runs-on: ubuntu-22.04
+    outputs:
+      force-docker-build: ${{ steps.changed-files-specific.outputs.any_changed }}
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine if Dockerfiles changed
+        id: changed-files-specific
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44
+        with:
+          files: docker/**/*
+
+      - name: Output all changed files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
+        run: |
+          echo "One or more test file(s) has changed."
+          echo "List all the files that have changed: $ALL_CHANGED_FILES"
+
+  run-docker-build:
+    needs: check-if-docker-build
+    if: ${{ needs.check-if-docker-build.outputs.force-docker-build == 'true' || github.event.inputs.rebuild-docker-images == 'true' }}
+    uses: ./.github/workflows/docker-build.yml
+
   test-linux:
     runs-on: ubuntu-22.04
+    needs: [check-if-docker-build, run-docker-build]
+    # Wonky if-conditional to allow this step to run AFTER docker images are rebuilt OR if the build stage skipped and we want to use dockerhub registry for images
+    if: |
+      always() &&
+      needs.check-if-docker-build.result == 'success' &&
+      (needs.run-docker-build.result == 'success' || needs.run-docker-build.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -33,46 +79,41 @@ jobs:
           cache-path: ~/.cache/electron
           cache-key: v-23.3.10-linux-electron
 
+      - name: Download test-runner if exists
+        if: needs.run-docker-build.result == 'success'
+        id: download-test-runner-image
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-builder-all-${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}
+          path: ${{ runner.temp }}
+
+      - name: Load test runner image if needed
+        if: needs.run-docker-build.result == 'success'
+        run: |
+          docker image load --input ${{ runner.temp }}/electron-builder-all-${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}.tar
+          docker image ls -a
+
       - name: Lint
         run: pnpm pretest
 
-      - name: Determine if Dockerfiles changed
-        id: changed-files-specific
-        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44
-        with:
-          files: docker/**/*
-
-      - name: Dockerfile has changed, rebuild for tests
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
-        run: pnpm docker-images
-
       - name: Run tests in docker image
-        run: pnpm test-linux
+        run: |
+          echo $TEST_RUNNER_IMAGE_TAG
+          pnpm test-linux
         env:
           TEST_FILES: ${{ matrix.testFiles }}
           FORCE_COLOR: 1
-
-  test-mac:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout code repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-      - name: Setup Tests
-        uses: ./.github/actions/pretest
-        with:
-          cache-path: ~/Library/Caches/electron
-          cache-key: v-23.3.10-macos-electron
-
-      - name: Test
-        run: pnpm ci:test
-        env:
-          TEST_FILES: masTest,dmgTest,filesTest,macPackagerTest,differentialUpdateTest
-          FORCE_COLOR: 1
+          TEST_RUNNER_IMAGE_TAG: electronuserland/builder:${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}-wine-mono
 
   # Need to separate from other tests because logic is specific to when TOKEN env vars are set
   test-updater:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    needs: [check-if-docker-build, run-docker-build]
+    # Wonky if-conditional to allow this step to run AFTER docker images are rebuilt OR if the build stage skipped and we want to use dockerhub registry for images
+    if: |
+      always() &&
+      needs.check-if-docker-build.result == 'success' &&
+      (needs.run-docker-build.result == 'success' || needs.run-docker-build.result == 'skipped')
     steps:
       - name: Checkout code repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -83,14 +124,30 @@ jobs:
           cache-path: ~/.cache/electron
           cache-key: v-23.3.10-update-electron
 
+      - name: Download test-runner if exists
+        if: needs.run-docker-build.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-builder-all-${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}
+          path: ${{ runner.temp }}
+
+      - name: Load test runner image if needed
+        if: needs.run-docker-build.result == 'success'
+        run: |
+          docker image load --input ${{ runner.temp }}/electron-builder-all-${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}.tar
+          docker image ls -a
+
       - name: Test
-        run: pnpm ci:test
+        run: |
+          echo $TEST_RUNNER_IMAGE_TAG
+          pnpm test-linux
         env:
           TEST_FILES: nsisUpdaterTest,linuxUpdaterTest,PublishManagerTest,differentialUpdateTest
           KEYGEN_TOKEN: ${{ secrets.KEYGEN_TOKEN }}
           BITBUCKET_TOKEN: ${{ secrets.BITBUCKET_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           FORCE_COLOR: 1
+          TEST_RUNNER_IMAGE_TAG: electronuserland/builder:${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}-wine-mono
 
       - name: Verify Docs Generation
         run: pnpm generate-all
@@ -119,4 +176,22 @@ jobs:
         env:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           TEST_FILES: ${{ matrix.testFiles }}
+          FORCE_COLOR: 1
+
+  test-mac:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: Setup Tests
+        uses: ./.github/actions/pretest
+        with:
+          cache-path: ~/Library/Caches/electron
+          cache-key: v-23.3.10-macos-electron
+
+      - name: Test
+        run: pnpm ci:test
+        env:
+          TEST_FILES: masTest,dmgTest,filesTest,macPackagerTest,differentialUpdateTest
           FORCE_COLOR: 1

--- a/docker/base/test.sh
+++ b/docker/base/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 pnpm i
-pnpm run test
+pnpm compile
+pnpm ci:test

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,36 +2,37 @@
 
 set -ex
 
+NODE_VERSION=$1
+NODE_TAG=$(cut -d '.' -f 1 <<< "$NODE_VERSION")
 DATE=$(date +%m.%y)
 
 docker build -t electronuserland/builder:base -t "electronuserland/builder:base-$DATE" docker/base
 
-## NOTE: Order the latest to oldest versions. The most recent node LTS should be tagged as the latest image
+docker build \
+  --build-arg NODE_VERSION="$NODE_VERSION" \
+  --build-arg IMAGE_VERSION="base-$DATE" \
+  -t "electronuserland/builder:$NODE_TAG" \
+  -t "electronuserland/builder:$NODE_TAG-$DATE" \
+  docker/node
 
-# Node 20
-docker build --build-arg NODE_VERSION=20.18.0 --build-arg IMAGE_VERSION=base-$DATE -t electronuserland/builder:20 -t "electronuserland/builder:20-$DATE" -t electronuserland/builder:latest docker/node
+docker build \
+  --build-arg IMAGE_VERSION="$NODE_TAG-$DATE" \
+  -t "electronuserland/builder:$NODE_TAG-wine" \
+  -t "electronuserland/builder:$NODE_TAG-wine-$DATE" \
+  docker/wine
 
-docker build --build-arg IMAGE_VERSION=20-$DATE -t electronuserland/builder:20-wine -t "electronuserland/builder:20-wine-$DATE" -t electronuserland/builder:wine docker/wine
-docker build --build-arg IMAGE_VERSION=20-wine-$DATE -t electronuserland/builder:20-wine-mono -t "electronuserland/builder:20-wine-mono-$DATE" -t electronuserland/builder:wine-mono docker/wine-mono
-docker build --build-arg IMAGE_VERSION=20-wine-$DATE -t electronuserland/builder:20-wine-chrome -t "electronuserland/builder:20-wine-chrome-$DATE" -t electronuserland/builder:wine-chrome docker/wine-chrome
+docker build \
+  --build-arg IMAGE_VERSION="$NODE_TAG-wine-$DATE" \
+  -t "electronuserland/builder:$NODE_TAG-wine-chrome" \
+  -t "electronuserland/builder:$NODE_TAG-wine-chrome-$DATE" \
+  docker/wine-chrome
 
-# Node 18
-docker build --build-arg NODE_VERSION=18.20.4 --build-arg IMAGE_VERSION=base-$DATE -t electronuserland/builder:18 -t "electronuserland/builder:18-$DATE" docker/node
+# We also use this image for running our unit tests
+docker build \
+  --build-arg IMAGE_VERSION="$NODE_TAG-wine-$DATE" \
+  -t "electronuserland/builder:$NODE_TAG-wine-mono" \
+  -t "electronuserland/builder:$NODE_TAG-wine-mono-$DATE" \
+  docker/wine-mono
 
-docker build --build-arg IMAGE_VERSION=18-$DATE -t electronuserland/builder:18-wine -t "electronuserland/builder:18-wine-$DATE" docker/wine
-docker build --build-arg IMAGE_VERSION=18-wine-$DATE -t electronuserland/builder:18-wine-mono -t "electronuserland/builder:18-wine-mono-$DATE" docker/wine-mono
-docker build --build-arg IMAGE_VERSION=18-wine-$DATE -t electronuserland/builder:18-wine-chrome -t "electronuserland/builder:18-wine-chrome-$DATE" docker/wine-chrome
-
-# Node 16
-docker build --build-arg NODE_VERSION=16.20.2 --build-arg IMAGE_VERSION=base-$DATE -t electronuserland/builder:16 -t "electronuserland/builder:16-$DATE" docker/node
-
-docker build --build-arg IMAGE_VERSION=16-$DATE -t electronuserland/builder:16-wine -t "electronuserland/builder:16-wine-$DATE" docker/wine
-docker build --build-arg IMAGE_VERSION=16-wine-$DATE -t electronuserland/builder:16-wine-mono -t "electronuserland/builder:16-wine-mono-$DATE" docker/wine-mono
-docker build --build-arg IMAGE_VERSION=16-wine-$DATE -t electronuserland/builder:16-wine-chrome -t "electronuserland/builder:16-wine-chrome-$DATE" docker/wine-chrome
-
-# Node 14
-docker build --build-arg NODE_VERSION=14.21.3 --build-arg IMAGE_VERSION=base-$DATE -t electronuserland/builder:14 -t "electronuserland/builder:14-$DATE" docker/node
-
-docker build --build-arg IMAGE_VERSION=14-$DATE -t electronuserland/builder:14-wine -t "electronuserland/builder:14-wine-$DATE" docker/wine
-docker build --build-arg IMAGE_VERSION=14-wine-$DATE -t electronuserland/builder:14-wine-mono -t "electronuserland/builder:14-wine-mono-$DATE" docker/wine-mono
-docker build --build-arg IMAGE_VERSION=14-wine-$DATE -t electronuserland/builder:14-wine-chrome -t "electronuserland/builder:14-wine-chrome-$DATE" docker/wine-chrome
+# Generate report
+docker images --filter=reference="electronuserland/builder:*"

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -ex
-
-docker image push --all-tags electronuserland/builder

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "///": "Please see https://github.com/electron-userland/electron-builder/blob/master/CONTRIBUTING.md#run-test-using-cli how to run particular test instead full (and very slow) run",
     "test": "node ./test/out/helpers/runTests.js skipArtifactPublisher",
     "test-all": "pnpm compile && pnpm pretest && pnpm ci:test",
-    "test-linux": "docker run --rm -e DEBUG=${DEBUG:-} -e UPDATE_SNAPSHOT=${UPDATE_SNAPSHOT:-false} -e TEST_FILES=\"${TEST_FILES:-HoistedNodeModuleTest}\" -v $(pwd):/project -v $(pwd)-node-modules:/project/node_modules -v $HOME/Library/Caches/electron:/root/.cache/electron -v $HOME/Library/Caches/electron-builder:/root/.cache/electron-builder electronuserland/builder:20-wine-mono /bin/bash -c \"pnpm install && node ./test/out/helpers/runTests.js\"",
+    "test-linux": "docker run --rm -e DEBUG=${DEBUG:-} -e UPDATE_SNAPSHOT=${UPDATE_SNAPSHOT:-false} -e TEST_FILES=\"${TEST_FILES:-HoistedNodeModuleTest}\" -v $(pwd):/project -v $(pwd)-node-modules:/project/node_modules -v $HOME/Library/Caches/electron:/root/.cache/electron -v $HOME/Library/Caches/electron-builder:/root/.cache/electron-builder ${TEST_RUNNER_IMAGE_TAG:-electronuserland/builder:20-wine-mono} /bin/bash -c \"pnpm install && node ./test/out/helpers/runTests.js\"",
     "test-update": "UPDATE_SNAPSHOT=true pnpm test-all",
     "docker-images": "docker/build.sh",
     "docker-push": "docker/push.sh",

--- a/pages/multi-platform-build.md
+++ b/pages/multi-platform-build.md
@@ -4,7 +4,7 @@
 * If your app has native dependency, it can be compiled only on the target platform unless [prebuild](https://www.npmjs.com/package/prebuild) is not used.
 
     [prebuild](https://www.npmjs.com/package/prebuild) is a solution, but most node modules [don't provide](https://github.com/atom/node-keytar/issues/27) prebuilt binaries.
-  
+
 * macOS Code Signing works only on macOS. [Cannot be fixed](http://stackoverflow.com/a/12156576).
 
 Free public [Electron Build Service](https://github.com/electron-userland/electron-build-service) is used to build Electron app for Linux on Windows. On macOS/Linux you can build Electron app for Windows locally, except Appx for Windows Store (in the future (feel free to file issue) electron-build-service will support Appx target).
@@ -34,17 +34,17 @@ You don't need to clean dist output before build — output directory is cleaned
           env:
             - ELECTRON_CACHE=$HOME/.cache/electron
             - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
-    
+
         - os: linux
           services: docker
           language: generic
-    
+
     cache:
       directories:
         - node_modules
         - $HOME/.cache/electron
         - $HOME/.cache/electron-builder
-    
+
     script:
       - |
         if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -60,7 +60,7 @@ You don't need to clean dist output before build — output directory is cleaned
         fi
     before_cache:
       - rm -rf $HOME/.cache/electron-builder/wine
-    
+
     branches:
       except:
         - "/^v\\d+\\.\\d+\\.\\d+$/"
@@ -77,24 +77,24 @@ Otherwise see above sample `.travis.yml` to build Windows on Linux using provide
 ??? example "sample appveyor.yml"
     ```yaml
     image: Visual Studio 2017
-    
+
     platform:
       - x64
-    
+
     cache:
       - node_modules
       - '%USERPROFILE%\.electron'
-    
+
     init:
       - git config --global core.autocrlf input
-    
+
     install:
       - ps: Install-Product node 10 x64
       - yarn
-    
+
     build_script:
       - yarn dist
-    
+
     test: off
     ```
 
@@ -188,11 +188,16 @@ Or to avoid second step, append to first command `/bin/bash -c "yarn && yarn dis
 
 ### Provided Docker Images
 
-* `electronuserland/builder` or `electronuserland/builder:18` — NodeJS 18 and required system dependencies. Based on `builder:base`. Use this image if you need to build only Linux targets.
-* `electronuserland/builder:wine` — Wine, NodeJS 18 and required system dependencies. Based on `builder:18`. Use this image if you need to build Windows targets.
+!!! tip
+    It is best to lock your `FROM` to a specific date-tag (e.g. `builder:18-07.23`) or sha, as opposed to using a tag like `latest` which may have its toolset upgraded, such as upgrading the node version.
+
+* `electronuserland/builder` or `electronuserland/builder:20` — NodeJS 20 and required system dependencies. Based on `builder:base`. Use this image if you need to build only Linux targets.
+* `electronuserland/builder:wine` — Wine, NodeJS 20 and required system dependencies. Based on `builder:20`. Use this image if you need to build Windows targets.
 * `electronuserland/builder:wine-mono` — Mono for Squirrel.Windows. Based on `builder:wine`. Use this image if you need to build Squirrel.Windows target.
 * `electronuserland/builder:wine-chrome` — `google-chrome-stable` and `xvfb` are available — you can use this image for headless testing of Electron application. Based on `builder:wine`.
 * `electronuserland/builder:base` — Required system dependencies. Not supposed to be used directly.
-There are also iterations of these docker images for Node 16 (`builder:16`, `builder:16-wine`, etc.) and Node 16 (`builder:14`, `builder:14-wine`, etc.)
+
+There are also iterations of these docker images for Node 14/16/18 (`builder:14`, `builder:14-wine`, etc.)
 Docker images are also tagged with the Date suffix `-%m.%y` to statically reference an image, ex: `builder:18-07.23`.
-Full docker build, node version, and tag script can be found here: [build.sh](https://github.com/electron-userland/electron-builder/blob/master/docker/build.sh)
+Full docker build script can be found here: [build.sh](https://github.com/electron-userland/electron-builder/blob/master/docker/build.sh)
+Node versions being built: [test.yaml](https://github.com/electron-userland/electron-builder/blob/master/.github/workflows/test.yaml)


### PR DESCRIPTION
This is to resolve a few of my concerns:

- "No space left on device" when attempting to build node 14/16/18/20 images AND run tests.
- No space = unable to add node 22 to the pipeline
- Tests running in parallel with docker deployment instead of sequentially

Note: Temporarily disables the `docker push` command so as to test with docker deploy on-github-tag GHA event

New workflow:
Test flow:
1. Determine if docker directory has changes. If so, rebuild all docker images using a matrix of runners (reusable workflow docker-build.yml)
2. If docker images are rebuilt, they're uploaded as tar artifacts from each runner
3. Test runner(s) download the tar image for `TEST_IMAGE_NODE_MAJOR_VERSION` (currently 20) and execute tests

If docker deployment pipeline, complete all above steps from Test flow (w/ force docker image rebuild) and then download ALL artfiacts from each docker-build runner to a central runner for pushing all at once

<img width="1372" alt="Screenshot 2025-01-18 at 10 32 23 AM" src="https://github.com/user-attachments/assets/c0528725-9fe4-4ec2-ae62-db6406f8689d" />
