### PR TITLE
feat(electron-updater): allow overriding AppUpdater.isStagingMatch

### DIFF
--- a/.changeset/flat-schools-mate.md
+++ b/.changeset/flat-schools-mate.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+feat: allow overriding AppUpdater.isStagingMatch


### PR DESCRIPTION
Alternative implementation for https://github.com/electron-userland/electron-builder/pull/9016

Add get/set/protected `isUserWithinRollout` interface to `AppUpdater` class, similarly to how it is implemented for `isUpdateSupported` so that you can override the default calculation of staging percentage.
The user will be offerred an update _if the other necessary conditions_ are met, but they would otherwise be below the rollout threshold.

### Usecase
staging rollout is observed when automatically querying for updates in background, but we also have a manual "Check for updates" button in Settings. This will allow the manual check to always offer you the latest version.