### PR TITLE
feat: add `isUpdateAvailable` property to `checkForUpdates` result

### DIFF
--- a/.changeset/fuzzy-trains-grab.md
+++ b/.changeset/fuzzy-trains-grab.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": minor
+---
+
+feat: add `isUpdateAvailable` property to `checkForUpdates` result

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -279,6 +279,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
 
   /**
    * Asks the server whether there is an update.
+   * @returns null if the updater is disabled, otherwise info about the latest version
    */
   checkForUpdates(): Promise<UpdateCheckResult | null> {
     if (!this.isUpdaterActive()) {
@@ -461,6 +462,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       )
       this.emit("update-not-available", updateInfo)
       return {
+        isUpdateAvailable: false,
         versionInfo: updateInfo,
         updateInfo,
       }
@@ -472,6 +474,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
     const cancellationToken = new CancellationToken()
     //noinspection ES6MissingAwait
     return {
+      isUpdateAvailable: true,
       versionInfo: updateInfo,
       updateInfo,
       cancellationToken,

--- a/packages/electron-updater/src/main.ts
+++ b/packages/electron-updater/src/main.ts
@@ -77,6 +77,8 @@ export interface ResolvedUpdateFileInfo {
 }
 
 export interface UpdateCheckResult {
+  readonly isUpdateAvailable: boolean
+  
   readonly updateInfo: UpdateInfo
 
   readonly downloadPromise?: Promise<Array<string>> | null


### PR DESCRIPTION
This clarifies a point of frustration I had while setting up the updater in an application.

I assumed that `null` would mean that there was no update, and got stuck when I discovered that the lib doesn't report whether the version was determined to be an update or not.
So this adds a property to inform the caller whether the version can be installed or not.