### PR TITLE
chore(tests): use `yarn` instead of `npm install` to resolve unit test instability

### DIFF
--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -282,8 +282,8 @@ test.ifAll.ifDevOrLinuxCi("asarUnpack node_modules which has many modules", () =
     },
     {
       isInstallDepsBefore: true,
-      projectDirCreated: projectDir =>
-        modifyPackageJson(projectDir, data => {
+      projectDirCreated: async projectDir => {
+        await modifyPackageJson(projectDir, data => {
           data.dependencies = {
             "@react-navigation/stack": "^6.3.7",
             "@sentry/electron": "^4.4.0",
@@ -305,7 +305,9 @@ test.ifAll.ifDevOrLinuxCi("asarUnpack node_modules which has many modules", () =
             yargs: "^16.2.0",
             "ci-info": "2.0.0",
           }
-        }),
+        })
+        await outputFile(path.join(projectDir, "yarn.lock"), "")
+      },
       packed: async context => {
         await assertThat(path.join(context.getResources(Platform.LINUX), "app.asar.unpacked/node_modules/jwt-decode")).isDirectory()
         await assertThat(path.join(context.getResources(Platform.LINUX), "app.asar.unpacked/node_modules/keytar")).isDirectory()
@@ -328,8 +330,8 @@ test.ifAll.ifDevOrLinuxCi("exclude some modules when asarUnpack node_modules whi
     },
     {
       isInstallDepsBefore: true,
-      projectDirCreated: projectDir =>
-        modifyPackageJson(projectDir, data => {
+      projectDirCreated: async projectDir => {
+        await modifyPackageJson(projectDir, data => {
           data.dependencies = {
             "@react-navigation/stack": "^6.3.7",
             "@sentry/electron": "^4.4.0",
@@ -351,7 +353,9 @@ test.ifAll.ifDevOrLinuxCi("exclude some modules when asarUnpack node_modules whi
             yargs: "^16.2.0",
             "ci-info": "2.0.0",
           }
-        }),
+        })
+        await outputFile(path.join(projectDir, "yarn.lock"), "")
+      },
       packed: async context => {
         await assertThat(path.join(context.getResources(Platform.LINUX), "app.asar.unpacked/node_modules/jwt-decode")).isDirectory()
         await assertThat(path.join(context.getResources(Platform.LINUX), "app.asar.unpacked/node_modules/keytar")).isDirectory()


### PR DESCRIPTION
error by npm install
```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: electronSquirrelDemo@1.0.0
npm error Found: react@18.2.0
npm error node_modules/react
npm error   react@"18.2.0" from the root project
npm error   peer react@"*" from @react-navigation/stack@6.3.7
npm error   node_modules/@react-navigation/stack
npm error     @react-navigation/stack@"6.3.7" from the root project
npm error   1 more (@react-navigation/native)
npm error
npm error Could not resolve dependency:
npm error peer react@"^19.0.0" from react-native@0.78.0
npm error node_modules/react-native
npm error   peer react-native@"*" from @react-navigation/stack@6.3.7
npm error   node_modules/@react-navigation/stack
npm error     @react-navigation/stack@"6.3.7" from the root project
npm error   peer react-native@"*" from @react-navigation/native@6.1.18
npm error   node_modules/@react-navigation/native
npm error     peer @react-navigation/native@"^6.0.0" from @react-navigation/stack@6.3.7
npm error     node_modules/@react-navigation/stack
npm error       @react-navigation/stack@"6.3.7" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error C:\Users\payne\AppData\Local\npm-cache\_logs\2025-02-19T23_41_16_166Z-eresolve-report.txt
npm error A complete log of this run can be found in: C:\Users\payne\AppData\Local\npm-cache\_logs\2025-02-19T23_41_16_166Z-debug-0.log

```

![image](https://github.com/user-attachments/assets/e3330404-d25a-4cfb-b1c4-99b2e2278161)

