### PR TITLE
fix(linux): AppImage update when filename contains spaces

### DIFF
--- a/.changeset/beige-pillows-relate.md
+++ b/.changeset/beige-pillows-relate.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix(linux): AppImage update fails when filename contains spaces

--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -86,16 +86,21 @@ export class AppImageUpdater extends BaseUpdater {
 
     let destination: string
     const existingBaseName = path.basename(appImageFile)
+    const installerPath = this.installerPath
+    if (installerPath == null) {
+      this.dispatchError(new Error("No valid update available, can't quit and install"))
+      return false
+    }
     // https://github.com/electron-userland/electron-builder/issues/2964
     // if no version in existing file name, it means that user wants to preserve current custom name
-    if (path.basename(options.installerPath) === existingBaseName || !/\d+\.\d+\.\d+/.test(existingBaseName)) {
+    if (path.basename(installerPath) === existingBaseName || !/\d+\.\d+\.\d+/.test(existingBaseName)) {
       // no version in the file name, overwrite existing
       destination = appImageFile
     } else {
-      destination = path.join(path.dirname(appImageFile), path.basename(options.installerPath))
+      destination = path.join(path.dirname(appImageFile), path.basename(installerPath))
     }
 
-    execFileSync("mv", ["-f", options.installerPath, destination])
+    execFileSync("mv", ["-f", installerPath, destination])
     if (destination !== appImageFile) {
       this.emit("appimage-filename-updated", destination)
     }

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -48,17 +48,7 @@ export abstract class BaseUpdater extends AppUpdater {
     }
 
     const downloadedUpdateHelper = this.downloadedUpdateHelper
-
-    // Get the installer path, ensuring spaces are escaped on Linux
-    // 1. Check if downloadedUpdateHelper is not null
-    // 2. Check if downloadedUpdateHelper.file is not null
-    // 3. If both checks pass:
-    //    a. If the platform is Linux, replace spaces with '\ ' for shell compatibility
-    //    b. If the platform is not Linux, use the original path
-    // 4. If any check fails, set installerPath to null
-    const installerPath =
-      downloadedUpdateHelper && downloadedUpdateHelper.file ? (process.platform === "linux" ? downloadedUpdateHelper.file.replace(/ /g, "\\ ") : downloadedUpdateHelper.file) : null
-
+    const installerPath = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.file
     const downloadedFileInfo = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.downloadedFileInfo
     if (installerPath == null || downloadedFileInfo == null) {
       this.dispatchError(new Error("No valid update available, can't quit and install"))

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -37,6 +37,10 @@ export abstract class BaseUpdater extends AppUpdater {
     })
   }
 
+  protected get installerPath(): string | null {
+    return this.downloadedUpdateHelper == null ? null : this.downloadedUpdateHelper.file
+  }
+
   // must be sync
   protected abstract doInstall(options: InstallOptions): boolean
 
@@ -48,7 +52,7 @@ export abstract class BaseUpdater extends AppUpdater {
     }
 
     const downloadedUpdateHelper = this.downloadedUpdateHelper
-    const installerPath = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.file
+    const installerPath = this.installerPath
     const downloadedFileInfo = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.downloadedFileInfo
     if (installerPath == null || downloadedFileInfo == null) {
       this.dispatchError(new Error("No valid update available, can't quit and install"))
@@ -61,7 +65,6 @@ export abstract class BaseUpdater extends AppUpdater {
     try {
       this._logger.info(`Install: isSilent: ${isSilent}, isForceRunAfter: ${isForceRunAfter}`)
       return this.doInstall({
-        installerPath,
         isSilent,
         isForceRunAfter,
         isAdminRightsRequired: downloadedFileInfo.isAdminRightsRequired,
@@ -154,7 +157,6 @@ export abstract class BaseUpdater extends AppUpdater {
 }
 
 export interface InstallOptions {
-  readonly installerPath: string
   readonly isSilent: boolean
   readonly isForceRunAfter: boolean
   readonly isAdminRightsRequired: boolean

--- a/packages/electron-updater/src/DebUpdater.ts
+++ b/packages/electron-updater/src/DebUpdater.ts
@@ -27,11 +27,19 @@ export class DebUpdater extends BaseUpdater {
     })
   }
 
+  protected get installerPath(): string | null {
+    return super.installerPath?.replace(/ /g, "\\ ") ?? null
+  }
+
   protected doInstall(options: InstallOptions): boolean {
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
-    const installerPath = options.installerPath.replace(/ /g, "\\ ")
+    const installerPath = this.installerPath
+    if (installerPath == null) {
+      this.dispatchError(new Error("No valid update available, can't quit and install"))
+      return false
+    }
     const cmd = ["dpkg", "-i", installerPath, "||", "apt-get", "install", "-f", "-y"]
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {

--- a/packages/electron-updater/src/DebUpdater.ts
+++ b/packages/electron-updater/src/DebUpdater.ts
@@ -31,7 +31,8 @@ export class DebUpdater extends BaseUpdater {
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
-    const cmd = ["dpkg", "-i", options.installerPath, "||", "apt-get", "install", "-f", "-y"]
+    const installerPath = options.installerPath.replace(/ /g, "\\ ")
+    const cmd = ["dpkg", "-i", installerPath, "||", "apt-get", "install", "-f", "-y"]
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {
       this.app.relaunch()

--- a/packages/electron-updater/src/PacmanUpdater.ts
+++ b/packages/electron-updater/src/PacmanUpdater.ts
@@ -27,11 +27,19 @@ export class PacmanUpdater extends BaseUpdater {
     })
   }
 
+  protected get installerPath(): string | null {
+    return super.installerPath?.replace(/ /g, "\\ ") ?? null
+  }
+
   protected doInstall(options: InstallOptions): boolean {
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
-    const installerPath = options.installerPath.replace(/ /g, "\\ ")
+    const installerPath = this.installerPath
+    if (installerPath == null) {
+      this.dispatchError(new Error("No valid update available, can't quit and install"))
+      return false
+    }
     const cmd = ["pacman", "-U", "--noconfirm", installerPath]
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {

--- a/packages/electron-updater/src/PacmanUpdater.ts
+++ b/packages/electron-updater/src/PacmanUpdater.ts
@@ -31,7 +31,8 @@ export class PacmanUpdater extends BaseUpdater {
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
-    const cmd = ["pacman", "-U", "--noconfirm", options.installerPath]
+    const installerPath = options.installerPath.replace(/ /g, "\\ ")
+    const cmd = ["pacman", "-U", "--noconfirm", installerPath]
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {
       this.app.relaunch()

--- a/packages/electron-updater/src/RpmUpdater.ts
+++ b/packages/electron-updater/src/RpmUpdater.ts
@@ -28,17 +28,17 @@ export class RpmUpdater extends BaseUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const upgradePath = options.installerPath
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
     const packageManager = this.spawnSyncLog("which zypper")
+    const installerPath = options.installerPath.replace(/ /g, "\\ ")
     let cmd: string[]
     if (!packageManager) {
       const packageManager = this.spawnSyncLog("which dnf || which yum")
-      cmd = [packageManager, "-y", "install", upgradePath]
+      cmd = [packageManager, "-y", "install", installerPath]
     } else {
-      cmd = [packageManager, "--no-refresh", "install", "--allow-unsigned-rpm", "-y", "-f", upgradePath]
+      cmd = [packageManager, "--no-refresh", "install", "--allow-unsigned-rpm", "-y", "-f", installerPath]
     }
     this.spawnSyncLog(sudo, [`${wrapper}/bin/bash`, "-c", `'${cmd.join(" ")}'${wrapper}`])
     if (options.isForceRunAfter) {

--- a/packages/electron-updater/src/RpmUpdater.ts
+++ b/packages/electron-updater/src/RpmUpdater.ts
@@ -27,12 +27,20 @@ export class RpmUpdater extends BaseUpdater {
     })
   }
 
+  protected get installerPath(): string | null {
+    return super.installerPath?.replace(/ /g, "\\ ") ?? null
+  }
+
   protected doInstall(options: InstallOptions): boolean {
     const sudo = this.wrapSudo()
     // pkexec doesn't want the command to be wrapped in " quotes
     const wrapper = /pkexec/i.test(sudo) ? "" : `"`
     const packageManager = this.spawnSyncLog("which zypper")
-    const installerPath = options.installerPath.replace(/ /g, "\\ ")
+    const installerPath = this.installerPath
+    if (installerPath == null) {
+      this.dispatchError(new Error("No valid update available, can't quit and install"))
+      return false
+    }
     let cmd: string[]
     if (!packageManager) {
       const packageManager = this.spawnSyncLog("which dnf || which yum")


### PR DESCRIPTION
Revert move of space escape to BaseUpdater (from #8403) and instead do it separately in DebUpdater, PacmanUpdater and RpmUpdater as this escape breaks AppImageUpdater. Fixes #8698.