### PR TITLE
fix: support `mas` packages for flipping fuses

### DIFF
--- a/.changeset/bright-students-add.md
+++ b/.changeset/bright-students-add.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: support `mas` packages for flipping fuses

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -422,6 +422,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
     const ext = {
       darwin: ".app",
+      mas: ".app",
       win32: ".exe",
       linux: "",
     }[electronPlatformName]


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/8946