### PR TITLE
fix: re-export various types from electron-updater

### DIFF
--- a/.changeset/light-pandas-reply.md
+++ b/.changeset/light-pandas-reply.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: re-export `CancellationToken`, `PackageFileInfo`, `ProgressInfo`, `UpdateFileInfo`, `UpdateInfo` from electron-updater

--- a/packages/electron-updater/src/types.ts
+++ b/packages/electron-updater/src/types.ts
@@ -3,6 +3,8 @@ import { EventEmitter } from "events"
 import { URL } from "url"
 import { LoginCallback } from "./electronHttpExecutor"
 
+export { CancellationToken, PackageFileInfo, ProgressInfo, UpdateFileInfo, UpdateInfo }
+
 export const DOWNLOAD_PROGRESS = "download-progress"
 export const UPDATE_DOWNLOADED = "update-downloaded"
 


### PR DESCRIPTION
fix: re-export `CancellationToken`, `PackageFileInfo`, `ProgressInfo`, `UpdateFileInfo`, `UpdateInfo` from electron-updater

Fixes: https://github.com/electron-userland/electron-builder/pull/8913#discussion_r1978579715
CC @lyswhut