### PR TITLE
fix: missing lowercase comparison in electron-updater

### DIFF
--- a/.changeset/wicked-zebras-begin.md
+++ b/.changeset/wicked-zebras-begin.md
@@ -3,4 +3,3 @@
 ---
 
 Fixed missing lowercase in extension comparison.
-Fixed invalid file path generated for update file.

--- a/.changeset/wicked-zebras-begin.md
+++ b/.changeset/wicked-zebras-begin.md
@@ -1,0 +1,6 @@
+---
+"electron-updater": patch
+---
+
+Fixed missing lowercase in extension comparison.
+Fixed invalid file path generated for update file.

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -12,7 +12,7 @@ import {
   BlockMap,
   retry,
 } from "builder-util-runtime"
-import { randomBytes, createHash } from "crypto"
+import { randomBytes } from "crypto"
 import { release } from "os"
 import { EventEmitter } from "events"
 import { mkdir, outputFile, readFile, rename, unlink } from "fs-extra"
@@ -701,10 +701,8 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       if (urlPath.toLowerCase().endsWith(`.${taskOptions.fileExtension.toLowerCase()}`)) {
         return path.basename(urlPath)
       } else {
-        // url like /latest, generate stable name
-        const hash = createHash("sha1")
-        hash.update(taskOptions.fileInfo.url.toString())
-        return hash.digest("hex")
+        // url like /latest, generate name
+        return taskOptions.fileInfo.info.url
       }
     }
 

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -12,7 +12,7 @@ import {
   BlockMap,
   retry,
 } from "builder-util-runtime"
-import { randomBytes } from "crypto"
+import { randomBytes, createHash } from "crypto"
 import { release } from "os"
 import { EventEmitter } from "events"
 import { mkdir, outputFile, readFile, rename, unlink } from "fs-extra"
@@ -698,11 +698,13 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
     function getCacheUpdateFileName(): string {
       // NodeJS URL doesn't decode automatically
       const urlPath = decodeURIComponent(taskOptions.fileInfo.url.pathname)
-      if (urlPath.endsWith(`.${taskOptions.fileExtension}`)) {
+      if (urlPath.toLowerCase().endsWith(`.${taskOptions.fileExtension.toLowerCase()}`)) {
         return path.basename(urlPath)
       } else {
-        // url like /latest, generate name
-        return taskOptions.fileInfo.info.url
+        // url like /latest, generate stable name
+        const hash = createHash("sha1")
+        hash.update(taskOptions.fileInfo.url.toString())
+        return hash.digest("hex")
       }
     }
 

--- a/packages/electron-updater/src/providers/Provider.ts
+++ b/packages/electron-updater/src/providers/Provider.ts
@@ -85,13 +85,13 @@ export function findFile(files: Array<ResolvedUpdateFileInfo>, extension: string
     throw newError("No files provided", "ERR_UPDATER_NO_FILES_PROVIDED")
   }
 
-  const result = files.find(it => it.url.pathname.toLowerCase().endsWith(`.${extension}`))
+  const result = files.find(it => it.url.pathname.toLowerCase().endsWith(`.${extension.toLowerCase()}`))
   if (result != null) {
     return result
   } else if (not == null) {
     return files[0]
   } else {
-    return files.find(fileInfo => !not.some(ext => fileInfo.url.pathname.toLowerCase().endsWith(`.${ext}`)))
+    return files.find(fileInfo => !not.some(ext => fileInfo.url.pathname.toLowerCase().endsWith(`.${ext.toLowerCase()}`)))
   }
 }
 


### PR DESCRIPTION
Each commit explains why the fix was required, but TLDR:

- Without a lowercase on the file extension, `https://myurl.com/myfile.AppImage` can never be equal to `AppImage`. I think it worked for most people because of the fallback 3 that takes whatever first file which is not in the `not`. In my case this file was a `tar.gz` so that didn't work.
- Since the extension didn't match it also took the `else` clause to generate the download file name which is based on the url. This generates invalid paths on the disk since it tries to create a file `pending/temp-https:/myurl.com/myfile.tar.gz`. I decided to use a sha1 instead of random so at least it will be stable between restarts since we check if the file is already downloaded.

We might want to change the logic of `getCacheUpdateFileName` to something simpler and uniform IMO, but I don't fully know the implications of that change.