### PR TITLE
chore: update snapshots and pin fixture dep versions

### DIFF
--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -188,11 +188,11 @@ exports[`npm tar 2`] = `
 {
   "files": {
     "index.html": {
-      "offset": "4567834",
+      "offset": "4567635",
       "size": 378,
     },
     "index.js": {
-      "offset": "4568212",
+      "offset": "4568013",
       "size": 619,
     },
     "node_modules": {
@@ -637,54 +637,54 @@ exports[`npm tar 2`] = `
                   "files": {
                     "all-signals.d.ts.map": {
                       "offset": "303025",
-                      "size": 150,
+                      "size": 169,
                     },
                     "all-signals.js": {
-                      "offset": "303175",
+                      "offset": "303194",
                       "size": 1553,
                     },
                     "all-signals.js.map": {
-                      "offset": "304728",
+                      "offset": "304747",
                       "size": 2231,
                     },
                     "index.d.ts.map": {
-                      "offset": "306959",
-                      "size": 1923,
+                      "offset": "306978",
+                      "size": 1921,
                     },
                     "index.js": {
-                      "offset": "308882",
-                      "size": 4102,
+                      "offset": "308899",
+                      "size": 4076,
                     },
                     "index.js.map": {
-                      "offset": "312984",
-                      "size": 9834,
+                      "offset": "312975",
+                      "size": 9835,
                     },
                     "package.json": {
-                      "offset": "322818",
+                      "offset": "322810",
                       "size": 25,
                     },
                     "proxy-signals.d.ts.map": {
-                      "offset": "322843",
-                      "size": 222,
+                      "offset": "322835",
+                      "size": 221,
                     },
                     "proxy-signals.js": {
-                      "offset": "323065",
+                      "offset": "323056",
                       "size": 1159,
                     },
                     "proxy-signals.js.map": {
-                      "offset": "324224",
+                      "offset": "324215",
                       "size": 1884,
                     },
                     "watchdog.d.ts.map": {
-                      "offset": "326108",
-                      "size": 212,
+                      "offset": "326099",
+                      "size": 211,
                     },
                     "watchdog.js": {
-                      "offset": "326320",
+                      "offset": "326310",
                       "size": 1574,
                     },
                     "watchdog.js.map": {
-                      "offset": "327894",
+                      "offset": "327884",
                       "size": 2214,
                     },
                   },
@@ -692,55 +692,55 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "all-signals.d.ts.map": {
-                      "offset": "330108",
-                      "size": 150,
+                      "offset": "330098",
+                      "size": 169,
                     },
                     "all-signals.js": {
-                      "offset": "330258",
+                      "offset": "330267",
                       "size": 1269,
                     },
                     "all-signals.js.map": {
-                      "offset": "331527",
+                      "offset": "331536",
                       "size": 2254,
                     },
                     "index.d.ts.map": {
-                      "offset": "333781",
-                      "size": 1923,
+                      "offset": "333790",
+                      "size": 1921,
                     },
                     "index.js": {
-                      "offset": "335704",
+                      "offset": "335711",
                       "size": 3613,
                     },
                     "index.js.map": {
-                      "offset": "339317",
+                      "offset": "339324",
                       "size": 9922,
                     },
                     "package.json": {
-                      "offset": "349239",
+                      "offset": "349246",
                       "size": 23,
                     },
                     "proxy-signals.d.ts.map": {
-                      "offset": "349262",
-                      "size": 222,
+                      "offset": "349269",
+                      "size": 221,
                     },
                     "proxy-signals.js": {
-                      "offset": "349484",
+                      "offset": "349490",
                       "size": 997,
                     },
                     "proxy-signals.js.map": {
-                      "offset": "350481",
+                      "offset": "350487",
                       "size": 1896,
                     },
                     "watchdog.d.ts.map": {
-                      "offset": "352377",
-                      "size": 212,
+                      "offset": "352383",
+                      "size": 211,
                     },
                     "watchdog.js": {
-                      "offset": "352589",
+                      "offset": "352594",
                       "size": 1416,
                     },
                     "watchdog.js.map": {
-                      "offset": "354005",
+                      "offset": "354010",
                       "size": 2223,
                     },
                   },
@@ -748,15 +748,15 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "356228",
-              "size": 2533,
+              "offset": "356233",
+              "size": 2329,
             },
           },
         },
         "glob": {
           "files": {
             "LICENSE": {
-              "offset": "358761",
+              "offset": "358562",
               "size": 775,
             },
             "dist": {
@@ -764,91 +764,91 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "glob.d.ts.map": {
-                      "offset": "359536",
+                      "offset": "359337",
                       "size": 4038,
                     },
                     "glob.js": {
-                      "offset": "363574",
+                      "offset": "363375",
                       "size": 8546,
                     },
                     "glob.js.map": {
-                      "offset": "372120",
+                      "offset": "371921",
                       "size": 28218,
                     },
                     "has-magic.d.ts.map": {
-                      "offset": "400338",
+                      "offset": "400139",
                       "size": 246,
                     },
                     "has-magic.js": {
-                      "offset": "400584",
+                      "offset": "400385",
                       "size": 1058,
                     },
                     "has-magic.js.map": {
-                      "offset": "401642",
+                      "offset": "401443",
                       "size": 1482,
                     },
                     "ignore.d.ts.map": {
-                      "offset": "403124",
+                      "offset": "402925",
                       "size": 886,
                     },
                     "ignore.js": {
-                      "offset": "404010",
+                      "offset": "403811",
                       "size": 4267,
                     },
                     "ignore.js.map": {
-                      "offset": "408277",
+                      "offset": "408078",
                       "size": 7471,
                     },
                     "index.d.ts.map": {
-                      "offset": "415748",
+                      "offset": "415549",
                       "size": 4085,
                     },
                     "index.js": {
-                      "offset": "419833",
+                      "offset": "419634",
                       "size": 2876,
                     },
                     "index.js.map": {
-                      "offset": "422709",
+                      "offset": "422510",
                       "size": 8370,
                     },
                     "package.json": {
-                      "offset": "431079",
+                      "offset": "430880",
                       "size": 25,
                     },
                     "pattern.d.ts.map": {
-                      "offset": "431104",
+                      "offset": "430905",
                       "size": 1314,
                     },
                     "pattern.js": {
-                      "offset": "432418",
+                      "offset": "432219",
                       "size": 7300,
                     },
                     "pattern.js.map": {
-                      "offset": "439718",
+                      "offset": "439519",
                       "size": 13391,
                     },
                     "processor.d.ts.map": {
-                      "offset": "453109",
+                      "offset": "452910",
                       "size": 1748,
                     },
                     "processor.js": {
-                      "offset": "454857",
+                      "offset": "454658",
                       "size": 10760,
                     },
                     "processor.js.map": {
-                      "offset": "465617",
+                      "offset": "465418",
                       "size": 19044,
                     },
                     "walker.d.ts.map": {
-                      "offset": "484661",
+                      "offset": "484462",
                       "size": 4195,
                     },
                     "walker.js": {
-                      "offset": "488856",
+                      "offset": "488657",
                       "size": 12869,
                     },
                     "walker.js.map": {
-                      "offset": "501725",
+                      "offset": "501526",
                       "size": 27899,
                     },
                   },
@@ -856,108 +856,108 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "bin.d.mts": {
-                      "offset": "529624",
+                      "offset": "529425",
                       "size": 65,
                     },
                     "bin.d.mts.map": {
-                      "offset": "529689",
+                      "offset": "529490",
                       "size": 105,
                     },
                     "bin.mjs": {
                       "executable": true,
-                      "offset": "529794",
+                      "offset": "529595",
                       "size": 9520,
                     },
                     "bin.mjs.map": {
-                      "offset": "539314",
+                      "offset": "539115",
                       "size": 14152,
                     },
                     "glob.d.ts.map": {
-                      "offset": "553466",
+                      "offset": "553267",
                       "size": 4038,
                     },
                     "glob.js": {
-                      "offset": "557504",
+                      "offset": "557305",
                       "size": 8339,
                     },
                     "glob.js.map": {
-                      "offset": "565843",
+                      "offset": "565644",
                       "size": 28377,
                     },
                     "has-magic.d.ts.map": {
-                      "offset": "594220",
+                      "offset": "594021",
                       "size": 246,
                     },
                     "has-magic.js": {
-                      "offset": "594466",
+                      "offset": "594267",
                       "size": 917,
                     },
                     "has-magic.js.map": {
-                      "offset": "595383",
+                      "offset": "595184",
                       "size": 1495,
                     },
                     "ignore.d.ts.map": {
-                      "offset": "596878",
+                      "offset": "596679",
                       "size": 886,
                     },
                     "ignore.js": {
-                      "offset": "597764",
+                      "offset": "597565",
                       "size": 4101,
                     },
                     "ignore.js.map": {
-                      "offset": "601865",
+                      "offset": "601666",
                       "size": 7514,
                     },
                     "index.d.ts.map": {
-                      "offset": "609379",
+                      "offset": "609180",
                       "size": 4085,
                     },
                     "index.js": {
-                      "offset": "613464",
+                      "offset": "613265",
                       "size": 1647,
                     },
                     "index.js.map": {
-                      "offset": "615111",
+                      "offset": "614912",
                       "size": 8404,
                     },
                     "package.json": {
-                      "offset": "623515",
+                      "offset": "623316",
                       "size": 23,
                     },
                     "pattern.d.ts.map": {
-                      "offset": "623538",
+                      "offset": "623339",
                       "size": 1314,
                     },
                     "pattern.js": {
-                      "offset": "624852",
+                      "offset": "624653",
                       "size": 7161,
                     },
                     "pattern.js.map": {
-                      "offset": "632013",
+                      "offset": "631814",
                       "size": 13407,
                     },
                     "processor.d.ts.map": {
-                      "offset": "645420",
+                      "offset": "645221",
                       "size": 1748,
                     },
                     "processor.js": {
-                      "offset": "647168",
+                      "offset": "646969",
                       "size": 10453,
                     },
                     "processor.js.map": {
-                      "offset": "657621",
+                      "offset": "657422",
                       "size": 19037,
                     },
                     "walker.d.ts.map": {
-                      "offset": "676658",
+                      "offset": "676459",
                       "size": 4195,
                     },
                     "walker.js": {
-                      "offset": "680853",
+                      "offset": "680654",
                       "size": 12569,
                     },
                     "walker.js.map": {
-                      "offset": "693422",
+                      "offset": "693223",
                       "size": 27953,
                     },
                   },
@@ -965,7 +965,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "721375",
+              "offset": "721176",
               "size": 1848,
             },
           },
@@ -973,15 +973,15 @@ exports[`npm tar 2`] = `
         "is-fullwidth-code-point": {
           "files": {
             "index.js": {
-              "offset": "723223",
+              "offset": "723024",
               "size": 1756,
             },
             "license": {
-              "offset": "724979",
+              "offset": "724780",
               "size": 1109,
             },
             "package.json": {
-              "offset": "726088",
+              "offset": "725889",
               "size": 537,
             },
           },
@@ -989,23 +989,23 @@ exports[`npm tar 2`] = `
         "isexe": {
           "files": {
             "LICENSE": {
-              "offset": "726625",
+              "offset": "726426",
               "size": 765,
             },
             "index.js": {
-              "offset": "727390",
+              "offset": "727191",
               "size": 1192,
             },
             "mode.js": {
-              "offset": "728582",
+              "offset": "728383",
               "size": 909,
             },
             "package.json": {
-              "offset": "729491",
+              "offset": "729292",
               "size": 512,
             },
             "windows.js": {
-              "offset": "730003",
+              "offset": "729804",
               "size": 890,
             },
           },
@@ -1013,7 +1013,7 @@ exports[`npm tar 2`] = `
         "jackspeak": {
           "files": {
             "LICENSE.md": {
-              "offset": "730893",
+              "offset": "730694",
               "size": 1550,
             },
             "dist": {
@@ -1021,31 +1021,31 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "732443",
+                      "offset": "732244",
                       "size": 8554,
                     },
                     "index.js": {
-                      "offset": "740997",
+                      "offset": "740798",
                       "size": 36491,
                     },
                     "index.js.map": {
-                      "offset": "777488",
+                      "offset": "777289",
                       "size": 80455,
                     },
                     "package.json": {
-                      "offset": "857943",
+                      "offset": "857744",
                       "size": 25,
                     },
                     "parse-args-cjs.cjs.map": {
-                      "offset": "857968",
+                      "offset": "857769",
                       "size": 1545,
                     },
                     "parse-args-cjs.d.cts.map": {
-                      "offset": "859513",
+                      "offset": "859314",
                       "size": 195,
                     },
                     "parse-args.js": {
-                      "offset": "859708",
+                      "offset": "859509",
                       "size": 1775,
                     },
                   },
@@ -1053,31 +1053,31 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "861483",
+                      "offset": "861284",
                       "size": 8554,
                     },
                     "index.js": {
-                      "offset": "870037",
+                      "offset": "869838",
                       "size": 35919,
                     },
                     "index.js.map": {
-                      "offset": "905956",
+                      "offset": "905757",
                       "size": 80458,
                     },
                     "package.json": {
-                      "offset": "986414",
+                      "offset": "986215",
                       "size": 23,
                     },
                     "parse-args.d.ts.map": {
-                      "offset": "986437",
+                      "offset": "986238",
                       "size": 186,
                     },
                     "parse-args.js": {
-                      "offset": "986623",
+                      "offset": "986424",
                       "size": 723,
                     },
                     "parse-args.js.map": {
-                      "offset": "987346",
+                      "offset": "987147",
                       "size": 1781,
                     },
                   },
@@ -1085,7 +1085,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "989127",
+              "offset": "988928",
               "size": 1580,
             },
           },
@@ -1093,7 +1093,7 @@ exports[`npm tar 2`] = `
         "lru-cache": {
           "files": {
             "LICENSE": {
-              "offset": "990707",
+              "offset": "990508",
               "size": 775,
             },
             "dist": {
@@ -1101,27 +1101,27 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "991482",
+                      "offset": "991283",
                       "size": 13941,
                     },
                     "index.js": {
-                      "offset": "1005423",
+                      "offset": "1005224",
                       "size": 55020,
                     },
                     "index.js.map": {
-                      "offset": "1060443",
+                      "offset": "1060244",
                       "size": 135954,
                     },
                     "index.min.js": {
-                      "offset": "1196397",
+                      "offset": "1196198",
                       "size": 17085,
                     },
                     "index.min.js.map": {
-                      "offset": "1213482",
+                      "offset": "1213283",
                       "size": 118359,
                     },
                     "package.json": {
-                      "offset": "1331841",
+                      "offset": "1331642",
                       "size": 25,
                     },
                   },
@@ -1129,27 +1129,27 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "1331866",
+                      "offset": "1331667",
                       "size": 13941,
                     },
                     "index.js": {
-                      "offset": "1345807",
+                      "offset": "1345608",
                       "size": 54894,
                     },
                     "index.js.map": {
-                      "offset": "1400701",
+                      "offset": "1400502",
                       "size": 135941,
                     },
                     "index.min.js": {
-                      "offset": "1536642",
+                      "offset": "1536443",
                       "size": 16996,
                     },
                     "index.min.js.map": {
-                      "offset": "1553638",
+                      "offset": "1553439",
                       "size": 118347,
                     },
                     "package.json": {
-                      "offset": "1671985",
+                      "offset": "1671786",
                       "size": 23,
                     },
                   },
@@ -1157,7 +1157,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "1672008",
+              "offset": "1671809",
               "size": 2118,
             },
           },
@@ -1165,7 +1165,7 @@ exports[`npm tar 2`] = `
         "minimatch": {
           "files": {
             "LICENSE": {
-              "offset": "1674126",
+              "offset": "1673927",
               "size": 775,
             },
             "dist": {
@@ -1173,79 +1173,79 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "assert-valid-pattern.d.ts.map": {
-                      "offset": "1674901",
+                      "offset": "1674702",
                       "size": 199,
                     },
                     "assert-valid-pattern.js": {
-                      "offset": "1675100",
+                      "offset": "1674901",
                       "size": 492,
                     },
                     "assert-valid-pattern.js.map": {
-                      "offset": "1675592",
+                      "offset": "1675393",
                       "size": 802,
                     },
                     "ast.d.ts.map": {
-                      "offset": "1676394",
+                      "offset": "1676195",
                       "size": 868,
                     },
                     "ast.js": {
-                      "offset": "1677262",
+                      "offset": "1677063",
                       "size": 22822,
                     },
                     "ast.js.map": {
-                      "offset": "1700084",
+                      "offset": "1699885",
                       "size": 40021,
                     },
                     "brace-expressions.d.ts.map": {
-                      "offset": "1740105",
+                      "offset": "1739906",
                       "size": 304,
                     },
                     "brace-expressions.js": {
-                      "offset": "1740409",
+                      "offset": "1740210",
                       "size": 5763,
                     },
                     "brace-expressions.js.map": {
-                      "offset": "1746172",
+                      "offset": "1745973",
                       "size": 10371,
                     },
                     "escape.d.ts.map": {
-                      "offset": "1756543",
+                      "offset": "1756344",
                       "size": 244,
                     },
                     "escape.js": {
-                      "offset": "1756787",
+                      "offset": "1756588",
                       "size": 968,
                     },
                     "escape.js.map": {
-                      "offset": "1757755",
+                      "offset": "1757556",
                       "size": 1378,
                     },
                     "index.d.ts.map": {
-                      "offset": "1759133",
+                      "offset": "1758934",
                       "size": 3194,
                     },
                     "index.js": {
-                      "offset": "1762327",
+                      "offset": "1762128",
                       "size": 40557,
                     },
                     "index.js.map": {
-                      "offset": "1802884",
+                      "offset": "1802685",
                       "size": 71631,
                     },
                     "package.json": {
-                      "offset": "1874515",
+                      "offset": "1874316",
                       "size": 25,
                     },
                     "unescape.d.ts.map": {
-                      "offset": "1874540",
+                      "offset": "1874341",
                       "size": 254,
                     },
                     "unescape.js": {
-                      "offset": "1874794",
+                      "offset": "1874595",
                       "size": 973,
                     },
                     "unescape.js.map": {
-                      "offset": "1875767",
+                      "offset": "1875568",
                       "size": 1403,
                     },
                   },
@@ -1253,79 +1253,79 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "assert-valid-pattern.d.ts.map": {
-                      "offset": "1877170",
+                      "offset": "1876971",
                       "size": 199,
                     },
                     "assert-valid-pattern.js": {
-                      "offset": "1877369",
+                      "offset": "1877170",
                       "size": 336,
                     },
                     "assert-valid-pattern.js.map": {
-                      "offset": "1877705",
+                      "offset": "1877506",
                       "size": 785,
                     },
                     "ast.d.ts.map": {
-                      "offset": "1878490",
+                      "offset": "1878291",
                       "size": 868,
                     },
                     "ast.js": {
-                      "offset": "1879358",
+                      "offset": "1879159",
                       "size": 22588,
                     },
                     "ast.js.map": {
-                      "offset": "1901946",
+                      "offset": "1901747",
                       "size": 40036,
                     },
                     "brace-expressions.d.ts.map": {
-                      "offset": "1941982",
+                      "offset": "1941783",
                       "size": 304,
                     },
                     "brace-expressions.js": {
-                      "offset": "1942286",
+                      "offset": "1942087",
                       "size": 5631,
                     },
                     "brace-expressions.js.map": {
-                      "offset": "1947917",
+                      "offset": "1947718",
                       "size": 10355,
                     },
                     "escape.d.ts.map": {
-                      "offset": "1958272",
+                      "offset": "1958073",
                       "size": 244,
                     },
                     "escape.js": {
-                      "offset": "1958516",
+                      "offset": "1958317",
                       "size": 848,
                     },
                     "escape.js.map": {
-                      "offset": "1959364",
+                      "offset": "1959165",
                       "size": 1364,
                     },
                     "index.d.ts.map": {
-                      "offset": "1960728",
+                      "offset": "1960529",
                       "size": 3194,
                     },
                     "index.js": {
-                      "offset": "1963922",
+                      "offset": "1963723",
                       "size": 39098,
                     },
                     "index.js.map": {
-                      "offset": "2003020",
+                      "offset": "2002821",
                       "size": 71657,
                     },
                     "package.json": {
-                      "offset": "2074677",
+                      "offset": "2074478",
                       "size": 23,
                     },
                     "unescape.d.ts.map": {
-                      "offset": "2074700",
+                      "offset": "2074501",
                       "size": 254,
                     },
                     "unescape.js": {
-                      "offset": "2074954",
+                      "offset": "2074755",
                       "size": 847,
                     },
                     "unescape.js.map": {
-                      "offset": "2075801",
+                      "offset": "2075602",
                       "size": 1389,
                     },
                   },
@@ -1333,7 +1333,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "2077190",
+              "offset": "2076991",
               "size": 1573,
             },
           },
@@ -1341,7 +1341,7 @@ exports[`npm tar 2`] = `
         "minipass": {
           "files": {
             "LICENSE": {
-              "offset": "2078763",
+              "offset": "2078564",
               "size": 787,
             },
             "dist": {
@@ -1349,19 +1349,19 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "2079550",
+                      "offset": "2079351",
                       "size": 8761,
                     },
                     "index.js": {
-                      "offset": "2088311",
+                      "offset": "2088112",
                       "size": 33796,
                     },
                     "index.js.map": {
-                      "offset": "2122107",
+                      "offset": "2121908",
                       "size": 66332,
                     },
                     "package.json": {
-                      "offset": "2188439",
+                      "offset": "2188240",
                       "size": 25,
                     },
                   },
@@ -1369,19 +1369,19 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "2188464",
+                      "offset": "2188265",
                       "size": 8761,
                     },
                     "index.js": {
-                      "offset": "2197225",
+                      "offset": "2197026",
                       "size": 33228,
                     },
                     "index.js.map": {
-                      "offset": "2230453",
+                      "offset": "2230254",
                       "size": 66339,
                     },
                     "package.json": {
-                      "offset": "2296792",
+                      "offset": "2296593",
                       "size": 23,
                     },
                   },
@@ -1389,7 +1389,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "2296815",
+              "offset": "2296616",
               "size": 1497,
             },
           },
@@ -1397,7 +1397,7 @@ exports[`npm tar 2`] = `
         "minizlib": {
           "files": {
             "LICENSE": {
-              "offset": "2298312",
+              "offset": "2298113",
               "size": 1339,
             },
             "dist": {
@@ -1405,31 +1405,31 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "constants.d.ts.map": {
-                      "offset": "2299651",
+                      "offset": "2299452",
                       "size": 146,
                     },
                     "constants.js": {
-                      "offset": "2299797",
+                      "offset": "2299598",
                       "size": 4299,
                     },
                     "constants.js.map": {
-                      "offset": "2304096",
+                      "offset": "2303897",
                       "size": 7298,
                     },
                     "index.d.ts.map": {
-                      "offset": "2311394",
+                      "offset": "2311195",
                       "size": 2773,
                     },
                     "index.js": {
-                      "offset": "2314167",
+                      "offset": "2313968",
                       "size": 12370,
                     },
                     "index.js.map": {
-                      "offset": "2326537",
+                      "offset": "2326338",
                       "size": 21939,
                     },
                     "package.json": {
-                      "offset": "2348476",
+                      "offset": "2348277",
                       "size": 25,
                     },
                   },
@@ -1437,31 +1437,31 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "constants.d.ts.map": {
-                      "offset": "2348501",
+                      "offset": "2348302",
                       "size": 146,
                     },
                     "constants.js": {
-                      "offset": "2348647",
+                      "offset": "2348448",
                       "size": 4034,
                     },
                     "constants.js.map": {
-                      "offset": "2352681",
+                      "offset": "2352482",
                       "size": 7321,
                     },
                     "index.d.ts.map": {
-                      "offset": "2360002",
+                      "offset": "2359803",
                       "size": 2773,
                     },
                     "index.js": {
-                      "offset": "2362775",
+                      "offset": "2362576",
                       "size": 11207,
                     },
                     "index.js.map": {
-                      "offset": "2373982",
+                      "offset": "2373783",
                       "size": 21959,
                     },
                     "package.json": {
-                      "offset": "2395941",
+                      "offset": "2395742",
                       "size": 23,
                     },
                   },
@@ -1469,7 +1469,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "2395964",
+              "offset": "2395765",
               "size": 1398,
             },
           },
@@ -1477,7 +1477,7 @@ exports[`npm tar 2`] = `
         "mkdirp": {
           "files": {
             "LICENSE": {
-              "offset": "2397362",
+              "offset": "2397163",
               "size": 1180,
             },
             "dist": {
@@ -1485,106 +1485,106 @@ exports[`npm tar 2`] = `
                 "cjs": {
                   "files": {
                     "package.json": {
-                      "offset": "2398542",
+                      "offset": "2398343",
                       "size": 1453,
                     },
                     "src": {
                       "files": {
                         "bin.d.ts.map": {
-                          "offset": "2399995",
+                          "offset": "2399796",
                           "size": 106,
                         },
                         "bin.js": {
                           "executable": true,
-                          "offset": "2400101",
+                          "offset": "2399902",
                           "size": 2430,
                         },
                         "bin.js.map": {
-                          "offset": "2402531",
+                          "offset": "2402332",
                           "size": 4434,
                         },
                         "find-made.d.ts.map": {
-                          "offset": "2406965",
+                          "offset": "2406766",
                           "size": 328,
                         },
                         "find-made.js": {
-                          "offset": "2407293",
+                          "offset": "2407094",
                           "size": 1144,
                         },
                         "find-made.js.map": {
-                          "offset": "2408437",
+                          "offset": "2408238",
                           "size": 2290,
                         },
                         "index.d.ts.map": {
-                          "offset": "2410727",
+                          "offset": "2410528",
                           "size": 664,
                         },
                         "index.js": {
-                          "offset": "2411391",
+                          "offset": "2411192",
                           "size": 3190,
                         },
                         "index.js.map": {
-                          "offset": "2414581",
+                          "offset": "2414382",
                           "size": 3055,
                         },
                         "mkdirp-manual.d.ts.map": {
-                          "offset": "2417636",
+                          "offset": "2417437",
                           "size": 487,
                         },
                         "mkdirp-manual.js": {
-                          "offset": "2418123",
+                          "offset": "2417924",
                           "size": 2618,
                         },
                         "mkdirp-manual.js.map": {
-                          "offset": "2420741",
+                          "offset": "2420542",
                           "size": 5079,
                         },
                         "mkdirp-native.d.ts.map": {
-                          "offset": "2425820",
+                          "offset": "2425621",
                           "size": 394,
                         },
                         "mkdirp-native.js": {
-                          "offset": "2426214",
+                          "offset": "2426015",
                           "size": 1689,
                         },
                         "mkdirp-native.js.map": {
-                          "offset": "2427903",
+                          "offset": "2427704",
                           "size": 3184,
                         },
                         "opts-arg.d.ts.map": {
-                          "offset": "2431087",
+                          "offset": "2430888",
                           "size": 1981,
                         },
                         "opts-arg.js": {
-                          "offset": "2433068",
+                          "offset": "2432869",
                           "size": 1364,
                         },
                         "opts-arg.js.map": {
-                          "offset": "2434432",
+                          "offset": "2434233",
                           "size": 4791,
                         },
                         "path-arg.d.ts.map": {
-                          "offset": "2439223",
+                          "offset": "2439024",
                           "size": 157,
                         },
                         "path-arg.js": {
-                          "offset": "2439380",
+                          "offset": "2439181",
                           "size": 953,
                         },
                         "path-arg.js.map": {
-                          "offset": "2440333",
+                          "offset": "2440134",
                           "size": 1621,
                         },
                         "use-native.d.ts.map": {
-                          "offset": "2441954",
+                          "offset": "2441755",
                           "size": 254,
                         },
                         "use-native.js": {
-                          "offset": "2442208",
+                          "offset": "2442009",
                           "size": 763,
                         },
                         "use-native.js.map": {
-                          "offset": "2442971",
+                          "offset": "2442772",
                           "size": 1478,
                         },
                       },
@@ -1594,91 +1594,91 @@ exports[`npm tar 2`] = `
                 "mjs": {
                   "files": {
                     "find-made.d.ts.map": {
-                      "offset": "2444449",
+                      "offset": "2444250",
                       "size": 325,
                     },
                     "find-made.js": {
-                      "offset": "2444774",
+                      "offset": "2444575",
                       "size": 915,
                     },
                     "find-made.js.map": {
-                      "offset": "2445689",
+                      "offset": "2445490",
                       "size": 2263,
                     },
                     "index.d.ts.map": {
-                      "offset": "2447952",
+                      "offset": "2447753",
                       "size": 661,
                     },
                     "index.js": {
-                      "offset": "2448613",
+                      "offset": "2448414",
                       "size": 1490,
                     },
                     "index.js.map": {
-                      "offset": "2450103",
+                      "offset": "2449904",
                       "size": 3126,
                     },
                     "mkdirp-manual.d.ts.map": {
-                      "offset": "2453229",
+                      "offset": "2453030",
                       "size": 484,
                     },
                     "mkdirp-manual.js": {
-                      "offset": "2453713",
+                      "offset": "2453514",
                       "size": 2321,
                     },
                     "mkdirp-manual.js.map": {
-                      "offset": "2456034",
+                      "offset": "2455835",
                       "size": 5080,
                     },
                     "mkdirp-native.d.ts.map": {
-                      "offset": "2461114",
+                      "offset": "2460915",
                       "size": 391,
                     },
                     "mkdirp-native.js": {
-                      "offset": "2461505",
+                      "offset": "2461306",
                       "size": 1374,
                     },
                     "mkdirp-native.js.map": {
-                      "offset": "2462879",
+                      "offset": "2462680",
                       "size": 3266,
                     },
                     "opts-arg.d.ts.map": {
-                      "offset": "2466145",
+                      "offset": "2465946",
                       "size": 1978,
                     },
                     "opts-arg.js": {
-                      "offset": "2468123",
+                      "offset": "2467924",
                       "size": 1249,
                     },
                     "opts-arg.js.map": {
-                      "offset": "2469372",
+                      "offset": "2469173",
                       "size": 4831,
                     },
                     "package.json": {
-                      "offset": "2474203",
+                      "offset": "2474004",
                       "size": 23,
                     },
                     "path-arg.d.ts.map": {
-                      "offset": "2474226",
+                      "offset": "2474027",
                       "size": 154,
                     },
                     "path-arg.js": {
-                      "offset": "2474380",
+                      "offset": "2474181",
                       "size": 813,
                     },
                     "path-arg.js.map": {
-                      "offset": "2475193",
+                      "offset": "2474994",
                       "size": 1630,
                     },
                     "use-native.d.ts.map": {
-                      "offset": "2476823",
+                      "offset": "2476624",
                       "size": 251,
                     },
                     "use-native.js": {
-                      "offset": "2477074",
+                      "offset": "2476875",
                       "size": 592,
                     },
                     "use-native.js.map": {
-                      "offset": "2477666",
+                      "offset": "2477467",
                       "size": 1546,
                     },
                   },
@@ -1686,7 +1686,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "2479212",
+              "offset": "2479013",
               "size": 1453,
             },
           },
@@ -1694,7 +1694,7 @@ exports[`npm tar 2`] = `
         "package-json-from-dist": {
           "files": {
             "LICENSE.md": {
-              "offset": "2480665",
+              "offset": "2480466",
               "size": 1764,
             },
             "dist": {
@@ -1702,19 +1702,19 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "2482429",
+                      "offset": "2482230",
                       "size": 342,
                     },
                     "index.js": {
-                      "offset": "2482771",
+                      "offset": "2482572",
                       "size": 5017,
                     },
                     "index.js.map": {
-                      "offset": "2487788",
+                      "offset": "2487589",
                       "size": 6769,
                     },
                     "package.json": {
-                      "offset": "2494557",
+                      "offset": "2494358",
                       "size": 25,
                     },
                   },
@@ -1722,19 +1722,19 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "2494582",
+                      "offset": "2494383",
                       "size": 342,
                     },
                     "index.js": {
-                      "offset": "2494924",
+                      "offset": "2494725",
                       "size": 4572,
                     },
                     "index.js.map": {
-                      "offset": "2499496",
+                      "offset": "2499297",
                       "size": 6795,
                     },
                     "package.json": {
-                      "offset": "2506291",
+                      "offset": "2506092",
                       "size": 23,
                     },
                   },
@@ -1742,7 +1742,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "2506314",
+              "offset": "2506115",
               "size": 1343,
             },
           },
@@ -1750,15 +1750,15 @@ exports[`npm tar 2`] = `
         "path-key": {
           "files": {
             "index.js": {
-              "offset": "2507657",
+              "offset": "2507458",
               "size": 415,
             },
             "license": {
-              "offset": "2508072",
+              "offset": "2507873",
               "size": 1109,
             },
             "package.json": {
-              "offset": "2509181",
+              "offset": "2508982",
               "size": 507,
             },
           },
@@ -1766,7 +1766,7 @@ exports[`npm tar 2`] = `
         "path-scurry": {
           "files": {
             "LICENSE.md": {
-              "offset": "2509688",
+              "offset": "2509489",
               "size": 1552,
             },
             "dist": {
@@ -1774,19 +1774,19 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "2511240",
+                      "offset": "2511041",
                       "size": 18164,
                     },
                     "index.js": {
-                      "offset": "2529404",
+                      "offset": "2529205",
                       "size": 66122,
                     },
                     "index.js.map": {
-                      "offset": "2595526",
+                      "offset": "2595327",
                       "size": 131555,
                     },
                     "package.json": {
-                      "offset": "2727081",
+                      "offset": "2726882",
                       "size": 25,
                     },
                   },
@@ -1794,19 +1794,19 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "2727106",
+                      "offset": "2726907",
                       "size": 18164,
                     },
                     "index.js": {
-                      "offset": "2745270",
+                      "offset": "2745071",
                       "size": 64317,
                     },
                     "index.js.map": {
-                      "offset": "2809587",
+                      "offset": "2809388",
                       "size": 131684,
                     },
                     "package.json": {
-                      "offset": "2941271",
+                      "offset": "2941072",
                       "size": 23,
                     },
                   },
@@ -1814,7 +1814,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "2941294",
+              "offset": "2941095",
               "size": 1746,
             },
           },
@@ -1822,7 +1822,7 @@ exports[`npm tar 2`] = `
         "rimraf": {
           "files": {
             "LICENSE": {
-              "offset": "2943040",
+              "offset": "2942841",
               "size": 775,
             },
             "dist": {
@@ -1830,199 +1830,199 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "default-tmp.d.ts.map": {
-                      "offset": "2943815",
+                      "offset": "2943616",
                       "size": 206,
                     },
                     "default-tmp.js": {
-                      "offset": "2944021",
+                      "offset": "2943822",
                       "size": 2482,
                     },
                     "default-tmp.js.map": {
-                      "offset": "2946503",
+                      "offset": "2946304",
                       "size": 4022,
                     },
                     "fix-eperm.d.ts.map": {
-                      "offset": "2950525",
+                      "offset": "2950326",
                       "size": 285,
                     },
                     "fix-eperm.js": {
-                      "offset": "2950810",
+                      "offset": "2950611",
                       "size": 1449,
                     },
                     "fix-eperm.js.map": {
-                      "offset": "2952259",
+                      "offset": "2952060",
                       "size": 2703,
                     },
                     "fs.d.ts.map": {
-                      "offset": "2954962",
+                      "offset": "2954763",
                       "size": 993,
                     },
                     "fs.js": {
-                      "offset": "2955955",
+                      "offset": "2955756",
                       "size": 3165,
                     },
                     "fs.js.map": {
-                      "offset": "2959120",
+                      "offset": "2958921",
                       "size": 5671,
                     },
                     "ignore-enoent.d.ts.map": {
-                      "offset": "2964791",
+                      "offset": "2964592",
                       "size": 227,
                     },
                     "ignore-enoent.js": {
-                      "offset": "2965018",
+                      "offset": "2964819",
                       "size": 535,
                     },
                     "ignore-enoent.js.map": {
-                      "offset": "2965553",
+                      "offset": "2965354",
                       "size": 922,
                     },
                     "index.d.ts.map": {
-                      "offset": "2966475",
+                      "offset": "2966276",
                       "size": 2617,
                     },
                     "index.js": {
-                      "offset": "2969092",
+                      "offset": "2968893",
                       "size": 4091,
                     },
                     "index.js.map": {
-                      "offset": "2973183",
+                      "offset": "2972984",
                       "size": 6283,
                     },
                     "opt-arg.d.ts.map": {
-                      "offset": "2979466",
+                      "offset": "2979267",
                       "size": 1177,
                     },
                     "opt-arg.js": {
-                      "offset": "2980643",
+                      "offset": "2980444",
                       "size": 1788,
                     },
                     "opt-arg.js.map": {
-                      "offset": "2982431",
+                      "offset": "2982232",
                       "size": 4129,
                     },
                     "package.json": {
-                      "offset": "2986560",
+                      "offset": "2986361",
                       "size": 25,
                     },
                     "path-arg.d.ts.map": {
-                      "offset": "2986585",
+                      "offset": "2986386",
                       "size": 229,
                     },
                     "path-arg.js": {
-                      "offset": "2986814",
+                      "offset": "2986615",
                       "size": 1964,
                     },
                     "path-arg.js.map": {
-                      "offset": "2988778",
+                      "offset": "2988579",
                       "size": 3291,
                     },
                     "platform.d.ts.map": {
-                      "offset": "2992069",
+                      "offset": "2991870",
                       "size": 125,
                     },
                     "platform.js": {
-                      "offset": "2992194",
+                      "offset": "2991995",
                       "size": 192,
                     },
                     "platform.js.map": {
-                      "offset": "2992386",
+                      "offset": "2992187",
                       "size": 273,
                     },
                     "readdir-or-error.d.ts.map": {
-                      "offset": "2992659",
+                      "offset": "2992460",
                       "size": 214,
                     },
                     "readdir-or-error.js": {
-                      "offset": "2992873",
+                      "offset": "2992674",
                       "size": 655,
                     },
                     "readdir-or-error.js.map": {
-                      "offset": "2993528",
+                      "offset": "2993329",
                       "size": 1024,
                     },
                     "retry-busy.d.ts.map": {
-                      "offset": "2994552",
+                      "offset": "2994353",
                       "size": 488,
                     },
                     "retry-busy.js": {
-                      "offset": "2995040",
+                      "offset": "2994841",
                       "size": 2335,
                     },
                     "retry-busy.js.map": {
-                      "offset": "2997375",
+                      "offset": "2997176",
                       "size": 4047,
                     },
                     "rimraf-manual.d.ts.map": {
-                      "offset": "3001422",
+                      "offset": "3001223",
                       "size": 189,
                     },
                     "rimraf-manual.js": {
-                      "offset": "3001611",
+                      "offset": "3001412",
                       "size": 760,
                     },
                     "rimraf-manual.js.map": {
-                      "offset": "3002371",
+                      "offset": "3002172",
                       "size": 713,
                     },
                     "rimraf-move-remove.d.ts.map": {
-                      "offset": "3003084",
+                      "offset": "3002885",
                       "size": 302,
                     },
                     "rimraf-move-remove.js": {
-                      "offset": "3003386",
+                      "offset": "3003187",
                       "size": 6655,
                     },
                     "rimraf-move-remove.js.map": {
-                      "offset": "3010041",
+                      "offset": "3009842",
                       "size": 13079,
                     },
                     "rimraf-native.d.ts.map": {
-                      "offset": "3023120",
+                      "offset": "3022921",
                       "size": 313,
                     },
                     "rimraf-native.js": {
-                      "offset": "3023433",
+                      "offset": "3023234",
                       "size": 646,
                     },
                     "rimraf-native.js.map": {
-                      "offset": "3024079",
+                      "offset": "3023880",
                       "size": 1167,
                     },
                     "rimraf-posix.d.ts.map": {
-                      "offset": "3025246",
+                      "offset": "3025047",
                       "size": 283,
                     },
                     "rimraf-posix.js": {
-                      "offset": "3025529",
+                      "offset": "3025330",
                       "size": 4310,
                     },
                     "rimraf-posix.js.map": {
-                      "offset": "3029839",
+                      "offset": "3029640",
                       "size": 8091,
                     },
                     "rimraf-windows.d.ts.map": {
-                      "offset": "3037930",
+                      "offset": "3037731",
                       "size": 290,
                     },
                     "rimraf-windows.js": {
-                      "offset": "3038220",
+                      "offset": "3038021",
                       "size": 6622,
                     },
                     "rimraf-windows.js.map": {
-                      "offset": "3044842",
+                      "offset": "3044643",
                       "size": 12287,
                     },
                     "use-native.d.ts.map": {
-                      "offset": "3057129",
+                      "offset": "3056930",
                       "size": 302,
                     },
                     "use-native.js": {
-                      "offset": "3057431",
+                      "offset": "3057232",
                       "size": 1082,
                     },
                     "use-native.js.map": {
-                      "offset": "3058513",
+                      "offset": "3058314",
                       "size": 1836,
                     },
                   },
@@ -2030,216 +2030,216 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "bin.d.mts": {
-                      "offset": "3060349",
+                      "offset": "3060150",
                       "size": 194,
                     },
                     "bin.d.mts.map": {
-                      "offset": "3060543",
+                      "offset": "3060344",
                       "size": 207,
                     },
                     "bin.mjs": {
                       "executable": true,
-                      "offset": "3060750",
+                      "offset": "3060551",
                       "size": 8729,
                     },
                     "bin.mjs.map": {
-                      "offset": "3069479",
+                      "offset": "3069280",
                       "size": 15918,
                     },
                     "default-tmp.d.ts.map": {
-                      "offset": "3085397",
+                      "offset": "3085198",
                       "size": 206,
                     },
                     "default-tmp.js": {
-                      "offset": "3085603",
+                      "offset": "3085404",
                       "size": 2054,
                     },
                     "default-tmp.js.map": {
-                      "offset": "3087657",
+                      "offset": "3087458",
                       "size": 4099,
                     },
                     "fix-eperm.d.ts.map": {
-                      "offset": "3091756",
+                      "offset": "3091557",
                       "size": 285,
                     },
                     "fix-eperm.js": {
-                      "offset": "3092041",
+                      "offset": "3091842",
                       "size": 1260,
                     },
                     "fix-eperm.js.map": {
-                      "offset": "3093301",
+                      "offset": "3093102",
                       "size": 2704,
                     },
                     "fs.d.ts.map": {
-                      "offset": "3096005",
+                      "offset": "3095806",
                       "size": 993,
                     },
                     "fs.js": {
-                      "offset": "3096998",
+                      "offset": "3096799",
                       "size": 1796,
                     },
                     "fs.js.map": {
-                      "offset": "3098794",
+                      "offset": "3098595",
                       "size": 5645,
                     },
                     "ignore-enoent.d.ts.map": {
-                      "offset": "3104439",
+                      "offset": "3104240",
                       "size": 227,
                     },
                     "ignore-enoent.js": {
-                      "offset": "3104666",
+                      "offset": "3104467",
                       "size": 332,
                     },
                     "ignore-enoent.js.map": {
-                      "offset": "3104998",
+                      "offset": "3104799",
                       "size": 893,
                     },
                     "index.d.ts.map": {
-                      "offset": "3105891",
+                      "offset": "3105692",
                       "size": 2617,
                     },
                     "index.js": {
-                      "offset": "3108508",
+                      "offset": "3108309",
                       "size": 2688,
                     },
                     "index.js.map": {
-                      "offset": "3111196",
+                      "offset": "3110997",
                       "size": 6548,
                     },
                     "opt-arg.d.ts.map": {
-                      "offset": "3117744",
+                      "offset": "3117545",
                       "size": 1177,
                     },
                     "opt-arg.js": {
-                      "offset": "3118921",
+                      "offset": "3118722",
                       "size": 1459,
                     },
                     "opt-arg.js.map": {
-                      "offset": "3120380",
+                      "offset": "3120181",
                       "size": 4065,
                     },
                     "package.json": {
-                      "offset": "3124445",
+                      "offset": "3124246",
                       "size": 23,
                     },
                     "path-arg.d.ts.map": {
-                      "offset": "3124468",
+                      "offset": "3124269",
                       "size": 229,
                     },
                     "path-arg.js": {
-                      "offset": "3124697",
+                      "offset": "3124498",
                       "size": 1664,
                     },
                     "path-arg.js.map": {
-                      "offset": "3126361",
+                      "offset": "3126162",
                       "size": 3348,
                     },
                     "platform.d.ts.map": {
-                      "offset": "3129709",
+                      "offset": "3129510",
                       "size": 125,
                     },
                     "platform.js": {
-                      "offset": "3129834",
+                      "offset": "3129635",
                       "size": 112,
                     },
                     "platform.js.map": {
-                      "offset": "3129946",
+                      "offset": "3129747",
                       "size": 270,
                     },
                     "readdir-or-error.d.ts.map": {
-                      "offset": "3130216",
+                      "offset": "3130017",
                       "size": 214,
                     },
                     "readdir-or-error.js": {
-                      "offset": "3130430",
+                      "offset": "3130231",
                       "size": 432,
                     },
                     "readdir-or-error.js.map": {
-                      "offset": "3130862",
+                      "offset": "3130663",
                       "size": 1025,
                     },
                     "retry-busy.d.ts.map": {
-                      "offset": "3131887",
+                      "offset": "3131688",
                       "size": 488,
                     },
                     "retry-busy.js": {
-                      "offset": "3132375",
+                      "offset": "3132176",
                       "size": 2049,
                     },
                     "retry-busy.js.map": {
-                      "offset": "3134424",
+                      "offset": "3134225",
                       "size": 4056,
                     },
                     "rimraf-manual.d.ts.map": {
-                      "offset": "3138480",
+                      "offset": "3138281",
                       "size": 189,
                     },
                     "rimraf-manual.js": {
-                      "offset": "3138669",
+                      "offset": "3138470",
                       "size": 389,
                     },
                     "rimraf-manual.js.map": {
-                      "offset": "3139058",
+                      "offset": "3138859",
                       "size": 822,
                     },
                     "rimraf-move-remove.d.ts.map": {
-                      "offset": "3139880",
+                      "offset": "3139681",
                       "size": 302,
                     },
                     "rimraf-move-remove.js": {
-                      "offset": "3140182",
+                      "offset": "3139983",
                       "size": 6181,
                     },
                     "rimraf-move-remove.js.map": {
-                      "offset": "3146363",
+                      "offset": "3146164",
                       "size": 13193,
                     },
                     "rimraf-native.d.ts.map": {
-                      "offset": "3159556",
+                      "offset": "3159357",
                       "size": 313,
                     },
                     "rimraf-native.js": {
-                      "offset": "3159869",
+                      "offset": "3159670",
                       "size": 430,
                     },
                     "rimraf-native.js.map": {
-                      "offset": "3160299",
+                      "offset": "3160100",
                       "size": 1170,
                     },
                     "rimraf-posix.d.ts.map": {
-                      "offset": "3161469",
+                      "offset": "3161270",
                       "size": 283,
                     },
                     "rimraf-posix.js": {
-                      "offset": "3161752",
+                      "offset": "3161553",
                       "size": 3932,
                     },
                     "rimraf-posix.js.map": {
-                      "offset": "3165684",
+                      "offset": "3165485",
                       "size": 8173,
                     },
                     "rimraf-windows.d.ts.map": {
-                      "offset": "3173857",
+                      "offset": "3173658",
                       "size": 290,
                     },
                     "rimraf-windows.js": {
-                      "offset": "3174147",
+                      "offset": "3173948",
                       "size": 6049,
                     },
                     "rimraf-windows.js.map": {
-                      "offset": "3180196",
+                      "offset": "3179997",
                       "size": 12442,
                     },
                     "use-native.d.ts.map": {
-                      "offset": "3192638",
+                      "offset": "3192439",
                       "size": 302,
                     },
                     "use-native.js": {
-                      "offset": "3192940",
+                      "offset": "3192741",
                       "size": 771,
                     },
                     "use-native.js.map": {
-                      "offset": "3193711",
+                      "offset": "3193512",
                       "size": 1866,
                     },
                   },
@@ -2247,7 +2247,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "3195577",
+              "offset": "3195378",
               "size": 1527,
             },
           },
@@ -2255,15 +2255,15 @@ exports[`npm tar 2`] = `
         "shebang-command": {
           "files": {
             "index.js": {
-              "offset": "3197104",
+              "offset": "3196905",
               "size": 387,
             },
             "license": {
-              "offset": "3197491",
+              "offset": "3197292",
               "size": 1116,
             },
             "package.json": {
-              "offset": "3198607",
+              "offset": "3198408",
               "size": 484,
             },
           },
@@ -2271,15 +2271,15 @@ exports[`npm tar 2`] = `
         "shebang-regex": {
           "files": {
             "index.js": {
-              "offset": "3199091",
+              "offset": "3198892",
               "size": 42,
             },
             "license": {
-              "offset": "3199133",
+              "offset": "3198934",
               "size": 1109,
             },
             "package.json": {
-              "offset": "3200242",
+              "offset": "3200043",
               "size": 480,
             },
           },
@@ -2287,7 +2287,7 @@ exports[`npm tar 2`] = `
         "signal-exit": {
           "files": {
             "LICENSE.txt": {
-              "offset": "3200722",
+              "offset": "3200523",
               "size": 790,
             },
             "dist": {
@@ -2295,43 +2295,43 @@ exports[`npm tar 2`] = `
                 "cjs": {
                   "files": {
                     "browser.d.ts.map": {
-                      "offset": "3201512",
+                      "offset": "3201313",
                       "size": 349,
                     },
                     "browser.js": {
-                      "offset": "3201861",
+                      "offset": "3201662",
                       "size": 322,
                     },
                     "browser.js.map": {
-                      "offset": "3202183",
+                      "offset": "3201984",
                       "size": 703,
                     },
                     "index.d.ts.map": {
-                      "offset": "3202886",
+                      "offset": "3202687",
                       "size": 460,
                     },
                     "index.js": {
-                      "offset": "3203346",
+                      "offset": "3203147",
                       "size": 9435,
                     },
                     "index.js.map": {
-                      "offset": "3212781",
+                      "offset": "3212582",
                       "size": 17544,
                     },
                     "package.json": {
-                      "offset": "3230325",
+                      "offset": "3230126",
                       "size": 25,
                     },
                     "signals.d.ts.map": {
-                      "offset": "3230350",
+                      "offset": "3230151",
                       "size": 196,
                     },
                     "signals.js": {
-                      "offset": "3230546",
+                      "offset": "3230347",
                       "size": 1560,
                     },
                     "signals.js.map": {
-                      "offset": "3232106",
+                      "offset": "3231907",
                       "size": 2091,
                     },
                   },
@@ -2339,43 +2339,43 @@ exports[`npm tar 2`] = `
                 "mjs": {
                   "files": {
                     "browser.d.ts.map": {
-                      "offset": "3234197",
+                      "offset": "3233998",
                       "size": 349,
                     },
                     "browser.js": {
-                      "offset": "3234546",
+                      "offset": "3234347",
                       "size": 138,
                     },
                     "browser.js.map": {
-                      "offset": "3234684",
+                      "offset": "3234485",
                       "size": 668,
                     },
                     "index.d.ts.map": {
-                      "offset": "3235352",
+                      "offset": "3235153",
                       "size": 460,
                     },
                     "index.js": {
-                      "offset": "3235812",
+                      "offset": "3235613",
                       "size": 9090,
                     },
                     "index.js.map": {
-                      "offset": "3244902",
+                      "offset": "3244703",
                       "size": 17592,
                     },
                     "package.json": {
-                      "offset": "3262494",
+                      "offset": "3262295",
                       "size": 23,
                     },
                     "signals.d.ts.map": {
-                      "offset": "3262517",
+                      "offset": "3262318",
                       "size": 196,
                     },
                     "signals.js": {
-                      "offset": "3262713",
+                      "offset": "3262514",
                       "size": 1438,
                     },
                     "signals.js.map": {
-                      "offset": "3264151",
+                      "offset": "3263952",
                       "size": 2098,
                     },
                   },
@@ -2383,7 +2383,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "3266249",
+              "offset": "3266050",
               "size": 2031,
             },
           },
@@ -2391,11 +2391,11 @@ exports[`npm tar 2`] = `
         "string-width": {
           "files": {
             "index.js": {
-              "offset": "3268280",
+              "offset": "3268081",
               "size": 1064,
             },
             "license": {
-              "offset": "3269344",
+              "offset": "3269145",
               "size": 1117,
             },
             "node_modules": {
@@ -2403,15 +2403,15 @@ exports[`npm tar 2`] = `
                 "ansi-regex": {
                   "files": {
                     "index.js": {
-                      "offset": "3271200",
+                      "offset": "3271001",
                       "size": 458,
                     },
                     "license": {
-                      "offset": "3271658",
+                      "offset": "3271459",
                       "size": 1117,
                     },
                     "package.json": {
-                      "offset": "3272775",
+                      "offset": "3272576",
                       "size": 671,
                     },
                   },
@@ -2419,39 +2419,39 @@ exports[`npm tar 2`] = `
                 "emoji-regex": {
                   "files": {
                     "LICENSE-MIT.txt": {
-                      "offset": "3273446",
+                      "offset": "3273247",
                       "size": 1077,
                     },
                     "RGI_Emoji.js": {
-                      "offset": "3274523",
+                      "offset": "3274324",
                       "size": 12976,
                     },
                     "es2015": {
                       "files": {
                         "RGI_Emoji.js": {
-                          "offset": "3287499",
+                          "offset": "3287300",
                           "size": 14024,
                         },
                         "index.js": {
-                          "offset": "3301523",
+                          "offset": "3301324",
                           "size": 17405,
                         },
                         "text.js": {
-                          "offset": "3318928",
+                          "offset": "3318729",
                           "size": 15796,
                         },
                       },
                     },
                     "index.js": {
-                      "offset": "3334724",
+                      "offset": "3334525",
                       "size": 15735,
                     },
                     "package.json": {
-                      "offset": "3350459",
+                      "offset": "3350260",
                       "size": 889,
                     },
                     "text.js": {
-                      "offset": "3351348",
+                      "offset": "3351149",
                       "size": 14468,
                     },
                   },
@@ -2459,15 +2459,15 @@ exports[`npm tar 2`] = `
                 "strip-ansi": {
                   "files": {
                     "index.js": {
-                      "offset": "3365816",
+                      "offset": "3365617",
                       "size": 468,
                     },
                     "license": {
-                      "offset": "3366284",
+                      "offset": "3366085",
                       "size": 1117,
                     },
                     "package.json": {
-                      "offset": "3367401",
+                      "offset": "3367202",
                       "size": 630,
                     },
                   },
@@ -2475,7 +2475,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "3270461",
+              "offset": "3270262",
               "size": 739,
             },
           },
@@ -2483,15 +2483,15 @@ exports[`npm tar 2`] = `
         "string-width-cjs": {
           "files": {
             "index.js": {
-              "offset": "3368031",
+              "offset": "3367832",
               "size": 923,
             },
             "license": {
-              "offset": "3368954",
+              "offset": "3368755",
               "size": 1109,
             },
             "package.json": {
-              "offset": "3370063",
+              "offset": "3369864",
               "size": 633,
             },
           },
@@ -2499,15 +2499,15 @@ exports[`npm tar 2`] = `
         "strip-ansi": {
           "files": {
             "index.js": {
-              "offset": "3370696",
+              "offset": "3370497",
               "size": 154,
             },
             "license": {
-              "offset": "3370850",
+              "offset": "3370651",
               "size": 1109,
             },
             "package.json": {
-              "offset": "3371959",
+              "offset": "3371760",
               "size": 511,
             },
           },
@@ -2515,15 +2515,15 @@ exports[`npm tar 2`] = `
         "strip-ansi-cjs": {
           "files": {
             "index.js": {
-              "offset": "3372470",
+              "offset": "3372271",
               "size": 154,
             },
             "license": {
-              "offset": "3372624",
+              "offset": "3372425",
               "size": 1109,
             },
             "package.json": {
-              "offset": "3373733",
+              "offset": "3373534",
               "size": 511,
             },
           },
@@ -2531,7 +2531,7 @@ exports[`npm tar 2`] = `
         "tar": {
           "files": {
             "LICENSE": {
-              "offset": "3374244",
+              "offset": "3374045",
               "size": 765,
             },
             "dist": {
@@ -2539,355 +2539,355 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "create.d.ts.map": {
-                      "offset": "3375009",
+                      "offset": "3374810",
                       "size": 192,
                     },
                     "create.js": {
-                      "offset": "3375201",
+                      "offset": "3375002",
                       "size": 2574,
                     },
                     "create.js.map": {
-                      "offset": "3377775",
+                      "offset": "3377576",
                       "size": 5193,
                     },
                     "cwd-error.d.ts.map": {
-                      "offset": "3382968",
+                      "offset": "3382769",
                       "size": 283,
                     },
                     "cwd-error.js": {
-                      "offset": "3383251",
+                      "offset": "3383052",
                       "size": 436,
                     },
                     "cwd-error.js.map": {
-                      "offset": "3383687",
+                      "offset": "3383488",
                       "size": 736,
                     },
                     "extract.d.ts.map": {
-                      "offset": "3384423",
+                      "offset": "3384224",
                       "size": 194,
                     },
                     "extract.js": {
-                      "offset": "3384617",
+                      "offset": "3384418",
                       "size": 3115,
                     },
                     "extract.js.map": {
-                      "offset": "3387732",
+                      "offset": "3387533",
                       "size": 3532,
                     },
                     "get-write-flag.d.ts.map": {
-                      "offset": "3391264",
+                      "offset": "3391065",
                       "size": 168,
                     },
                     "get-write-flag.js": {
-                      "offset": "3391432",
+                      "offset": "3391233",
                       "size": 1304,
                     },
                     "get-write-flag.js.map": {
-                      "offset": "3392736",
+                      "offset": "3392537",
                       "size": 1909,
                     },
                     "header.d.ts.map": {
-                      "offset": "3394645",
+                      "offset": "3394446",
                       "size": 1830,
                     },
                     "header.js": {
-                      "offset": "3396475",
+                      "offset": "3396276",
                       "size": 11814,
                     },
                     "header.js.map": {
-                      "offset": "3408289",
+                      "offset": "3408090",
                       "size": 24151,
                     },
                     "index.d.ts.map": {
-                      "offset": "3432440",
+                      "offset": "3432241",
                       "size": 827,
                     },
                     "index.js": {
-                      "offset": "3433267",
+                      "offset": "3433068",
                       "size": 2805,
                     },
                     "index.js.map": {
-                      "offset": "3436072",
+                      "offset": "3435873",
                       "size": 1457,
                     },
                     "large-numbers.d.ts.map": {
-                      "offset": "3437529",
+                      "offset": "3437330",
                       "size": 217,
                     },
                     "large-numbers.js": {
-                      "offset": "3437746",
+                      "offset": "3437547",
                       "size": 2733,
                     },
                     "large-numbers.js.map": {
-                      "offset": "3440479",
+                      "offset": "3440280",
                       "size": 5930,
                     },
                     "list.d.ts.map": {
-                      "offset": "3446409",
+                      "offset": "3446210",
                       "size": 287,
                     },
                     "list.js": {
-                      "offset": "3446696",
+                      "offset": "3446497",
                       "size": 4894,
                     },
                     "list.js.map": {
-                      "offset": "3451590",
+                      "offset": "3451391",
                       "size": 7006,
                     },
                     "make-command.d.ts.map": {
-                      "offset": "3458596",
+                      "offset": "3458397",
                       "size": 4407,
                     },
                     "make-command.js": {
-                      "offset": "3463003",
+                      "offset": "3462804",
                       "size": 2046,
                     },
                     "make-command.js.map": {
-                      "offset": "3465049",
+                      "offset": "3464850",
                       "size": 9053,
                     },
                     "mkdir.d.ts.map": {
-                      "offset": "3474102",
+                      "offset": "3473903",
                       "size": 800,
                     },
                     "mkdir.js": {
-                      "offset": "3474902",
+                      "offset": "3474703",
                       "size": 7476,
                     },
                     "mkdir.js.map": {
-                      "offset": "3482378",
+                      "offset": "3482179",
                       "size": 15069,
                     },
                     "mode-fix.d.ts.map": {
-                      "offset": "3497447",
+                      "offset": "3497248",
                       "size": 174,
                     },
                     "mode-fix.js": {
-                      "offset": "3497621",
+                      "offset": "3497422",
                       "size": 876,
                     },
                     "mode-fix.js.map": {
-                      "offset": "3498497",
+                      "offset": "3498298",
                       "size": 1409,
                     },
                     "normalize-unicode.d.ts.map": {
-                      "offset": "3499906",
+                      "offset": "3499707",
                       "size": 173,
                     },
                     "normalize-unicode.js": {
-                      "offset": "3500079",
+                      "offset": "3499880",
                       "size": 639,
                     },
                     "normalize-unicode.js.map": {
-                      "offset": "3500718",
+                      "offset": "3500519",
                       "size": 1021,
                     },
                     "normalize-windows-path.d.ts.map": {
-                      "offset": "3501739",
+                      "offset": "3501540",
                       "size": 184,
                     },
                     "normalize-windows-path.js": {
-                      "offset": "3501923",
+                      "offset": "3501724",
                       "size": 601,
                     },
                     "normalize-windows-path.js.map": {
-                      "offset": "3502524",
+                      "offset": "3502325",
                       "size": 943,
                     },
                     "options.d.ts.map": {
-                      "offset": "3503467",
+                      "offset": "3503268",
                       "size": 5832,
                     },
                     "options.js": {
-                      "offset": "3509299",
+                      "offset": "3509100",
                       "size": 2117,
                     },
                     "options.js.map": {
-                      "offset": "3511416",
+                      "offset": "3511217",
                       "size": 26512,
                     },
                     "pack.d.ts.map": {
-                      "offset": "3537928",
+                      "offset": "3537729",
                       "size": 3795,
                     },
                     "pack.js": {
-                      "offset": "3541723",
+                      "offset": "3541524",
                       "size": 14697,
                     },
                     "pack.js.map": {
-                      "offset": "3556420",
+                      "offset": "3556221",
                       "size": 28002,
                     },
                     "package.json": {
-                      "offset": "3584422",
+                      "offset": "3584223",
                       "size": 25,
                     },
                     "parse.d.ts.map": {
-                      "offset": "3584447",
+                      "offset": "3584248",
                       "size": 3705,
                     },
                     "parse.js": {
-                      "offset": "3588152",
+                      "offset": "3587953",
                       "size": 21999,
                     },
                     "parse.js.map": {
-                      "offset": "3610151",
+                      "offset": "3609952",
                       "size": 39932,
                     },
                     "path-reservations.d.ts.map": {
-                      "offset": "3650083",
+                      "offset": "3649884",
                       "size": 419,
                     },
                     "path-reservations.js": {
-                      "offset": "3650502",
+                      "offset": "3650303",
                       "size": 5729,
                     },
                     "path-reservations.js.map": {
-                      "offset": "3656231",
+                      "offset": "3656032",
                       "size": 10885,
                     },
                     "pax.d.ts.map": {
-                      "offset": "3667116",
+                      "offset": "3666917",
                       "size": 882,
                     },
                     "pax.js": {
-                      "offset": "3667998",
+                      "offset": "3667799",
                       "size": 4904,
                     },
                     "pax.js.map": {
-                      "offset": "3672902",
+                      "offset": "3672703",
                       "size": 10047,
                     },
                     "read-entry.d.ts.map": {
-                      "offset": "3682949",
+                      "offset": "3682750",
                       "size": 1180,
                     },
                     "read-entry.js": {
-                      "offset": "3684129",
+                      "offset": "3683930",
                       "size": 4458,
                     },
                     "read-entry.js.map": {
-                      "offset": "3688587",
+                      "offset": "3688388",
                       "size": 8160,
                     },
                     "replace.d.ts.map": {
-                      "offset": "3696747",
+                      "offset": "3696548",
                       "size": 144,
                     },
                     "replace.js": {
-                      "offset": "3696891",
+                      "offset": "3696692",
                       "size": 7855,
                     },
                     "replace.js.map": {
-                      "offset": "3704746",
+                      "offset": "3704547",
                       "size": 15068,
                     },
                     "strip-absolute-path.d.ts.map": {
-                      "offset": "3719814",
+                      "offset": "3719615",
                       "size": 178,
                     },
                     "strip-absolute-path.js": {
-                      "offset": "3719992",
+                      "offset": "3719793",
                       "size": 1232,
                     },
                     "strip-absolute-path.js.map": {
-                      "offset": "3721224",
+                      "offset": "3721025",
                       "size": 1915,
                     },
                     "strip-trailing-slashes.d.ts.map": {
-                      "offset": "3723139",
+                      "offset": "3722940",
                       "size": 183,
                     },
                     "strip-trailing-slashes.js": {
-                      "offset": "3723322",
+                      "offset": "3723123",
                       "size": 651,
                     },
                     "strip-trailing-slashes.js.map": {
-                      "offset": "3723973",
+                      "offset": "3723774",
                       "size": 1073,
                     },
                     "symlink-error.d.ts.map": {
-                      "offset": "3725046",
+                      "offset": "3724847",
                       "size": 321,
                     },
                     "symlink-error.js": {
-                      "offset": "3725367",
+                      "offset": "3725168",
                       "size": 528,
                     },
                     "symlink-error.js.map": {
-                      "offset": "3725895",
+                      "offset": "3725696",
                       "size": 846,
                     },
                     "types.d.ts.map": {
-                      "offset": "3726741",
+                      "offset": "3726542",
                       "size": 767,
                     },
                     "types.js": {
-                      "offset": "3727508",
+                      "offset": "3727309",
                       "size": 1476,
                     },
                     "types.js.map": {
-                      "offset": "3728984",
+                      "offset": "3728785",
                       "size": 3506,
                     },
                     "unpack.d.ts.map": {
-                      "offset": "3732490",
+                      "offset": "3732291",
                       "size": 3985,
                     },
                     "unpack.js": {
-                      "offset": "3736475",
+                      "offset": "3736276",
                       "size": 35213,
                     },
                     "unpack.js.map": {
-                      "offset": "3771688",
+                      "offset": "3771489",
                       "size": 61895,
                     },
                     "update.d.ts.map": {
-                      "offset": "3833583",
+                      "offset": "3833384",
                       "size": 140,
                     },
                     "update.js": {
-                      "offset": "3833723",
+                      "offset": "3833524",
                       "size": 1229,
                     },
                     "update.js.map": {
-                      "offset": "3834952",
+                      "offset": "3834753",
                       "size": 2260,
                     },
                     "warn-method.d.ts.map": {
-                      "offset": "3837212",
+                      "offset": "3837013",
                       "size": 1111,
                     },
                     "warn-method.js": {
-                      "offset": "3838323",
+                      "offset": "3838124",
                       "size": 927,
                     },
                     "warn-method.js.map": {
-                      "offset": "3839250",
+                      "offset": "3839051",
                       "size": 2609,
                     },
                     "winchars.d.ts.map": {
-                      "offset": "3841859",
+                      "offset": "3841660",
                       "size": 195,
                     },
                     "winchars.js": {
-                      "offset": "3842054",
+                      "offset": "3841855",
                       "size": 704,
                     },
                     "winchars.js.map": {
-                      "offset": "3842758",
+                      "offset": "3842559",
                       "size": 1669,
                     },
                     "write-entry.d.ts.map": {
-                      "offset": "3844427",
+                      "offset": "3844228",
                       "size": 4833,
                     },
                     "write-entry.js": {
-                      "offset": "3849260",
+                      "offset": "3849061",
                       "size": 25038,
                     },
                     "write-entry.js.map": {
-                      "offset": "3874298",
+                      "offset": "3874099",
                       "size": 48218,
                     },
                   },
@@ -2895,355 +2895,355 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "create.d.ts.map": {
-                      "offset": "3922516",
+                      "offset": "3922317",
                       "size": 192,
                     },
                     "create.js": {
-                      "offset": "3922708",
+                      "offset": "3922509",
                       "size": 2163,
                     },
                     "create.js.map": {
-                      "offset": "3924871",
+                      "offset": "3924672",
                       "size": 5329,
                     },
                     "cwd-error.d.ts.map": {
-                      "offset": "3930200",
+                      "offset": "3930001",
                       "size": 283,
                     },
                     "cwd-error.js": {
-                      "offset": "3930483",
+                      "offset": "3930284",
                       "size": 310,
                     },
                     "cwd-error.js.map": {
-                      "offset": "3930793",
+                      "offset": "3930594",
                       "size": 727,
                     },
                     "extract.d.ts.map": {
-                      "offset": "3931520",
+                      "offset": "3931321",
                       "size": 194,
                     },
                     "extract.js": {
-                      "offset": "3931714",
+                      "offset": "3931515",
                       "size": 1692,
                     },
                     "extract.js.map": {
-                      "offset": "3933406",
+                      "offset": "3933207",
                       "size": 3634,
                     },
                     "get-write-flag.d.ts.map": {
-                      "offset": "3937040",
+                      "offset": "3936841",
                       "size": 168,
                     },
                     "get-write-flag.js": {
-                      "offset": "3937208",
+                      "offset": "3937009",
                       "size": 1018,
                     },
                     "get-write-flag.js.map": {
-                      "offset": "3938226",
+                      "offset": "3938027",
                       "size": 1931,
                     },
                     "header.d.ts.map": {
-                      "offset": "3940157",
+                      "offset": "3939958",
                       "size": 1830,
                     },
                     "header.js": {
-                      "offset": "3941987",
+                      "offset": "3941788",
                       "size": 10604,
                     },
                     "header.js.map": {
-                      "offset": "3952591",
+                      "offset": "3952392",
                       "size": 24197,
                     },
                     "index.d.ts.map": {
-                      "offset": "3976788",
+                      "offset": "3976589",
                       "size": 827,
                     },
                     "index.js": {
-                      "offset": "3977615",
+                      "offset": "3977416",
                       "size": 647,
                     },
                     "index.js.map": {
-                      "offset": "3978262",
+                      "offset": "3978063",
                       "size": 1631,
                     },
                     "large-numbers.d.ts.map": {
-                      "offset": "3979893",
+                      "offset": "3979694",
                       "size": 217,
                     },
                     "large-numbers.js": {
-                      "offset": "3980110",
+                      "offset": "3979911",
                       "size": 2581,
                     },
                     "large-numbers.js.map": {
-                      "offset": "3982691",
+                      "offset": "3982492",
                       "size": 5903,
                     },
                     "list.d.ts.map": {
-                      "offset": "3988594",
+                      "offset": "3988395",
                       "size": 287,
                     },
                     "list.js": {
-                      "offset": "3988881",
+                      "offset": "3988682",
                       "size": 3234,
                     },
                     "list.js.map": {
-                      "offset": "3992115",
+                      "offset": "3991916",
                       "size": 7098,
                     },
                     "make-command.d.ts.map": {
-                      "offset": "3999213",
+                      "offset": "3999014",
                       "size": 4407,
                     },
                     "make-command.js": {
-                      "offset": "4003620",
+                      "offset": "4003421",
                       "size": 1870,
                     },
                     "make-command.js.map": {
-                      "offset": "4005490",
+                      "offset": "4005291",
                       "size": 9075,
                     },
                     "mkdir.d.ts.map": {
-                      "offset": "4014565",
+                      "offset": "4014366",
                       "size": 800,
                     },
                     "mkdir.js": {
-                      "offset": "4015365",
+                      "offset": "4015166",
                       "size": 6452,
                     },
                     "mkdir.js.map": {
-                      "offset": "4021817",
+                      "offset": "4021618",
                       "size": 15156,
                     },
                     "mode-fix.d.ts.map": {
-                      "offset": "4036973",
+                      "offset": "4036774",
                       "size": 174,
                     },
                     "mode-fix.js": {
-                      "offset": "4037147",
+                      "offset": "4036948",
                       "size": 753,
                     },
                     "mode-fix.js.map": {
-                      "offset": "4037900",
+                      "offset": "4037701",
                       "size": 1393,
                     },
                     "normalize-unicode.d.ts.map": {
-                      "offset": "4039293",
+                      "offset": "4039094",
                       "size": 173,
                     },
                     "normalize-unicode.js": {
-                      "offset": "4039466",
+                      "offset": "4039267",
                       "size": 489,
                     },
                     "normalize-unicode.js.map": {
-                      "offset": "4039955",
+                      "offset": "4039756",
                       "size": 1004,
                     },
                     "normalize-windows-path.d.ts.map": {
-                      "offset": "4040959",
+                      "offset": "4040760",
                       "size": 184,
                     },
                     "normalize-windows-path.js": {
-                      "offset": "4041143",
+                      "offset": "4040944",
                       "size": 490,
                     },
                     "normalize-windows-path.js.map": {
-                      "offset": "4041633",
+                      "offset": "4041434",
                       "size": 950,
                     },
                     "options.d.ts.map": {
-                      "offset": "4042583",
+                      "offset": "4042384",
                       "size": 5832,
                     },
                     "options.js": {
-                      "offset": "4048415",
+                      "offset": "4048216",
                       "size": 1639,
                     },
                     "options.js.map": {
-                      "offset": "4050054",
+                      "offset": "4049855",
                       "size": 26398,
                     },
                     "pack.d.ts.map": {
-                      "offset": "4076452",
+                      "offset": "4076253",
                       "size": 3795,
                     },
                     "pack.js": {
-                      "offset": "4080247",
+                      "offset": "4080048",
                       "size": 13005,
                     },
                     "pack.js.map": {
-                      "offset": "4093252",
+                      "offset": "4093053",
                       "size": 28182,
                     },
                     "package.json": {
-                      "offset": "4121434",
+                      "offset": "4121235",
                       "size": 23,
                     },
                     "parse.d.ts.map": {
-                      "offset": "4121457",
+                      "offset": "4121258",
                       "size": 3705,
                     },
                     "parse.js": {
-                      "offset": "4125162",
+                      "offset": "4124963",
                       "size": 21741,
                     },
                     "parse.js.map": {
-                      "offset": "4146903",
+                      "offset": "4146704",
                       "size": 40129,
                     },
                     "path-reservations.d.ts.map": {
-                      "offset": "4187032",
+                      "offset": "4186833",
                       "size": 419,
                     },
                     "path-reservations.js": {
-                      "offset": "4187451",
+                      "offset": "4187252",
                       "size": 5461,
                     },
                     "path-reservations.js.map": {
-                      "offset": "4192912",
+                      "offset": "4192713",
                       "size": 10944,
                     },
                     "pax.d.ts.map": {
-                      "offset": "4203856",
+                      "offset": "4203657",
                       "size": 882,
                     },
                     "pax.js": {
-                      "offset": "4204738",
+                      "offset": "4204539",
                       "size": 4754,
                     },
                     "pax.js.map": {
-                      "offset": "4209492",
+                      "offset": "4209293",
                       "size": 10085,
                     },
                     "read-entry.d.ts.map": {
-                      "offset": "4219577",
+                      "offset": "4219378",
                       "size": 1180,
                     },
                     "read-entry.js": {
-                      "offset": "4220757",
+                      "offset": "4220558",
                       "size": 4175,
                     },
                     "read-entry.js.map": {
-                      "offset": "4224932",
+                      "offset": "4224733",
                       "size": 8188,
                     },
                     "replace.d.ts.map": {
-                      "offset": "4233120",
+                      "offset": "4232921",
                       "size": 144,
                     },
                     "replace.js": {
-                      "offset": "4233264",
+                      "offset": "4233065",
                       "size": 7185,
                     },
                     "replace.js.map": {
-                      "offset": "4240449",
+                      "offset": "4240250",
                       "size": 15258,
                     },
                     "strip-absolute-path.d.ts.map": {
-                      "offset": "4255707",
+                      "offset": "4255508",
                       "size": 178,
                     },
                     "strip-absolute-path.js": {
-                      "offset": "4255885",
+                      "offset": "4255686",
                       "size": 1060,
                     },
                     "strip-absolute-path.js.map": {
-                      "offset": "4256945",
+                      "offset": "4256746",
                       "size": 1923,
                     },
                     "strip-trailing-slashes.d.ts.map": {
-                      "offset": "4258868",
+                      "offset": "4258669",
                       "size": 183,
                     },
                     "strip-trailing-slashes.js": {
-                      "offset": "4259051",
+                      "offset": "4258852",
                       "size": 489,
                     },
                     "strip-trailing-slashes.js.map": {
-                      "offset": "4259540",
+                      "offset": "4259341",
                       "size": 1056,
                     },
                     "symlink-error.d.ts.map": {
-                      "offset": "4260596",
+                      "offset": "4260397",
                       "size": 321,
                     },
                     "symlink-error.js": {
-                      "offset": "4260917",
+                      "offset": "4260718",
                       "size": 390,
                     },
                     "symlink-error.js.map": {
-                      "offset": "4261307",
+                      "offset": "4261108",
                       "size": 837,
                     },
                     "types.d.ts.map": {
-                      "offset": "4262144",
+                      "offset": "4261945",
                       "size": 767,
                     },
                     "types.js": {
-                      "offset": "4262911",
+                      "offset": "4262712",
                       "size": 1277,
                     },
                     "types.js.map": {
-                      "offset": "4264188",
+                      "offset": "4263989",
                       "size": 3502,
                     },
                     "unpack.d.ts.map": {
-                      "offset": "4267690",
+                      "offset": "4267491",
                       "size": 3985,
                     },
                     "unpack.js": {
-                      "offset": "4271675",
+                      "offset": "4271476",
                       "size": 32445,
                     },
                     "unpack.js.map": {
-                      "offset": "4304120",
+                      "offset": "4303921",
                       "size": 62081,
                     },
                     "update.d.ts.map": {
-                      "offset": "4366201",
+                      "offset": "4366002",
                       "size": 140,
                     },
                     "update.js": {
-                      "offset": "4366341",
+                      "offset": "4366142",
                       "size": 1006,
                     },
                     "update.js.map": {
-                      "offset": "4367347",
+                      "offset": "4367148",
                       "size": 2324,
                     },
                     "warn-method.d.ts.map": {
-                      "offset": "4369671",
+                      "offset": "4369472",
                       "size": 1111,
                     },
                     "warn-method.js": {
-                      "offset": "4370782",
+                      "offset": "4370583",
                       "size": 795,
                     },
                     "warn-method.js.map": {
-                      "offset": "4371577",
+                      "offset": "4371378",
                       "size": 2593,
                     },
                     "winchars.d.ts.map": {
-                      "offset": "4374170",
+                      "offset": "4373971",
                       "size": 195,
                     },
                     "winchars.js": {
-                      "offset": "4374365",
+                      "offset": "4374166",
                       "size": 549,
                     },
                     "winchars.js.map": {
-                      "offset": "4374914",
+                      "offset": "4374715",
                       "size": 1642,
                     },
                     "write-entry.d.ts.map": {
-                      "offset": "4376556",
+                      "offset": "4376357",
                       "size": 4833,
                     },
                     "write-entry.js": {
-                      "offset": "4381389",
+                      "offset": "4381190",
                       "size": 22781,
                     },
                     "write-entry.js.map": {
-                      "offset": "4404170",
+                      "offset": "4403971",
                       "size": 48386,
                     },
                   },
@@ -3251,7 +3251,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "4452556",
+              "offset": "4452357",
               "size": 8322,
             },
           },
@@ -3259,24 +3259,24 @@ exports[`npm tar 2`] = `
         "which": {
           "files": {
             "LICENSE": {
-              "offset": "4460878",
+              "offset": "4460679",
               "size": 765,
             },
             "bin": {
               "files": {
                 "node-which": {
                   "executable": true,
-                  "offset": "4461643",
+                  "offset": "4461444",
                   "size": 985,
                 },
               },
             },
             "package.json": {
-              "offset": "4462628",
+              "offset": "4462429",
               "size": 681,
             },
             "which.js": {
-              "offset": "4463309",
+              "offset": "4463110",
               "size": 3163,
             },
           },
@@ -3285,11 +3285,11 @@ exports[`npm tar 2`] = `
           "files": {
             "index.js": {
               "executable": true,
-              "offset": "4466472",
+              "offset": "4466273",
               "size": 5778,
             },
             "license": {
-              "offset": "4472250",
+              "offset": "4472051",
               "size": 1117,
             },
             "node_modules": {
@@ -3297,15 +3297,15 @@ exports[`npm tar 2`] = `
                 "ansi-regex": {
                   "files": {
                     "index.js": {
-                      "offset": "4474204",
+                      "offset": "4474005",
                       "size": 458,
                     },
                     "license": {
-                      "offset": "4474662",
+                      "offset": "4474463",
                       "size": 1117,
                     },
                     "package.json": {
-                      "offset": "4475779",
+                      "offset": "4475580",
                       "size": 671,
                     },
                   },
@@ -3313,15 +3313,15 @@ exports[`npm tar 2`] = `
                 "ansi-styles": {
                   "files": {
                     "index.js": {
-                      "offset": "4476450",
+                      "offset": "4476251",
                       "size": 5267,
                     },
                     "license": {
-                      "offset": "4481717",
+                      "offset": "4481518",
                       "size": 1117,
                     },
                     "package.json": {
-                      "offset": "4482834",
+                      "offset": "4482635",
                       "size": 627,
                     },
                   },
@@ -3329,15 +3329,15 @@ exports[`npm tar 2`] = `
                 "strip-ansi": {
                   "files": {
                     "index.js": {
-                      "offset": "4483461",
+                      "offset": "4483262",
                       "size": 468,
                     },
                     "license": {
-                      "offset": "4483929",
+                      "offset": "4483730",
                       "size": 1117,
                     },
                     "package.json": {
-                      "offset": "4485046",
+                      "offset": "4484847",
                       "size": 630,
                     },
                   },
@@ -3345,7 +3345,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "4473367",
+              "offset": "4473168",
               "size": 837,
             },
           },
@@ -3354,11 +3354,11 @@ exports[`npm tar 2`] = `
           "files": {
             "index.js": {
               "executable": true,
-              "offset": "4485676",
+              "offset": "4485477",
               "size": 5772,
             },
             "license": {
-              "offset": "4491448",
+              "offset": "4491249",
               "size": 1117,
             },
             "node_modules": {
@@ -3366,15 +3366,15 @@ exports[`npm tar 2`] = `
                 "string-width": {
                   "files": {
                     "index.js": {
-                      "offset": "4493264",
+                      "offset": "4493065",
                       "size": 923,
                     },
                     "license": {
-                      "offset": "4494187",
+                      "offset": "4493988",
                       "size": 1109,
                     },
                     "package.json": {
-                      "offset": "4495296",
+                      "offset": "4495097",
                       "size": 633,
                     },
                   },
@@ -3382,7 +3382,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "4492565",
+              "offset": "4492366",
               "size": 699,
             },
           },
@@ -3390,7 +3390,7 @@ exports[`npm tar 2`] = `
         "yallist": {
           "files": {
             "LICENSE.md": {
-              "offset": "4495929",
+              "offset": "4495730",
               "size": 1764,
             },
             "dist": {
@@ -3398,19 +3398,19 @@ exports[`npm tar 2`] = `
                 "commonjs": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "4497693",
+                      "offset": "4497494",
                       "size": 2413,
                     },
                     "index.js": {
-                      "offset": "4500106",
+                      "offset": "4499907",
                       "size": 9914,
                     },
                     "index.js.map": {
-                      "offset": "4510020",
+                      "offset": "4509821",
                       "size": 22191,
                     },
                     "package.json": {
-                      "offset": "4532211",
+                      "offset": "4532012",
                       "size": 25,
                     },
                   },
@@ -3418,19 +3418,19 @@ exports[`npm tar 2`] = `
                 "esm": {
                   "files": {
                     "index.d.ts.map": {
-                      "offset": "4532236",
+                      "offset": "4532037",
                       "size": 2413,
                     },
                     "index.js": {
-                      "offset": "4534649",
+                      "offset": "4534450",
                       "size": 9762,
                     },
                     "index.js.map": {
-                      "offset": "4544411",
+                      "offset": "4544212",
                       "size": 22172,
                     },
                     "package.json": {
-                      "offset": "4566583",
+                      "offset": "4566384",
                       "size": 23,
                     },
                   },
@@ -3438,7 +3438,7 @@ exports[`npm tar 2`] = `
               },
             },
             "package.json": {
-              "offset": "4566606",
+              "offset": "4566407",
               "size": 1228,
             },
           },
@@ -3446,7 +3446,7 @@ exports[`npm tar 2`] = `
       },
     },
     "package.json": {
-      "offset": "4568831",
+      "offset": "4568632",
       "size": 322,
     },
   },

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -180,7 +180,7 @@ test.ifDevOrLinuxCi("local node module with file protocol", () => {
         })
       },
       packed: async context => {
-        assertThat(path.join(path.join(context.getResources(Platform.LINUX), "app.asar.unpacked", "node_modules", "foo", "package.json"))).isFile()
+        return assertThat(path.join(path.join(context.getResources(Platform.LINUX), "app.asar.unpacked", "node_modules", "foo", "package.json"))).isFile()
       },
     }
   )
@@ -285,24 +285,24 @@ test.ifAll.ifDevOrLinuxCi("asarUnpack node_modules which has many modules", () =
       projectDirCreated: async projectDir => {
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
-            "@react-navigation/stack": "^6.3.7",
-            "@sentry/electron": "^4.4.0",
-            axios: "^1.1.3",
-            "deep-equal": "^2.1.0",
-            dotenv: "^16.4.5",
-            "electron-log": "^4.4.8",
-            "electron-updater": "^6.0.4",
-            "electron-window-state": "^5.0.3",
-            "jwt-decode": "^3.1.2",
-            keytar: "^7.9.0",
-            webpack: "^5.74.0",
-            "pubsub-js": "^1.9.4",
-            react: "^18.2.0",
-            "react-dom": "^18.2.0",
-            "react-native-web": "^0.18.10",
-            "react-router-dom": "^6.4.0",
-            "source-map-support": "^0.5.16",
-            yargs: "^16.2.0",
+            "@react-navigation/stack": "6.3.7",
+            "@sentry/electron": "4.4.0",
+            axios: "1.1.3",
+            "deep-equal": "2.1.0",
+            dotenv: "16.4.5",
+            "electron-log": "4.4.8",
+            "electron-updater": "6.0.4",
+            "electron-window-state": "5.0.3",
+            "jwt-decode": "3.1.2",
+            keytar: "7.9.0",
+            webpack: "5.74.0",
+            "pubsub-js": "1.9.4",
+            react: "18.2.0",
+            "react-dom": "18.2.0",
+            "react-native-web": "0.18.10",
+            "react-router-dom": "6.4.0",
+            "source-map-support": "0.5.16",
+            yargs: "16.2.0",
             "ci-info": "2.0.0",
           }
         })
@@ -333,24 +333,24 @@ test.ifAll.ifDevOrLinuxCi("exclude some modules when asarUnpack node_modules whi
       projectDirCreated: async projectDir => {
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
-            "@react-navigation/stack": "^6.3.7",
-            "@sentry/electron": "^4.4.0",
-            axios: "^1.1.3",
-            "deep-equal": "^2.1.0",
-            dotenv: "^16.4.5",
-            "electron-log": "^4.4.8",
-            "electron-updater": "^6.0.4",
-            "electron-window-state": "^5.0.3",
-            "jwt-decode": "^3.1.2",
-            keytar: "^7.9.0",
-            webpack: "^5.74.0",
-            "pubsub-js": "^1.9.4",
-            react: "^18.2.0",
-            "react-dom": "^18.2.0",
-            "react-native-web": "^0.18.10",
-            "react-router-dom": "^6.4.0",
-            "source-map-support": "^0.5.16",
-            yargs: "^16.2.0",
+            "@react-navigation/stack": "6.3.7",
+            "@sentry/electron": "4.4.0",
+            axios: "1.1.3",
+            "deep-equal": "2.1.0",
+            dotenv: "16.4.5",
+            "electron-log": "4.4.8",
+            "electron-updater": "6.0.4",
+            "electron-window-state": "5.0.3",
+            "jwt-decode": "3.1.2",
+            keytar: "7.9.0",
+            webpack: "5.74.0",
+            "pubsub-js": "1.9.4",
+            react: "18.2.0",
+            "react-dom": "18.2.0",
+            "react-native-web": "0.18.10",
+            "react-router-dom": "6.4.0",
+            "source-map-support": "0.5.16",
+            yargs: "16.2.0",
             "ci-info": "2.0.0",
           }
         })


### PR DESCRIPTION
fixtures that install deps had sub-deps change again. We need to figure out a way to utilize `--frozen-lockfile` or similar for our fixtures