### PR TITLE
chore(test): stabilize CI by implementing automatic retry for system errors (like dmgs and file locks)

### DIFF
--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -7,7 +7,7 @@ export class YarnNodeModulesCollector extends NpmNodeModulesCollector {
 
   public readonly installOptions = Promise.resolve({
     cmd: process.platform === "win32" ? "yarn.cmd" : "yarn",
-    args: ["install", "--frozen-lockfile"],
+    args: ["install", "--frozen-lockfile", "--network-concurrency 1"],
     lockfile: "yarn.lock",
   })
 }

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -7,7 +7,7 @@ export class YarnNodeModulesCollector extends NpmNodeModulesCollector {
 
   public readonly installOptions = Promise.resolve({
     cmd: process.platform === "win32" ? "yarn.cmd" : "yarn",
-    args: ["install", "--frozen-lockfile", "--network-concurrency 1"],
+    args: ["install", "--frozen-lockfile"],
     lockfile: "yarn.lock",
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,12 +626,6 @@ importers:
       fs-extra:
         specifier: ^10.1.0
         version: 10.1.0
-      jest:
-        specifier: 29.7.0
-        version: 29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
-      jest-junit:
-        specifier: ^12.0.0
-        version: 12.3.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -678,12 +672,21 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.1
         version: 4.0.3
+      '@types/micromatch':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/semver':
         specifier: ^7.3.13
         version: 7.5.8
+      '@vitest/runner':
+        specifier: ^3.0.7
+        version: 3.0.7
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.24.9)
+      birpc:
+        specifier: ^2.2.0
+        version: 2.2.0
       esbuild:
         specifier: ^0.12.14
         version: 0.12.29
@@ -693,9 +696,15 @@ importers:
       fast-xml-parser:
         specifier: 4.4.1
         version: 4.4.1
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
       sanitize-filename:
         specifier: ^1.6.3
         version: 1.6.3
+      tinypool:
+        specifier: ^1.0.2
+        version: 1.0.2
       vitest:
         specifier: ^3.0.4
         version: 3.0.5(@types/node@22.10.1)(@vitest/ui@3.0.4(vitest@3.0.5))(sass@1.82.0)(yaml@2.6.1)
@@ -2292,6 +2301,9 @@ packages:
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -2363,6 +2375,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/micromatch@4.0.9':
+    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
 
   '@types/mime@2.0.3':
     resolution: {integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==}
@@ -2536,6 +2551,9 @@ packages:
   '@vitest/runner@3.0.5':
     resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
+  '@vitest/runner@3.0.7':
+    resolution: {integrity: sha512-WeEl38Z0S2ZcuRTeyYqaZtm4e26tq6ZFqh5y8YD9YxfWuu0OFiGFUbnxNynwLjNRHPsXyee2M9tV7YxOTPZl2g==}
+
   '@vitest/snapshot@3.0.5':
     resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
 
@@ -2552,6 +2570,9 @@ packages:
 
   '@vitest/utils@3.0.5':
     resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
+
+  '@vitest/utils@3.0.7':
+    resolution: {integrity: sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -2631,10 +2652,6 @@ packages:
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
     engines: {node: '>=18'}
-
-  ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2849,6 +2866,9 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  birpc@2.2.0:
+    resolution: {integrity: sha512-1/22obknhoj56PcE+pZPp6AbWDdY55M81/ofpPW3Ltlp9Eh4zoFFLswvZmNpRTb790CY5tsNfgbYeNOqIARJfQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -3191,11 +3211,6 @@ packages:
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
-
-  create-jest@29.7.0:
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -4068,11 +4083,6 @@ packages:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
 
-  import-local@3.2.0:
-    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
-    engines: {node: '>=8'}
-    hasBin: true
-
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -4374,16 +4384,6 @@ packages:
     resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-cli@29.7.0:
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
   jest-config@29.7.0:
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4423,10 +4423,6 @@ packages:
   jest-haste-map@29.7.0:
     resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  jest-junit@12.3.0:
-    resolution: {integrity: sha512-+NmE5ogsEjFppEl90GChrk7xgz8xzvF0f+ZT5AnhW6suJC93gvQtmQjfyjDnE0Z2nXJqEkxF0WXlvjG/J+wn/g==}
-    engines: {node: '>=10.12.0'}
 
   jest-leak-detector@29.7.0:
     resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
@@ -4509,16 +4505,6 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest@29.7.0:
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4578,10 +4564,6 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-
-  kleur@3.0.3:
-    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
-    engines: {node: '>=6'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -5260,10 +5242,6 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
-  prompts@2.4.2:
-    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
-    engines: {node: '>= 6'}
-
   property-information@6.5.0:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
 
@@ -5417,10 +5395,6 @@ packages:
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-
-  resolve-cwd@3.0.0:
-    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
-    engines: {node: '>=8'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -5617,9 +5591,6 @@ packages:
     resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
     engines: {node: '>=18'}
 
-  sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -5780,10 +5751,6 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
-
-  strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -6154,10 +6121,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -6335,9 +6298,6 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-
-  xml@1.0.1:
-    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -7771,7 +7731,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -8246,7 +8206,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.6.3
+      semver: 7.7.1
 
   '@npmcli/move-file@2.0.1':
     dependencies:
@@ -8472,6 +8432,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.0
 
+  '@types/braces@3.0.5': {}
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.0.4
@@ -8556,6 +8518,10 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/micromatch@4.0.9':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/mime@2.0.3': {}
 
@@ -8750,6 +8716,11 @@ snapshots:
       '@vitest/utils': 3.0.5
       pathe: 2.0.3
 
+  '@vitest/runner@3.0.7':
+    dependencies:
+      '@vitest/utils': 3.0.7
+      pathe: 2.0.3
+
   '@vitest/snapshot@3.0.5':
     dependencies:
       '@vitest/pretty-format': 3.0.5
@@ -8780,6 +8751,12 @@ snapshots:
   '@vitest/utils@3.0.5':
     dependencies:
       '@vitest/pretty-format': 3.0.5
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.0.7':
+    dependencies:
+      '@vitest/pretty-format': 3.0.7
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -8835,7 +8812,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8874,8 +8851,6 @@ snapshots:
   ansi-escapes@7.0.0:
     dependencies:
       environment: 1.1.0
-
-  ansi-regex@4.1.1: {}
 
   ansi-regex@5.0.1: {}
 
@@ -9125,6 +9100,8 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  birpc@2.2.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -9517,21 +9494,6 @@ snapshots:
   crc@3.8.0:
     dependencies:
       buffer: 5.7.1
-
-  create-jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   create-require@1.1.1: {}
 
@@ -10508,7 +10470,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10527,7 +10489,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10573,11 +10535,6 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-
-  import-local@3.2.0:
-    dependencies:
-      pkg-dir: 4.2.0
-      resolve-cwd: 3.0.0
 
   imurmurhash@0.1.4: {}
 
@@ -10885,25 +10842,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)):
     dependencies:
       '@babel/core': 7.24.9
@@ -11000,13 +10938,6 @@ snapshots:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
-
-  jest-junit@12.3.0:
-    dependencies:
-      mkdirp: 1.0.4
-      strip-ansi: 5.2.0
-      uuid: 8.3.2
-      xml: 1.0.1
 
   jest-leak-detector@29.7.0:
     dependencies:
@@ -11199,18 +11130,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -11262,8 +11181,6 @@ snapshots:
       is-buffer: 1.1.6
 
   kind-of@6.0.3: {}
-
-  kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -11944,11 +11861,6 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
-  prompts@2.4.2:
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
-
   property-information@6.5.0: {}
 
   pseudomap@1.0.2: {}
@@ -12114,10 +12026,6 @@ snapshots:
       pe-library: 0.4.1
 
   resolve-alpn@1.2.1: {}
-
-  resolve-cwd@3.0.0:
-    dependencies:
-      resolve-from: 5.0.0
 
   resolve-from@4.0.0: {}
 
@@ -12344,8 +12252,6 @@ snapshots:
       mrmime: 2.0.0
       totalist: 3.0.1
 
-  sisteransi@1.0.5: {}
-
   slash@3.0.0: {}
 
   slice-ansi@3.0.0:
@@ -12401,7 +12307,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -12541,10 +12447,6 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
-
-  strip-ansi@5.2.0:
-    dependencies:
-      ansi-regex: 4.1.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -12927,8 +12829,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
-
   v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
@@ -13146,8 +13046,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-
-  xml@1.0.1: {}
 
   xmlbuilder@15.1.1: {}
 

--- a/scripts/checkDeps.js
+++ b/scripts/checkDeps.js
@@ -24,7 +24,7 @@ async function check(projectDir, devPackageData) {
   // console.log(`Checking ${projectDir}`)
 
   const result = await new Promise(resolve => {
-    depCheck(projectDir, { ignoreDirs: ["out", "test", "pages", "typings", "docker", "certs", "templates", "vendor"] }, resolve)
+    depCheck(projectDir, { ignoreDirs: ["out", "pages", "typings", "docker", "certs", "templates", "vendor"] }, resolve)
   })
 
   let unusedDependencies = result.dependencies

--- a/test/fixtures/test-app-hoisted/.yarnrc.yml
+++ b/test/fixtures/test-app-hoisted/.yarnrc.yml
@@ -1,0 +1,1 @@
+cacheFolder: "./.yarn/cache"

--- a/test/fixtures/test-app-one/.yarnrc.yml
+++ b/test/fixtures/test-app-one/.yarnrc.yml
@@ -1,0 +1,1 @@
+cacheFolder: "./.yarn/cache"

--- a/test/fixtures/test-app-yarn-hoisted/.yarnrc.yml
+++ b/test/fixtures/test-app-yarn-hoisted/.yarnrc.yml
@@ -1,0 +1,1 @@
+cacheFolder: "./.yarn/cache"

--- a/test/fixtures/test-app-yarn-several-workspace/.yarnrc.yml
+++ b/test/fixtures/test-app-yarn-several-workspace/.yarnrc.yml
@@ -1,0 +1,1 @@
+cacheFolder: "./.yarn/cache"

--- a/test/fixtures/test-app-yarn-workspace-version-conflict/.yarnrc.yml
+++ b/test/fixtures/test-app-yarn-workspace-version-conflict/.yarnrc.yml
@@ -1,0 +1,1 @@
+cacheFolder: "./.yarn/cache"

--- a/test/fixtures/test-app-yarn-workspace/.yarnrc.yml
+++ b/test/fixtures/test-app-yarn-workspace/.yarnrc.yml
@@ -1,0 +1,1 @@
+cacheFolder: "./.yarn/cache"

--- a/test/fixtures/test-app/.yarnrc.yml
+++ b/test/fixtures/test-app/.yarnrc.yml
@@ -1,0 +1,1 @@
+cacheFolder: "./.yarn/cache"

--- a/test/package.json
+++ b/test/package.json
@@ -19,8 +19,6 @@
     "electron-updater": "workspace:*",
     "electron-winstaller": "5.4.0",
     "fs-extra": "^10.1.0",
-    "jest": "29.7.0",
-    "jest-junit": "^12.0.0",
     "js-yaml": "^4.1.0",
     "lazy-val": "^1.0.5",
     "path-sort": "^0.1.0",
@@ -38,43 +36,18 @@
     "@types/adm-zip": "0.5.6",
     "@types/fs-extra": "^9.0.11",
     "@types/js-yaml": "^4.0.1",
+    "@types/micromatch": "^4.0.9",
     "@types/semver": "^7.3.13",
+    "@vitest/runner": "^3.0.7",
     "babel-jest": "^29.7.0",
-    "fast-xml-parser": "4.4.1",
-    "vitest": "^3.0.4",
-    "vitest-mock-commonjs": "^1.0.2",
+    "birpc": "^2.2.0",
     "esbuild": "^0.12.14",
     "esbuild-jest": "^0.5.0",
-    "sanitize-filename": "^1.6.3"
-  },
-  "jest": {
-    "snapshotResolver": "<rootDir>/snapshotResolver.js",
-    "testEnvironment": "node",
-    "roots": [
-      "src"
-    ],
-    "transformIgnorePatterns": [
-      "./node_modules",
-      "../node_modules",
-      "../packages"
-    ],
-    "transform": {
-      "^.+\\.ts$": [
-        "esbuild-jest",
-        {
-          "sourcemap": "inline",
-          "loaders": {
-            ".ts": "ts"
-          }
-        }
-      ]
-    },
-    "testPathIgnorePatterns": [
-      "[\\/]{1}helpers[\\/]{1}"
-    ],
-    "testRegex": "\\.[jt]s$",
-    "setupFilesAfterEnv": [
-      "<rootDir>/jestSetup.js"
-    ]
+    "fast-xml-parser": "4.4.1",
+    "micromatch": "^4.0.8",
+    "sanitize-filename": "^1.6.3",
+    "tinypool": "^1.0.2",
+    "vitest": "^3.0.4",
+    "vitest-mock-commonjs": "^1.0.2"
   }
 }

--- a/test/src/ArtifactPublisherTest.ts
+++ b/test/src/ArtifactPublisherTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Platform } from "app-builder-lib"
 import { createPublisher } from "app-builder-lib/out/publish/PublishManager"
 import { Arch } from "builder-util"

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { checkBuildRequestOptions } from "app-builder-lib"
 import { doMergeConfigs } from "app-builder-lib/out/util/config/config"
 import { Arch, createTargets, DIR_TARGET, Platform } from "electron-builder"
@@ -148,7 +149,7 @@ test("relative index", ({ expect }) =>
     }
   ))
 
-it.ifDevOrLinuxCi("electron version from electron-prebuilt dependency", ({ expect }) =>
+test.ifDevOrLinuxCi("electron version from electron-prebuilt dependency", ({ expect }) =>
   app(
     expect,
     {

--- a/test/src/ExtraBuildResourcesTest.ts
+++ b/test/src/ExtraBuildResourcesTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, build, PackagerOptions, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"

--- a/test/src/HoistTest.ts
+++ b/test/src/HoistTest.ts
@@ -1,3 +1,4 @@
+import { it, describe } from "@test/vitest/vitest-test-wrapper"
 // copy from https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-nm/tests/hoist.test.ts
 import { hoist, HoisterTree, HoisterResult, HoisterDependencyKind } from "app-builder-lib/out/node-module-collector/hoist"
 import { expect } from "vitest"

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { assertPack, linuxDirTarget, verifyAsarFileTree, modifyPackageJson } from "./helpers/packTester"
 import { Platform, Arch, DIR_TARGET } from "electron-builder"
 import { outputFile } from "fs-extra"

--- a/test/src/MemoLazyTest.ts
+++ b/test/src/MemoLazyTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { MemoLazy } from "builder-util-runtime"
 import { Lazy } from "lazy-val"
 

--- a/test/src/PublishManagerTest.ts
+++ b/test/src/PublishManagerTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { GenericServerOptions, GithubOptions, KeygenOptions, SpacesOptions } from "builder-util-runtime"
 import { Arch, createTargets, Platform } from "electron-builder"
 import { outputFile } from "fs-extra"

--- a/test/src/RepoSlugTest.ts
+++ b/test/src/RepoSlugTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { getRepositoryInfo } from "app-builder-lib/out/util/repositoryInfo"
 import { ExpectStatic } from "vitest"
 

--- a/test/src/binDownloadTest.ts
+++ b/test/src/binDownloadTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { getBinFromUrl } from "app-builder-lib/out/binDownload"
 
 test("download binary from Github", async ({ expect }) => {

--- a/test/src/configurationValidationTest.ts
+++ b/test/src/configurationValidationTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { validateConfiguration } from "app-builder-lib/out/util/config/config"
 import { Arch, DebugLogger } from "builder-util"
 import { Configuration, Platform } from "electron-builder"

--- a/test/src/extraMetadataTest.ts
+++ b/test/src/extraMetadataTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { readAsarJson } from "app-builder-lib/out/asar/asar"
 import { Platform } from "electron-builder"
 import { coerceTypes } from "electron-builder/out/builder"

--- a/test/src/filenameUtilTest.ts
+++ b/test/src/filenameUtilTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { getCompleteExtname } from "builder-util/out/filename"
 
 // [inputFilename, expectedExtname]

--- a/test/src/filesTest.ts
+++ b/test/src/filesTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { TmpDir, archFromString, copyDir } from "builder-util"
 import { DIR_TARGET, Platform } from "electron-builder"
 import { outputFile } from "fs-extra"

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Platform } from "app-builder-lib"
 import { readAsar } from "app-builder-lib/out/asar/asar"
 import { outputFile } from "fs-extra"

--- a/test/src/helpers/customWindowsSign.mjs
+++ b/test/src/helpers/customWindowsSign.mjs
@@ -1,3 +1,5 @@
+import { expect } from "vitest"
+
 // test custom windows sign using path to file
 export default async function (configuration) {
   const info = configuration.cscInfo

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { DIR_TARGET, Platform, archFromString } from "electron-builder"
 import { outputFile } from "fs-extra"
 import * as path from "path"

--- a/test/src/linux/debTest.ts
+++ b/test/src/linux/debTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import { app, execShell, getTarExecutable } from "../helpers/packTester"

--- a/test/src/linux/flatpakTest.ts
+++ b/test/src/linux/flatpakTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 

--- a/test/src/linux/fpmTest.ts
+++ b/test/src/linux/fpmTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 

--- a/test/src/linux/linuxArchiveTest.ts
+++ b/test/src/linux/linuxArchiveTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 

--- a/test/src/linux/linuxPackagerTest.ts
+++ b/test/src/linux/linuxPackagerTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { GenericServerOptions } from "builder-util-runtime"
 import { Arch, build, Platform } from "electron-builder"
 import { outputFile } from "fs-extra"

--- a/test/src/linux/snapHeavyTest.ts
+++ b/test/src/linux/snapHeavyTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "app-builder-lib"
 import { app, snapTarget } from "../helpers/packTester"
 

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import { app, assertPack, snapTarget } from "../helpers/packTester"
 

--- a/test/src/mac/dmgTest.ts
+++ b/test/src/mac/dmgTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { PlatformPackager } from "app-builder-lib"
 import { Arch, copyFile, exec } from "builder-util"
 import { attachAndExecute, getDmgTemplatePath } from "dmg-builder/out/dmgUtil"

--- a/test/src/mac/dmgTest.ts
+++ b/test/src/mac/dmgTest.ts
@@ -1,5 +1,5 @@
 import { test, describe } from "@test/vitest/vitest-test-wrapper"
-import { PlatformPackager } from "app-builder-lib"
+import { Configuration, PackagerOptions, PlatformPackager } from "app-builder-lib"
 import { Arch, copyFile, exec } from "builder-util"
 import { attachAndExecute, getDmgTemplatePath } from "dmg-builder/out/dmgUtil"
 import { Platform } from "electron-builder"
@@ -278,15 +278,18 @@ describe("dmg", { sequential: true }, () => {
     })
   })
 
-  const packagerOptions = {
+  const packagerOptions: () => PackagerOptions = () => ({
     targets: dmgTarget,
     config: {
       publish: null,
     },
-  }
+    dmg: {
+      artifactName: "${productName}-${version}-" + Date.now() + ".${ext}",
+    },
+  })
 
   test.ifMac("multi language license", ({ expect }) =>
-    app(expect, packagerOptions, {
+    app(expect, packagerOptions(), {
       projectDirCreated: projectDir => {
         return Promise.all([
           // writeFile(path.join(projectDir, "build", "license_en.txt"), "Hi"),
@@ -298,7 +301,7 @@ describe("dmg", { sequential: true }, () => {
   )
 
   test.ifMac("license ja", ({ expect }) =>
-    app(expect, packagerOptions, {
+    app(expect, packagerOptions(), {
       projectDirCreated: projectDir => {
         return fs.writeFile(path.join(projectDir, "build", "license_ja.txt"), "こんにちは".repeat(12))
       },
@@ -306,7 +309,7 @@ describe("dmg", { sequential: true }, () => {
   )
 
   test.ifMac("license en", ({ expect }) =>
-    app(expect, packagerOptions, {
+    app(expect, packagerOptions(), {
       projectDirCreated: projectDir => {
         return copyTestAsset("license_en.txt", path.join(projectDir, "build", "license_en.txt"))
       },
@@ -314,7 +317,7 @@ describe("dmg", { sequential: true }, () => {
   )
 
   test.ifMac("license rtf", ({ expect }) =>
-    app(expect, packagerOptions, {
+    app(expect, packagerOptions(), {
       projectDirCreated: projectDir => {
         return copyTestAsset("license_de.rtf", path.join(projectDir, "build", "license_de.rtf"))
       },
@@ -325,7 +328,7 @@ describe("dmg", { sequential: true }, () => {
     app(
       expect,
       {
-        ...packagerOptions,
+        ...packagerOptions(),
         effectiveOptionComputed: async it => {
           if ("licenseData" in it) {
             // Clean `file` path from the data because the path is dynamic at runtime
@@ -334,7 +337,7 @@ describe("dmg", { sequential: true }, () => {
             })
             expect(it.licenseData).toMatchSnapshot()
           }
-          return false
+          return Promise.resolve(false)
         },
       },
       {

--- a/test/src/mac/macArchiveTest.ts
+++ b/test/src/mac/macArchiveTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, exec } from "builder-util"
 import { parseXml } from "builder-util-runtime"
 import { Platform } from "electron-builder"

--- a/test/src/mac/macCodeSignTest.ts
+++ b/test/src/mac/macCodeSignTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { createKeychain } from "app-builder-lib/out/codeSign/macCodeSign"
 import { removePassword, TmpDir } from "builder-util"
 import { CSC_LINK } from "../helpers/codeSignData"

--- a/test/src/mac/macIconTest.ts
+++ b/test/src/mac/macIconTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { copyOrLinkFile } from "builder-util"
 import { Arch, createTargets, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"

--- a/test/src/mac/masTest.ts
+++ b/test/src/mac/masTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import * as path from "path"
 import { CheckingMacPackager } from "../helpers/CheckingPackager"

--- a/test/src/macroExpanderTest.ts
+++ b/test/src/macroExpanderTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { expandMacro } from "app-builder-lib/out/util/macroExpander"
 
 const appInfoStub: any = {

--- a/test/src/mainEntryTest.ts
+++ b/test/src/mainEntryTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { createTargets, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"

--- a/test/src/protonTest.ts
+++ b/test/src/protonTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { copyDir } from "builder-util"
 import { Arch, Platform } from "electron-builder"
 import { app, AssertPackOptions } from "./helpers/packTester"

--- a/test/src/updater/differentialUpdateTest.ts
+++ b/test/src/updater/differentialUpdateTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Configuration, Platform } from "app-builder-lib"
 import { getBinFromUrl } from "app-builder-lib/out/binDownload"
 import { doSpawn, getArchSuffix } from "builder-util"
@@ -154,7 +155,7 @@ test.ifMac("Mac Intel", ({ expect }) => testMac(expect, Arch.x64))
 test.ifMac("Mac universal", ({ expect }) => testMac(expect, Arch.universal))
 
 // only run on arm64 macs, otherwise of course no files can be found to be updated to (due to arch mismatch)
-test.ifMac.ifEnv(process.arch === "arm64")("Mac arm64", ({ expect }) => testMac(expect, Arch.arm64))
+test.ifEnv(process.platform === "darwin" && process.arch === "arm64")("Mac arm64", ({ expect }) => testMac(expect, Arch.arm64))
 
 async function checkResult(expect: ExpectStatic, updater: BaseUpdater) {
   // disable automatic install otherwise mac updater will permanently wait on mocked electron's native updater to receive update (mocked server can't install)

--- a/test/src/updater/linuxUpdaterTest.ts
+++ b/test/src/updater/linuxUpdaterTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { GithubOptions } from "builder-util-runtime"
 import { DebUpdater, PacmanUpdater, RpmUpdater } from "electron-updater"
 import { assertThat } from "../helpers/fileAssert"

--- a/test/src/updater/macUpdaterTest.ts
+++ b/test/src/updater/macUpdaterTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { configureRequestOptionsFromUrl, GithubOptions } from "builder-util-runtime"
 import { MacUpdater } from "electron-updater/out/MacUpdater"
 import { EventEmitter } from "events"

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { BitbucketOptions, GenericServerOptions, GithubOptions, KeygenOptions, S3Options, SpacesOptions } from "builder-util-runtime"
 import { BitbucketPublisher } from "electron-publish"
 import { UpdateCheckResult } from "electron-updater"

--- a/test/src/urlUtilTest.ts
+++ b/test/src/urlUtilTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { blockmapFiles, newUrlFromBase } from "electron-updater/out/util"
 import { URL } from "url"
 

--- a/test/src/vitest/vitest-fork-runner.ts
+++ b/test/src/vitest/vitest-fork-runner.ts
@@ -1,0 +1,193 @@
+import { createBirpc } from "birpc"
+import EventEmitter from "node:events"
+import * as nodeos from "node:os"
+import { resolve } from "node:path"
+import v8 from "node:v8"
+import type { TinypoolChannel, Options as TinypoolOptions } from "tinypool"
+import { Tinypool } from "tinypool"
+import { ContextRPC, ContextTestEnvironment, SerializedConfig, WorkerGlobalState } from "vitest"
+import { createMethodsRPC, WorkspaceProject, type ProcessPool, type Vitest } from "vitest/node"
+import { groupFilesByEnv, isSupposedToRetry } from "./vitest-utils"
+
+type WorkerRpc = WorkerGlobalState["rpc"]
+
+type RunWithFiles = (specs: any[], invalidates?: string[]) => Promise<void>
+
+const POOL_NAME = "custom-forks"
+
+function createChildProcessChannel(project: WorkspaceProject) {
+  const emitter = new EventEmitter()
+  const cleanup = () => emitter.removeAllListeners()
+
+  const events = { message: "message", response: "response" }
+  const channel: TinypoolChannel = {
+    onMessage: callback => emitter.on(events.message, callback),
+    postMessage: message => emitter.emit(events.response, message),
+  }
+
+  const rpc: WorkerRpc = createBirpc(createMethodsRPC(project, { cacheFs: true }), {
+    eventNames: ["onCancel"],
+    serialize: v8.serialize,
+    deserialize: v => v8.deserialize(Buffer.from(v)),
+    post(v) {
+      emitter.emit(events.message, v)
+    },
+    on(fn) {
+      emitter.on(events.response, fn)
+    },
+    onTimeoutError(functionName) {
+      throw new Error(`[vitest-pool]: Timeout calling "${functionName}"`)
+    },
+  })
+
+  project.vitest.onCancel(reason => rpc.onCancel(reason))
+
+  return { channel, cleanup }
+}
+
+
+export default function createForksPool(ctx: Vitest, { execArgv, env }: any): ProcessPool {
+  const numCpus = typeof nodeos.availableParallelism === "function" ? nodeos.availableParallelism() : nodeos.cpus().length
+
+  const threadsCount = ctx.config.watch ? Math.max(Math.floor(numCpus / 2), 1) : Math.max(numCpus - 1, 1)
+
+  const poolOptions = ctx.config.poolOptions?.forks ?? {}
+
+  const maxThreads = poolOptions.maxForks ?? ctx.config.maxWorkers ?? threadsCount
+  const minThreads = poolOptions.minForks ?? ctx.config.minWorkers ?? threadsCount
+
+  const worker = resolve(ctx.distPath, "workers/forks.js")
+
+  const options: TinypoolOptions = {
+    runtime: "child_process",
+    filename: resolve(ctx.distPath, "worker.js"),
+
+    maxThreads,
+    minThreads,
+
+    env,
+    execArgv: [...(poolOptions.execArgv ?? []), ...execArgv],
+
+    terminateTimeout: ctx.config.teardownTimeout,
+    concurrentTasksPerWorker: 1,
+  }
+
+  const isolated = poolOptions.isolate ?? true
+
+  if (isolated) {
+    options.isolateWorkers = true
+  }
+
+  if (poolOptions.singleFork || !ctx.config.fileParallelism) {
+    options.maxThreads = 1
+    options.minThreads = 1
+  }
+
+  const pool = new Tinypool(options)
+
+  const runWithFiles = (name: string): RunWithFiles => {
+    let id = 0
+
+    async function runFiles(project: WorkspaceProject, config: SerializedConfig, files: string[], environment: ContextTestEnvironment, invalidates: string[] = []) {
+      ctx.state.clearFiles(project, files)
+      const { channel, cleanup } = createChildProcessChannel(project)
+      const workerId = ++id
+      const data: ContextRPC = {
+        pool: POOL_NAME,
+        worker,
+        config,
+        files,
+        invalidates,
+        environment,
+        workerId,
+        projectName: project.name,
+        providedContext: project.getProvidedContext(),
+      }
+      await runTestWithPotentialRetry(data, channel, files, project, cleanup, true)
+    }
+
+    return async (specs, invalidates) => {
+      // Cancel pending tasks from pool when possible
+      ctx.onCancel(() => pool.cancelPendingTasks())
+
+      const configs = new Map<WorkspaceProject, SerializedConfig>()
+      const getConfig = (project: WorkspaceProject): SerializedConfig => {
+        if (configs.has(project)) {
+          return configs.get(project)!
+        }
+
+        const config = project.serializedConfig
+        configs.set(project, config)
+        return config
+      }
+
+      const workspaceMap = new Map<string, WorkspaceProject[]>()
+      for (const spec of specs) {
+        const file = spec.moduleId
+        const project = spec.project.workspaceProject
+        const workspaceFiles = workspaceMap.get(file) ?? []
+        workspaceFiles.push(project)
+        workspaceMap.set(file, workspaceFiles)
+      }
+
+      const filesByEnv = await groupFilesByEnv(specs)
+      const files = Object.values(filesByEnv).flat()
+      const results: PromiseSettledResult<void>[] = []
+      results.push(...(await Promise.allSettled(files.map(({ file, environment, project }) => runFiles(project, getConfig(project), [file], environment, invalidates)))))
+
+      const errors = results.filter((r): r is PromiseRejectedResult => r.status === "rejected").map(r => r.reason)
+      if (errors.length > 0) {
+        throw new Error("Errors occurred while running tests. For more information, see serialized error.")
+        // throw new AggregateError(errors, "Errors occurred while running tests. For more information, see serialized error.")
+      }
+    }
+
+    async function runTestWithPotentialRetry(
+      data: ContextRPC,
+      channel: TinypoolChannel,
+      files: string[],
+      project: WorkspaceProject,
+      cleanup: () => EventEmitter<[never]>,
+      shouldRetry: boolean
+    ) {
+      try {
+        await pool.run(data, { name, channel })
+      } catch (error: any) {
+        // Flaky test failure
+        if (shouldRetry && isSupposedToRetry(error.message ?? error)) {
+          await new Promise<void>(resolve => setTimeout(resolve, 10000))
+          ctx.logger.log(`Retrying test(s) ${files.join(", ")} due to flaky test failure:`, error.message)
+          await runTestWithPotentialRetry(data, channel, files, project, cleanup, false)
+          return
+        }
+
+        if (!(error instanceof Error)) {
+          throw error
+        }
+
+        // Worker got stuck and won't terminate - this may cause process to hang
+        if (/Failed to terminate worker/.test(error.message)) {
+          ctx.state.addProcessTimeoutCause(`Failed to terminate worker while running ${files.join(", ")}.`)
+        }
+        // Intentionally cancelled
+        else if (
+          (ctx as any).isCancelling && // TODO: Remove this when vitest is updated
+          /The task has been cancelled/.test(error.message)
+        ) {
+          ctx.state.cancelFiles(files, project)
+        } else {
+          throw error
+        }
+      } finally {
+        cleanup()
+      }
+    }
+  }
+
+  return {
+    name: POOL_NAME,
+    runTests: runWithFiles("run"),
+    collectTests: runWithFiles("collect"),
+    close: () => pool.destroy(),
+  }
+}

--- a/test/src/vitest/vitest-global-setup.ts
+++ b/test/src/vitest/vitest-global-setup.ts
@@ -1,0 +1,12 @@
+
+import type { TestProject } from 'vitest/node'
+import { getBin, getBinFromUrl } from "app-builder-lib/out/binDownload"
+
+export default async function setup(project: TestProject) {
+  await getBinFromUrl("wix", "4.0.0.5512.2", "/X5poahdCc3199Vt6AP7gluTlT1nxi9cbbHhZhCMEu+ngyP1LiBMn+oZX7QAZVaKeBMc2SjVp7fJqNLqsUnPNQ==")
+  await getBinFromUrl("linux-tools", "mac-10.12.3", "SQ8fqIRVXuQVWnVgaMTDWyf2TLAJjJYw3tRSqQJECmgF6qdM7Kogfa6KD49RbGzzMYIFca9Uw3MdsxzOPRWcYw==")
+  await getBinFromUrl("nsis-resources", "3.4.1", "Dqd6g+2buwwvoG1Vyf6BHR1b+25QMmPcwZx40atOT57gH27rkjOei1L0JTldxZu4NFoEmW4kJgZ3DlSWVON3+Q==")
+  await getBinFromUrl("nsis", "3.0.4.1", "VKMiizYdmNdJOWpRGz4trl4lD++BvYP2irAXpMilheUP0pc93iKlWAoP843Vlraj8YG19CVn0j+dCo/hURz9+Q==")
+  await getBinFromUrl("ran", "0.1.3", "imfA3LtT6umMM0BuQ29MgO3CJ9uleN5zRBi3sXzcTbMOeYZ6SQeN7eKr3kXZikKnVOIwbH+DDO43wkiR/qTdkg==")
+  await getBin("winCodeSign")
+}

--- a/test/src/vitest/vitest-setup.ts
+++ b/test/src/vitest/vitest-setup.ts
@@ -1,5 +1,6 @@
 import { isCI as isCi } from "ci-info"
-import { afterEach, test, vitest } from "vitest"
+import { afterEach, vitest } from "vitest"
+import * as wrappedTest from "@test/vitest/vitest-test-wrapper"
 
 afterEach(() => {
   vitest.clearAllMocks()
@@ -9,16 +10,11 @@ const isWindows = process.platform === "win32"
 const isMac = process.platform === "darwin"
 const isLinux = process.platform === "linux"
 
-const skip = test.skip
-// const skipSuite = describe.skip
-// const isAllTests = process.env.ALL_TESTS !== "false"
+const test: any = wrappedTest.test
 
-// describe = isAllTests ? describe : skipSuite
-// test = isAllTests ? test : skip
-// skip = skip
+const skip = test.skip
 
 test.ifEnv = test.runIf
-skip.ifEnv = test.runIf
 
 test.ifMac = isMac ? test : skip
 

--- a/test/src/vitest/vitest-setup.ts
+++ b/test/src/vitest/vitest-setup.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, vitest, test as wrappedTest } from "@test/vitest/vitest-test-wrapper";
+import { afterAll, afterEach, beforeEach, vitest, test as wrappedTest } from "@test/vitest/vitest-test-wrapper";
 import { isCI as isCi } from "ci-info";
 import { TmpDir } from "temp-file";
 
@@ -10,7 +10,9 @@ beforeEach(async () => {
 })
 afterEach(() => {
   vitest.clearAllMocks()
-  tmpDir.cleanupSync()
+})
+afterAll(async () => {
+  await tmpDir.cleanup()
 })
 
 const isWindows = process.platform === "win32"

--- a/test/src/vitest/vitest-setup.ts
+++ b/test/src/vitest/vitest-setup.ts
@@ -1,11 +1,11 @@
-import { isCI as isCi } from "ci-info"
-import { afterEach, beforeEach, vitest, test as wrappedTest } from "@test/vitest/vitest-test-wrapper"
-import { TmpDir } from "temp-file"
+import { afterEach, beforeEach, vitest, test as wrappedTest } from "@test/vitest/vitest-test-wrapper";
+import { isCI as isCi } from "ci-info";
+import { TmpDir } from "temp-file";
 
 const tmpDir = new TmpDir()
 
 beforeEach(async () => {
-  // must set custom yarn cache dir due to concurrency of tests sometimes colliding in the yarn cache (
+  // must set custom yarn cache dir due to concurrency of tests sometimes colliding in the yarn cache
   process.env.YARN_CACHE_FOLDER = await tmpDir.getTempDir()
 })
 afterEach(() => {

--- a/test/src/vitest/vitest-setup.ts
+++ b/test/src/vitest/vitest-setup.ts
@@ -1,16 +1,23 @@
 import { isCI as isCi } from "ci-info"
-import { afterEach, vitest } from "vitest"
-import * as wrappedTest from "@test/vitest/vitest-test-wrapper"
+import { afterEach, beforeEach, vitest, test as wrappedTest } from "@test/vitest/vitest-test-wrapper"
+import { TmpDir } from "temp-file"
 
+const tmpDir = new TmpDir()
+
+beforeEach(async () => {
+  // must set custom yarn cache dir due to concurrency of tests sometimes colliding in the yarn cache (
+  process.env.YARN_CACHE_FOLDER = await tmpDir.getTempDir()
+})
 afterEach(() => {
   vitest.clearAllMocks()
+  tmpDir.cleanupSync()
 })
 
 const isWindows = process.platform === "win32"
 const isMac = process.platform === "darwin"
 const isLinux = process.platform === "linux"
 
-const test: any = wrappedTest.test
+const test: any = wrappedTest
 
 const skip = test.skip
 

--- a/test/src/vitest/vitest-setup.ts
+++ b/test/src/vitest/vitest-setup.ts
@@ -1,15 +1,19 @@
 import { afterAll, afterEach, beforeEach, vitest, test as wrappedTest } from "@test/vitest/vitest-test-wrapper";
 import { isCI as isCi } from "ci-info";
+import { rm } from "fs-extra";
 import { TmpDir } from "temp-file";
 
 const tmpDir = new TmpDir()
 
 beforeEach(async () => {
-  // must set custom yarn cache dir due to concurrency of tests sometimes colliding in the yarn cache
-  process.env.YARN_CACHE_FOLDER = await tmpDir.getTempDir()
+  // // must set custom yarn cache dir due to concurrency of tests sometimes colliding in the yarn cache
+  // process.env.YARN_CACHE_FOLDER = await tmpDir.getTempDir()
+  // console.log(process.env.YARN_CACHE_FOLDER)
 })
-afterEach(() => {
+afterEach(async () => {
+
   vitest.clearAllMocks()
+  // await rm(process.env.YARN_CACHE_FOLDER!, { force: true, recursive: true })
 })
 afterAll(async () => {
   await tmpDir.cleanup()

--- a/test/src/vitest/vitest-test-wrapper.ts
+++ b/test/src/vitest/vitest-test-wrapper.ts
@@ -30,6 +30,6 @@ export const test = createTaskCollector(function (this: TaskCustomOptions, name:
   })
 }) as CustomTestMatcher
 
-export { afterAll, beforeAll, describe, vitest } from "vitest"
+export { afterEach, afterAll, beforeEach, beforeAll, describe, vitest } from "vitest"
 export { test as it }
 

--- a/test/src/vitest/vitest-test-wrapper.ts
+++ b/test/src/vitest/vitest-test-wrapper.ts
@@ -1,0 +1,35 @@
+import { Awaitable, TaskCustomOptions, TestContext } from "vitest"
+import { createTaskCollector, getCurrentSuite } from "vitest/suite"
+import { CustomTestMatcher } from "./vitest"
+import { isSupposedToRetry } from "./vitest-utils"
+
+export const test = createTaskCollector(function (this: TaskCustomOptions, name: string, ...args: any[]) {
+  // it's a vitest test configuration: retry, timeout, etc.
+  const options = typeof args[0] === "object" ? args[0] : {}
+  // if no test configuration, test function is in args[0]. WHY IS VITEST SO INCONSISTENT?
+  const runTest: (context: TestContext) => Awaitable<void> = typeof args[0] === "function" ? args[0] : args[1]
+
+  const wrapped = async (context: TestContext) => {
+    try {
+      await runTest(context)
+    } catch (error: any) {
+      if (!isSupposedToRetry(error.message ?? error)) {
+        throw error
+      }
+      console.log(`retrying unit test due to flaky error:\n${error.message ?? error}`)
+      await new Promise(resolve => setTimeout(resolve, 10000))
+      await runTest(context)
+    }
+  }
+
+  return getCurrentSuite().task(name, {
+    ...this, // so "todo"/"skip"/... are tracked correctly
+    ...options,
+    // repeats: options.repeats ?? 3,
+    handler: wrapped,
+  })
+}) as CustomTestMatcher
+
+export { afterAll, beforeAll, describe, vitest } from "vitest"
+export { test as it }
+

--- a/test/src/vitest/vitest-utils.ts
+++ b/test/src/vitest/vitest-utils.ts
@@ -102,11 +102,12 @@ export function loadEnvironment(ctx: ContextRPC): Environment {
 export const isSupposedToRetry = (errorMessage: string) => {
   const isOsError = [
     "Command failed: hdiutil",
+    "dmgbuild/core.py",
+    "yarn process failed",
     "ERR_ELECTRON_BUILDER_CANNOT_EXECUTE",
     "EPERM: operation not permitted",
     "The Windows Installer service failed to start",
-    "yarn process failed",
-    "dmgbuild/core.py",
+    "being used by another process",
   ].some(msg => errorMessage.includes(msg))
   process.stdout.write(`isSupposedToRetry: ${isOsError}\n${errorMessage}\n\n`)
   return isOsError

--- a/test/src/vitest/vitest-utils.ts
+++ b/test/src/vitest/vitest-utils.ts
@@ -1,0 +1,112 @@
+import mm from "micromatch"
+import fs from "node:fs/promises"
+import type { ContextRPC, ContextTestEnvironment } from "vitest"
+import { Environment, builtinEnvironments } from "vitest/environments"
+import type { EnvironmentOptions, TestSpecification, TransformModePatterns, VitestEnvironment, WorkspaceProject } from "vitest/node"
+
+export function groupBy<T, K extends string | number | symbol>(collection: T[], iteratee: (item: T) => K) {
+  return collection.reduce(
+    (acc, item) => {
+      const key = iteratee(item)
+      acc[key] ||= []
+      acc[key].push(item)
+      return acc
+    },
+    {} as Record<K, T[]>
+  )
+}
+
+function getTransformMode(patterns: TransformModePatterns, filename: string): "web" | "ssr" | undefined {
+  if (patterns.web && mm.isMatch(filename, patterns.web, {})) {
+    return "web"
+  }
+  if (patterns.ssr && mm.isMatch(filename, patterns.ssr, {})) {
+    return "ssr"
+  }
+  return undefined
+}
+
+type TestEnvironmentSpecification = TestSpecification & {
+  environment: ContextTestEnvironment
+  file: string
+}
+
+export async function groupFilesByEnv(specs: TestSpecification[]): Promise<Record<string, TestEnvironmentSpecification[]>> {
+  const filesWithEnv = await Promise.all(
+    specs.map(async spec => {
+      const { moduleId, project } = spec
+      const code = await fs.readFile(moduleId, "utf-8")
+
+      // 1. Check for control comments in the file
+      let env = code.match(/@(?:vitest|jest)-environment\s+([\w-]+)\b/)?.[1]
+      // 2. Check for globals
+      if (!env) {
+        for (const [glob, target] of project.config.environmentMatchGlobs || []) {
+          if (mm.isMatch(moduleId, glob, { cwd: project.config.root })) {
+            env = target
+            break
+          }
+        }
+      }
+      // 3. Fallback to global env
+      env ||= project.config.environment || "node"
+
+      const transformMode = getTransformMode(project.config.testTransformMode, moduleId)
+
+      let envOptionsJson = code.match(/@(?:vitest|jest)-environment-options\s+(.+)/)?.[1]
+      if (envOptionsJson?.endsWith("*/")) {
+        // Trim closing Docblock characters the above regex might have captured
+        envOptionsJson = envOptionsJson.slice(0, -2)
+      }
+
+      const envOptions = JSON.parse(envOptionsJson || "null")
+      const envKey = env === "happy-dom" ? "happyDOM" : env
+      const environment: ContextTestEnvironment = {
+        name: env as VitestEnvironment,
+        transformMode,
+        options: envOptions ? ({ [envKey]: envOptions } as EnvironmentOptions) : null,
+      }
+      return {
+        ...spec,
+        environment,
+        file: moduleId,
+      } as TestEnvironmentSpecification
+    })
+  )
+
+  return groupBy(filesWithEnv, ({ environment }) => environment.name)
+}
+
+export function groupFilesByProject(specs: TestSpecification[]) {
+  return groupBy(specs, ({ project }) => project.name)
+}
+
+export function getUniqueProjects(specs: TestSpecification[]): WorkspaceProject[] {
+  const projects = new Set<WorkspaceProject>()
+  for (const spec of specs) {
+    projects.add(spec.project)
+  }
+  return [...projects]
+}
+
+export function loadEnvironment(ctx: ContextRPC): Environment {
+  const name = ctx.environment.name
+  if (name in builtinEnvironments) {
+    return builtinEnvironments[name as keyof typeof builtinEnvironments]
+  }
+
+  throw new Error("Custom Environment is not yet supported")
+}
+// Handle electron-builder flaky (due to parallel file operations such as hdiutil and EPERM file locks) tests by retrying
+// This is a workaround until we can find a better solution. For now, we just slot in a 500ms delay and retry once.
+export const isSupposedToRetry = (errorMessage: string) => {
+  const isOsError = [
+    "Command failed: hdiutil",
+    "ERR_ELECTRON_BUILDER_CANNOT_EXECUTE",
+    "EPERM: operation not permitted",
+    "The Windows Installer service failed to start",
+    "yarn process failed",
+  ].some(msg => errorMessage.includes(msg))
+  process.stdout.write(`isSupposedToRetry: ${isOsError}\n${errorMessage}\n\n`)
+  return isOsError
+}

--- a/test/src/vitest/vitest-utils.ts
+++ b/test/src/vitest/vitest-utils.ts
@@ -106,6 +106,7 @@ export const isSupposedToRetry = (errorMessage: string) => {
     "EPERM: operation not permitted",
     "The Windows Installer service failed to start",
     "yarn process failed",
+    "dmgbuild/core.py",
   ].some(msg => errorMessage.includes(msg))
   process.stdout.write(`isSupposedToRetry: ${isOsError}\n${errorMessage}\n\n`)
   return isOsError

--- a/test/src/vitest/vitest.d.ts
+++ b/test/src/vitest/vitest.d.ts
@@ -2,6 +2,27 @@ import 'vitest'
 
 type Test = typeof import('vitest')['test']
 
+type RunIfReturnType = CustomTestMatcher2
+
+interface CustomTestMatcher2 extends Test {
+  ifNotWindows: RunIfReturnType
+  ifMac: RunIfReturnType
+  ifNotMac: RunIfReturnType
+  ifWindows: RunIfReturnType
+  ifNotCi: RunIfReturnType
+  ifCi: RunIfReturnType
+  ifNotCiMac: RunIfReturnType
+  ifNotCiWin: RunIfReturnType
+  ifDevOrWinCi: RunIfReturnType
+  ifWinCi: RunIfReturnType
+  ifDevOrLinuxCi: RunIfReturnType
+  ifLinux: RunIfReturnType
+  ifLinuxOrDevMac: RunIfReturnType
+  ifAll: RunIfReturnType
+  ifEnv: (envVar: any) => CustomTestMatcher
+}
+
+
 interface CustomTestMatcher extends Test {
   ifNotWindows: CustomTestMatcher
   ifMac: CustomTestMatcher
@@ -23,6 +44,11 @@ interface CustomTestMatcher extends Test {
 declare module 'vitest' {
   interface TestAPI extends CustomTestMatcher {}
   type TestAPI = CustomTestMatcher
+}
+
+declare module '@test/vitest/vitest-test-wrapper' {
+  interface TestAPI extends CustomTestMatcher2 {}
+  type TestAPI = CustomTestMatcher2
 }
 
 declare global {

--- a/test/src/windows/appxTest.ts
+++ b/test/src/windows/appxTest.ts
@@ -1,3 +1,4 @@
+import { test, it } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import { readFile } from "fs-extra"
 import { mkdir } from "fs/promises"

--- a/test/src/windows/assistedInstallerTest.ts
+++ b/test/src/windows/assistedInstallerTest.ts
@@ -1,10 +1,11 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, archFromString, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { app, assertPack, copyTestAsset } from "../helpers/packTester"
 import { checkHelpers, doTest, expectUpdateMetadata } from "../helpers/winHelper"
 
-const nsisTarget = Platform.WINDOWS.createTarget(["nsis"])
+const nsisTarget = Platform.WINDOWS.createTarget(["nsis"], Arch.x64)
 
 test.ifNotCiMac("assisted", ({ expect }) =>
   app(
@@ -35,8 +36,7 @@ test.ifNotCiMac("assisted", ({ expect }) =>
       signedWin: true,
       projectDirCreated: projectDir => copyTestAsset("license.txt", path.join(projectDir, "build", "license.txt")),
     }
-  )
-)
+  ))
 
 test.ifNotCiMac("allowElevation false, app requestedExecutionLevel admin", ({ expect }) =>
   app(expect, {

--- a/test/src/windows/msiTest.ts
+++ b/test/src/windows/msiTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Platform } from "electron-builder"
 import * as fs from "fs"
 import { app } from "../helpers/packTester"

--- a/test/src/windows/msiWrappedTest.ts
+++ b/test/src/windows/msiWrappedTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Platform } from "electron-builder"
 import { XMLParser } from "fast-xml-parser"
 import * as fs from "fs"

--- a/test/src/windows/oneClickInstallerTest.ts
+++ b/test/src/windows/oneClickInstallerTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import { copyFile, writeFile } from "fs-extra"
 import * as path from "path"

--- a/test/src/windows/portableTest.ts
+++ b/test/src/windows/portableTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import * as path from "path"
 import { app, copyTestAsset, getFixtureDir } from "../helpers/packTester"

--- a/test/src/windows/squirrelWindowsTest.ts
+++ b/test/src/windows/squirrelWindowsTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import * as path from "path"
 import { CheckingWinPackager } from "../helpers/CheckingPackager"

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 

--- a/test/src/windows/winCodeSignTest.ts
+++ b/test/src/windows/winCodeSignTest.ts
@@ -1,3 +1,4 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { parseDn } from "builder-util-runtime"
 import { DIR_TARGET, Platform } from "electron-builder"
 import { outputFile } from "fs-extra"

--- a/test/src/windows/winPackagerTest.ts
+++ b/test/src/windows/winPackagerTest.ts
@@ -1,30 +1,28 @@
+import { test, describe } from "@test/vitest/vitest-test-wrapper"
 import { Arch, DIR_TARGET, Platform } from "electron-builder"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { CheckingWinPackager } from "../helpers/CheckingPackager"
 import { app, appThrows, assertPack, platform } from "../helpers/packTester"
 
-test(
-  "beta version",
-  ({ expect }) =>
-    app(
-      expect,
-      {
-        targets: Platform.WINDOWS.createTarget(["nsis"], Arch.x64, Arch.arm64),
-        config: {
-          extraMetadata: {
-            version: "3.0.0-beta.2",
-          },
-          nsis: {
-            buildUniversalInstaller: false,
-          },
+test("beta version", { retry: 3 }, ({ expect }) =>
+  app(
+    expect,
+    {
+      targets: Platform.WINDOWS.createTarget(["nsis"], Arch.x64, Arch.arm64),
+      config: {
+        extraMetadata: {
+          version: "3.0.0-beta.2",
+        },
+        nsis: {
+          buildUniversalInstaller: false,
         },
       },
-      {
-        signedWin: true,
-      }
-    ),
-  { retry: 3 }
+    },
+    {
+      signedWin: true,
+    }
+  )
 )
 
 test("win zip", ({ expect }) =>

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,7 +4,10 @@
     "rootDir": "src",
     "outDir": "out",
     "skipLibCheck": true,
-    "baseUrl": "../packages"
+    "baseUrl": "../packages",
+    "paths": {
+      "@test/*": ["../test/src/*"]
+    }
   },
   "references": [
     {

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default () => {
     test: {
       // Use instead: import { test, describe } from "@test/vitest/vitest-test-wrapper"
       globals: false,
-
+      globalSetup: "./test/src/vitest/vitest-global-setup.ts",
       setupFiles: "./test/src/vitest/vitest-setup.ts",
       include: [`test/src/**/${includeRegex}.ts`],
       update: process.env.UPDATE_SNAPSHOT === "true",


### PR DESCRIPTION
This is to stabilize CI by implementing 1 automatic retry for `EPERM`/`hdiutil`/`app-builder-bin` errors (usually due to file locks)

Error messages triggering a retry with 10sec delay for locks to reset:
```
    "Command failed: hdiutil",
    "ERR_ELECTRON_BUILDER_CANNOT_EXECUTE",
    "EPERM: operation not permitted",
    "The Windows Installer service failed to start",
    "yarn process failed",
```