### PR TITLE
fix: Fix the issue of the missing ms package

### DIFF
--- a/.changeset/many-lemons-press.md
+++ b/.changeset/many-lemons-press.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+use include instead of omit for npm list

--- a/.changeset/many-lemons-press.md
+++ b/.changeset/many-lemons-press.md
@@ -2,4 +2,4 @@
 "app-builder-lib": patch
 ---
 
-delete peerDepenencies when collecting node modules
+Fix the issue of the missing ms package

--- a/.changeset/many-lemons-press.md
+++ b/.changeset/many-lemons-press.md
@@ -2,4 +2,4 @@
 "app-builder-lib": patch
 ---
 
-use include instead of omit for npm list
+delete peerDepenencies when collecting node modules

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -75,7 +75,7 @@ export abstract class NodeModulesCollector {
 
   abstract getCommand(): string
   abstract getArgs(): string[]
-  abstract deletePeerDeps(tree: DependencyTree): void
+  abstract removeNonProductionDependencie(tree: DependencyTree): void
 
   protected async getDependenciesTree(): Promise<DependencyTree> {
     const command = this.getCommand()
@@ -139,7 +139,7 @@ export abstract class NodeModulesCollector {
   public async getNodeModules(): Promise<NodeModuleInfo[]> {
     const tree = await this.getDependenciesTree()
     const realTree = this.getTreeFromWorkspaces(tree)
-    this.deletePeerDeps(realTree)
+    this.removeNonProductionDependencie(realTree)
     const dependencyGraph = this.convertToDependencyGraph(realTree)
     const hoisterResult = hoist(this.transToHoisterTree(dependencyGraph), { check: true })
     this._getNodeModules(hoisterResult.dependencies, this.nodeModules)

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -33,7 +33,7 @@ export abstract class NodeModulesCollector {
     return node
   }
 
-  private resolvePath(filePath: string) {
+  protected resolvePath(filePath: string) {
     try {
       const stats = fs.lstatSync(filePath)
       if (stats.isSymbolicLink()) {
@@ -75,6 +75,7 @@ export abstract class NodeModulesCollector {
 
   abstract getCommand(): string
   abstract getArgs(): string[]
+  abstract deletePeerDeps(tree: DependencyTree): void
 
   protected async getDependenciesTree(): Promise<DependencyTree> {
     const command = this.getCommand()
@@ -127,6 +128,7 @@ export abstract class NodeModulesCollector {
   public async getNodeModules(): Promise<NodeModuleInfo[]> {
     const tree = await this.getDependenciesTree()
     const realTree = this.getTreeFromWorkspaces(tree)
+    this.deletePeerDeps(realTree)
     const dependencyGraph = this.convertToDependencyGraph(realTree)
     const hoisterResult = hoist(this.transToHoisterTree(dependencyGraph), { check: true })
     this._getNodeModules(hoisterResult.dependencies, this.nodeModules)

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -85,7 +85,18 @@ export abstract class NodeModulesCollector {
       shell: true,
     })
     const dependencyTree: DependencyTree | DependencyTree[] = JSON.parse(dependencies)
-    return Array.isArray(dependencyTree) ? dependencyTree[0] : dependencyTree
+
+    // pnpm returns an array of dependency trees
+    if (Array.isArray(dependencyTree)) {
+      const tree = dependencyTree[0]
+      if (tree.optionalDependencies) {
+        tree.dependencies = { ...tree.dependencies, ...tree.optionalDependencies }
+      }
+      return tree
+    }
+
+    // yarn and npm return a single dependency tree
+    return dependencyTree
   }
 
   private _getNodeModules(dependencies: Set<HoisterResult>, result: NodeModuleInfo[]) {

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -15,13 +15,13 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
   }
 
   deletePeerDeps(tree: DependencyTree) {
-    const _dependencies = tree._dependencies || {}
     const dependencies = tree.dependencies || {}
+    const _dependencies = tree._dependencies || {}
     for (const [key, value] of Object.entries(dependencies)) {
-      if (_dependencies[key]) {
+      if (!_dependencies[key]) {
+        delete dependencies[key]
         continue
       }
-      delete dependencies[key]
       this.deletePeerDeps(value)
     }
   }

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -14,7 +14,7 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
     return ["list", "-a", "--include", "prod", "--include", "optional", "--omit", "dev", "--json", "--long", "--silent"]
   }
 
-  deletePeerDeps(tree: DependencyTree) {
+  removeNonProductionDependencie(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
     const _dependencies = tree._dependencies || {}
     for (const [key, value] of Object.entries(dependencies)) {
@@ -22,7 +22,7 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
         delete dependencies[key]
         continue
       }
-      this.deletePeerDeps(value)
+      this.removeNonProductionDependencie(value)
     }
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -15,12 +15,13 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
   }
 
   deletePeerDeps(tree: DependencyTree) {
+    const _dependencies = tree._dependencies || {}
     const dependencies = tree.dependencies || {}
-    const peerDependencies = tree.peerDependencies || {}
     for (const [key, value] of Object.entries(dependencies)) {
-      if (peerDependencies[key]) {
-        delete dependencies[key]
+      if (_dependencies[key]) {
+        continue
       }
+      delete dependencies[key]
       this.deletePeerDeps(value)
     }
   }

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -22,7 +22,7 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
     }
     
     for (const [key, value] of Object.entries(dependencies)) {
-      if (!_dependencies[key]) {
+      if (!_dependencies[key] || Object.keys(value).length === 0) {
         delete dependencies[key]
         continue
       }

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -1,4 +1,5 @@
 import { NodeModulesCollector } from "./nodeModulesCollector"
+import { DependencyTree } from "./types"
 
 export class NpmNodeModulesCollector extends NodeModulesCollector {
   constructor(rootDir: string) {
@@ -10,6 +11,17 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
   }
 
   getArgs(): string[] {
-    return ["list", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
+    return ["list", "-a", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
+  }
+
+  deletePeerDeps(tree: DependencyTree) {
+    const dependencies = tree.dependencies || {}
+    const peerDependencies = tree.peerDependencies || {}
+    for (const [key, value] of Object.entries(dependencies)) {
+      if (peerDependencies[key]) {
+        delete dependencies[key]
+      }
+      this.deletePeerDeps(value)
+    }
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -11,7 +11,7 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
   }
 
   getArgs(): string[] {
-    return ["list", "-a", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
+    return ["list", "-a", "--include", "prod", "--include", "optional", "--omit", "dev", "--json", "--long", "--silent"]
   }
 
   deletePeerDeps(tree: DependencyTree) {

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -10,6 +10,6 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
   }
 
   getArgs(): string[] {
-    return ["list", "--omit", "dev", "-a", "--json", "--long", "--silent"]
+    return ["list", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -17,6 +17,11 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
   removeNonProductionDependencie(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
     const _dependencies = tree._dependencies || {}
+
+    if (dependencies && Object.keys(dependencies).length === 0) {
+      tree.dependencies = this.allDependencies.get(`${tree.name}@${tree.version}`)?.dependencies || {}
+    }
+
     for (const [key, value] of Object.entries(dependencies)) {
       if (!_dependencies[key]) {
         delete dependencies[key]

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -20,7 +20,7 @@ export class NpmNodeModulesCollector extends NodeModulesCollector {
     if (dependencies && Object.keys(dependencies).length === 0) {
       tree.dependencies = this.allDependencies.get(`${tree.name}@${tree.version}`)?.dependencies || {}
     }
-    
+
     for (const [key, value] of Object.entries(dependencies)) {
       if (!_dependencies[key] || Object.keys(value).length === 0) {
         delete dependencies[key]

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -1,5 +1,5 @@
 import { NodeModulesCollector } from "./nodeModulesCollector"
-import { DependencyTree } from "./types"
+import { DependencyTree,Dependency } from "./types"
 import * as path from "path"
 
 export class PnpmNodeModulesCollector extends NodeModulesCollector {
@@ -18,15 +18,15 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
   deletePeerDeps(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
     const p = path.normalize(this.resolvePath(tree.path))
-    const pJson: DependencyTree = require(path.join(p, "package.json"))
-    const _dependencies = pJson.dependencies || {}
+    const pJson: Dependency= require(path.join(p, "package.json"))
+    const _dependencies = pJson.dependencies||{}
     const _optionalDependencies = pJson.optionalDependencies || {}
     const prodDependencies = { ..._dependencies, ..._optionalDependencies }
     for (const [key, value] of Object.entries(dependencies)) {
-      if (prodDependencies[key]) {
+      if (!prodDependencies[key]) {
+        delete dependencies[key]
         continue
       }
-      delete dependencies[key]
       this.deletePeerDeps(value)
     }
   }

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -19,11 +19,14 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
     const dependencies = tree.dependencies || {}
     const p = path.normalize(this.resolvePath(tree.path))
     const pJson: DependencyTree = require(path.join(p, "package.json"))
-    const peerDependencies = pJson.peerDependencies || {}
+    const _dependencies = pJson.dependencies || {}
+    const _optionalDependencies = pJson.optionalDependencies || {}
+    const prodDependencies = { ..._dependencies, ..._optionalDependencies }
     for (const [key, value] of Object.entries(dependencies)) {
-      if (peerDependencies[key]) {
-        delete dependencies[key]
+      if (prodDependencies[key]) {
+        continue
       }
+      delete dependencies[key]
       this.deletePeerDeps(value)
     }
   }

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -1,4 +1,6 @@
 import { NodeModulesCollector } from "./nodeModulesCollector"
+import { DependencyTree } from "./types"
+import * as path from "path"
 
 export class PnpmNodeModulesCollector extends NodeModulesCollector {
   constructor(rootDir: string) {
@@ -11,5 +13,18 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
 
   getArgs(): string[] {
     return ["list", "--prod", "--json", "--long", "--depth", "Infinity"]
+  }
+
+  deletePeerDeps(tree: DependencyTree) {
+    const dependencies = tree.dependencies || {}
+    for (const [key, value] of Object.entries(dependencies)) {
+      const p = path.normalize(this.resolvePath(value.path))
+      const pJson: DependencyTree = require(path.join(p, "package.json"))
+      const peerDependencies = pJson.peerDependencies || {}
+      if (peerDependencies[key]) {
+        delete dependencies[key]
+      }
+      this.deletePeerDeps(value)
+    }
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -17,10 +17,10 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
 
   deletePeerDeps(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
+    const p = path.normalize(this.resolvePath(tree.path))
+    const pJson: DependencyTree = require(path.join(p, "package.json"))
+    const peerDependencies = pJson.peerDependencies || {}
     for (const [key, value] of Object.entries(dependencies)) {
-      const p = path.normalize(this.resolvePath(value.path))
-      const pJson: DependencyTree = require(path.join(p, "package.json"))
-      const peerDependencies = pJson.peerDependencies || {}
       if (peerDependencies[key]) {
         delete dependencies[key]
       }

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -15,7 +15,7 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
     return ["list", "--prod", "--json", "--depth", "Infinity"]
   }
 
-  deletePeerDeps(tree: DependencyTree) {
+  removeNonProductionDependencie(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
     const p = path.normalize(this.resolvePath(tree.path))
     const pJson: Dependency = require(path.join(p, "package.json"))
@@ -27,7 +27,7 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
         delete dependencies[key]
         continue
       }
-      this.deletePeerDeps(value)
+      this.removeNonProductionDependencie(value)
     }
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -1,5 +1,5 @@
 import { NodeModulesCollector } from "./nodeModulesCollector"
-import { DependencyTree,Dependency } from "./types"
+import { DependencyTree, Dependency } from "./types"
 import * as path from "path"
 
 export class PnpmNodeModulesCollector extends NodeModulesCollector {
@@ -18,8 +18,8 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
   deletePeerDeps(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
     const p = path.normalize(this.resolvePath(tree.path))
-    const pJson: Dependency= require(path.join(p, "package.json"))
-    const _dependencies = pJson.dependencies||{}
+    const pJson: Dependency = require(path.join(p, "package.json"))
+    const _dependencies = pJson.dependencies || {}
     const _optionalDependencies = pJson.optionalDependencies || {}
     const prodDependencies = { ..._dependencies, ..._optionalDependencies }
     for (const [key, value] of Object.entries(dependencies)) {

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -12,7 +12,7 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector {
   }
 
   getArgs(): string[] {
-    return ["list", "--prod", "--json", "--long", "--depth", "Infinity"]
+    return ["list", "--prod", "--json", "--depth", "Infinity"]
   }
 
   deletePeerDeps(tree: DependencyTree) {

--- a/packages/app-builder-lib/src/node-module-collector/types.ts
+++ b/packages/app-builder-lib/src/node-module-collector/types.ts
@@ -14,6 +14,12 @@ export interface DependencyTree {
   dependencies: {
     [packageName: string]: DependencyTree
   }
+  optionalDependencies?: {
+    [packageName: string]: DependencyTree
+  }
+  peerDependencies?: {
+    [packageName: string]: DependencyTree
+  }
 }
 
 export interface DependencyGraph {

--- a/packages/app-builder-lib/src/node-module-collector/types.ts
+++ b/packages/app-builder-lib/src/node-module-collector/types.ts
@@ -11,7 +11,7 @@ export interface DependencyTree {
   readonly from?: string
   readonly workspaces?: string[]
   readonly path: string
-  dependencies: {
+  dependencies?: {
     [packageName: string]: DependencyTree
   }
   // for npm list --json

--- a/packages/app-builder-lib/src/node-module-collector/types.ts
+++ b/packages/app-builder-lib/src/node-module-collector/types.ts
@@ -16,7 +16,7 @@ export interface DependencyTree {
   }
   // for npm list --json
   _dependencies?: {
-    [packageName: string]:  string 
+    [packageName: string]: string
   }
   optionalDependencies?: {
     [packageName: string]: DependencyTree
@@ -28,10 +28,10 @@ export interface DependencyTree {
 
 export interface Dependency {
   dependencies?: {
-    [packageName: string]: string 
+    [packageName: string]: string
   }
   optionalDependencies?: {
-    [packageName: string]: string 
+    [packageName: string]: string
   }
 }
 

--- a/packages/app-builder-lib/src/node-module-collector/types.ts
+++ b/packages/app-builder-lib/src/node-module-collector/types.ts
@@ -16,13 +16,22 @@ export interface DependencyTree {
   }
   // for npm list --json
   _dependencies?: {
-    [packageName: string]: DependencyTree
+    [packageName: string]:  string 
   }
   optionalDependencies?: {
     [packageName: string]: DependencyTree
   }
   peerDependencies?: {
     [packageName: string]: DependencyTree
+  }
+}
+
+export interface Dependency {
+  dependencies?: {
+    [packageName: string]: string 
+  }
+  optionalDependencies?: {
+    [packageName: string]: string 
   }
 }
 

--- a/packages/app-builder-lib/src/node-module-collector/types.ts
+++ b/packages/app-builder-lib/src/node-module-collector/types.ts
@@ -14,6 +14,10 @@ export interface DependencyTree {
   dependencies: {
     [packageName: string]: DependencyTree
   }
+  // for npm list --json
+  _dependencies?: {
+    [packageName: string]: DependencyTree
+  }
   optionalDependencies?: {
     [packageName: string]: DependencyTree
   }

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -10,6 +10,6 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
   }
 
   getArgs(): string[] {
-    return ["list", "--omit", "dev", "-a", "--json", "--long", "--silent"]
+    return ["list", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -1,4 +1,5 @@
 import { NodeModulesCollector } from "./nodeModulesCollector"
+import { DependencyTree } from "./types"
 
 export class YarnNodeModulesCollector extends NodeModulesCollector {
   constructor(rootDir: string) {
@@ -10,6 +11,16 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
   }
 
   getArgs(): string[] {
-    return ["list", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
+    return ["list", "-a", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
+  }
+  deletePeerDeps(tree: DependencyTree) {
+    const dependencies = tree.dependencies || {}
+    const peerDependencies = tree.peerDependencies || {}
+    for (const [key, value] of Object.entries(dependencies)) {
+      if (peerDependencies[key]) {
+        delete dependencies[key]
+      }
+      this.deletePeerDeps(value)
+    }
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -17,6 +17,11 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
   removeNonProductionDependencie(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
     const _dependencies = tree._dependencies || {}
+
+    if (dependencies && Object.keys(dependencies).length === 0) {
+      tree.dependencies = this.allDependencies.get(`${tree.name}@${tree.version}`)?.dependencies || {}
+    }
+
     for (const [key, value] of Object.entries(dependencies)) {
       if (!_dependencies[key]) {
         delete dependencies[key]

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -15,13 +15,13 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
   }
 
   deletePeerDeps(tree: DependencyTree) {
-    const _dependencies = tree._dependencies || {}
     const dependencies = tree.dependencies || {}
+    const _dependencies = tree._dependencies || {}
     for (const [key, value] of Object.entries(dependencies)) {
-      if (_dependencies[key]) {
+      if (!_dependencies[key]) {
+        delete dependencies[key]
         continue
       }
-      delete dependencies[key]
       this.deletePeerDeps(value)
     }
   }

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -13,13 +13,15 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
   getArgs(): string[] {
     return ["list", "-a", "--include", "prod", "--include", "optional", "--omit", "dev", "--json", "--long", "--silent"]
   }
+
   deletePeerDeps(tree: DependencyTree) {
+    const _dependencies = tree._dependencies || {}
     const dependencies = tree.dependencies || {}
-    const peerDependencies = tree.peerDependencies || {}
     for (const [key, value] of Object.entries(dependencies)) {
-      if (peerDependencies[key]) {
-        delete dependencies[key]
+      if (_dependencies[key]) {
+        continue
       }
+      delete dependencies[key]
       this.deletePeerDeps(value)
     }
   }

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -22,7 +22,7 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
     }
 
     for (const [key, value] of Object.entries(dependencies)) {
-      if (!_dependencies[key]) {
+      if (!_dependencies[key] || Object.keys(value).length === 0) {
         delete dependencies[key]
         continue
       }

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -11,7 +11,7 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
   }
 
   getArgs(): string[] {
-    return ["list", "-a", "--include", "prod", "--include", "optional", "--json", "--long", "--silent"]
+    return ["list", "-a", "--include", "prod", "--include", "optional", "--omit", "dev", "--json", "--long", "--silent"]
   }
   deletePeerDeps(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -14,7 +14,7 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
     return ["list", "-a", "--include", "prod", "--include", "optional", "--omit", "dev", "--json", "--long", "--silent"]
   }
 
-  deletePeerDeps(tree: DependencyTree) {
+  removeNonProductionDependencie(tree: DependencyTree) {
     const dependencies = tree.dependencies || {}
     const _dependencies = tree._dependencies || {}
     for (const [key, value] of Object.entries(dependencies)) {
@@ -22,7 +22,7 @@ export class YarnNodeModulesCollector extends NodeModulesCollector {
         delete dependencies[key]
         continue
       }
-      this.deletePeerDeps(value)
+      this.removeNonProductionDependencie(value)
     }
   }
 }

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -142,9 +142,181 @@ exports[`pnpm es5-ext without hoisted config 2`] = `
 }
 `;
 
+exports[`pnpm optional dependencies 1`] = `
+{
+  "linux": [],
+}
+`;
+
+exports[`pnpm optional dependencies 2`] = `
+{
+  "files": {
+    "index.html": {
+      "offset": "30097",
+      "size": 378,
+    },
+    "index.js": {
+      "offset": "30475",
+      "size": 619,
+    },
+    "node_modules": {
+      "files": {
+        "edge-cs": {
+          "files": {
+            "LICENSE.txt": {
+              "offset": "0",
+              "size": 565,
+            },
+            "lib": {
+              "files": {
+                "bootstrap": {
+                  "files": {
+                    "Dummy.cs": {
+                      "offset": "565",
+                      "size": 41,
+                    },
+                    "project.json": {
+                      "offset": "606",
+                      "size": 175,
+                    },
+                  },
+                },
+                "edge-cs.js": {
+                  "offset": "781",
+                  "size": 363,
+                },
+              },
+            },
+            "package.json": {
+              "offset": "1144",
+              "size": 606,
+            },
+            "src": {
+              "files": {
+                "Edge.js.CSharp": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "offset": "1750",
+                      "size": 11533,
+                    },
+                    "gulpfile.js": {
+                      "offset": "13283",
+                      "size": 515,
+                    },
+                    "package.json": {
+                      "offset": "13798",
+                      "size": 62,
+                    },
+                    "project.json": {
+                      "offset": "13860",
+                      "size": 775,
+                    },
+                  },
+                },
+                "edge-cs": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "offset": "14635",
+                      "size": 9315,
+                    },
+                    "Properties": {
+                      "files": {
+                        "AssemblyInfo.cs": {
+                          "offset": "23950",
+                          "size": 1426,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "tools": {
+              "files": {
+                "install.js": {
+                  "offset": "25376",
+                  "size": 968,
+                },
+              },
+            },
+          },
+        },
+        "electron-clear-data": {
+          "files": {
+            "LICENSE.md": {
+              "offset": "26344",
+              "size": 1059,
+            },
+            "dist": {
+              "files": {
+                "main.js": {
+                  "offset": "27403",
+                  "size": 1734,
+                },
+              },
+            },
+            "package.json": {
+              "offset": "29137",
+              "size": 960,
+            },
+          },
+        },
+      },
+    },
+    "package.json": {
+      "offset": "31094",
+      "size": 395,
+    },
+  },
+}
+`;
+
 exports[`yarn electron-clear-data 1`] = `
 {
   "win": [],
+}
+`;
+
+exports[`yarn electron-clear-data 2`] = `
+{
+  "files": {
+    "index.html": {
+      "offset": "3753",
+      "size": 378,
+    },
+    "index.js": {
+      "offset": "4131",
+      "size": 619,
+    },
+    "node_modules": {
+      "files": {
+        "electron-clear-data": {
+          "files": {
+            "LICENSE.md": {
+              "offset": "0",
+              "size": 1059,
+            },
+            "dist": {
+              "files": {
+                "main.js": {
+                  "offset": "1059",
+                  "size": 1734,
+                },
+              },
+            },
+            "package.json": {
+              "offset": "2793",
+              "size": 960,
+            },
+          },
+        },
+      },
+    },
+    "package.json": {
+      "offset": "4750",
+      "size": 339,
+    },
+  },
 }
 `;
 

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -457,6 +457,41 @@ exports[`yarn electron-clear-data 2`] = `
 }
 `;
 
+exports[`yarn ms 1`] = `
+{
+  "linux": [],
+}
+`;
+
+exports[`yarn ms 2`] = `
+{
+  "description": "Tiny millisecond conversion utility",
+  "devDependencies": {
+    "eslint": "4.18.2",
+    "expect.js": "0.3.1",
+    "husky": "0.14.3",
+    "lint-staged": "5.0.0",
+    "mocha": "4.0.1",
+    "prettier": "2.0.5",
+  },
+  "files": [
+    "index.js",
+  ],
+  "license": "MIT",
+  "lint-staged": {
+    "*.js": [
+      "npm run lint",
+      "prettier --single-quote --write",
+      "git add",
+    ],
+  },
+  "main": "./index",
+  "name": "ms",
+  "repository": "vercel/ms",
+  "version": "2.1.3",
+}
+`;
+
 exports[`yarn parse-asn1 1`] = `
 {
   "linux": [],

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -142,6 +142,12 @@ exports[`pnpm es5-ext without hoisted config 2`] = `
 }
 `;
 
+exports[`yarn electron-clear-data 1`] = `
+{
+  "win": [],
+}
+`;
+
 exports[`yarn parse-asn1 1`] = `
 {
   "linux": [],

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -290,6 +290,98 @@ exports[`yarn electron-clear-data 2`] = `
     },
     "node_modules": {
       "files": {
+        "edge-cs": {
+          "files": {
+            "LICENSE.txt": {
+              "size": 565,
+              "unpacked": true,
+            },
+            "lib": {
+              "files": {
+                "bootstrap": {
+                  "files": {
+                    "Dummy.cs": {
+                      "size": 41,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 175,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs.dll": {
+                  "size": 10752,
+                  "unpacked": true,
+                },
+                "edge-cs.js": {
+                  "size": 363,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "package.json": {
+              "size": 606,
+              "unpacked": true,
+            },
+            "src": {
+              "files": {
+                "Edge.js.CSharp": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 11533,
+                      "unpacked": true,
+                    },
+                    "gulpfile.js": {
+                      "size": 515,
+                      "unpacked": true,
+                    },
+                    "package.json": {
+                      "size": 62,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 775,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 9315,
+                      "unpacked": true,
+                    },
+                    "Properties": {
+                      "files": {
+                        "AssemblyInfo.cs": {
+                          "size": 1426,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "tools": {
+              "files": {
+                "install.js": {
+                  "size": 968,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+          },
+          "unpacked": true,
+        },
         "electron-clear-data": {
           "files": {
             "LICENSE.md": {
@@ -314,7 +406,148 @@ exports[`yarn electron-clear-data 2`] = `
     },
     "package.json": {
       "offset": "4750",
-      "size": 339,
+      "size": 395,
+    },
+  },
+}
+`;
+
+exports[`yarn electron-clear-data 3`] = `
+{
+  "win": [],
+}
+`;
+
+exports[`yarn electron-clear-data 4`] = `
+{
+  "files": {
+    "index.html": {
+      "offset": "3753",
+      "size": 378,
+    },
+    "index.js": {
+      "offset": "4131",
+      "size": 619,
+    },
+    "node_modules": {
+      "files": {
+        "edge-cs": {
+          "files": {
+            "LICENSE.txt": {
+              "size": 565,
+              "unpacked": true,
+            },
+            "lib": {
+              "files": {
+                "bootstrap": {
+                  "files": {
+                    "Dummy.cs": {
+                      "size": 41,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 175,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs.dll": {
+                  "size": 10752,
+                  "unpacked": true,
+                },
+                "edge-cs.js": {
+                  "size": 363,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "package.json": {
+              "size": 606,
+              "unpacked": true,
+            },
+            "src": {
+              "files": {
+                "Edge.js.CSharp": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 11533,
+                      "unpacked": true,
+                    },
+                    "gulpfile.js": {
+                      "size": 515,
+                      "unpacked": true,
+                    },
+                    "package.json": {
+                      "size": 62,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 775,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 9315,
+                      "unpacked": true,
+                    },
+                    "Properties": {
+                      "files": {
+                        "AssemblyInfo.cs": {
+                          "size": 1426,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "tools": {
+              "files": {
+                "install.js": {
+                  "size": 968,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+          },
+          "unpacked": true,
+        },
+        "electron-clear-data": {
+          "files": {
+            "LICENSE.md": {
+              "offset": "0",
+              "size": 1059,
+            },
+            "dist": {
+              "files": {
+                "main.js": {
+                  "offset": "1059",
+                  "size": 1734,
+                },
+              },
+            },
+            "package.json": {
+              "offset": "2793",
+              "size": 960,
+            },
+          },
+        },
+      },
+    },
+    "package.json": {
+      "offset": "4750",
+      "size": 395,
     },
   },
 }

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -73,6 +73,147 @@ exports[`conflict versions 2`] = `
 }
 `;
 
+exports[`npm electron-clear-data 1`] = `
+{
+  "win": [],
+}
+`;
+
+exports[`npm electron-clear-data 2`] = `
+{
+  "files": {
+    "index.html": {
+      "offset": "3753",
+      "size": 378,
+    },
+    "index.js": {
+      "offset": "4131",
+      "size": 619,
+    },
+    "node_modules": {
+      "files": {
+        "edge-cs": {
+          "files": {
+            "LICENSE.txt": {
+              "size": 565,
+              "unpacked": true,
+            },
+            "lib": {
+              "files": {
+                "bootstrap": {
+                  "files": {
+                    "Dummy.cs": {
+                      "size": 41,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 175,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs.dll": {
+                  "size": 10752,
+                  "unpacked": true,
+                },
+                "edge-cs.js": {
+                  "size": 363,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "package.json": {
+              "size": 606,
+              "unpacked": true,
+            },
+            "src": {
+              "files": {
+                "Edge.js.CSharp": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 11533,
+                      "unpacked": true,
+                    },
+                    "gulpfile.js": {
+                      "size": 515,
+                      "unpacked": true,
+                    },
+                    "package.json": {
+                      "size": 62,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 775,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 9315,
+                      "unpacked": true,
+                    },
+                    "Properties": {
+                      "files": {
+                        "AssemblyInfo.cs": {
+                          "size": 1426,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "tools": {
+              "files": {
+                "install.js": {
+                  "size": 968,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+          },
+          "unpacked": true,
+        },
+        "electron-clear-data": {
+          "files": {
+            "LICENSE.md": {
+              "offset": "0",
+              "size": 1059,
+            },
+            "dist": {
+              "files": {
+                "main.js": {
+                  "offset": "1059",
+                  "size": 1734,
+                },
+              },
+            },
+            "package.json": {
+              "offset": "2793",
+              "size": 960,
+            },
+          },
+        },
+      },
+    },
+    "package.json": {
+      "offset": "4750",
+      "size": 395,
+    },
+  },
+}
+`;
+
 exports[`npm tar 1`] = `
 {
   "linux": [],
@@ -278,147 +419,6 @@ exports[`yarn electron-clear-data 1`] = `
 `;
 
 exports[`yarn electron-clear-data 2`] = `
-{
-  "files": {
-    "index.html": {
-      "offset": "3753",
-      "size": 378,
-    },
-    "index.js": {
-      "offset": "4131",
-      "size": 619,
-    },
-    "node_modules": {
-      "files": {
-        "edge-cs": {
-          "files": {
-            "LICENSE.txt": {
-              "size": 565,
-              "unpacked": true,
-            },
-            "lib": {
-              "files": {
-                "bootstrap": {
-                  "files": {
-                    "Dummy.cs": {
-                      "size": 41,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 175,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
-                "edge-cs.dll": {
-                  "size": 10752,
-                  "unpacked": true,
-                },
-                "edge-cs.js": {
-                  "size": 363,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
-            },
-            "package.json": {
-              "size": 606,
-              "unpacked": true,
-            },
-            "src": {
-              "files": {
-                "Edge.js.CSharp": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 11533,
-                      "unpacked": true,
-                    },
-                    "gulpfile.js": {
-                      "size": 515,
-                      "unpacked": true,
-                    },
-                    "package.json": {
-                      "size": 62,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 775,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
-                "edge-cs": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 9315,
-                      "unpacked": true,
-                    },
-                    "Properties": {
-                      "files": {
-                        "AssemblyInfo.cs": {
-                          "size": 1426,
-                          "unpacked": true,
-                        },
-                      },
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
-            },
-            "tools": {
-              "files": {
-                "install.js": {
-                  "size": 968,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
-            },
-          },
-          "unpacked": true,
-        },
-        "electron-clear-data": {
-          "files": {
-            "LICENSE.md": {
-              "offset": "0",
-              "size": 1059,
-            },
-            "dist": {
-              "files": {
-                "main.js": {
-                  "offset": "1059",
-                  "size": 1734,
-                },
-              },
-            },
-            "package.json": {
-              "offset": "2793",
-              "size": 960,
-            },
-          },
-        },
-      },
-    },
-    "package.json": {
-      "offset": "4750",
-      "size": 395,
-    },
-  },
-}
-`;
-
-exports[`yarn electron-clear-data 3`] = `
-{
-  "win": [],
-}
-`;
-
-exports[`yarn electron-clear-data 4`] = `
 {
   "files": {
     "index.html": {
@@ -820,6 +820,127 @@ exports[`yarn several workspaces and asarUnpack 2`] = `
     },
     "package.json": {
       "offset": "18219",
+      "size": 326,
+    },
+  },
+}
+`;
+
+exports[`yarn some module add by manual instead of install 1`] = `
+{
+  "win": [],
+}
+`;
+
+exports[`yarn some module add by manual instead of install 2`] = `
+{
+  "files": {
+    "index.html": {
+      "offset": "0",
+      "size": 378,
+    },
+    "index.js": {
+      "offset": "378",
+      "size": 619,
+    },
+    "node_modules": {
+      "files": {
+        "edge-cs": {
+          "files": {
+            "LICENSE.txt": {
+              "size": 565,
+              "unpacked": true,
+            },
+            "lib": {
+              "files": {
+                "bootstrap": {
+                  "files": {
+                    "Dummy.cs": {
+                      "size": 41,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 175,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs.dll": {
+                  "size": 10752,
+                  "unpacked": true,
+                },
+                "edge-cs.js": {
+                  "size": 363,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "package.json": {
+              "size": 606,
+              "unpacked": true,
+            },
+            "src": {
+              "files": {
+                "Edge.js.CSharp": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 11533,
+                      "unpacked": true,
+                    },
+                    "gulpfile.js": {
+                      "size": 515,
+                      "unpacked": true,
+                    },
+                    "package.json": {
+                      "size": 62,
+                      "unpacked": true,
+                    },
+                    "project.json": {
+                      "size": 775,
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+                "edge-cs": {
+                  "files": {
+                    "EdgeCompiler.cs": {
+                      "size": 9315,
+                      "unpacked": true,
+                    },
+                    "Properties": {
+                      "files": {
+                        "AssemblyInfo.cs": {
+                          "size": 1426,
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "tools": {
+              "files": {
+                "install.js": {
+                  "size": 968,
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+          },
+          "unpacked": true,
+        },
+      },
+    },
+    "package.json": {
+      "offset": "997",
       "size": 326,
     },
   },

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -83,132 +83,96 @@ exports[`npm electron-clear-data 2`] = `
 {
   "files": {
     "index.html": {
-      "offset": "3753",
+      "offset": "26472",
       "size": 378,
     },
     "index.js": {
-      "offset": "4131",
+      "offset": "26850",
       "size": 619,
     },
     "node_modules": {
       "files": {
-        "edge-cs": {
+        "debug": {
           "files": {
-            "LICENSE.txt": {
-              "size": 565,
-              "unpacked": true,
+            "LICENSE": {
+              "offset": "0",
+              "size": 1107,
             },
-            "lib": {
-              "files": {
-                "bootstrap": {
-                  "files": {
-                    "Dummy.cs": {
-                      "size": 41,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 175,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
-                "edge-cs.dll": {
-                  "size": 10752,
-                  "unpacked": true,
-                },
-                "edge-cs.js": {
-                  "size": 363,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
+            "Makefile": {
+              "offset": "1107",
+              "size": 1234,
+            },
+            "node.js": {
+              "offset": "2341",
+              "size": 40,
             },
             "package.json": {
-              "size": 606,
-              "unpacked": true,
+              "offset": "2381",
+              "size": 830,
             },
             "src": {
               "files": {
-                "Edge.js.CSharp": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 11533,
-                      "unpacked": true,
-                    },
-                    "gulpfile.js": {
-                      "size": 515,
-                      "unpacked": true,
-                    },
-                    "package.json": {
-                      "size": 62,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 775,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
+                "browser.js": {
+                  "offset": "3211",
+                  "size": 5707,
                 },
-                "edge-cs": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 9315,
-                      "unpacked": true,
-                    },
-                    "Properties": {
-                      "files": {
-                        "AssemblyInfo.cs": {
-                          "size": 1426,
-                          "unpacked": true,
-                        },
-                      },
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
+                "debug.js": {
+                  "offset": "8918",
+                  "size": 4889,
+                },
+                "index.js": {
+                  "offset": "13807",
+                  "size": 263,
+                },
+                "node.js": {
+                  "offset": "14070",
+                  "size": 4339,
                 },
               },
-              "unpacked": true,
-            },
-            "tools": {
-              "files": {
-                "install.js": {
-                  "size": 968,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
             },
           },
-          "unpacked": true,
         },
         "electron-clear-data": {
           "files": {
             "LICENSE.md": {
-              "offset": "0",
+              "offset": "18409",
               "size": 1059,
             },
             "dist": {
               "files": {
                 "main.js": {
-                  "offset": "1059",
+                  "offset": "19468",
                   "size": 1734,
                 },
               },
             },
             "package.json": {
-              "offset": "2793",
+              "offset": "21202",
               "size": 960,
+            },
+          },
+        },
+        "ms": {
+          "files": {
+            "index.js": {
+              "offset": "22162",
+              "size": 2764,
+            },
+            "license.md": {
+              "offset": "24926",
+              "size": 1077,
+            },
+            "package.json": {
+              "offset": "26003",
+              "size": 469,
             },
           },
         },
       },
     },
     "package.json": {
-      "offset": "4750",
-      "size": 395,
+      "offset": "27469",
+      "size": 393,
     },
   },
 }
@@ -293,90 +257,50 @@ exports[`pnpm optional dependencies 2`] = `
 {
   "files": {
     "index.html": {
-      "offset": "30097",
+      "offset": "26472",
       "size": 378,
     },
     "index.js": {
-      "offset": "30475",
+      "offset": "26850",
       "size": 619,
     },
     "node_modules": {
       "files": {
-        "edge-cs": {
+        "debug": {
           "files": {
-            "LICENSE.txt": {
+            "LICENSE": {
               "offset": "0",
-              "size": 565,
+              "size": 1107,
             },
-            "lib": {
-              "files": {
-                "bootstrap": {
-                  "files": {
-                    "Dummy.cs": {
-                      "offset": "565",
-                      "size": 41,
-                    },
-                    "project.json": {
-                      "offset": "606",
-                      "size": 175,
-                    },
-                  },
-                },
-                "edge-cs.js": {
-                  "offset": "781",
-                  "size": 363,
-                },
-              },
+            "Makefile": {
+              "offset": "1107",
+              "size": 1234,
+            },
+            "node.js": {
+              "offset": "2341",
+              "size": 40,
             },
             "package.json": {
-              "offset": "1144",
-              "size": 606,
+              "offset": "2381",
+              "size": 830,
             },
             "src": {
               "files": {
-                "Edge.js.CSharp": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "offset": "1750",
-                      "size": 11533,
-                    },
-                    "gulpfile.js": {
-                      "offset": "13283",
-                      "size": 515,
-                    },
-                    "package.json": {
-                      "offset": "13798",
-                      "size": 62,
-                    },
-                    "project.json": {
-                      "offset": "13860",
-                      "size": 775,
-                    },
-                  },
+                "browser.js": {
+                  "offset": "3211",
+                  "size": 5707,
                 },
-                "edge-cs": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "offset": "14635",
-                      "size": 9315,
-                    },
-                    "Properties": {
-                      "files": {
-                        "AssemblyInfo.cs": {
-                          "offset": "23950",
-                          "size": 1426,
-                        },
-                      },
-                    },
-                  },
+                "debug.js": {
+                  "offset": "8918",
+                  "size": 4889,
                 },
-              },
-            },
-            "tools": {
-              "files": {
-                "install.js": {
-                  "offset": "25376",
-                  "size": 968,
+                "index.js": {
+                  "offset": "13807",
+                  "size": 263,
+                },
+                "node.js": {
+                  "offset": "14070",
+                  "size": 4339,
                 },
               },
             },
@@ -385,28 +309,44 @@ exports[`pnpm optional dependencies 2`] = `
         "electron-clear-data": {
           "files": {
             "LICENSE.md": {
-              "offset": "26344",
+              "offset": "18409",
               "size": 1059,
             },
             "dist": {
               "files": {
                 "main.js": {
-                  "offset": "27403",
+                  "offset": "19468",
                   "size": 1734,
                 },
               },
             },
             "package.json": {
-              "offset": "29137",
+              "offset": "21202",
               "size": 960,
+            },
+          },
+        },
+        "ms": {
+          "files": {
+            "index.js": {
+              "offset": "22162",
+              "size": 2764,
+            },
+            "license.md": {
+              "offset": "24926",
+              "size": 1077,
+            },
+            "package.json": {
+              "offset": "26003",
+              "size": 469,
             },
           },
         },
       },
     },
     "package.json": {
-      "offset": "31094",
-      "size": 395,
+      "offset": "27469",
+      "size": 393,
     },
   },
 }
@@ -422,132 +362,96 @@ exports[`yarn electron-clear-data 2`] = `
 {
   "files": {
     "index.html": {
-      "offset": "3753",
+      "offset": "26472",
       "size": 378,
     },
     "index.js": {
-      "offset": "4131",
+      "offset": "26850",
       "size": 619,
     },
     "node_modules": {
       "files": {
-        "edge-cs": {
+        "debug": {
           "files": {
-            "LICENSE.txt": {
-              "size": 565,
-              "unpacked": true,
+            "LICENSE": {
+              "offset": "0",
+              "size": 1107,
             },
-            "lib": {
-              "files": {
-                "bootstrap": {
-                  "files": {
-                    "Dummy.cs": {
-                      "size": 41,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 175,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
-                "edge-cs.dll": {
-                  "size": 10752,
-                  "unpacked": true,
-                },
-                "edge-cs.js": {
-                  "size": 363,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
+            "Makefile": {
+              "offset": "1107",
+              "size": 1234,
+            },
+            "node.js": {
+              "offset": "2341",
+              "size": 40,
             },
             "package.json": {
-              "size": 606,
-              "unpacked": true,
+              "offset": "2381",
+              "size": 830,
             },
             "src": {
               "files": {
-                "Edge.js.CSharp": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 11533,
-                      "unpacked": true,
-                    },
-                    "gulpfile.js": {
-                      "size": 515,
-                      "unpacked": true,
-                    },
-                    "package.json": {
-                      "size": 62,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 775,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
+                "browser.js": {
+                  "offset": "3211",
+                  "size": 5707,
                 },
-                "edge-cs": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 9315,
-                      "unpacked": true,
-                    },
-                    "Properties": {
-                      "files": {
-                        "AssemblyInfo.cs": {
-                          "size": 1426,
-                          "unpacked": true,
-                        },
-                      },
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
+                "debug.js": {
+                  "offset": "8918",
+                  "size": 4889,
+                },
+                "index.js": {
+                  "offset": "13807",
+                  "size": 263,
+                },
+                "node.js": {
+                  "offset": "14070",
+                  "size": 4339,
                 },
               },
-              "unpacked": true,
-            },
-            "tools": {
-              "files": {
-                "install.js": {
-                  "size": 968,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
             },
           },
-          "unpacked": true,
         },
         "electron-clear-data": {
           "files": {
             "LICENSE.md": {
-              "offset": "0",
+              "offset": "18409",
               "size": 1059,
             },
             "dist": {
               "files": {
                 "main.js": {
-                  "offset": "1059",
+                  "offset": "19468",
                   "size": 1734,
                 },
               },
             },
             "package.json": {
-              "offset": "2793",
+              "offset": "21202",
               "size": 960,
+            },
+          },
+        },
+        "ms": {
+          "files": {
+            "index.js": {
+              "offset": "22162",
+              "size": 2764,
+            },
+            "license.md": {
+              "offset": "24926",
+              "size": 1077,
+            },
+            "package.json": {
+              "offset": "26003",
+              "size": 469,
             },
           },
         },
       },
     },
     "package.json": {
-      "offset": "4750",
-      "size": 395,
+      "offset": "27469",
+      "size": 393,
     },
   },
 }
@@ -836,112 +740,76 @@ exports[`yarn some module add by manual instead of install 2`] = `
 {
   "files": {
     "index.html": {
-      "offset": "0",
+      "offset": "22719",
       "size": 378,
     },
     "index.js": {
-      "offset": "378",
+      "offset": "23097",
       "size": 619,
     },
     "node_modules": {
       "files": {
-        "edge-cs": {
+        "debug": {
           "files": {
-            "LICENSE.txt": {
-              "size": 565,
-              "unpacked": true,
+            "LICENSE": {
+              "offset": "0",
+              "size": 1107,
             },
-            "lib": {
-              "files": {
-                "bootstrap": {
-                  "files": {
-                    "Dummy.cs": {
-                      "size": 41,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 175,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
-                },
-                "edge-cs.dll": {
-                  "size": 10752,
-                  "unpacked": true,
-                },
-                "edge-cs.js": {
-                  "size": 363,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
+            "Makefile": {
+              "offset": "1107",
+              "size": 1234,
+            },
+            "node.js": {
+              "offset": "2341",
+              "size": 40,
             },
             "package.json": {
-              "size": 606,
-              "unpacked": true,
+              "offset": "2381",
+              "size": 830,
             },
             "src": {
               "files": {
-                "Edge.js.CSharp": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 11533,
-                      "unpacked": true,
-                    },
-                    "gulpfile.js": {
-                      "size": 515,
-                      "unpacked": true,
-                    },
-                    "package.json": {
-                      "size": 62,
-                      "unpacked": true,
-                    },
-                    "project.json": {
-                      "size": 775,
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
+                "browser.js": {
+                  "offset": "3211",
+                  "size": 5707,
                 },
-                "edge-cs": {
-                  "files": {
-                    "EdgeCompiler.cs": {
-                      "size": 9315,
-                      "unpacked": true,
-                    },
-                    "Properties": {
-                      "files": {
-                        "AssemblyInfo.cs": {
-                          "size": 1426,
-                          "unpacked": true,
-                        },
-                      },
-                      "unpacked": true,
-                    },
-                  },
-                  "unpacked": true,
+                "debug.js": {
+                  "offset": "8918",
+                  "size": 4889,
+                },
+                "index.js": {
+                  "offset": "13807",
+                  "size": 263,
+                },
+                "node.js": {
+                  "offset": "14070",
+                  "size": 4339,
                 },
               },
-              "unpacked": true,
-            },
-            "tools": {
-              "files": {
-                "install.js": {
-                  "size": 968,
-                  "unpacked": true,
-                },
-              },
-              "unpacked": true,
             },
           },
-          "unpacked": true,
+        },
+        "ms": {
+          "files": {
+            "index.js": {
+              "offset": "18409",
+              "size": 2764,
+            },
+            "license.md": {
+              "offset": "21173",
+              "size": 1077,
+            },
+            "package.json": {
+              "offset": "22250",
+              "size": 469,
+            },
+          },
         },
       },
     },
     "package.json": {
-      "offset": "997",
-      "size": 326,
+      "offset": "23716",
+      "size": 324,
     },
   },
 }

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -98,30 +98,30 @@ test.ifAll("pnpm es5-ext without hoisted config", () =>
 )
 
 test.ifAll("pnpm optional dependencies", () =>
-   assertPack(
-     "test-app-hoisted",
-     {
-       targets: linuxDirTarget,
-     },
-     {
-       isInstallDepsBefore: true,
-       projectDirCreated: projectDir => {
-         return Promise.all([
-           modifyPackageJson(projectDir, data => {
-             data.dependencies = {
-               "electron-clear-data": "^1.0.5",
-             }
-             data.optionalDependencies = {
-               "edge-cs": "1.2.1",
-             }
-           }),
-           outputFile(path.join(projectDir, "pnpm-lock.yaml"), ""),
-         ])
-       },
-       packed: context => verifyAsarFileTree(context.getResources(Platform.LINUX)),
-     }
-   )
- )
+  assertPack(
+    "test-app-hoisted",
+    {
+      targets: linuxDirTarget,
+    },
+    {
+      isInstallDepsBefore: true,
+      projectDirCreated: projectDir => {
+        return Promise.all([
+          modifyPackageJson(projectDir, data => {
+            data.dependencies = {
+              "electron-clear-data": "^1.0.5",
+            }
+            data.optionalDependencies = {
+              "edge-cs": "1.2.1",
+            }
+          }),
+          outputFile(path.join(projectDir, "pnpm-lock.yaml"), ""),
+        ])
+      },
+      packed: context => verifyAsarFileTree(context.getResources(Platform.LINUX)),
+    }
+  )
+)
 
 test.ifAll("yarn electron-clear-data", () =>
   assertPack(
@@ -185,7 +185,7 @@ test.ifAll("yarn some module add by manual instead of install", () =>
       isInstallDepsBefore: true,
       projectDirCreated: async (projectDir, tmpDir) => {
         await outputFile(path.join(projectDir, "package-lock.json"), "")
-        await outputFile(path.join(projectDir,"node_modules", "package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
+        await outputFile(path.join(projectDir, "node_modules", "package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
             "edge-cs": "1.2.1",
@@ -196,7 +196,6 @@ test.ifAll("yarn some module add by manual instead of install", () =>
     }
   )
 )
-
 
 //github.com/electron-userland/electron-builder/issues/8426
 test.ifAll("yarn parse-asn1", () =>

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -98,30 +98,30 @@ test.ifAll("pnpm es5-ext without hoisted config", () =>
 )
 
 test.ifAll("pnpm optional dependencies", () =>
-  assertPack(
-    "test-app-hoisted",
-    {
-      targets: linuxDirTarget,
-    },
-    {
-      isInstallDepsBefore: true,
-      projectDirCreated: projectDir => {
-        return Promise.all([
-          modifyPackageJson(projectDir, data => {
-            data.dependencies = {
-              "electron-clear-data": "^1.0.5",
-            }
-            data.optionalDependencies = {
-              "edge-cs": "1.2.1",
-            }
-          }),
-          outputFile(path.join(projectDir, "pnpm-lock.yaml"), ""),
-        ])
-      },
-      packed: context => verifyAsarFileTree(context.getResources(Platform.LINUX)),
-    }
-  )
-)
+   assertPack(
+     "test-app-hoisted",
+     {
+       targets: linuxDirTarget,
+     },
+     {
+       isInstallDepsBefore: true,
+       projectDirCreated: projectDir => {
+         return Promise.all([
+           modifyPackageJson(projectDir, data => {
+             data.dependencies = {
+               "electron-clear-data": "^1.0.5",
+             }
+             data.optionalDependencies = {
+               "edge-cs": "1.2.1",
+             }
+           }),
+           outputFile(path.join(projectDir, "pnpm-lock.yaml"), ""),
+         ])
+       },
+       packed: context => verifyAsarFileTree(context.getResources(Platform.LINUX)),
+     }
+   )
+ )
 
 test.ifAll("yarn electron-clear-data", () =>
   assertPack(
@@ -149,7 +149,7 @@ test.ifAll("yarn electron-clear-data", () =>
   )
 )
 
-test.ifAll("yarn electron-clear-data", () =>
+test.ifAll("npm electron-clear-data", () =>
   assertPack(
     "test-app-hoisted",
     {
@@ -174,6 +174,29 @@ test.ifAll("yarn electron-clear-data", () =>
     }
   )
 )
+
+test.ifAll("yarn some module add by manual instead of install", () =>
+  assertPack(
+    "test-app-hoisted",
+    {
+      targets: Platform.WINDOWS.createTarget(DIR_TARGET, Arch.x64),
+    },
+    {
+      isInstallDepsBefore: true,
+      projectDirCreated: async (projectDir, tmpDir) => {
+        await outputFile(path.join(projectDir, "package-lock.json"), "")
+        await outputFile(path.join(projectDir,"node_modules", "package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
+        await modifyPackageJson(projectDir, data => {
+          data.dependencies = {
+            "edge-cs": "1.2.1",
+          }
+        })
+      },
+      packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),
+    }
+  )
+)
+
 
 //github.com/electron-userland/electron-builder/issues/8426
 test.ifAll("yarn parse-asn1", () =>

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -186,7 +186,7 @@ test.ifAll("yarn some module add by manual instead of install", () =>
       isInstallDepsBefore: true,
       projectDirCreated: async (projectDir, tmpDir) => {
         await outputFile(path.join(projectDir, "yarn.lock"), "")
-        await outputFile(path.join(projectDir, "node_modules","foo","package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
+        await outputFile(path.join(projectDir, "node_modules", "foo", "package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
             debug: "3.1.0",

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -137,8 +137,37 @@ test.ifAll("yarn electron-clear-data", () =>
             data.dependencies = {
               "electron-clear-data": "^1.0.5",
             }
+              data.optionalDependencies = {
+            "edge-cs": "1.2.1",
+            }
           }),
           outputFile(path.join(projectDir, "yarn.lock"), ""),
+        ])
+      },
+       packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),
+    }
+  )
+)
+
+test.ifAll("yarn electron-clear-data", () =>
+  assertPack(
+    "test-app-hoisted",
+    {
+      targets: Platform.WINDOWS.createTarget(DIR_TARGET, Arch.x64),
+    },
+    {
+      isInstallDepsBefore: true,
+      projectDirCreated: projectDir => {
+        return Promise.all([
+          modifyPackageJson(projectDir, data => {
+            data.dependencies = {
+              "electron-clear-data": "^1.0.5",
+            }
+              data.optionalDependencies = {
+            "edge-cs": "1.2.1",
+            }
+          }),
+          outputFile(path.join(projectDir, "package-lock.json"), ""),
         ])
       },
        packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -215,7 +215,7 @@ test.ifAll("yarn ms", () =>
               "electron-clear-data": "^1.0.5",
             }
             data.devDependencies = {
-             "electron": "34.0.2"
+              electron: "34.0.2",
             }
           }),
           outputFile(path.join(projectDir, "yarn.lock"), ""),

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -3,7 +3,6 @@ import { Platform, Arch, DIR_TARGET } from "electron-builder"
 import { outputFile } from "fs-extra"
 import * as path from "path"
 import { readAsarJson } from "app-builder-lib/out/asar/asar"
-import { assertThat } from "./helpers/fileAssert"
 
 test.ifAll("yarn workspace", () =>
   assertPack(
@@ -110,19 +109,16 @@ test.ifAll("pnpm optional dependencies", () =>
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.dependencies = {
-              "edge-cs": "1.2.1",
+              "electron-clear-data": "^1.0.5",
             }
             data.optionalDependencies = {
-              "electron-clear-data": "^1.0.5",
+            "edge-cs": "1.2.1",
             }
           }),
           outputFile(path.join(projectDir, "pnpm-lock.yaml"), ""),
         ])
       },
-      packed: async context => {
-        expect(await readAsarJson(path.join(context.getResources(Platform.LINUX), "app.asar"), "node_modules/electron-clear-data/package.json")).toMatchSnapshot()
-        await assertThat(path.join(context.getResources(Platform.LINUX), "app", "node_modules", "electron")).doesNotExist()
-      },
+       packed: context => verifyAsarFileTree(context.getResources(Platform.LINUX)),
     }
   )
 )
@@ -145,6 +141,7 @@ test.ifAll("yarn electron-clear-data", () =>
           outputFile(path.join(projectDir, "yarn.lock"), ""),
         ])
       },
+       packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),
     }
   )
 )

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -112,13 +112,13 @@ test.ifAll("pnpm optional dependencies", () =>
               "electron-clear-data": "^1.0.5",
             }
             data.optionalDependencies = {
-            "edge-cs": "1.2.1",
+              "edge-cs": "1.2.1",
             }
           }),
           outputFile(path.join(projectDir, "pnpm-lock.yaml"), ""),
         ])
       },
-       packed: context => verifyAsarFileTree(context.getResources(Platform.LINUX)),
+      packed: context => verifyAsarFileTree(context.getResources(Platform.LINUX)),
     }
   )
 )
@@ -137,14 +137,14 @@ test.ifAll("yarn electron-clear-data", () =>
             data.dependencies = {
               "electron-clear-data": "^1.0.5",
             }
-              data.optionalDependencies = {
-            "edge-cs": "1.2.1",
+            data.optionalDependencies = {
+              "edge-cs": "1.2.1",
             }
           }),
           outputFile(path.join(projectDir, "yarn.lock"), ""),
         ])
       },
-       packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),
+      packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),
     }
   )
 )
@@ -163,14 +163,14 @@ test.ifAll("yarn electron-clear-data", () =>
             data.dependencies = {
               "electron-clear-data": "^1.0.5",
             }
-              data.optionalDependencies = {
-            "edge-cs": "1.2.1",
+            data.optionalDependencies = {
+              "edge-cs": "1.2.1",
             }
           }),
           outputFile(path.join(projectDir, "package-lock.json"), ""),
         ])
       },
-       packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),
+      packed: context => verifyAsarFileTree(context.getResources(Platform.WINDOWS)),
     }
   )
 )

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -114,7 +114,7 @@ test.only("yarn electron-clear-data", () =>
           }),
           outputFile(path.join(projectDir, "yarn.lock"), ""),
         ])
-      }
+      },
     }
   ))
 

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -1,5 +1,5 @@
 import { assertPack, linuxDirTarget, verifyAsarFileTree, modifyPackageJson } from "./helpers/packTester"
-import { Platform } from "electron-builder"
+import { Platform, Arch, DIR_TARGET } from "electron-builder"
 import { outputFile } from "fs-extra"
 import * as path from "path"
 import { readAsarJson } from "app-builder-lib/out/asar/asar"
@@ -96,6 +96,27 @@ test.ifAll("pnpm es5-ext without hoisted config", () =>
     }
   )
 )
+
+test.only("yarn electron-clear-data", () =>
+  assertPack(
+    "test-app-hoisted",
+    {
+      targets: Platform.MAC.createTarget(DIR_TARGET, Arch.x64),
+    },
+    {
+      isInstallDepsBefore: true,
+      projectDirCreated: projectDir => {
+        return Promise.all([
+          modifyPackageJson(projectDir, data => {
+            data.dependencies = {
+              "electron-clear-data": "^1.0.5",
+            }
+          }),
+          outputFile(path.join(projectDir, "yarn.lock"), ""),
+        ])
+      },
+    }
+  ))
 
 //github.com/electron-userland/electron-builder/issues/8426
 https: test.ifAll("yarn parse-asn1", () =>

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -101,7 +101,7 @@ test.only("yarn electron-clear-data", () =>
   assertPack(
     "test-app-hoisted",
     {
-      targets: Platform.MAC.createTarget(DIR_TARGET, Arch.x64),
+      targets: Platform.WINDOWS.createTarget(DIR_TARGET, Arch.x64),
     },
     {
       isInstallDepsBefore: true,
@@ -114,12 +114,12 @@ test.only("yarn electron-clear-data", () =>
           }),
           outputFile(path.join(projectDir, "yarn.lock"), ""),
         ])
-      },
+      }
     }
   ))
 
 //github.com/electron-userland/electron-builder/issues/8426
-https: test.ifAll("yarn parse-asn1", () =>
+test.ifAll("yarn parse-asn1", () =>
   assertPack(
     "test-app-hoisted",
     {
@@ -145,7 +145,7 @@ https: test.ifAll("yarn parse-asn1", () =>
 )
 
 //github.com/electron-userland/electron-builder/issues/8431
-https: test.ifAll("npm tar", () =>
+test.ifAll("npm tar", () =>
   assertPack(
     "test-app-hoisted",
     {

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -185,8 +185,8 @@ test.ifAll("yarn some module add by manual instead of install", () =>
     {
       isInstallDepsBefore: true,
       projectDirCreated: async (projectDir, tmpDir) => {
-        await outputFile(path.join(projectDir, "package-lock.json"), "")
-        await outputFile(path.join(projectDir, "node_modules", "package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
+        await outputFile(path.join(projectDir, "yarn.lock"), "")
+        await outputFile(path.join(projectDir, "node_modules","foo","package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
             debug: "3.1.0",

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -199,6 +199,33 @@ test.ifAll("yarn some module add by manual instead of install", () =>
 )
 
 //github.com/electron-userland/electron-builder/issues/8426
+test.ifAll("yarn ms", () =>
+  assertPack(
+    "test-app-hoisted",
+    {
+      targets: linuxDirTarget,
+    },
+    {
+      isInstallDepsBefore: true,
+      projectDirCreated: projectDir => {
+        return Promise.all([
+          modifyPackageJson(projectDir, data => {
+            data.dependencies = {
+              "@sentry/electron": "5.11.0",
+              "@babel/parser": "7.26.7",
+            }
+          }),
+          outputFile(path.join(projectDir, "yarn.lock"), ""),
+        ])
+      },
+      packed: async context => {
+        expect(await readAsarJson(path.join(context.getResources(Platform.LINUX), "app.asar"), "node_modules/ms/package.json")).toMatchSnapshot()
+      },
+    }
+  )
+)
+
+//github.com/electron-userland/electron-builder/issues/8426
 test.ifAll("yarn parse-asn1", () =>
   assertPack(
     "test-app-hoisted",

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -112,7 +112,7 @@ test.ifAll("pnpm optional dependencies", () =>
               "electron-clear-data": "^1.0.5",
             }
             data.optionalDependencies = {
-              "edge-cs": "1.2.1",
+              debug: "3.1.0",
             }
           }),
           outputFile(path.join(projectDir, "pnpm-lock.yaml"), ""),
@@ -138,7 +138,7 @@ test.ifAll("yarn electron-clear-data", () =>
               "electron-clear-data": "^1.0.5",
             }
             data.optionalDependencies = {
-              "edge-cs": "1.2.1",
+              debug: "3.1.0",
             }
           }),
           outputFile(path.join(projectDir, "yarn.lock"), ""),
@@ -164,7 +164,7 @@ test.ifAll("npm electron-clear-data", () =>
               "electron-clear-data": "^1.0.5",
             }
             data.optionalDependencies = {
-              "edge-cs": "1.2.1",
+              debug: "3.1.0",
             }
           }),
           outputFile(path.join(projectDir, "package-lock.json"), ""),
@@ -175,6 +175,7 @@ test.ifAll("npm electron-clear-data", () =>
   )
 )
 
+// https://github.com/electron-userland/electron-builder/issues/8842
 test.ifAll("yarn some module add by manual instead of install", () =>
   assertPack(
     "test-app-hoisted",
@@ -188,7 +189,7 @@ test.ifAll("yarn some module add by manual instead of install", () =>
         await outputFile(path.join(projectDir, "node_modules", "package.json"), `{"name":"foo","version":"9.0.0","main":"index.js","license":"MIT"}`)
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
-            "edge-cs": "1.2.1",
+            debug: "3.1.0",
           }
         })
       },


### PR DESCRIPTION
**Root Cause**
In the data returned by npm list, if there are duplicate packages with the same version in the dependencies, only one will be present.

![image](https://github.com/user-attachments/assets/26ecac89-0b04-4e25-b0d6-f688642e22c2)

![image](https://github.com/user-attachments/assets/1f323c50-5a10-4cb5-ae57-2cb9c8b37073)


**How to fix**

First, traverse all the packages and store them in a map. Then, when removing non-production dependencies, if you find that the dependencies are empty, retrieve them again from the complete list of packages.


**UT**
```javascript
//github.com/electron-userland/electron-builder/issues/8842
test.ifAll("yarn ms", () =>
  assertPack(
    "test-app-hoisted",
    {
      targets: linuxDirTarget,
    },
    {
      isInstallDepsBefore: true,
      projectDirCreated: projectDir => {
        return Promise.all([
          modifyPackageJson(projectDir, data => {
            data.dependencies = {
              "@sentry/electron": "5.11.0",
              "electron-clear-data": "^1.0.5",
            }
            data.devDependencies = {
              electron: "34.0.2",
            }
          }),
          outputFile(path.join(projectDir, "yarn.lock"), ""),
        ])
      },
      packed: async context => {
        expect(await readAsarJson(path.join(context.getResources(Platform.LINUX), "app.asar"), "node_modules/ms/package.json")).toMatchSnapshot()
      },
    }
  )
)
```
