### PR TITLE
fix(win): execute `customUnInstall` before `atomicRMDir` function in NSIS uninstaller

### DIFF
--- a/.changeset/spicy-cougars-type.md
+++ b/.changeset/spicy-cougars-type.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: improve atomicRMDir function in NSIS uninstaller

--- a/packages/app-builder-lib/templates/nsis/uninstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/uninstaller.nsh
@@ -141,6 +141,10 @@ Section "un.install"
 
   !insertmacro setLinkVars
 
+  !ifmacrodef customUnInstall
+    !insertmacro customUnInstall
+  !endif
+
   # delete the installed files
   !ifmacrodef customRemoveFiles
     !insertmacro customRemoveFiles
@@ -234,10 +238,6 @@ Section "un.install"
     DeleteRegKey SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY_2}"
   !endif
   DeleteRegKey SHELL_CONTEXT "${INSTALL_REGISTRY_KEY}"
-
-  !ifmacrodef customUnInstall
-    !insertmacro customUnInstall
-  !endif
 
   !ifdef ONE_CLICK
     !insertmacro quitSuccess


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8874.