### PR TITLE
chore: adding retry to `winPackagerTest`

### DIFF
--- a/test/src/windows/winPackagerTest.ts
+++ b/test/src/windows/winPackagerTest.ts
@@ -4,6 +4,9 @@ import * as path from "path"
 import { CheckingWinPackager } from "../helpers/CheckingPackager"
 import { app, appThrows, assertPack, platform } from "../helpers/packTester"
 
+// some tests are flaky, specifically `beta`?
+jest.retryTimes(3)
+
 test.ifAll(
   "beta version",
   app(


### PR DESCRIPTION
chore: adding retry to `winPackagerTest` since one test is pretty flaky when running on mac/linux? ¯\_(ツ)_/¯
Specifically the `beta` test:
```
    Failed to open file: /tmp/et-db411cd21f3bbd882f3a5a30c58db6ff/t-pUzazs/test-project-0/dist/__uninstaller-nsis-TestApp.exe
```
Will investigate this later, and this should be considered a temporary resolution