### PR TITLE
fix: upgrading TrustedSigning module to 0.5.0

### DIFF
--- a/.changeset/tender-elephants-love.md
+++ b/.changeset/tender-elephants-love.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: upgrading TrustedSigning module and setting it as minimum version instead of required

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -39,7 +39,7 @@ export class WindowsSignAzureManager implements SignManager {
       // Logging to debug just in case users run into this. If NuGet isn't present, Install-Module -Name TrustedSigning will fail, so we'll get the logs at that point
       log.debug({ message: error.message || error.stack }, "unable to install PackageProvider Nuget. Might be a false alarm though as some systems already have it installed")
     }
-    await vm.exec(ps, ["-NoProfile", "-NonInteractive", "-Command", "Install-Module -Name TrustedSigning -RequiredVersion 0.4.1 -Force -Repository PSGallery -Scope CurrentUser"])
+    await vm.exec(ps, ["-NoProfile", "-NonInteractive", "-Command", "Install-Module -Name TrustedSigning -MinimumVersion 0.5.0 -Force -Repository PSGallery -Scope CurrentUser"])
 
     // Preemptively check env vars once during initialization
     // Options: https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet#definition


### PR DESCRIPTION
Also setting it as `-MinimumVersion` instead of Required to allow for future flexibility

Relates to https://github.com/electron-userland/electron-builder/issues/8700