### PR TITLE
fix(mac): allow ad-hoc identities for codesigning

### DIFF
--- a/.changeset/tame-radios-pump.md
+++ b/.changeset/tame-radios-pump.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): allow ad-hoc identities for codesigning

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2702,7 +2702,7 @@
           ]
         },
         "identity": {
-          "description": "The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](./code-signing.md) instead of specifying this option.\nMAS installer identity is specified in the [mas](./mas.md).",
+          "description": "The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](./code-signing.md) instead of specifying this option.\nMAS installer identity is specified in the [mas](./mas.md).\n\nSet to `-` to use an ad-hoc identity for signing. Set to `null` to skip signing entirely.",
           "type": [
             "null",
             "string"
@@ -3334,7 +3334,7 @@
           ]
         },
         "identity": {
-          "description": "The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](./code-signing.md) instead of specifying this option.\nMAS installer identity is specified in the [mas](./mas.md).",
+          "description": "The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](./code-signing.md) instead of specifying this option.\nMAS installer identity is specified in the [mas](./mas.md).\n\nSet to `-` to use an ad-hoc identity for signing. Set to `null` to skip signing entirely.",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -57,7 +57,14 @@ export function isSignAllowed(isPrintWarn = true): boolean {
   return true
 }
 
-export async function reportError(isMas: boolean, certificateTypes: CertType[], qualifier: string | Nullish, keychainFile: string | Nullish, isForceCodeSigning: boolean) {
+export async function reportError(
+  isMas: boolean,
+  certificateTypes: CertType[],
+  qualifier: string | Nullish,
+  keychainFile: string | Nullish,
+  isForceCodeSigning: boolean,
+  usingAdHocFallback: boolean
+) {
   const logFields: Fields = {}
   if (qualifier == null) {
     logFields.reason = ""
@@ -88,10 +95,11 @@ export async function reportError(isMas: boolean, certificateTypes: CertType[], 
       .join("\n")
   }
 
+  const skipMessage = usingAdHocFallback ? "falling back to ad-hoc signature for macOS application code signing" : "skipped macOS application code signing"
   if (isMas || isForceCodeSigning) {
-    throw new Error(Logger.createMessage("skipped macOS application code signing", logFields, "error", it => it))
+    throw new Error(Logger.createMessage(skipMessage, logFields, "error", it => it))
   } else {
-    log.warn(logFields, "skipped macOS application code signing")
+    log.warn(logFields, skipMessage)
   }
 }
 

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -57,14 +57,7 @@ export function isSignAllowed(isPrintWarn = true): boolean {
   return true
 }
 
-export async function reportError(
-  isMas: boolean,
-  certificateTypes: CertType[],
-  qualifier: string | Nullish,
-  keychainFile: string | Nullish,
-  isForceCodeSigning: boolean,
-  usingAdHocFallback: boolean
-) {
+export async function reportError(isMas: boolean, certificateTypes: CertType[], qualifier: string | Nullish, keychainFile: string | Nullish, isForceCodeSigning: boolean) {
   const logFields: Fields = {}
   if (qualifier == null) {
     logFields.reason = ""
@@ -95,7 +88,7 @@ export async function reportError(
       .join("\n")
   }
 
-  const skipMessage = usingAdHocFallback ? "falling back to ad-hoc signature for macOS application code signing" : "skipped macOS application code signing"
+  const skipMessage = "skipped macOS application code signing"
   if (isMas || isForceCodeSigning) {
     throw new Error(Logger.createMessage(skipMessage, logFields, "error", it => it))
   } else {

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -1,6 +1,7 @@
 import { notarize } from "@electron/notarize"
 import { NotarizeOptionsNotaryTool, NotaryToolKeychainCredentials } from "@electron/notarize/lib/types"
 import { PerFileSignOptions, SignOptions } from "@electron/osx-sign/dist/cjs/types"
+import { Identity } from "@electron/osx-sign/dist/cjs/util-identities"
 import { Arch, AsyncTaskManager, copyFile, deepAssign, exec, getArchSuffix, InvalidConfigurationError, log, orIfFileNotExist, statOrNull, unlinkIfExists, use } from "builder-util"
 import { MemoLazy, Nullish } from "builder-util-runtime"
 import * as fs from "fs/promises"
@@ -8,7 +9,7 @@ import { mkdir, readdir } from "fs/promises"
 import { Lazy } from "lazy-val"
 import * as path from "path"
 import { AppInfo } from "./appInfo"
-import { CertType, CodeSigningInfo, createKeychain, CreateKeychainOptions, findIdentity, Identity, isSignAllowed, removeKeychain, reportError, sign } from "./codeSign/macCodeSign"
+import { CertType, CodeSigningInfo, createKeychain, CreateKeychainOptions, findIdentity, isSignAllowed, removeKeychain, reportError, sign } from "./codeSign/macCodeSign"
 import { DIR_TARGET, Platform, Target } from "./core"
 import { AfterPackContext, ElectronPlatformName } from "./index"
 import { MacConfiguration, MasConfiguration } from "./options/macOptions"
@@ -229,7 +230,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
     }
   }
 
-  private async sign(appPath: string, outDir: string | null, masOptions: MasConfiguration | null, arch: Arch | null): Promise<boolean> {
+  private async sign(appPath: string, outDir: string | null, masOptions: MasConfiguration | null, arch: Arch): Promise<boolean> {
     if (!isSignAllowed()) {
       return false
     }
@@ -237,12 +238,16 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
     const isMas = masOptions != null
     const options = masOptions == null ? this.platformSpecificBuildOptions : masOptions
     const qualifier = options.identity
+    const fallBackToAdhoc = arch === Arch.arm64 || arch === Arch.universal
 
     if (qualifier === null) {
       if (this.forceCodeSigning) {
         throw new InvalidConfigurationError("identity explicitly is set to null, but forceCodeSigning is set to true")
       }
       log.info({ reason: "identity explicitly is set to null" }, "skipped macOS code signing")
+      if (fallBackToAdhoc) {
+        log.warn("arm64 requires signing, but identity is set to null and signing is being skipped")
+      }
       return false
     }
 
@@ -268,9 +273,17 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
         }
       }
 
+      if (qualifier === "-") {
+        identity = new Identity("-", undefined)
+      }
+
       if (!options.sign && identity == null) {
-        await reportError(isMas, certificateTypes, qualifier, keychainFile, this.forceCodeSigning)
-        return false
+        await reportError(isMas, certificateTypes, qualifier, keychainFile, this.forceCodeSigning, fallBackToAdhoc)
+        if (fallBackToAdhoc) {
+          identity = new Identity("-", undefined)
+        } else {
+          return false
+        }
       }
     }
 
@@ -514,7 +527,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
       await Promise.all(
         directories.map(async (file: string) => {
           if (shouldSign(file)) {
-            await this.sign(path.join(sourceDirectory, file), null, null, null)
+            await this.sign(path.join(sourceDirectory, file), null, null, packContext.arch)
           }
         })
       )

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -21,6 +21,8 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   /**
    * The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](./code-signing.md) instead of specifying this option.
    * MAS installer identity is specified in the [mas](./mas.md).
+   *
+   * Set to `-` to use an ad-hoc identity for signing. Set to `null` to skip signing entirely.
    */
   readonly identity?: string | null
 

--- a/pages/code-signing-mac.md
+++ b/pages/code-signing-mac.md
@@ -1,6 +1,6 @@
 macOS code signing is supported. If the configuration values are provided correctly in your package.json, then signing should be automatically executed.
 
-On a macOS development machine, a valid and appropriate identity from your keychain will be automatically used.
+On a macOS development machine, a valid and appropriate identity from your keychain will be automatically used. If no such identity exists, the default behavior depends on the target architecture. On ARM or universal builds, an ad-hoc signature will be applied by default. On Intel-only builds, the default behavior is to not sign at all.
 
 !!! tip
     See article [Notarizing your Electron application](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/).
@@ -23,7 +23,7 @@ On a macOS development machine, a valid and appropriate identity from your keych
 
 To disable Code Signing when building for macOS leave all the above vars unset except for `CSC_IDENTITY_AUTO_DISCOVERY` which needs to be set to `false`. This can be done by running `export CSC_IDENTITY_AUTO_DISCOVERY=false`.
 
-Another way — set `mac.identity` to `null`. You can pass aditional configuration using CLI as well: `-c.mac.identity=null`.
+Another way — set `mac.identity` to `null`. You can pass additional configuration using CLI as well: `-c.mac.identity=null`. If you are building for ARM, you likely actually want to use ad-hoc signing, in which case you should set `mac.identity` to `-`.
 
 ## Code Signing and Notarization Tutorial
 Thank you to a community member for putting this together.


### PR DESCRIPTION
Fixes #5850

If no signing identity is present while an app is built and it is downloaded via a web browser, macOS on ARM shows "app is damaged" errors that are hard to bypass for the average user (see #5850 and some other duplicates). This seems to be because the default signature applied by the linker to the executables isn't valid due to something the build system is doing [1]. It is thus an error to not manually codesign the resulting app, even if no stable signing identity is available (in which case it must be an ad-hoc signature).

The damaged warning is **not** the same as the unverified warning. Not paying for a developer account does not mean your app must show "this app is damaged" warnings to users, but it will show an unverified warning. The damaged warning cannot be bypassed through the GUI (such as in System Settings) and requires running commands to remove the quarantine attribute (as of the current macOS version). An unverified warning, on the other hand, has [supported GUI methods of bypassing the warning and running the app](https://support.apple.com/en-us/102445#openanyway). A proper (free) ad-hoc signature means that the damaged warning will not show up, but the unverified warning will.

Since there are no problems for those with "proper" signing certificates, it follows that the existing signing system does make a valid signature, and if it can be repurposed to accept empty identities (for ad-hoc signatures), this will resolve the issue. This PR does two main things:

- Add an option to use ad-hoc signatures by passing `-` as the `identity`. This is the same convention that the `codesign` command uses.
- Use ad-hoc signatures as a fallback by default when building ARM or universal builds if no valid identity is present. This can be overridden by setting the `identity` to `null`.

I tested these changes with FreeTube, which previously showed "'FreeTube' is damaged" warnings.
Before these changes, the warning looks like the below and can't be bypassed in System Settings.
<img width="372" alt="image" src="https://github.com/user-attachments/assets/6973e0d5-3996-4c98-8bb4-30d5186125e9" />

With these changes, the new warning looks like
<img width="372" alt="Screenshot 2025-04-02 at 4 57 11 PM" src="https://github.com/user-attachments/assets/a1826060-dad0-4ebe-94dc-1455092f2b88" />
And System Settings shows an option to bypass the warning like it does on Intel.
<img width="701" alt="Screenshot 2025-04-02 at 4 57 22 PM" src="https://github.com/user-attachments/assets/ab42ff79-6b4a-403e-b637-26e1e946214a" />

---

[1] For additional details if you're curious, see the [macOS 11.0.1 release notes](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes#New-Features). Specifically (emphasis mine):
> To reduce the impact on existing development workflows, starting with Xcode 12 beta 4, the toolchain will now automatically sign your executables whenever you build from Xcode, or use command-line utilities such as clang(1) or ld(1). Since this signing mechanism generates signatures directly at link time, and **doesn’t cover any resource other than the executable**, it is expected to be faster than a traditional codesign(1) invocation. If you **use a custom workflow involving tools that modify a binary after linking** (e.g. strip or install_name_tool) you might need to manually call codesign(1) as an additional build phase to properly ad-hoc sign your binary. 