### PR TITLE
chore: deploy docker image w/ node 22

### DIFF
--- a/.changeset/strong-timers-film.md
+++ b/.changeset/strong-timers-film.md
@@ -1,5 +1,0 @@
----
-"electron-builder": major
----
-
-chore: upgrade node version to 22 and distribute node 22 image

--- a/.changeset/strong-timers-film.md
+++ b/.changeset/strong-timers-film.md
@@ -1,0 +1,5 @@
+---
+"electron-builder": major
+---
+
+chore: upgrade node version to 22 and distribute node 22 image

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'pnpm'
 
     - name: Install dependencies

--- a/.github/actions/pretest/action.yml
+++ b/.github/actions/pretest/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Setup node
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'pnpm'
 
     - name: Install dependencies

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  LATEST_IMAGE_NODE_MAJOR_VERSION: 20
+  LATEST_IMAGE_NODE_MAJOR_VERSION: 22
 
 jobs:
   run-docker-build-and-test:
@@ -48,6 +48,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: electron-builder-all-20
+          path: ${{ runner.temp }}
+
+      - name: Download images artifact - node22
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-builder-all-22
           path: ${{ runner.temp }}
 
       - name: Load all images

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         nodeVersion: [
-          # 22.13.0,
+          22.13.0,
           20.18.1,
           18.20.5,
           16.20.2,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ permissions:
   contents: read
 
 env:
-  TEST_IMAGE_NODE_MAJOR_VERSION: 20
+  TEST_IMAGE_NODE_MAJOR_VERSION: 22
 
 jobs:
   check-if-docker-build:

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_VERSION=base
 FROM electronuserland/builder:$IMAGE_VERSION
 
-ARG NODE_VERSION 20.15.1
+ARG NODE_VERSION 22.13.0
 
 # this package is used for snapcraft and we should not clear apt list - to avoid apt-get update during snap build
 RUN curl -L https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz | tar xz -C /usr/local --strip-components=1 && \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_VERSION=base
 FROM --platform=linux/x86_64 electronuserland/builder:$IMAGE_VERSION
 
-ARG NODE_VERSION
+ARG NODE_VERSION=22.13.0
 
 # this package is used for snapcraft and we should not clear apt list - to avoid apt-get update during snap build
 RUN curl -L https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz | tar xz -C /usr/local --strip-components=1 && \

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "///": "Please see https://github.com/electron-userland/electron-builder/blob/master/CONTRIBUTING.md#run-test-using-cli how to run particular test instead full (and very slow) run",
     "test": "node ./test/out/helpers/runTests.js skipArtifactPublisher",
     "test-all": "pnpm compile && pnpm pretest && pnpm ci:test",
-    "test-linux": "docker run --rm -e DEBUG=${DEBUG:-} -e UPDATE_SNAPSHOT=${UPDATE_SNAPSHOT:-false} -e TEST_FILES=\"${TEST_FILES:-HoistedNodeModuleTest}\" -v $(pwd):/project -v $(pwd)-node-modules:/project/node_modules -v $HOME/Library/Caches/electron:/root/.cache/electron -v $HOME/Library/Caches/electron-builder:/root/.cache/electron-builder ${TEST_RUNNER_IMAGE_TAG:-electronuserland/builder:20-wine-mono} /bin/bash -c \"pnpm install && node ./test/out/helpers/runTests.js\"",
+    "test-linux": "docker run --rm -e DEBUG=${DEBUG:-} -e UPDATE_SNAPSHOT=${UPDATE_SNAPSHOT:-false} -e TEST_FILES=\"${TEST_FILES:-HoistedNodeModuleTest}\" -v $(pwd):/project -v $(pwd)-node-modules:/project/node_modules -v $HOME/Library/Caches/electron:/root/.cache/electron -v $HOME/Library/Caches/electron-builder:/root/.cache/electron-builder ${TEST_RUNNER_IMAGE_TAG:-electronuserland/builder:22-wine-mono} /bin/bash -c \"pnpm install && node ./test/out/helpers/runTests.js\"",
     "test-update": "UPDATE_SNAPSHOT=true pnpm test-all",
     "docker-images": "docker/build.sh",
     "docker-push": "docker/push.sh",

--- a/packages/electron-builder/package.json
+++ b/packages/electron-builder/package.json
@@ -44,7 +44,8 @@
   ],
   "author": "Vladimir Krivosheev",
   "contributors": [
-    "Stefan Judis"
+    "Stefan Judis",
+    "Mike Maietta"
   ],
   "license": "MIT",
   "bugs": "https://github.com/electron-userland/electron-builder/issues",


### PR DESCRIPTION
This PR updates electron-builder to node 22 (note: this is separate from electron-updater) in order to adopt updates/fixes from @electron/* packages. Read more @ https://www.electronjs.org/blog/ecosystem-node-22

In order to continue supporting the ecosystem, this PR also adds a new docker image set for node 22. `electronuserland/builder:22`. This will now be `latest` tag