### PR TITLE
feat(electron-updater): add ignoreStagingPercentage option for checking updates

### DIFF
--- a/packages/electron-updater/src/types.ts
+++ b/packages/electron-updater/src/types.ts
@@ -81,3 +81,7 @@ export interface ResolvedUpdateFileInfo {
 export type UpdaterEvents = "login" | "checking-for-update" | "update-available" | "update-not-available" | "update-cancelled" | "download-progress" | "update-downloaded" | "error"
 
 export type LoginHandler = (authInfo: any, callback: LoginCallback) => void
+
+export type CheckForUpdatesOptions = {
+  ignoreStagingPercentage?: boolean
+}


### PR DESCRIPTION
## Description

Add `ignoreStagingPercentage` option to the interface of `AppUpdater.checkForUpdates()`, so that you can override the staging percentage and get offerred an update _if the other necessary conditions_ are met.

### Usecase
staging rollout is observed when automatically querying for updates in background, but we also have a manual "Check for updates" button in Settings. This will allow the manual check to always offer you the latest version.