### PR TITLE
fix: Only update AppArmor profile if not chroot'ed

### DIFF
--- a/.changeset/kind-items-clean.md
+++ b/.changeset/kind-items-clean.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: Only update AppArmor profile if not chroot'ed

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -42,7 +42,10 @@ if test -d "/etc/apparmor.d"; then
   if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
     cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
 
-    if hash apparmor_parser 2>/dev/null; then
+    # Updating the current AppArmor profile is not possible and probably not meaningful in a chroot'ed environment.
+    # Use cases are for example environments where images for clients are maintained.
+    # There, AppArmor might correctly be installed, but live updating makes no sense.
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
       # Extra flags taken from dh_apparmor:
       # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
       # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -568,7 +568,10 @@ if test -d "/etc/apparmor.d"; then
   if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
     cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
 
-    if hash apparmor_parser 2>/dev/null; then
+    # Updating the current AppArmor profile is not possible and probably not meaningful in a chroot'ed environment.
+    # Use cases are for example environments where images for clients are maintained.
+    # There, AppArmor might correctly be installed, but live updating makes no sense.
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
       # Extra flags taken from dh_apparmor:
       # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
       # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport


### PR DESCRIPTION
This prevents `postinst` script failure when run in a `chroot` environment.

This closes #8841.