### PR TITLE
fix(mac): only fuse macOS universal builds on the combined universal package

### DIFF
--- a/.changeset/eighty-swans-hang.md
+++ b/.changeset/eighty-swans-hang.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): only fuse macOS universal builds on the combined universal package

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -124,7 +124,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
 
         const x64Arch = Arch.x64
         const x64AppOutDir = outDirName(x64Arch)
-        await super.doPack(outDir, x64AppOutDir, platformName, x64Arch, platformSpecificBuildOptions, targets, false, true)
+        await super.doPack(outDir, x64AppOutDir, platformName, x64Arch, platformSpecificBuildOptions, targets, false, true, true)
 
         if (this.info.cancellationToken.cancelled) {
           return
@@ -132,7 +132,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
 
         const arm64Arch = Arch.arm64
         const arm64AppOutPath = outDirName(arm64Arch)
-        await super.doPack(outDir, arm64AppOutPath, platformName, arm64Arch, platformSpecificBuildOptions, targets, false, true)
+        await super.doPack(outDir, arm64AppOutPath, platformName, arm64Arch, platformSpecificBuildOptions, targets, false, true, true)
 
         if (this.info.cancellationToken.cancelled) {
           return
@@ -176,6 +176,8 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
         if (this.info.cancellationToken.cancelled) {
           return
         }
+
+        await this.doAddElectronFuses(packContext)
 
         await this.doSignAfterPack(outDir, appOutDir, platformName, arch, platformSpecificBuildOptions, targets)
         break

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -34,6 +34,20 @@ import { resolveFunction } from "./util/resolve"
 import { flipFuses, FuseConfig, FuseV1Config, FuseV1Options, FuseVersion } from "@electron/fuses"
 import { FuseOptionsV1 } from "./configuration"
 
+export type DoPackOptions<DC extends PlatformSpecificBuildOptions> = {
+  outDir: string
+  appOutDir: string
+  platformName: ElectronPlatformName
+  arch: Arch
+  platformSpecificBuildOptions: DC
+  targets: Array<Target>
+  options?: {
+    sign?: boolean
+    disableAsarIntegrity?: boolean
+    disableFuses?: boolean
+  }
+}
+
 export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> {
   get packagerOptions(): PackagerOptions {
     return this.info.options
@@ -138,7 +152,14 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
   async pack(outDir: string, arch: Arch, targets: Array<Target>, taskManager: AsyncTaskManager): Promise<any> {
     const appOutDir = this.computeAppOutDir(outDir, arch)
-    await this.doPack(outDir, appOutDir, this.platform.nodeName as ElectronPlatformName, arch, this.platformSpecificBuildOptions, targets)
+    await this.doPack({
+      outDir,
+      appOutDir,
+      platformName: this.platform.nodeName as ElectronPlatformName,
+      arch,
+      platformSpecificBuildOptions: this.platformSpecificBuildOptions,
+      targets,
+    })
     this.packageInDistributableFormat(appOutDir, arch, targets, taskManager)
   }
 
@@ -188,17 +209,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
   }
 
-  protected async doPack(
-    outDir: string,
-    appOutDir: string,
-    platformName: ElectronPlatformName,
-    arch: Arch,
-    platformSpecificBuildOptions: DC,
-    targets: Array<Target>,
-    sign = true,
-    disableAsarIntegrity = false,
-    disableFuses = false
-  ) {
+  protected async doPack(packOptions: DoPackOptions<DC>) {
     if (this.packagerOptions.prepackaged != null) {
       return
     }
@@ -209,6 +220,8 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
     // Due to node-gyp rewriting GYP_MSVS_VERSION when reused across the same session, we must reset the env var: https://github.com/electron-userland/electron-builder/issues/7256
     delete process.env.GYP_MSVS_VERSION
+
+    const { outDir, appOutDir, platformName, arch, platformSpecificBuildOptions, targets, options } = packOptions
 
     const beforePack = await resolveFunction(this.appInfo.type, this.config.beforePack, "beforePack")
     if (beforePack != null) {
@@ -306,7 +319,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       await framework.beforeCopyExtraFiles({
         packager: this,
         appOutDir,
-        asarIntegrity: asarOptions == null || disableAsarIntegrity ? null : await computeData({ resourcesPath, resourcesRelativePath }),
+        asarIntegrity: asarOptions == null || options?.disableAsarIntegrity ? null : await computeData({ resourcesPath, resourcesRelativePath }),
         platformName,
       })
     }
@@ -332,10 +345,10 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     const isAsar = asarOptions != null
     await this.sanityCheckPackage(appOutDir, isAsar, framework, !!this.config.disableSanityCheckAsar)
 
-    if (!disableFuses) {
+    if (!options?.disableFuses) {
       await this.doAddElectronFuses(packContext)
     }
-    if (sign) {
+    if (options?.sign ?? true) {
       await this.doSignAfterPack(outDir, appOutDir, platformName, arch, platformSpecificBuildOptions, targets)
     }
   }

--- a/test/src/helpers/CheckingPackager.ts
+++ b/test/src/helpers/CheckingPackager.ts
@@ -6,6 +6,7 @@ import { MacPackager } from "app-builder-lib/out/macPackager"
 import { DmgTarget } from "dmg-builder"
 import { WinPackager } from "app-builder-lib/out/winPackager"
 import { SignOptions as MacSignOptions } from "@electron/osx-sign/dist/cjs/types"
+import { DoPackOptions } from "app-builder-lib/out/platformPackager"
 
 export class CheckingWinPackager extends WinPackager {
   effectiveDistOptions: any
@@ -50,7 +51,7 @@ export class CheckingMacPackager extends MacPackager {
   }
 
   //noinspection JSUnusedLocalSymbols
-  async doPack(outDir: string, appOutDir: string, platformName: string, arch: Arch, customBuildOptions: MacConfiguration, targets: Array<Target>) {
+  async doPack(_options: DoPackOptions<MacConfiguration>) {
     // skip
   }
 


### PR DESCRIPTION
Without this `@electron/universal` would error complaining that the x64 and the arm64 builds varied in an unexpected place. Could have maybe overridden `addElectronFuses` in MacPackager, but we didn't have a reference to the fact we were building a universal package from the param in `doPack` and didn't want to explore adding more properties in the area.

Fixes https://github.com/electron-userland/electron-builder/issues/8798