### PR TITLE
fix: allow `skipLibCheck: false`

### DIFF
--- a/.changeset/metal-bulldogs-film.md
+++ b/.changeset/metal-bulldogs-film.md
@@ -1,0 +1,8 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+"builder-util-runtime": patch
+"dmg-builder": patch
+---
+
+chore: extract common `undefined | null` to reuse current (unexported) type `Nullish`. Expose `FileMatcher` instead of `@internal` flag

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,7 @@ export default [{
         sourceType: "script",
 
         parserOptions: {
-            project: ["./packages/*/tsconfig.json"],
+            project: ["./packages/*/tsconfig.json", "./test/tsconfig.json"],
         },
     },
 

--- a/packages/app-builder-lib/src/appInfo.ts
+++ b/packages/app-builder-lib/src/appInfo.ts
@@ -4,6 +4,7 @@ import { PlatformSpecificBuildOptions } from "./options/PlatformSpecificBuildOpt
 import { Packager } from "./packager"
 import { expandMacro } from "./util/macroExpander"
 import { sanitizeFileName } from "builder-util/out/filename"
+import { Nullish } from "builder-util-runtime"
 
 // fpm bug - rpm build --description is not escaped, well... decided to replace quite to smart quote
 // http://leancrew.com/all-this/2010/11/smart-quotes-in-javascript/
@@ -35,7 +36,7 @@ export class AppInfo {
 
   constructor(
     private readonly info: Packager,
-    buildVersion: string | null | undefined,
+    buildVersion: string | Nullish,
     private readonly platformSpecificOptions: PlatformSpecificBuildOptions | null = null,
     normalizeNfd = false
   ) {
@@ -116,7 +117,7 @@ export class AppInfo {
   }
 
   get id(): string {
-    let appId: string | null | undefined = null
+    let appId: string | Nullish = null
     for (const options of [this.platformSpecificOptions, this.info.config]) {
       if (options != null && appId == null) {
         appId = options.appId

--- a/packages/app-builder-lib/src/binDownload.ts
+++ b/packages/app-builder-lib/src/binDownload.ts
@@ -1,4 +1,5 @@
 import { executeAppBuilder } from "builder-util"
+import { Nullish } from "builder-util-runtime"
 
 const versionToPromise = new Map<string, Promise<string>>()
 
@@ -54,7 +55,7 @@ export function getBin(name: string, url?: string | null, checksum?: string | nu
   return promise
 }
 
-function doGetBin(name: string, url: string | undefined | null, checksum: string | null | undefined): Promise<string> {
+function doGetBin(name: string, url: string | Nullish, checksum: string | Nullish): Promise<string> {
   const args = ["download-artifact", "--name", name]
   if (url != null) {
     args.push("--url", url)

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -13,6 +13,7 @@ import { importCertificate } from "./codesign"
 import { Identity as _Identity } from "@electron/osx-sign/dist/cjs/util-identities"
 import { SignOptions } from "@electron/osx-sign/dist/cjs/types"
 import { signAsync } from "@electron/osx-sign"
+import { Nullish } from "builder-util-runtime"
 
 export const appleCertificatePrefixes = ["Developer ID Application:", "Developer ID Installer:", "3rd Party Mac Developer Application:", "3rd Party Mac Developer Installer:"]
 
@@ -59,13 +60,7 @@ export function isSignAllowed(isPrintWarn = true): boolean {
   return true
 }
 
-export async function reportError(
-  isMas: boolean,
-  certificateTypes: CertType[],
-  qualifier: string | null | undefined,
-  keychainFile: string | null | undefined,
-  isForceCodeSigning: boolean
-) {
+export async function reportError(isMas: boolean, certificateTypes: CertType[], qualifier: string | Nullish, keychainFile: string | Nullish, isForceCodeSigning: boolean) {
   const logFields: Fields = {}
   if (qualifier == null) {
     logFields.reason = ""

--- a/packages/app-builder-lib/src/codeSign/signManager.ts
+++ b/packages/app-builder-lib/src/codeSign/signManager.ts
@@ -1,14 +1,14 @@
 import { Lazy } from "lazy-val"
 import { WindowsSignOptions } from "./windowsCodeSign"
 import { Target } from "../core"
-import { MemoLazy } from "builder-util-runtime"
+import { MemoLazy, Nullish } from "builder-util-runtime"
 import { FileCodeSigningInfo, CertificateFromStoreInfo } from "./windowsSignToolManager"
 import { WindowsConfiguration } from "../options/winOptions"
 
 export interface SignManager {
   readonly computedPublisherName: Lazy<Array<string> | null>
   readonly cscInfo: MemoLazy<WindowsConfiguration, FileCodeSigningInfo | CertificateFromStoreInfo | null>
-  computePublisherName(target: Target, publisherName: string | null | undefined): Promise<string>
+  computePublisherName(target: Target, publisherName: string | Nullish): Promise<string>
   initialize(): Promise<void>
   signFile(options: WindowsSignOptions): Promise<boolean>
 }

--- a/packages/app-builder-lib/src/core.ts
+++ b/packages/app-builder-lib/src/core.ts
@@ -1,5 +1,5 @@
 import { Arch, archFromString, ArchType } from "builder-util"
-import { AllPublishOptions } from "builder-util-runtime"
+import { AllPublishOptions, Nullish } from "builder-util-runtime"
 
 // https://github.com/YousefED/typescript-json-schema/issues/80
 export type Publish = AllPublishOptions | Array<AllPublishOptions> | null
@@ -73,7 +73,7 @@ export class Platform {
 
 export abstract class Target {
   abstract readonly outDir: string
-  abstract readonly options: TargetSpecificOptions | null | undefined
+  abstract readonly options: TargetSpecificOptions | Nullish
 
   protected constructor(
     readonly name: string,

--- a/packages/app-builder-lib/src/electron/electronVersion.ts
+++ b/packages/app-builder-lib/src/electron/electronVersion.ts
@@ -1,7 +1,7 @@
 import { getProjectRootPath } from "@electron/rebuild/lib/search-module"
 
 import { InvalidConfigurationError, log } from "builder-util"
-import { parseXml } from "builder-util-runtime"
+import { ObjectMap, parseXml } from "builder-util-runtime"
 import { httpExecutor } from "builder-util"
 import { readJson } from "fs-extra"
 import { Lazy } from "lazy-val"
@@ -11,7 +11,7 @@ import * as semver from "semver"
 import { Configuration } from "../configuration"
 import { getConfig } from "../util/config/config"
 
-export type MetadataValue = Lazy<{ [key: string]: any } | null>
+export type MetadataValue = Lazy<ObjectMap<any> | null>
 
 const electronPackages = ["electron", "electron-prebuilt", "electron-prebuilt-compile", "electron-nightly"]
 

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -6,6 +6,7 @@ import * as path from "path"
 import { Configuration, FileSet, Packager, PlatformSpecificBuildOptions } from "./index"
 import { PlatformPackager } from "./platformPackager"
 import { createFilter, hasMagic } from "./util/filter"
+import { Nullish } from "builder-util-runtime"
 
 // https://github.com/electron-userland/electron-builder/issues/733
 const minimatchOptions = { dot: true }
@@ -38,7 +39,6 @@ function ensureNoEndSlash(file: string): string {
   }
 }
 
-/** @internal */
 export class FileMatcher {
   readonly from: string
   readonly to: string
@@ -233,7 +233,7 @@ export function getNodeModuleFileMatcher(
   // grab only excludes
   const matcher = new FileMatcher(appDir, destination, macroExpander)
 
-  function addPatterns(patterns: Array<string | FileSet> | string | null | undefined | FileSet) {
+  function addPatterns(patterns: Array<string | FileSet> | string | Nullish | FileSet) {
     if (patterns == null) {
       return
     } else if (!Array.isArray(patterns)) {
@@ -295,7 +295,7 @@ export function getFileMatchers(
   const defaultMatcher = new FileMatcher(options.defaultSrc, defaultDestination, options.macroExpander)
   const fileMatchers: Array<FileMatcher> = []
 
-  function addPatterns(patterns: Array<string | FileSet> | string | null | undefined | FileSet) {
+  function addPatterns(patterns: Array<string | FileSet> | string | Nullish | FileSet) {
     if (patterns == null) {
       return
     } else if (!Array.isArray(patterns)) {

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -19,7 +19,7 @@ import { getTemplatePath } from "./util/pathManager"
 import * as fs from "fs/promises"
 import { notarize } from "@electron/notarize"
 import { NotarizeOptionsNotaryTool, NotaryToolKeychainCredentials } from "@electron/notarize/lib/types"
-import { MemoLazy } from "builder-util-runtime"
+import { MemoLazy, Nullish } from "builder-util-runtime"
 import { resolveFunction } from "./util/resolve"
 
 export type CustomMacSignOptions = SignOptions
@@ -443,7 +443,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
   }
 
   //noinspection JSMethodCanBeStatic
-  protected async doFlat(appPath: string, outFile: string, identity: Identity, keychain: string | null | undefined): Promise<any> {
+  protected async doFlat(appPath: string, outFile: string, identity: Identity, keychain: string | Nullish): Promise<any> {
     // productbuild doesn't created directory for out file
     await mkdir(path.dirname(outFile), { recursive: true })
 

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -1,3 +1,4 @@
+import { ObjectMap } from "builder-util-runtime"
 import { CompressionLevel, Publish, TargetConfiguration, TargetSpecificOptions } from "../core"
 import { FileAssociation } from "./FileAssociation"
 
@@ -224,7 +225,7 @@ export interface ReleaseInfo {
   /**
    * Vendor specific information.
    */
-  vendor?: { [key: string]: any } | null
+  vendor?: ObjectMap<any> | null
 }
 
 /**

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -1,3 +1,4 @@
+import { ObjectMap } from "builder-util-runtime"
 import { TargetSpecificOptions } from "../core"
 import { CommonLinuxOptions } from "./linuxOptions"
 
@@ -16,7 +17,7 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
   /**
    * The custom environment. Defaults to `{"TMPDIR: "$XDG_RUNTIME_DIR"}`. If you set custom, it will be merged with default.
    */
-  readonly environment?: { [key: string]: string } | null
+  readonly environment?: ObjectMap<string> | null
 
   /**
    * The 78 character long summary. Defaults to [productName](./configuration.md#productName).
@@ -117,7 +118,7 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
   /**
    * Specifies any files to make accessible from locations such as `/usr`, `/var`, and `/etc`. See [snap layouts](https://snapcraft.io/docs/snap-layouts) to learn more.
    */
-  readonly layout?: { [key: string]: { [key: string]: string } } | null
+  readonly layout?: ObjectMap<ObjectMap<string>> | null
 
   /**
    * Specifies which files from the app part to stage and which to exclude. Individual files, directories, wildcards, globstars, and exclusions are accepted. See [Snapcraft filesets](https://snapcraft.io/docs/snapcraft-filesets) to learn more about the format.
@@ -144,9 +145,9 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
 }
 
 export interface PlugDescriptor {
-  [key: string]: { [key: string]: any } | null
+  [key: string]: ObjectMap<any> | null
 }
 
 export interface SlotDescriptor {
-  [key: string]: { [key: string]: any } | null
+  [key: string]: ObjectMap<any> | null
 }

--- a/packages/app-builder-lib/src/options/metadata.ts
+++ b/packages/app-builder-lib/src/options/metadata.ts
@@ -1,3 +1,4 @@
+import { ObjectMap } from "builder-util-runtime"
 import { Configuration } from "../configuration"
 
 export interface Metadata {
@@ -37,7 +38,7 @@ export interface Metadata {
   readonly build?: Configuration
 
   /** @private */
-  readonly dependencies?: { [key: string]: string }
+  readonly dependencies?: ObjectMap<string>
   /** @private */
   readonly version?: string
   /** @private */

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -1,5 +1,6 @@
 import { PlatformSpecificBuildOptions, TargetConfigType } from "../index"
 import { CustomWindowsSign } from "../codeSign/windowsSignToolManager"
+import { Nullish } from "builder-util-runtime"
 
 export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   /**
@@ -167,5 +168,5 @@ export interface WindowsAzureSigningConfiguration {
    * Allow other CLI parameters (verbatim case-sensitive) to `Invoke-TrustedSigning`
    * Note: Key-Value pairs with `undefined`/`null` value are filtered out of the command.
    */
-  [k: string]: string | undefined | null
+  [k: string]: string | Nullish
 }

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -33,6 +33,7 @@ import { expandMacro as doExpandMacro } from "./util/macroExpander"
 import { resolveFunction } from "./util/resolve"
 import { flipFuses, FuseConfig, FuseV1Config, FuseV1Options, FuseVersion } from "@electron/fuses"
 import { FuseOptionsV1 } from "./configuration"
+import { Nullish } from "builder-util-runtime"
 
 export type DoPackOptions<DC extends PlatformSpecificBuildOptions> = {
   outDir: string
@@ -103,7 +104,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return new AppInfo(this.info, null, this.platformSpecificBuildOptions)
   }
 
-  private static normalizePlatformSpecificBuildOptions(options: any | null | undefined): any {
+  private static normalizePlatformSpecificBuildOptions(options: any | Nullish): any {
     return options == null ? Object.create(null) : options
   }
 
@@ -119,13 +120,13 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
   }
 
-  getCscLink(extraEnvName?: string | null): string | null | undefined {
+  getCscLink(extraEnvName?: string | null): string | Nullish {
     // allow to specify as empty string
     const envValue = chooseNotNull(extraEnvName == null ? null : process.env[extraEnvName], process.env.CSC_LINK)
     return chooseNotNull(chooseNotNull(this.info.config.cscLink, this.platformSpecificBuildOptions.cscLink), envValue)
   }
 
-  doGetCscPassword(): string | null | undefined {
+  doGetCscPassword(): string | Nullish {
     // allow to specify as empty string
     return chooseNotNull(chooseNotNull(this.info.config.cscKeyPassword, this.platformSpecificBuildOptions.cscKeyPassword), process.env.CSC_KEY_PASSWORD)
   }
@@ -690,7 +691,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
   }
 
   expandArtifactNamePattern(
-    targetSpecificOptions: TargetSpecificOptions | null | undefined,
+    targetSpecificOptions: TargetSpecificOptions | Nullish,
     ext: string,
     arch?: Arch | null,
     defaultPattern?: string,
@@ -701,7 +702,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return this.computeArtifactName(pattern, ext, !isUserForced && skipDefaultArch && arch === defaultArchFromString(defaultArch) ? null : arch)
   }
 
-  artifactPatternConfig(targetSpecificOptions: TargetSpecificOptions | null | undefined, defaultPattern: string | undefined) {
+  artifactPatternConfig(targetSpecificOptions: TargetSpecificOptions | Nullish, defaultPattern: string | undefined) {
     const userSpecifiedPattern = targetSpecificOptions?.artifactName || this.platformSpecificBuildOptions.artifactName || this.config.artifactName
     return {
       isUserForced: !!userSpecifiedPattern,
@@ -709,12 +710,12 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
   }
 
-  expandArtifactBeautyNamePattern(targetSpecificOptions: TargetSpecificOptions | null | undefined, ext: string, arch?: Arch | null): string {
+  expandArtifactBeautyNamePattern(targetSpecificOptions: TargetSpecificOptions | Nullish, ext: string, arch?: Arch | null): string {
     // tslint:disable-next-line:no-invalid-template-strings
     return this.expandArtifactNamePattern(targetSpecificOptions, ext, arch, "${productName} ${version} ${arch}.${ext}", true)
   }
 
-  private computeArtifactName(pattern: any, ext: string, arch: Arch | null | undefined): string {
+  private computeArtifactName(pattern: any, ext: string, arch: Arch | Nullish): string {
     const archName = arch == null ? null : getArtifactArchName(arch, ext)
     return this.expandMacro(pattern, archName, {
       ext,
@@ -725,7 +726,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return doExpandMacro(pattern, arch, this.appInfo, { os: this.platform.buildConfigurationKey, ...extra }, isProductNameSanitized)
   }
 
-  generateName2(ext: string | null, classifier: string | null | undefined, deployment: boolean): string {
+  generateName2(ext: string | null, classifier: string | Nullish, deployment: boolean): string {
     const dotExt = ext == null ? "" : `.${ext}`
     const separator = ext === "deb" ? "_" : "-"
     return `${deployment ? this.appInfo.name : this.appInfo.productFilename}${separator}${this.appInfo.version}${classifier == null ? "" : `${separator}${classifier}`}${dotExt}`
@@ -739,7 +740,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return asArray(this.config.fileAssociations).concat(asArray(this.platformSpecificBuildOptions.fileAssociations))
   }
 
-  async getResource(custom: string | null | undefined, ...names: Array<string>): Promise<string | null> {
+  async getResource(custom: string | Nullish, ...names: Array<string>): Promise<string | null> {
     const resourcesDir = this.info.buildResourcesDir
     if (custom === undefined) {
       const resourceList = await this.resourceList
@@ -869,7 +870,7 @@ export function normalizeExt(ext: string) {
   return ext.startsWith(".") ? ext.substring(1) : ext
 }
 
-export function chooseNotNull<T>(v1: T | null | undefined, v2: T | null | undefined): T | null | undefined {
+export function chooseNotNull<T>(v1: T | Nullish, v2: T | Nullish): T | Nullish {
   return v1 == null ? v2 : v1
 }
 

--- a/packages/app-builder-lib/src/publish/PublishManager.ts
+++ b/packages/app-builder-lib/src/publish/PublishManager.ts
@@ -11,6 +11,7 @@ import {
   PublishConfiguration,
   PublishProvider,
   BitbucketOptions,
+  Nullish,
 } from "builder-util-runtime"
 import _debug from "debug"
 import {
@@ -390,7 +391,7 @@ export function computeDownloadUrl(publishConfiguration: PublishConfiguration, f
 
 export async function getPublishConfigs(
   platformPackager: PlatformPackager<any>,
-  targetSpecificOptions: PlatformSpecificBuildOptions | null | undefined,
+  targetSpecificOptions: PlatformSpecificBuildOptions | Nullish,
   arch: Arch | null,
   errorIfCannot: boolean
 ): Promise<Array<PublishConfiguration> | null> {

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -10,10 +10,11 @@ import { getTemplatePath } from "../util/pathManager"
 import { VmManager } from "../vm/vm"
 import { WinPackager } from "../winPackager"
 import { createStageDir } from "./targetUtil"
+import { Nullish, ObjectMap } from "builder-util-runtime"
 
 const APPX_ASSETS_DIR_NAME = "appx"
 
-const vendorAssetsForDefaultAssets: { [key: string]: string } = {
+const vendorAssetsForDefaultAssets: ObjectMap<string> = {
   "StoreLogo.png": "SampleAppx.50x50.png",
   "Square150x150Logo.png": "SampleAppx.150x150.png",
   "Square44x44Logo.png": "SampleAppx.44x44.png",
@@ -386,7 +387,7 @@ export default class AppXTarget extends Target {
 }
 
 // get the resource - language tag, see https://docs.microsoft.com/en-us/windows/uwp/globalizing/manage-language-and-region#specify-the-supported-languages-in-the-apps-manifest
-function resourceLanguageTag(userLanguages: Array<string> | null | undefined): string {
+function resourceLanguageTag(userLanguages: Array<string> | Nullish): string {
   if (userLanguages == null || userLanguages.length === 0) {
     userLanguages = [DEFAULT_RESOURCE_LANG]
   }

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -18,6 +18,7 @@ import { hashFile } from "../util/hash"
 import { ArtifactCreated } from "../packagerApi"
 import { getAppUpdatePublishConfiguration } from "../publish/PublishManager"
 import { getPath7za } from "builder-util"
+import { Nullish } from "builder-util-runtime"
 
 interface FpmOptions {
   name: string
@@ -60,7 +61,7 @@ export default class FpmTarget extends Target {
       ...packager.platformSpecificBuildOptions,
     }
 
-    function getResource(value: string | null | undefined, defaultFile: string) {
+    function getResource(value: string | Nullish, defaultFile: string) {
       if (value == null) {
         return path.join(defaultTemplatesDir, defaultFile)
       }

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -5,6 +5,7 @@ import { LinuxPackager } from "../linuxPackager"
 import { LinuxTargetSpecificOptions } from "../options/linuxOptions"
 import { IconInfo } from "../platformPackager"
 import { join } from "path"
+import { ObjectMap } from "builder-util-runtime"
 
 export const installPrefix = "/opt"
 
@@ -91,14 +92,14 @@ export class LinuxTargetHelper {
     }
   }
 
-  async writeDesktopEntry(targetSpecificOptions: LinuxTargetSpecificOptions, exec?: string, destination?: string | null, extra?: { [key: string]: string }): Promise<string> {
+  async writeDesktopEntry(targetSpecificOptions: LinuxTargetSpecificOptions, exec?: string, destination?: string | null, extra?: ObjectMap<string>): Promise<string> {
     const data = await this.computeDesktopEntry(targetSpecificOptions, exec, extra)
     const file = destination || (await this.packager.getTempFile(`${this.packager.appInfo.productFilename}.desktop`))
     await outputFile(file, data)
     return file
   }
 
-  computeDesktopEntry(targetSpecificOptions: LinuxTargetSpecificOptions, exec?: string, extra?: { [key: string]: string }): Promise<string> {
+  computeDesktopEntry(targetSpecificOptions: LinuxTargetSpecificOptions, exec?: string, extra?: ObjectMap<string>): Promise<string> {
     if (exec != null && exec.length === 0) {
       throw new Error("Specified exec is empty")
     }

--- a/packages/app-builder-lib/src/targets/pkg.ts
+++ b/packages/app-builder-lib/src/targets/pkg.ts
@@ -9,6 +9,7 @@ import { findIdentity, Identity } from "../codeSign/macCodeSign"
 import { Target } from "../core"
 import { MacPackager } from "../macPackager"
 import { readdirSync } from "fs"
+import { Nullish } from "builder-util-runtime"
 
 const certType = "Developer ID Installer"
 
@@ -205,7 +206,7 @@ export class PkgTarget extends Target {
   }
 }
 
-export function prepareProductBuildArgs(identity: Identity | null, keychain: string | null | undefined): Array<string> {
+export function prepareProductBuildArgs(identity: Identity | null, keychain: string | Nullish): Array<string> {
   const args: Array<string> = []
   if (identity != null) {
     args.push("--sign", identity.hash!)

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -1,5 +1,5 @@
 import { Arch, deepAssign, executeAppBuilder, InvalidConfigurationError, log, replaceDefault as _replaceDefault, serializeToYaml, toLinuxArchString } from "builder-util"
-import { SnapStoreOptions, asArray } from "builder-util-runtime"
+import { Nullish, ObjectMap, SnapStoreOptions, asArray } from "builder-util-runtime"
 import { outputFile, readFile } from "fs-extra"
 import { load } from "js-yaml"
 import * as path from "path"
@@ -28,7 +28,7 @@ export default class SnapTarget extends Target {
     super(name)
   }
 
-  private replaceDefault(inList: Array<string> | null | undefined, defaultList: Array<string>) {
+  private replaceDefault(inList: Array<string> | Nullish, defaultList: Array<string>) {
     const result = _replaceDefault(inList, defaultList)
     if (result !== defaultList) {
       this.isUseTemplateApp = false
@@ -350,7 +350,7 @@ function isArrayEqualRegardlessOfSort(a: Array<string>, b: Array<string>) {
   return a.length === b.length && a.every((value, index) => value === b[index])
 }
 
-function normalizePlugConfiguration(raw: Array<string | PlugDescriptor> | PlugDescriptor | null | undefined): { [key: string]: { [name: string]: any } | null } | null {
+function normalizePlugConfiguration(raw: Array<string | PlugDescriptor> | PlugDescriptor | Nullish): ObjectMap<ObjectMap<any> | null> | null {
   if (raw == null) {
     return null
   }

--- a/packages/app-builder-lib/src/util/appBuilder.ts
+++ b/packages/app-builder-lib/src/util/appBuilder.ts
@@ -1,4 +1,5 @@
 import { executeAppBuilder } from "builder-util"
+import { ObjectMap } from "builder-util-runtime"
 import { SpawnOptions } from "child_process"
 
 export function executeAppBuilderAsJson<T>(args: Array<string>): Promise<T> {
@@ -28,7 +29,7 @@ export function executeAppBuilderAndWriteJson(args: Array<string>, data: any, ex
   )
 }
 
-export function objectToArgs(to: Array<string>, argNameToValue: { [key: string]: string | null }): void {
+export function objectToArgs(to: Array<string>, argNameToValue: ObjectMap<string | null>): void {
   for (const name of Object.keys(argNameToValue)) {
     const value = argNameToValue[name]
     if (value != null) {

--- a/packages/app-builder-lib/src/util/bundledTool.ts
+++ b/packages/app-builder-lib/src/util/bundledTool.ts
@@ -1,9 +1,11 @@
+import { Nullish } from "builder-util-runtime"
+
 export interface ToolInfo {
   path: string
   env?: any
 }
 
-export function computeEnv(oldValue: string | null | undefined, newValues: Array<string>): string {
+export function computeEnv(oldValue: string | Nullish, newValues: Array<string>): string {
   const parsedOldValue = oldValue ? oldValue.split(":") : []
   return newValues
     .concat(parsedOldValue)

--- a/packages/app-builder-lib/src/util/config/config.ts
+++ b/packages/app-builder-lib/src/util/config/config.ts
@@ -7,6 +7,7 @@ import { Configuration } from "../../configuration"
 import { FileSet } from "../../options/PlatformSpecificBuildOptions"
 import { reactCra } from "../../presets/rectCra"
 import { PACKAGE_VERSION } from "../../version"
+import { Nullish, ObjectMap } from "builder-util-runtime"
 const validateSchema = require("@develar/schema-utils")
 
 // https://github.com/electron-userland/electron-builder/issues/1847
@@ -35,8 +36,8 @@ function mergePublish(config: Configuration, configFromOptions: Configuration) {
 export async function getConfig(
   projectDir: string,
   configPath: string | null,
-  configFromOptions: Configuration | null | undefined,
-  packageMetadata: Lazy<{ [key: string]: any } | null> = new Lazy(() => orNullIfFileNotExist(readJson(path.join(projectDir, "package.json"))))
+  configFromOptions: Configuration | Nullish,
+  packageMetadata: Lazy<ObjectMap<any> | null> = new Lazy(() => orNullIfFileNotExist(readJson(path.join(projectDir, "package.json"))))
 ): Promise<Configuration> {
   const configRequest: ReadConfigRequest = { packageKey: "build", configFilename: "electron-builder", projectDir, packageMetadata }
   const configAndEffectiveFile = await _getConfig<Configuration>(configRequest, configPath)
@@ -81,7 +82,7 @@ export async function getConfig(
   return doMergeConfigs([...parentConfigs, config])
 }
 
-function asArray(value: string[] | string | undefined | null): string[] {
+function asArray(value: string[] | string | Nullish): string[] {
   return Array.isArray(value) ? value : typeof value === "string" ? [value] : []
 }
 
@@ -263,7 +264,7 @@ export async function validateConfiguration(config: Configuration, debugLogger: 
 
 const DEFAULT_APP_DIR_NAMES = ["app", "www"]
 
-export async function computeDefaultAppDirectory(projectDir: string, userAppDir: string | null | undefined): Promise<string> {
+export async function computeDefaultAppDirectory(projectDir: string, userAppDir: string | Nullish): Promise<string> {
   if (userAppDir != null) {
     const absolutePath = path.resolve(projectDir, userAppDir)
     const stat = await statOrNull(absolutePath)

--- a/packages/app-builder-lib/src/util/config/load.ts
+++ b/packages/app-builder-lib/src/util/config/load.ts
@@ -7,6 +7,7 @@ import { loadTsConfig } from "config-file-ts"
 import { DotenvParseInput, expand } from "dotenv-expand"
 import { resolveModule } from "../resolve"
 import { log } from "builder-util"
+import { ObjectMap } from "builder-util-runtime"
 
 export interface ReadConfigResult<T> {
   readonly result: T
@@ -73,7 +74,7 @@ export interface ReadConfigRequest {
   configFilename: string
 
   projectDir: string
-  packageMetadata: Lazy<{ [key: string]: any } | null> | null
+  packageMetadata: Lazy<ObjectMap<any> | null> | null
 }
 
 export async function loadConfig<T>(request: ReadConfigRequest): Promise<ReadConfigResult<T> | null> {

--- a/packages/app-builder-lib/src/util/license.ts
+++ b/packages/app-builder-lib/src/util/license.ts
@@ -1,6 +1,7 @@
 import * as path from "path"
 import { langIdToName, toLangWithRegion } from "./langs"
 import { PlatformPackager } from "../platformPackager"
+import { Nullish } from "builder-util-runtime"
 
 export function getLicenseAssets(fileNames: Array<string>, packager: PlatformPackager<any>) {
   return fileNames
@@ -24,7 +25,7 @@ export function getLicenseAssets(fileNames: Array<string>, packager: PlatformPac
 }
 
 export async function getNotLocalizedLicenseFile(
-  custom: string | null | undefined,
+  custom: string | Nullish,
   packager: PlatformPackager<any>,
   supportedExtension: Array<string> = ["rtf", "txt", "html"]
 ): Promise<string | null> {

--- a/packages/app-builder-lib/src/util/macroExpander.ts
+++ b/packages/app-builder-lib/src/util/macroExpander.ts
@@ -1,7 +1,8 @@
 import { InvalidConfigurationError } from "builder-util"
 import { AppInfo } from "../appInfo"
+import { Nullish } from "builder-util-runtime"
 
-export function expandMacro(pattern: string, arch: string | null | undefined, appInfo: AppInfo, extra: any = {}, isProductNameSanitized = true): string {
+export function expandMacro(pattern: string, arch: string | Nullish, appInfo: AppInfo, extra: any = {}, isProductNameSanitized = true): string {
   if (arch == null) {
     pattern = pattern
       // tslint:disable-next-line:no-invalid-template-strings

--- a/packages/app-builder-lib/src/util/packageMetadata.ts
+++ b/packages/app-builder-lib/src/util/packageMetadata.ts
@@ -4,6 +4,7 @@ import * as path from "path"
 import * as semver from "semver"
 import { Metadata } from "../options/metadata"
 import { normalizePackageData } from "./normalizePackageData"
+import { Nullish, ObjectMap } from "builder-util-runtime"
 
 /** @internal */
 export async function readPackageJson(file: string): Promise<any> {
@@ -38,7 +39,7 @@ export function checkMetadata(metadata: Metadata, devMetadata: any | null, appPa
     errors.push(`Please specify '${missedFieldName}' in the package.json (${appPackageFile})`)
   }
 
-  const checkNotEmpty = (name: string, value: string | null | undefined) => {
+  const checkNotEmpty = (name: string, value: string | Nullish) => {
     if (isEmptyOrSpaces(value)) {
       reportError(name)
     }
@@ -92,7 +93,7 @@ function versionSatisfies(version: string | semver.SemVer | null, range: string 
   return semver.satisfies(coerced, range, loose)
 }
 
-function checkDependencies(dependencies: { [key: string]: string } | null | undefined, errors: Array<string>) {
+function checkDependencies(dependencies: ObjectMap<string> | Nullish, errors: Array<string>) {
   if (dependencies == null) {
     return
   }

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -10,6 +10,7 @@ import { getProjectRootPath } from "@electron/rebuild/lib/search-module"
 import { rebuild as remoteRebuild } from "./rebuild/rebuild"
 import { executeAppBuilderAndWriteJson } from "./appBuilder"
 import { RebuildMode } from "@electron/rebuild/lib/types"
+import { Nullish } from "builder-util-runtime"
 
 export async function installOrRebuild(config: Configuration, appDir: string, options: RebuildOptions, forceInstall = false) {
   const effectiveOptions: RebuildOptions = {
@@ -153,7 +154,7 @@ function getPackageToolPath() {
   }
 }
 
-function isRunningYarn(execPath: string | null | undefined) {
+function isRunningYarn(execPath: string | Nullish) {
   const userAgent = process.env.npm_config_user_agent
   return process.env.FORCE_YARN === "true" || (execPath != null && path.basename(execPath).startsWith("yarn")) || (userAgent != null && /\byarn\b/.test(userAgent))
 }

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -25,6 +25,7 @@ import { time } from "./util/timer"
 import { getWindowsVm, VmManager } from "./vm/vm"
 import { execWine } from "./wine"
 import { SignManager } from "./codeSign/signManager"
+import { Nullish } from "builder-util-runtime"
 
 export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   _iconPath = new Lazy(() => this.getOrConvertIcon("ico"))
@@ -114,7 +115,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     return this._iconPath.value
   }
 
-  doGetCscPassword(): string | undefined | null {
+  doGetCscPassword(): string | Nullish {
     return chooseNotNull(chooseNotNull(this.platformSpecificBuildOptions.signtoolOptions?.certificatePassword, process.env.WIN_CSC_KEY_PASSWORD), super.doGetCscPassword())
   }
 

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -8,6 +8,7 @@ import { URL } from "url"
 import { CancellationToken } from "./CancellationToken"
 import { newError } from "./error"
 import { ProgressCallbackTransform, ProgressInfo } from "./ProgressCallbackTransform"
+import { Nullish } from "."
 
 const debug = _debug("electron-builder")
 
@@ -424,7 +425,7 @@ export class DigestTransform extends Transform {
   }
 }
 
-function checkSha2(sha2Header: string | null | undefined, sha2: string | null | undefined, callback: (error: Error | null) => void): boolean {
+function checkSha2(sha2Header: string | Nullish, sha2: string | Nullish, callback: (error: Error | null) => void): boolean {
   if (sha2Header != null && sha2 != null && sha2Header !== sha2) {
     callback(new Error(`checksum mismatch: expected ${sha2} but got ${sha2Header} (X-Checksum-Sha2 header)`))
     return false

--- a/packages/builder-util-runtime/src/index.ts
+++ b/packages/builder-util-runtime/src/index.ts
@@ -44,7 +44,7 @@ export const CURRENT_APP_INSTALLER_FILE_NAME = "installer.exe"
 // nsis-web
 export const CURRENT_APP_PACKAGE_FILE_NAME = "package.7z"
 
-export function asArray<T>(v: null | undefined | T | Array<T>): Array<T> {
+export function asArray<T>(v: Nullish | T | Array<T>): Array<T> {
   if (v == null) {
     return []
   } else if (Array.isArray(v)) {
@@ -53,3 +53,7 @@ export function asArray<T>(v: null | undefined | T | Array<T>): Array<T> {
     return [v]
   }
 }
+
+export type Nullish = null | undefined
+
+export type ObjectMap<ValueType> = { [key: string]: ValueType }

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -1,4 +1,5 @@
 import { OutgoingHttpHeaders } from "http"
+import { Nullish } from "."
 
 export type PublishProvider = "github" | "s3" | "spaces" | "generic" | "custom" | "snapStore" | "keygen" | "bitbucket"
 
@@ -427,7 +428,7 @@ function s3Url(options: S3Options) {
   return appendPath(url, options.path)
 }
 
-function appendPath(url: string, p: string | null | undefined): string {
+function appendPath(url: string, p: string | Nullish): string {
   if (p != null && p.length > 0) {
     if (!p.startsWith("/")) {
       url += "/"

--- a/packages/builder-util-runtime/src/uuid.ts
+++ b/packages/builder-util-runtime/src/uuid.ts
@@ -26,7 +26,7 @@ export class UUID {
   private readonly version: number
 
   // from rfc4122#appendix-C
-  static readonly OID = UUID.parse("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+  static readonly OID: Buffer = UUID.parse("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
 
   constructor(uuid: Buffer | string) {
     const check = UUID.check(uuid)
@@ -103,7 +103,7 @@ export class UUID {
   }
 
   // read stringified uuid into a Buffer
-  static parse(input: string) {
+  static parse(input: string): Buffer {
     const buffer = Buffer.allocUnsafe(16)
     let j = 0
     for (let i = 0; i < 16; i++) {

--- a/packages/builder-util-runtime/src/xml.ts
+++ b/packages/builder-util-runtime/src/xml.ts
@@ -1,9 +1,10 @@
 import * as sax from "sax"
 import { newError } from "./error"
+import { ObjectMap } from "./"
 
 export class XElement {
   value = ""
-  attributes: { [key: string]: string } | null = null
+  attributes: ObjectMap<string> | null = null
   isCData = false
   elements: Array<XElement> | null = null
 
@@ -83,7 +84,7 @@ export function parseXml(data: string): XElement {
 
   parser.onopentag = saxElement => {
     const element = new XElement(saxElement.name)
-    element.attributes = saxElement.attributes as { [key: string]: string }
+    element.attributes = saxElement.attributes as ObjectMap<string>
 
     if (rootElement === null) {
       rootElement = element

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -8,6 +8,7 @@ import { Mode } from "stat-mode"
 import { log } from "./log"
 import { orIfFileNotExist, orNullIfFileNotExist } from "./promise"
 import * as isCI from "is-ci"
+import { Nullish } from "builder-util-runtime"
 
 export const MAX_FILE_REQUESTS = 8
 export const CONCURRENCY = { concurrency: MAX_FILE_REQUESTS }
@@ -216,7 +217,7 @@ export function copyOrLinkFile(src: string, dest: string, stats?: Stats | null, 
   return doCopyFile(src, dest, stats)
 }
 
-function doCopyFile(src: string, dest: string, stats: Stats | null | undefined): Promise<any> {
+function doCopyFile(src: string, dest: string, stats: Stats | Nullish): Promise<any> {
   const promise = _nodeCopyFile(src, dest)
   if (stats == null) {
     return promise

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -1,5 +1,5 @@
 import { appBuilderPath } from "app-builder-bin"
-import { safeStringifyJson, retry as _retry } from "builder-util-runtime"
+import { safeStringifyJson, retry as _retry, ObjectMap, Nullish } from "builder-util-runtime"
 import * as chalk from "chalk"
 import { ChildProcess, execFile, ExecFileOptions, SpawnOptions } from "child_process"
 import { spawn as _spawn } from "cross-spawn"
@@ -52,7 +52,7 @@ export function removePassword(input: string) {
   })
 }
 
-function getProcessEnv(env: { [key: string]: string | undefined } | undefined | null): NodeJS.ProcessEnv | undefined {
+function getProcessEnv(env: ObjectMap<string | undefined> | Nullish): NodeJS.ProcessEnv | undefined {
   if (process.platform === "win32") {
     return env == null ? undefined : env
   }
@@ -276,12 +276,11 @@ export class ExecError extends Error {
   }
 }
 
-type Nullish = null | undefined
 export function use<T, R>(value: T | Nullish, task: (value: T) => R): R | null {
   return value == null ? null : task(value)
 }
 
-export function isEmptyOrSpaces(s: string | null | undefined): s is "" | null | undefined {
+export function isEmptyOrSpaces(s: string | Nullish): s is "" | Nullish {
   return s == null || s.trim().length === 0
 }
 
@@ -298,7 +297,7 @@ export function addValue<K, T>(map: Map<K, Array<T>>, key: K, value: T) {
   }
 }
 
-export function replaceDefault(inList: Array<string> | null | undefined, defaultList: Array<string>): Array<string> {
+export function replaceDefault(inList: Array<string> | Nullish, defaultList: Array<string>): Array<string> {
   if (inList == null || (inList.length === 1 && inList[0] === "default")) {
     return defaultList
   }
@@ -315,7 +314,7 @@ export function replaceDefault(inList: Array<string> | null | undefined, default
   return inList
 }
 
-export function getPlatformIconFileName(value: string | null | undefined, isMac: boolean) {
+export function getPlatformIconFileName(value: string | Nullish, isMac: boolean) {
   if (value === undefined) {
     return undefined
   }
@@ -346,7 +345,7 @@ export function isPullRequest() {
   )
 }
 
-export function isEnvTrue(value: string | null | undefined) {
+export function isEnvTrue(value: string | Nullish) {
   if (value != null) {
     value = value.trim()
   }

--- a/packages/dmg-builder/src/dmg.ts
+++ b/packages/dmg-builder/src/dmg.ts
@@ -5,7 +5,7 @@ import { createBlockmap } from "app-builder-lib/out/targets/differentialUpdateIn
 import { executeAppBuilderAsJson } from "app-builder-lib/out/util/appBuilder"
 import { sanitizeFileName } from "builder-util/out/filename"
 import { Arch, AsyncTaskManager, exec, getArchSuffix, InvalidConfigurationError, isEmptyOrSpaces, log, copyDir, copyFile, exists, statOrNull } from "builder-util"
-import { CancellationToken } from "builder-util-runtime"
+import { CancellationToken, Nullish } from "builder-util-runtime"
 import { stat } from "fs-extra"
 import * as path from "path"
 import { TmpDir } from "temp-file"
@@ -212,7 +212,7 @@ function addLogLevel(args: Array<string>): Array<string> {
   return args
 }
 
-async function computeAssetSize(cancellationToken: CancellationToken, dmgFile: string, specification: DmgOptions, backgroundFile: string | null | undefined) {
+async function computeAssetSize(cancellationToken: CancellationToken, dmgFile: string, specification: DmgOptions, backgroundFile: string | Nullish) {
   const asyncTaskManager = new AsyncTaskManager(cancellationToken)
   asyncTaskManager.addTask(stat(dmgFile))
 
@@ -233,7 +233,7 @@ async function computeAssetSize(cancellationToken: CancellationToken, dmgFile: s
   return result
 }
 
-async function customizeDmg(volumePath: string, specification: DmgOptions, packager: MacPackager, backgroundFile: string | null | undefined) {
+async function customizeDmg(volumePath: string, specification: DmgOptions, packager: MacPackager, backgroundFile: string | Nullish) {
   const window = specification.window
   const isValidIconTextSize = !!specification.iconTextSize && specification.iconTextSize >= 10 && specification.iconTextSize <= 16
   const iconTextSize = isValidIconTextSize ? specification.iconTextSize : 12

--- a/test/src/updater/differentialUpdateTest.ts
+++ b/test/src/updater/differentialUpdateTest.ts
@@ -1,7 +1,7 @@
 import { Arch, Configuration, Platform } from "app-builder-lib"
 import { getBinFromUrl } from "app-builder-lib/out/binDownload"
 import { doSpawn, getArchSuffix } from "builder-util"
-import { GenericServerOptions, S3Options } from "builder-util-runtime"
+import { GenericServerOptions, Nullish, S3Options } from "builder-util-runtime"
 import { AppImageUpdater, BaseUpdater, MacUpdater, NoOpLogger, NsisUpdater } from "electron-updater"
 import { EventEmitter } from "events"
 import { move } from "fs-extra"
@@ -29,7 +29,7 @@ async function doBuild(outDirs: Array<string>, targets: Map<Platform, Map<Arch, 
   async function buildApp(
     version: string,
     targets: Map<Platform, Map<Arch, Array<string>>>,
-    extraConfig: Configuration | null | undefined,
+    extraConfig: Configuration | Nullish,
     packed: (context: PackedContext) => Promise<any>
   ) {
     await assertPack(


### PR DESCRIPTION
Tasks:
- Extract common `undefined | null` logic everywhere to reuse (now-exported) type `Nullish`
- Expose `FileMatcher` by removing `@internal` flag (why was it internal to begin with?)
- Created base type `ObjectMap` to reduce writing `{ [key: string]: <anything> }` everywhere.
- Updated eslint to register `test/tsconfig.json`
- Fixes `skipLibCheck: false` by forcing UUID.ts to return a `Buffer` instead of `Buffer<ArrayBuffer>`, which the compiler doesn't like depending on version of node you're on

This should fix: https://github.com/electron-userland/electron-builder/issues/8812