### PR TITLE
fix: `AsyncEventEmitter` `filterListeners` doesn't work with promises

### DIFF
--- a/.changeset/few-zebras-swim.md
+++ b/.changeset/few-zebras-swim.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: remove Promise ability from AsyncEventEmitter as it's impossible to filter listeners by without being async

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -260,18 +260,18 @@ export class Packager {
     log.info({ version: PACKAGE_VERSION, os: getOsRelease() }, "electron-builder")
   }
 
-  addPackagerEventHandlers() {
+  async addPackagerEventHandlers() {
     const { type } = this.appInfo
-    this.eventEmitter.on("artifactBuildStarted", resolveFunction(type, this.config.artifactBuildStarted, "artifactBuildStarted"), "user")
-    this.eventEmitter.on("artifactBuildCompleted", resolveFunction(type, this.config.artifactBuildCompleted, "artifactBuildCompleted"), "user")
+    this.eventEmitter.on("artifactBuildStarted", await resolveFunction(type, this.config.artifactBuildStarted, "artifactBuildStarted"), "user")
+    this.eventEmitter.on("artifactBuildCompleted", await resolveFunction(type, this.config.artifactBuildCompleted, "artifactBuildCompleted"), "user")
 
-    this.eventEmitter.on("appxManifestCreated", resolveFunction(type, this.config.appxManifestCreated, "appxManifestCreated"), "user")
-    this.eventEmitter.on("msiProjectCreated", resolveFunction(type, this.config.msiProjectCreated, "msiProjectCreated"), "user")
+    this.eventEmitter.on("appxManifestCreated", await resolveFunction(type, this.config.appxManifestCreated, "appxManifestCreated"), "user")
+    this.eventEmitter.on("msiProjectCreated", await resolveFunction(type, this.config.msiProjectCreated, "msiProjectCreated"), "user")
 
-    this.eventEmitter.on("beforePack", resolveFunction(type, this.config.beforePack, "beforePack"), "user")
-    this.eventEmitter.on("afterExtract", resolveFunction(type, this.config.afterExtract, "afterExtract"), "user")
-    this.eventEmitter.on("afterPack", resolveFunction(type, this.config.afterPack, "afterPack"), "user")
-    this.eventEmitter.on("afterSign", resolveFunction(type, this.config.afterSign, "afterSign"), "user")
+    this.eventEmitter.on("beforePack", await resolveFunction(type, this.config.beforePack, "beforePack"), "user")
+    this.eventEmitter.on("afterExtract", await resolveFunction(type, this.config.afterExtract, "afterExtract"), "user")
+    this.eventEmitter.on("afterPack", await resolveFunction(type, this.config.afterPack, "afterPack"), "user")
+    this.eventEmitter.on("afterSign", await resolveFunction(type, this.config.afterSign, "afterSign"), "user")
   }
 
   onAfterPack(handler: PackagerEvents["afterPack"]): Packager {
@@ -396,7 +396,7 @@ export class Packager {
     }
 
     this._appInfo = new AppInfo(this, null)
-    this.addPackagerEventHandlers()
+    await this.addPackagerEventHandlers()
 
     this._framework = await createFrameworkInfo(this.config, this)
 

--- a/packages/app-builder-lib/src/util/asyncEventEmitter.ts
+++ b/packages/app-builder-lib/src/util/asyncEventEmitter.ts
@@ -5,7 +5,7 @@ type Handler = (...args: any[]) => Promise<void> | void
 
 export type HandlerType = "system" | "user"
 
-type Handle = { handler: Handler | Promise<Handler | Nullish>; type: HandlerType }
+type Handle = { handler: Handler | Nullish; type: HandlerType }
 
 export type EventMap = {
   [key: string]: Handler
@@ -23,7 +23,7 @@ export class AsyncEventEmitter<T extends EventMap> implements TypedEventEmitter<
   private readonly listeners: Map<keyof T, Handle[] | undefined> = new Map()
   private readonly cancellationToken = new CancellationToken()
 
-  on<E extends keyof T>(event: E, listener: T[E] | Promise<T[E] | Nullish> | Nullish, type: HandlerType = "system"): this {
+  on<E extends keyof T>(event: E, listener: T[E] | Nullish, type: HandlerType = "system"): this {
     if (!listener) {
       return this
     }
@@ -72,10 +72,7 @@ export class AsyncEventEmitter<T extends EventMap> implements TypedEventEmitter<
 
   filterListeners<E extends keyof T>(event: E, type: HandlerType | undefined): Handle[] {
     const listeners = this.listeners.get(event) ?? []
-    if (type) {
-      return listeners.filter(l => l.type === type)
-    }
-    return listeners
+    return type ? listeners.filter(l => l.type === type) : listeners
   }
 
   clear() {

--- a/packages/app-builder-lib/src/util/asyncEventEmitter.ts
+++ b/packages/app-builder-lib/src/util/asyncEventEmitter.ts
@@ -5,7 +5,7 @@ type Handler = (...args: any[]) => Promise<void> | void
 
 export type HandlerType = "system" | "user"
 
-type Handle = { handler: Handler | Nullish; type: HandlerType }
+type Handle = { handler: Handler; type: HandlerType }
 
 export type EventMap = {
   [key: string]: Handler


### PR DESCRIPTION
Removes Promise ability from `.on` assignment of listeners in AsyncEventEmitter as it's impossible to filter listeners without `filterListeners` being async. 