### PR TITLE
chore(test): creating custom test runner for `vitest`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,9 +681,15 @@ importers:
       '@types/semver':
         specifier: ^7.3.13
         version: 7.5.8
+      '@vitest/runner':
+        specifier: ^3.0.7
+        version: 3.0.7
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.24.9)
+      birpc:
+        specifier: ^2.2.0
+        version: 2.2.0
       esbuild:
         specifier: ^0.12.14
         version: 0.12.29
@@ -693,9 +699,15 @@ importers:
       fast-xml-parser:
         specifier: 4.4.1
         version: 4.4.1
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
       sanitize-filename:
         specifier: ^1.6.3
         version: 1.6.3
+      tinypool:
+        specifier: ^1.0.2
+        version: 1.0.2
       vitest:
         specifier: ^3.0.4
         version: 3.0.5(@types/node@22.10.1)(@vitest/ui@3.0.4(vitest@3.0.5))(sass@1.82.0)(yaml@2.6.1)
@@ -2536,6 +2548,9 @@ packages:
   '@vitest/runner@3.0.5':
     resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
+  '@vitest/runner@3.0.7':
+    resolution: {integrity: sha512-WeEl38Z0S2ZcuRTeyYqaZtm4e26tq6ZFqh5y8YD9YxfWuu0OFiGFUbnxNynwLjNRHPsXyee2M9tV7YxOTPZl2g==}
+
   '@vitest/snapshot@3.0.5':
     resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
 
@@ -2552,6 +2567,9 @@ packages:
 
   '@vitest/utils@3.0.5':
     resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
+
+  '@vitest/utils@3.0.7':
+    resolution: {integrity: sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -2849,6 +2867,9 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  birpc@2.2.0:
+    resolution: {integrity: sha512-1/22obknhoj56PcE+pZPp6AbWDdY55M81/ofpPW3Ltlp9Eh4zoFFLswvZmNpRTb790CY5tsNfgbYeNOqIARJfQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -7771,7 +7792,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -8246,7 +8267,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.1
 
   '@npmcli/move-file@2.0.1':
     dependencies:
@@ -8750,6 +8771,11 @@ snapshots:
       '@vitest/utils': 3.0.5
       pathe: 2.0.3
 
+  '@vitest/runner@3.0.7':
+    dependencies:
+      '@vitest/utils': 3.0.7
+      pathe: 2.0.3
+
   '@vitest/snapshot@3.0.5':
     dependencies:
       '@vitest/pretty-format': 3.0.5
@@ -8780,6 +8806,12 @@ snapshots:
   '@vitest/utils@3.0.5':
     dependencies:
       '@vitest/pretty-format': 3.0.5
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.0.7':
+    dependencies:
+      '@vitest/pretty-format': 3.0.7
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -8835,7 +8867,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9125,6 +9157,8 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  birpc@2.2.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -10508,7 +10542,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10527,7 +10561,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12401,7 +12435,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color

--- a/scripts/checkDeps.js
+++ b/scripts/checkDeps.js
@@ -24,7 +24,7 @@ async function check(projectDir, devPackageData) {
   // console.log(`Checking ${projectDir}`)
 
   const result = await new Promise(resolve => {
-    depCheck(projectDir, { ignoreDirs: ["out", "test", "pages", "typings", "docker", "certs", "templates", "vendor"] }, resolve)
+    depCheck(projectDir, { ignoreDirs: ["out", "pages", "typings", "docker", "certs", "templates", "vendor"] }, resolve)
   })
 
   let unusedDependencies = result.dependencies

--- a/test/package.json
+++ b/test/package.json
@@ -45,36 +45,10 @@
     "vitest-mock-commonjs": "^1.0.2",
     "esbuild": "^0.12.14",
     "esbuild-jest": "^0.5.0",
+    "tinypool": "^1.0.2",
+    "micromatch": "^4.0.8",
+    "@vitest/runner": "^3.0.7",
+    "birpc": "^2.2.0",
     "sanitize-filename": "^1.6.3"
-  },
-  "jest": {
-    "snapshotResolver": "<rootDir>/snapshotResolver.js",
-    "testEnvironment": "node",
-    "roots": [
-      "src"
-    ],
-    "transformIgnorePatterns": [
-      "./node_modules",
-      "../node_modules",
-      "../packages"
-    ],
-    "transform": {
-      "^.+\\.ts$": [
-        "esbuild-jest",
-        {
-          "sourcemap": "inline",
-          "loaders": {
-            ".ts": "ts"
-          }
-        }
-      ]
-    },
-    "testPathIgnorePatterns": [
-      "[\\/]{1}helpers[\\/]{1}"
-    ],
-    "testRegex": "\\.[jt]s$",
-    "setupFilesAfterEnv": [
-      "<rootDir>/jestSetup.js"
-    ]
   }
 }

--- a/test/vitest-fork-runner.ts
+++ b/test/vitest-fork-runner.ts
@@ -153,7 +153,12 @@ export default function createForksPool(ctx: Vitest, { execArgv, env }): Process
       // This is a workaround until we can find a better solution. For now, just slot in a 500ms delay and retry once.
       const isSupposedToRetry = (error: Error) => {
         const { message } = error
-        const isOsError = /Command failed: hdiutil/.test(message) || /ERR_ELECTRON_BUILDER_CANNOT_EXECUTE/.test(message) || /EPERM: operation not permitted/.test(message)
+        const isOsError =
+        /Command failed: hdiutil/.test(message) ||
+        /ERR_ELECTRON_BUILDER_CANNOT_EXECUTE/.test(message) ||
+        /EPERM: operation not permitted/.test(message) ||
+        /yarn-tarball.tgz/.test(message) ||
+        /Error: yarn process failed/.test(message)
         return isOsError && shouldRetry
       }
 

--- a/test/vitest-fork-runner.ts
+++ b/test/vitest-fork-runner.ts
@@ -1,0 +1,198 @@
+import { createBirpc } from "birpc"
+import EventEmitter from "node:events"
+import * as nodeos from "node:os"
+import { resolve } from "node:path"
+import v8 from "node:v8"
+import type { TinypoolChannel, Options as TinypoolOptions } from "tinypool"
+import { Tinypool } from "tinypool"
+import { ContextRPC, ContextTestEnvironment, SerializedConfig, WorkerGlobalState } from "vitest"
+import { createMethodsRPC, WorkspaceProject, type ProcessPool, type Vitest } from "vitest/node"
+import { groupFilesByEnv } from "./vitest-utils"
+
+type WorkerRpc = WorkerGlobalState["rpc"]
+
+type RunWithFiles = (specs: any[], invalidates?: string[]) => Promise<void>
+
+const POOL_NAME = "custom-forks"
+
+function createChildProcessChannel(project: WorkspaceProject) {
+  const emitter = new EventEmitter()
+  const cleanup = () => emitter.removeAllListeners()
+
+  const events = { message: "message", response: "response" }
+  const channel: TinypoolChannel = {
+    onMessage: callback => emitter.on(events.message, callback),
+    postMessage: message => emitter.emit(events.response, message),
+  }
+
+  const rpc: WorkerRpc = createBirpc(createMethodsRPC(project, { cacheFs: true }), {
+    eventNames: ["onCancel"],
+    serialize: v8.serialize,
+    deserialize: v => v8.deserialize(Buffer.from(v)),
+    post(v) {
+      emitter.emit(events.message, v)
+    },
+    on(fn) {
+      emitter.on(events.response, fn)
+    },
+    onTimeoutError(functionName) {
+      throw new Error(`[vitest-pool]: Timeout calling "${functionName}"`)
+    },
+  })
+
+  project.vitest.onCancel(reason => rpc.onCancel(reason))
+
+  return { channel, cleanup }
+}
+
+
+export default function createForksPool(ctx: Vitest, { execArgv, env }): ProcessPool {
+  const numCpus = typeof nodeos.availableParallelism === "function" ? nodeos.availableParallelism() : nodeos.cpus().length
+
+  const threadsCount = ctx.config.watch ? Math.max(Math.floor(numCpus / 2), 1) : Math.max(numCpus - 1, 1)
+
+  const poolOptions = ctx.config.poolOptions?.forks ?? {}
+
+  const maxThreads = poolOptions.maxForks ?? ctx.config.maxWorkers ?? threadsCount
+  const minThreads = poolOptions.minForks ?? ctx.config.minWorkers ?? threadsCount
+
+  const worker = resolve(ctx.distPath, "workers/forks.js")
+
+  const options: TinypoolOptions = {
+    runtime: "child_process",
+    filename: resolve(ctx.distPath, "worker.js"),
+
+    maxThreads,
+    minThreads,
+
+    env,
+    execArgv: [...(poolOptions.execArgv ?? []), ...execArgv],
+
+    terminateTimeout: ctx.config.teardownTimeout,
+    concurrentTasksPerWorker: 1,
+  }
+
+  const isolated = poolOptions.isolate ?? true
+
+  if (isolated) {
+    options.isolateWorkers = true
+  }
+
+  if (poolOptions.singleFork || !ctx.config.fileParallelism) {
+    options.maxThreads = 1
+    options.minThreads = 1
+  }
+
+  const pool = new Tinypool(options)
+
+  const runWithFiles = (name: string): RunWithFiles => {
+    let id = 0
+
+    async function runFiles(project: WorkspaceProject, config: SerializedConfig, files: string[], environment: ContextTestEnvironment, invalidates: string[] = []) {
+      ctx.state.clearFiles(project, files)
+      const { channel, cleanup } = createChildProcessChannel(project)
+      const workerId = ++id
+      const data: ContextRPC = {
+        pool: POOL_NAME,
+        worker,
+        config,
+        files,
+        invalidates,
+        environment,
+        workerId,
+        projectName: project.name,
+        providedContext: project.getProvidedContext(),
+      }
+      await runTestWithPotentialRetry(data, channel, files, project, cleanup, true)
+    }
+
+    return async (specs, invalidates) => {
+      // Cancel pending tasks from pool when possible
+      ctx.onCancel(() => pool.cancelPendingTasks())
+
+      const configs = new Map<WorkspaceProject, SerializedConfig>()
+      const getConfig = (project: WorkspaceProject): SerializedConfig => {
+        if (configs.has(project)) {
+          return configs.get(project)!
+        }
+
+        const config = project.serializedConfig
+        configs.set(project, config)
+        return config
+      }
+
+      const workspaceMap = new Map<string, WorkspaceProject[]>()
+      for (const spec of specs) {
+        const file = spec.moduleId
+        const project = spec.project.workspaceProject
+        const workspaceFiles = workspaceMap.get(file) ?? []
+        workspaceFiles.push(project)
+        workspaceMap.set(file, workspaceFiles)
+      }
+
+      const filesByEnv = await groupFilesByEnv(specs)
+      const files = Object.values(filesByEnv).flat()
+      const results: PromiseSettledResult<void>[] = []
+      results.push(...(await Promise.allSettled(files.map(({ file, environment, project }) => runFiles(project, getConfig(project), [file], environment, invalidates)))))
+
+      const errors = results.filter((r): r is PromiseRejectedResult => r.status === "rejected").map(r => r.reason)
+      if (errors.length > 0) {
+        throw new AggregateError(errors, "Errors occurred while running tests. For more information, see serialized error.")
+      }
+    }
+
+    async function runTestWithPotentialRetry(
+      data: ContextRPC,
+      channel: TinypoolChannel,
+      files: string[],
+      project: WorkspaceProject,
+      cleanup: () => EventEmitter<[never]>,
+      shouldRetry: boolean
+    ) {
+      // Handle electron-builder flaky (due to parallel file operations such as hdiutil and EPERM file locks) tests by retrying
+      // This is a workaround until we can find a better solution. For now, just slot in a 500ms delay and retry once.
+      const isSupposedToRetry = (error: Error) => {
+        const { message } = error
+        const isOsError = /Command failed: hdiutil/.test(message) || /ERR_ELECTRON_BUILDER_CANNOT_EXECUTE/.test(message) || /EPERM: operation not permitted/.test(message)
+        return isOsError && shouldRetry
+      }
+
+      try {
+        await pool.run(data, { name, channel })
+      } catch (error) {
+        if (!(error instanceof Error)) {
+          throw error
+        }
+
+        // Worker got stuck and won't terminate - this may cause process to hang
+        if (/Failed to terminate worker/.test(error.message)) {
+          ctx.state.addProcessTimeoutCause(`Failed to terminate worker while running ${files.join(", ")}.`)
+        }
+        // Intentionally cancelled
+        else if (
+          (ctx as any).isCancelling && // TODO: Remove this when vitest is updated
+          /The task has been cancelled/.test(error.message)
+        ) {
+          ctx.state.cancelFiles(files, project)
+        }
+        // Flaky test failure
+        else if (isSupposedToRetry(error)) {
+          await new Promise<void>(resolve => setTimeout(resolve, 500))
+          ctx.logger.log(`Retrying test ${files.join(", ")} due to flaky test failure:`, error.message)
+          await runTestWithPotentialRetry(data, channel, files, project, cleanup, false)
+        } else {
+          throw error
+        }
+      } finally {
+        cleanup()
+      }
+    }
+  }
+
+  return {
+    name: POOL_NAME,
+    runTests: runWithFiles("run"),
+    collectTests: runWithFiles("collect"),
+    close: () => pool.destroy(),
+  }
+}

--- a/test/vitest-utils.ts
+++ b/test/vitest-utils.ts
@@ -1,0 +1,99 @@
+import mm from "micromatch"
+import fs from "node:fs/promises"
+import type { ContextRPC, ContextTestEnvironment } from "vitest"
+import { Environment, builtinEnvironments } from "vitest/environments"
+import type { EnvironmentOptions, TestSpecification, TransformModePatterns, VitestEnvironment, WorkspaceProject } from "vitest/node"
+
+export function groupBy<T, K extends string | number | symbol>(collection: T[], iteratee: (item: T) => K) {
+  return collection.reduce(
+    (acc, item) => {
+      const key = iteratee(item)
+      acc[key] ||= []
+      acc[key].push(item)
+      return acc
+    },
+    {} as Record<K, T[]>
+  )
+}
+
+function getTransformMode(patterns: TransformModePatterns, filename: string): "web" | "ssr" | undefined {
+  if (patterns.web && mm.isMatch(filename, patterns.web, {})) {
+    return "web"
+  }
+  if (patterns.ssr && mm.isMatch(filename, patterns.ssr, {})) {
+    return "ssr"
+  }
+  return undefined
+}
+
+type TestEnvironmentSpecification = TestSpecification & {
+  environment: ContextTestEnvironment
+  file: string
+}
+
+export async function groupFilesByEnv(specs: TestSpecification[]): Promise<Record<string, TestEnvironmentSpecification[]>> {
+  const filesWithEnv = await Promise.all(
+    specs.map(async spec => {
+      const { moduleId, project } = spec
+      const code = await fs.readFile(moduleId, "utf-8")
+
+      // 1. Check for control comments in the file
+      let env = code.match(/@(?:vitest|jest)-environment\s+([\w-]+)\b/)?.[1]
+      // 2. Check for globals
+      if (!env) {
+        for (const [glob, target] of project.config.environmentMatchGlobs || []) {
+          if (mm.isMatch(moduleId, glob, { cwd: project.config.root })) {
+            env = target
+            break
+          }
+        }
+      }
+      // 3. Fallback to global env
+      env ||= project.config.environment || "node"
+
+      const transformMode = getTransformMode(project.config.testTransformMode, moduleId)
+
+      let envOptionsJson = code.match(/@(?:vitest|jest)-environment-options\s+(.+)/)?.[1]
+      if (envOptionsJson?.endsWith("*/")) {
+        // Trim closing Docblock characters the above regex might have captured
+        envOptionsJson = envOptionsJson.slice(0, -2)
+      }
+
+      const envOptions = JSON.parse(envOptionsJson || "null")
+      const envKey = env === "happy-dom" ? "happyDOM" : env
+      const environment: ContextTestEnvironment = {
+        name: env as VitestEnvironment,
+        transformMode,
+        options: envOptions ? ({ [envKey]: envOptions } as EnvironmentOptions) : null,
+      }
+      return {
+        ...spec,
+        environment,
+        file: moduleId,
+      } as TestEnvironmentSpecification
+    })
+  )
+
+  return groupBy(filesWithEnv, ({ environment }) => environment.name)
+}
+
+export async function groupFilesByProject(specs: TestSpecification[]) {
+  return groupBy(specs, ({ project }) => project.name)
+}
+
+export function getUniqueProjects(specs: TestSpecification[]): WorkspaceProject[] {
+  const projects = new Set<WorkspaceProject>()
+  for (const spec of specs) {
+    projects.add(spec.project)
+  }
+  return [...projects]
+}
+
+export function loadEnvironment(ctx: ContextRPC): Environment {
+  const name = ctx.environment.name
+  if (name in builtinEnvironments) {
+    return builtinEnvironments[name as keyof typeof builtinEnvironments]
+  }
+
+  throw new Error("Custom Environment is not yet supported")
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,6 @@ export default () => {
   const includeRegex = `(${testRegex.join("|")})`
   console.log("TEST_FILES pattern", includeRegex)
 
-  const isWindows = process.platform === "win32"
-
   return defineConfig({
     server: {
       https: {
@@ -20,6 +18,9 @@ export default () => {
       setupFiles: "./test/vitest-setup.ts",
       include: [`test/src/**/${includeRegex}.ts`],
       update: process.env.UPDATE_SNAPSHOT === "true",
+
+      // Note: only implemented isolated workers
+      pool: './test/vitest-fork-runner.ts',
 
       name: "node",
       environment: "node",
@@ -38,26 +39,15 @@ export default () => {
         },
       },
 
-      // Speed things up a bit -- these help but probably won't be needed someday
-      maxConcurrency: 20,
-      pool: "forks",
-      poolOptions: {
-        forks: {
-          isolate: false,
-        },
-      },
-      isolate: false, // only safe with the poolOptions above
 
-      slowTestThreshold: 10 * 1000,
-      testTimeout: (isWindows ? 8 : 5) * 1000 * 60, // disk operations can be slow. We're generous with the timeout here to account for less-performant hardware
+
+      slowTestThreshold: 60 * 1000,
+      testTimeout: 8 * 60 * 1000, // disk operations can be slow. We're generous with the timeout here to account for less-performant hardware
       coverage: {
         reporter: ["lcov", "text"],
       },
       reporters: ["default", "html"],
       outputFile: "coverage/sonar-report.xml",
-      snapshotFormat: {
-        printBasicPrototype: false,
-      },
       resolveSnapshotPath: (testPath, snapshotExtension) => {
         return testPath
           .replace(/\.[tj]s$/, `.js${snapshotExtension}`)


### PR DESCRIPTION
This is to stabilize CI by implementing 1 automatic retry for `EPERM`/`hdiutil`/`app-builder-bin` errors (usually due to file locks)