### PR TITLE
fix: Azure trust signing fails with spaces in parameters

### DIFF
--- a/.changeset/friendly-drinks-allow.md
+++ b/.changeset/friendly-drinks-allow.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Fix: Azure trust signing fails with spaces in parameters

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -130,7 +130,8 @@ export class WindowsSignAzureManager implements SignManager {
     const paramsString = Object.entries(params)
       .filter(([_, value]) => value != null)
       .reduce((res, [field, value]) => {
-        return [...res, `-${field}`, value]
+        const escapedValue = String(value).replace(/'/g, "''")
+        return [...res, `-${field}`, `'${escapedValue}'`]
       }, [] as string[])
       .join(" ")
     await vm.exec(ps, ["-NoProfile", "-NonInteractive", "-Command", `Invoke-TrustedSigning ${paramsString}`])


### PR DESCRIPTION
## Why
Azure trust signing fails when parameters contain spaces or special characters, breaking the build process for applications using this signing method.

## How
By properly escaping PowerShell parameter values using single quotes and handling existing quotes in values.

## What
- Added string value wrapping with single quotes
- Escape existing single quotes by doubling them (`''`)
- Converted parameters to string to ensure consistent handling

## Technical Details
While this approach quotes all parameters, it remains compatible with the various parameter types used by `Invoke-TrustedSigning`:

- String parameters (like `-Files`, `-Endpoint`, `-CertificateProfileName`): Properly handled with quotes to preserve spaces
- Integer parameters (like `-FilesFolderDepth`): PowerShell automatically converts quoted values like `'0'` to integers
- Boolean parameters (like `-AppendSignature`): PowerShell correctly interprets quoted boolean values (`'$true'` → `$true`)

PowerShell's automatic type conversion ensures these quoted values are interpreted correctly, while fixing the escaping issues with spaces and special characters in paths.