### PR TITLE
chore: add test for windows signature verification

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
           "console": "integratedTerminal",
           "internalConsoleOptions": "openOnFirstSessionStart",
           "env": {
-            "TEST_FILES": "BuildTest"
+            "TEST_FILES": "nsisUpdaterTest",
+            "UPDATE_SNAPSHOT": "true"
           }
       }
   ]

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -50,19 +50,19 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
             return
           }
           const data = parseOut(stdout)
-          if (data.Status === 0) {
-            try {
-              const normlaizedUpdateFilePath = path.normalize(data.Path)
-              const normalizedTempUpdateFile = path.normalize(unescapedTempUpdateFile)
-              logger.info(`LiteralPath: ${normlaizedUpdateFilePath}. Update Path: ${normalizedTempUpdateFile}`)
-              if (normlaizedUpdateFilePath !== normalizedTempUpdateFile) {
-                handleError(logger, new Error(`LiteralPath of ${normlaizedUpdateFilePath} is different than ${normalizedTempUpdateFile}`), stderr, reject)
-                resolve(null)
-                return
-              }
-            } catch (error: any) {
-              logger.warn(`Unable to verify LiteralPath of update asset due to missing data.Path. Skipping this step of validation. Message: ${error.message ?? error.stack}`)
+          try {
+            const normlaizedUpdateFilePath = path.normalize(data.Path)
+            const normalizedTempUpdateFile = path.normalize(unescapedTempUpdateFile)
+            logger.info(`LiteralPath: ${normlaizedUpdateFilePath}. Update Path: ${normalizedTempUpdateFile}`)
+            if (normlaizedUpdateFilePath !== normalizedTempUpdateFile) {
+              handleError(logger, new Error(`LiteralPath of ${normlaizedUpdateFilePath} is different than ${normalizedTempUpdateFile}`), stderr, reject)
+              resolve(null)
+              return
             }
+          } catch (error: any) {
+            logger.warn(`Unable to verify LiteralPath of update asset due to missing data.Path. Skipping this step of validation. Message: ${error.message ?? error.stack}`)
+          }
+          if (data.Status === 0) {
             const subject = parseDn(data.SignerCertificate.Subject)
             let match = false
             for (const name of publisherNames) {

--- a/test/snapshots/updater/nsisUpdaterTest.js.snap
+++ b/test/snapshots/updater/nsisUpdaterTest.js.snap
@@ -533,6 +533,28 @@ exports[`test error 2`] = `
 ]
 `;
 
+exports[`test windows signature 1`] = `
+{
+  "win": [
+    {
+      "arch": "x64",
+      "file": "test-app.exe",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    {
+      "file": "test-app.exe.blockmap",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`valid signature - multiple publisher DNs 1`] = `
 {
   "files": [

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -417,8 +417,7 @@ test.skip.ifWindows("test downloaded installer", async () => {
   expect(actualEvents).toMatchObject(["checking-for-update", "update-available", "update-downloaded", "before-quit-for-update"])
 })
 
-
-test.only("test windows signature", () => {
+test.ifWindows("test windows signature", () => {
   const artifactName = "test-app.exe"
   const publisherName = "CN=test-ci-cert"
   return assertPack(
@@ -428,7 +427,7 @@ test.only("test windows signature", () => {
       config: {
         artifactName,
         directories: {
-          output: "Humpenöder--ÝæƙƢǭቒႴሧᐇᢇXXX Pálfi ööö"
+          output: "Humpenöder--ÝæƙƢǭቒႴሧᐇᢇXXX Pálfi ööö",
         },
         win: {
           signtoolOptions: {
@@ -440,13 +439,13 @@ test.only("test windows signature", () => {
     {
       signedWin: true,
       packed: async (context: PackedContext) => {
-       // This will throw a warning about cert not being root-signed (expected, it's a local generated cert for CI)
-       // We're testing signature verification logic of checking LiteralPath specifically with non-english characters (e.g. usernames)
+        // This will throw a warning about cert not being root-signed (expected, it's a local generated cert for CI)
+        // We're testing signature verification logic of checking LiteralPath specifically with non-english characters (e.g. usernames)
         await verifySignature([publisherName], path.join(context.outDir, artifactName), console).catch(warning => {
           expect(warning.includes("LiteralPath")).toBeFalsy()
           expect(warning.includes("A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider")).toBeTruthy()
-      })
-      }
+        })
+      },
     }
   )
 })


### PR DESCRIPTION
Verifying logic of LiteralPath when usernames contain non-A-Z characters.