### PR TITLE
chore(docker): upgrade image `buildpack-deps:focal-curl` to `jammy-curl` 22.04 (BREAKING)

### DIFF
--- a/.changeset/funny-pandas-worry.md
+++ b/.changeset/funny-pandas-worry.md
@@ -1,0 +1,5 @@
+---
+"electron-builder": major
+---
+
+chore: upgrade buildpack-deps base image from `focal` to `jammy`. This also forces upgrading `python`->`python3` package and wine-stable

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,7 @@ jobs:
   build-docker-images:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         nodeVersion: [
           # 22.13.0,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,6 +71,7 @@ jobs:
         testFiles:
           - ArtifactPublisherTest,BuildTest,ExtraBuildTest,RepoSlugTest,binDownloadTest,configurationValidationTest,filenameUtilTest,filesTest,globTest,ignoreTest,macroExpanderTest,mainEntryTest,urlUtilTest,extraMetadataTest,linuxArchiveTest,linuxPackagerTest,HoistedNodeModuleTest,MemoLazyTest
           - snapTest,debTest,fpmTest,protonTest
+          - winPackagerTest,installerTest,BuildTest
     steps:
       - name: Checkout code repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -105,6 +106,7 @@ jobs:
           echo $TEST_RUNNER_IMAGE_TAG
           pnpm test-linux
         env:
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           TEST_FILES: ${{ matrix.testFiles }}
           FORCE_COLOR: 1
           TEST_RUNNER_IMAGE_TAG: electronuserland/builder:${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}-wine-mono

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -14,12 +14,20 @@ RUN apt-get update -yqq && apt-get -qq dist-upgrade && \
   # libsecret-1-dev is required even for prebuild keytar (https://atom.github.io/node-keytar/)
   apt-get -qq install --no-install-recommends \
         qtbase5-dev build-essential autoconf libssl-dev gcc-multilib g++-multilib \
-        lzip rpm python3 libcurl4 git git-lfs ssh unzip libarchive-tools \
+        lzip rpm python2 python3 libcurl4 git git-lfs ssh unzip libarchive-tools \
         libxtst6 libsecret-1-dev libopenjp2-tools liblzo2-2 \
   && \
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
+
+# Resolves the following error due to dependency requirements
+# /root/.cache/electron-builder/winCodeSign/winCodeSign-2.6.0/linux/osslsigncode: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory
+# The missing libcrypto.so.1.1 is part of libssl1.1 but Ubuntu 22.04 upgraded to libssl3, so we must install it manually
+ARG LIB_SSL1_VERSION=2.23
+RUN wget -q "http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu${LIB_SSL1_VERSION}_amd64.deb" && \
+  dpkg -i libssl1.1*.deb && \
+  rm libssl1.1*.deb
 
 COPY ./test.sh /test.sh
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,9 +1,11 @@
-FROM buildpack-deps:focal-curl
+# hardcoding `--platform` with a constant throws a warning during build.
+# That's OK as this image can't be built on arm64 machines due to gcc-multilib & g++-multilib only provided for x64
+FROM --platform=linux/x86_64 buildpack-deps:22.04-curl
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN curl -L https://yarnpkg.com/latest.tar.gz | tar xvz && mv yarn-* /yarn && ln -s /yarn/bin/yarn /usr/bin/yarn
-RUN apt-get -qq update && apt-get -qq dist-upgrade && \
+RUN apt-get update -yqq && apt-get -qq dist-upgrade && \
   # add repo for git-lfs
   curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
   # git ssh for using as docker image on CircleCI
@@ -12,23 +14,23 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && \
   # libsecret-1-dev is required even for prebuild keytar (https://atom.github.io/node-keytar/)
   apt-get -qq install --no-install-recommends \
         qtbase5-dev build-essential autoconf libssl-dev gcc-multilib g++-multilib \
-        lzip rpm python libcurl4 git git-lfs ssh unzip libarchive-tools \
+        lzip rpm python3 libcurl4 git git-lfs ssh unzip libarchive-tools \
         libxtst6 libsecret-1-dev libopenjp2-tools liblzo2-2 \
   && \
   # git-lfs
   git lfs install && \
   apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
 
-COPY test.sh /test.sh
+COPY ./test.sh /test.sh
 
 WORKDIR /project
 
 # fix error /usr/local/bundle/gems/fpm-1.5.0/lib/fpm/package/freebsd.rb:72:in `encode': "\xE2" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
 # http://jaredmarkell.com/docker-and-locales/
 # http://askubuntu.com/a/601498
-ENV LANG C.UTF-8
-ENV LANGUAGE C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
-ENV DEBUG_COLORS true
-ENV FORCE_COLOR true
+ENV DEBUG_COLORS=true
+ENV FORCE_COLOR=true

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_VERSION=base
-FROM electronuserland/builder:$IMAGE_VERSION
+FROM --platform=linux/x86_64 electronuserland/builder:$IMAGE_VERSION
 
-ARG NODE_VERSION 20.15.1
+ARG NODE_VERSION
 
 # this package is used for snapcraft and we should not clear apt list - to avoid apt-get update during snap build
 RUN curl -L https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz | tar xz -C /usr/local --strip-components=1 && \

--- a/docker/wine-chrome/Dockerfile
+++ b/docker/wine-chrome/Dockerfile
@@ -1,8 +1,9 @@
 ARG IMAGE_VERSION=wine
-FROM electronuserland/builder:$IMAGE_VERSION
+FROM --platform=linux/x86_64 electronuserland/builder:$IMAGE_VERSION
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
-  apt-get update -y && apt-get install -y --no-install-recommends xvfb google-chrome-stable libgconf-2-4 && \
+  apt-get -qq update -y && \
+  apt-get -qq install -y --no-install-recommends xvfb google-chrome-stable libgconf-2-4 && \
   # clean
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/wine-mono/Dockerfile
+++ b/docker/wine-mono/Dockerfile
@@ -1,8 +1,8 @@
 ARG IMAGE_VERSION=wine
-FROM electronuserland/builder:$IMAGE_VERSION
+FROM --platform=linux/x86_64 electronuserland/builder:$IMAGE_VERSION
 
 # since mono is required only for deprecated target Squirrel.Windows, extracted to separate docker image to reduce size
 
-RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends mono-devel ca-certificates-mono && \
+RUN apt-get -qq update -y && \
+  apt-get -qq install -y --no-install-recommends mono-devel ca-certificates-mono && \
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -1,21 +1,29 @@
 ARG IMAGE_VERSION=latest
-FROM electronuserland/builder:$IMAGE_VERSION
+FROM --platform=linux/x86_64 electronuserland/builder:$IMAGE_VERSION
 
 RUN dpkg --add-architecture i386 && \
-  curl -Lo /usr/share/keyrings/winehq.asc https://dl.winehq.org/wine-builds/winehq.key && \
-  echo 'deb [signed-by=/usr/share/keyrings/winehq.asc] https://dl.winehq.org/wine-builds/ubuntu/ focal main' > /etc/apt/sources.list.d/winehq.list && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-    # We can't install `winehq-stable`, we must manually lock each dependency to v6 (ref: https://github.com/electron-userland/electron-builder/issues/6780),
-    winehq-stable=6.0.4~focal-1 \
-    wine-stable=6.0.4~focal-1 \
-    wine-stable-i386=6.0.4~focal-1 \
-    wine-stable-amd64=6.0.4~focal-1 \
-  && \
+  mkdir -pm755 /etc/apt/keyrings && \
+  # wine
+  # https://gitlab.winehq.org/wine/wine/-/wikis/Debian-Ubuntu#install-wine
+  wget -O - https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key - && \
+  wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources && \
+  apt-get -qq update && \
+  apt-get -qq install -y --install-recommends winehq-stable && \
+  # powershell
+  # https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.4
+  apt-get install -yq apt-transport-https software-properties-common && \
+  wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb && \
+  dpkg -i packages-microsoft-prod.deb && \
+  rm packages-microsoft-prod.deb && \
+  apt-get -qq update && \
+  apt-get install -y powershell && \
   # clean
-  apt-get clean && rm -rf /var/lib/apt/lists/*
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
-RUN curl -L https://github.com/electron-userland/electron-builder-binaries/releases/download/wine-2.0.3-mac-10.13/wine-home.zip > /tmp/wine-home.zip && unzip /tmp/wine-home.zip -d /root/.wine && unlink /tmp/wine-home.zip
+ENV WINEDEBUG=-all,err+all
+ENV WINEDLLOVERRIDES=winemenubuilder.exe=d
 
-ENV WINEDEBUG -all,err+all
-ENV WINEDLLOVERRIDES winemenubuilder.exe=d
+# We expect this to error in the logs due to no screen display, but it seems to be the only way to init a ~/.wine config dir
+# Note: We could run this via xvfb-run, but since `winecfg` is a GUI config tool, the docker build process hangs as the process never exits
+RUN winecfg

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -492,7 +492,7 @@ exports[`yarn two package.json w/ native module 2`] = `
                       "unpacked": true,
                     },
                     "pty.node": {
-                      "size": 72880,
+                      "size": 76144,
                       "unpacked": true,
                     },
                   },


### PR DESCRIPTION
- Required upgrading packages `python`->`python3`, wine-stable `6` -> `9`, and added `python2` for backward compatibility (note, `python` alias does not get created by `apt-get install`, must be accessed via `python2`)
- Adds `powershell` to `wine` image for Azure Signing
- Adds `--platform=linux/x86_64` in `FROM` line so as to allow building these images on arm64 macs
- Manually adds `libssl1.1` to `base` Docker image since Ubuntu 22.04 upgraded to `libssl3` and some upstream dependencies (e.g. `osslsigncode`) still require `libssl1.1`.
- Adds windows installer unit tests to linux matrix runners