### PR TITLE
fix: malformed Files param when using Azure Trusted Signing

### DIFF
--- a/.changeset/perfect-pumpkins-repeat.md
+++ b/.changeset/perfect-pumpkins-repeat.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: malformed `Files` param when using Azure Trusted Signing

--- a/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignAzureManager.ts
@@ -125,7 +125,7 @@ export class WindowsSignAzureManager implements SignManager {
       TimestampRfc3161: timestampRfc3161 || "http://timestamp.acs.microsoft.com",
       TimestampDigest: timestampDigest || "SHA256",
       FileDigest: fileDigest || "SHA256",
-      Files: `"${options.path}"`,
+      Files: options.path,
     }
     const paramsString = Object.entries(params)
       .filter(([_, value]) => value != null)


### PR DESCRIPTION
Resolves https://github.com/electron-userland/electron-builder/issues/8985.