### PR TITLE
fix: docker deploy script runs out of space

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -24,42 +24,24 @@ jobs:
     name: Build and Push Docker
     needs: run-docker-build-and-test
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: true
+      matrix:
+        nodeMajorVersion: [
+          14, 16, 18, 20, 22
+        ]
     steps:
-      - name: Download images artifact - node14
+      - name: Download images artifact - node${{ matrix.nodeMajorVersion }}
         uses: actions/download-artifact@v4
         with:
-          name: electron-builder-all-14
-          path: ${{ runner.temp }}
-
-      - name: Download images artifact - node16
-        uses: actions/download-artifact@v4
-        with:
-          name: electron-builder-all-16
-          path: ${{ runner.temp }}
-
-      - name: Download images artifact - node18
-        uses: actions/download-artifact@v4
-        with:
-          name: electron-builder-all-18
-          path: ${{ runner.temp }}
-
-      - name: Download images artifact - node20
-        uses: actions/download-artifact@v4
-        with:
-          name: electron-builder-all-20
-          path: ${{ runner.temp }}
-
-      - name: Download images artifact - node22
-        uses: actions/download-artifact@v4
-        with:
-          name: electron-builder-all-22
+          name: electron-builder-all-${{ matrix.nodeMajorVersion }}
           path: ${{ runner.temp }}
 
       - name: Load all images
-        run: find ${{ runner.temp }} -type f -name "electron-builder-all-*.tar" -exec docker image load --input "{}" \;
+        run: docker image load --input ${{ runner.temp }}/electron-builder-all-${{ matrix.nodeMajorVersion }}.tar
 
-      - name: Tag LTS images for electron-builder latest/wine/wine-chrome/wine-mono
+      - name: Tag LTS (${{ env.LATEST_IMAGE_NODE_MAJOR_VERSION }}) images for electron-builder latest/wine/wine-chrome/wine-mono
+        if: ${{ matrix.nodeMajorVersion == env.LATEST_IMAGE_NODE_MAJOR_VERSION }}
         run: |
           docker image tag electronuserland/builder:${{ env.LATEST_IMAGE_NODE_MAJOR_VERSION }} electronuserland/builder:latest
           docker image tag electronuserland/builder:${{ env.LATEST_IMAGE_NODE_MAJOR_VERSION }}-wine electronuserland/builder:wine

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_VERSION=base
 FROM --platform=linux/x86_64 electronuserland/builder:$IMAGE_VERSION
 
-ARG NODE_VERSION=22.13.0
+ARG NODE_VERSION
 
 # this package is used for snapcraft and we should not clear apt list - to avoid apt-get update during snap build
 RUN curl -L https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz | tar xz -C /usr/local --strip-components=1 && \


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/actions/runs/12857907910/job/35846664284
```
Run find /home/runner/work/_temp -type f -name "electron-builder-all-*.tar" -exec docker image load --input "{}" \;

write /blobs/sha256/b729d0d4583d5643ae5524776c32beeb[1](https://github.com/electron-userland/electron-builder/actions/runs/12857907910/job/35846664284#step:7:1)6104bef87a499098bb514093541db5a: no space left on device
write /blobs/sha256/bc995f40c4ff5af1b6fcc18f6d23c4e4146c150237a21454d8c4e[6](https://github.com/electron-userland/electron-builder/actions/runs/12857907910/job/35846664284#step:7:7)ec4e438abc: no space left on device
write /blobs/sha256/f315cb4a43eb539a64d546702b5cf46078ccfab6bab356a509d4eba44b325fcc: no space left on device
write /blobs/sha256/8409398aaa6198[7](https://github.com/electron-userland/electron-builder/actions/runs/12857907910/job/35846664284#step:7:8)5565f16ffe27c9b4fa330f3767dba4e8b6479546a8585389f: no space left on device
write /blobs/sha256/b987f39d0208bed353c2a63c64999[8](https://github.com/electron-userland/electron-builder/actions/runs/12857907910/job/35846664284#step:7:9)2374c449178e434833c7a7aa863d49e544: no space left on device
```

Splits deployment of each node version into a matrix by major node versions so as to reduce usage of disk space on a single runner

Verified: https://github.com/electron-userland/electron-builder/actions/runs/12858165049