### PR TITLE
fix(mac): always build dmg's with APFS (BREAKING)

### DIFF
--- a/.changeset/cuddly-comics-cough.md
+++ b/.changeset/cuddly-comics-cough.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": major
+---
+
+fix: removing conditional logic that would build HFS+ dmg on non-arm64 macs as HFS+ was sunset in macos 15.2

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -201,14 +201,7 @@ async function createStageDmg(tempDmg: string, appPath: string, volumeName: stri
     imageArgs.push("-debug")
   }
 
-  let filesystem = ["HFS+", "-fsargs", "-c c=64,a=16,e=16"]
-  if (process.arch === "arm64") {
-    // Apple Silicon `hdiutil` dropped support for HFS+, so we force the latest type
-    // https://github.com/electron-userland/electron-builder/issues/4606
-    filesystem = ["APFS"]
-    log.warn(null, "Detected arm64 process, HFS+ is unavailable. Creating dmg with APFS - supports Mac OSX 10.12+")
-  }
-  imageArgs.push("-fs", ...filesystem)
+  imageArgs.push("-fs", "APFS")
   imageArgs.push(tempDmg)
   await hdiUtil(imageArgs)
   return tempDmg


### PR DESCRIPTION
Removes conditional logic that would build HFS+ dmg on non-arm64 macs as HFS+ was sunset in macos 15.2. The warning of this deprecation has been present for significant time and we can also drop support for macos <10.12 for electron-builder v26

Fixes: https://github.com/electron-userland/electron-builder/issues/8769