### PR TITLE
fix(mac): when using default `osx-sign`, specifically pass in identity name instead of hash

### DIFF
--- a/.changeset/sixty-crabs-approve.md
+++ b/.changeset/sixty-crabs-approve.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: when using osx-sign, specifically pass in identity name instead of hash

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -438,7 +438,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
       customSign ? "executing custom sign" : "signing"
     )
 
-    return customSign ? Promise.resolve(customSign(opts, this)) : sign(opts)
+    return customSign ? Promise.resolve(customSign(opts, this)) : sign({ ...opts, identity: identity ? identity.name : undefined })
   }
 
   //noinspection JSMethodCanBeStatic


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/8861 https://github.com/electron-userland/electron-builder/issues/7995