### PR TITLE
feat: Allow users to pass a custom headers URL

### DIFF
--- a/.changeset/fresh-phones-return.md
+++ b/.changeset/fresh-phones-return.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+feat: Allow users to pass a custom electrons headers URL via env var

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -48,12 +48,6 @@ export interface ElectronDownloadOptions {
    */
   mirror?: string | null
 
-  /**
-   * The mirror base URL for Electron headers.
-   * @default https://electronjs.org/headers
-   */
-  headersMirror?: string | 'https://electronjs.org/headers'
-
   /** @private */
   customDir?: string | null
   /** @private */

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -48,6 +48,12 @@ export interface ElectronDownloadOptions {
    */
   mirror?: string | null
 
+  /**
+   * The mirror base URL for Electron headers.
+   * @default https://electronjs.org/headers
+   */
+  headersMirror?: string | 'https://electronjs.org/headers'
+
   /** @private */
   customDir?: string | null
   /** @private */

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -11,8 +11,6 @@ import { Configuration } from "../configuration"
 import { executeAppBuilderAndWriteJson } from "./appBuilder"
 import { NodeModuleDirInfo } from "./packageDependencies"
 import { rebuild as remoteRebuild } from "./rebuild/rebuild"
-import { ElectronDownloadOptions } from "../electron/ElectronFramework"
-import { getConfig } from "../util/config/config"
 
 export async function installOrRebuild(config: Configuration, appDir: string, options: RebuildOptions, forceInstall = false) {
   const effectiveOptions: RebuildOptions = {
@@ -42,21 +40,11 @@ export interface DesktopFrameworkInfo {
   useCustomDist: boolean
 }
 
-async function getDownloadConfig(config: Configuration | null = null): Promise<ElectronDownloadOptions> {
-  const projectDir = process.cwd()
-  if (config == null) {
-    config = await getConfig(projectDir, null, null)
-  }
-  return {
-    ...config.electronDownload,
-  }
-}
-
 function getElectronGypCacheDir() {
   return path.join(homedir(), ".electron-gyp")
 }
 
-export function getGypEnv(frameworkInfo: DesktopFrameworkInfo, platform: NodeJS.Platform, arch: string, buildFromSource: boolean, downloadConfig: ElectronDownloadOptions) {
+export function getGypEnv(frameworkInfo: DesktopFrameworkInfo, platform: NodeJS.Platform, arch: string, buildFromSource: boolean) {
   const npmConfigArch = arch === "armv7l" ? "arm" : arch
   const common: any = {
     ...process.env,
@@ -84,7 +72,7 @@ export function getGypEnv(frameworkInfo: DesktopFrameworkInfo, platform: NodeJS.
   // https://github.com/nodejs/node-gyp/issues/21
   return {
     ...common,
-    npm_config_disturl: downloadConfig.headersMirror,
+    npm_config_disturl: common.npm_config_electron_headers_disturl || "https://electronjs.org/headers",
     npm_config_target: frameworkInfo.version,
     npm_config_runtime: "electron",
     npm_config_devdir: getElectronGypCacheDir(),
@@ -131,7 +119,7 @@ async function installDependencies(config: Configuration, appDir: string, option
   }
   await spawn(execPath, execArgs, {
     cwd: appDir,
-    env: getGypEnv(options.frameworkInfo, platform, arch, options.buildFromSource === true, await getDownloadConfig(config)),
+    env: getGypEnv(options.frameworkInfo, platform, arch, options.buildFromSource === true),
   })
 
   // Some native dependencies no longer use `install` hook for building their native module, (yarn 3+ removed implicit link of `install` and `rebuild` steps)
@@ -155,7 +143,7 @@ export async function nodeGypRebuild(platform: NodeJS.Platform, arch: string, fr
   if (major <= 13 || (major == 14 && minor <= 1) || (major == 15 && minor <= 2)) {
     args.push("--force-process-config")
   }
-  await spawn(nodeGyp, args, { env: getGypEnv(frameworkInfo, platform, arch, true, await getDownloadConfig()) })
+  await spawn(nodeGyp, args, { env: getGypEnv(frameworkInfo, platform, arch, true) })
 }
 
 function getPackageToolPath() {

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -72,7 +72,7 @@ export function getGypEnv(frameworkInfo: DesktopFrameworkInfo, platform: NodeJS.
   // https://github.com/nodejs/node-gyp/issues/21
   return {
     ...common,
-    npm_config_disturl: "https://electronjs.org/headers",
+    npm_config_disturl: common.npm_config_electron_headers_disturl || "https://electronjs.org/headers",
     npm_config_target: frameworkInfo.version,
     npm_config_runtime: "electron",
     npm_config_devdir: getElectronGypCacheDir(),

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -72,7 +72,7 @@ export function getGypEnv(frameworkInfo: DesktopFrameworkInfo, platform: NodeJS.
   // https://github.com/nodejs/node-gyp/issues/21
   return {
     ...common,
-    npm_config_disturl: common.npm_config_electron_headers_disturl || "https://electronjs.org/headers",
+    npm_config_disturl: common.npm_config_electron_mirror || "https://electronjs.org/headers",
     npm_config_target: frameworkInfo.version,
     npm_config_runtime: "electron",
     npm_config_devdir: getElectronGypCacheDir(),


### PR DESCRIPTION
Prior to this `packages/app-builder-lib/src/util/yarn.ts` hard-coded the Electron headers `disturl` with no option to configure it for a local mirror.  This commit changes it to try the environment variable `npm_config_electron_headers_disturl` before using the hard-coded value. This lets users set the variable
`electron_headers_disturl=https://example.com/custom-headers-mirror` to use a local mirror.