### PR TITLE
fix(electron-updater): allow forceDevUpdateConfig also on Linux

### DIFF
--- a/.changeset/shaggy-teachers-relax.md
+++ b/.changeset/shaggy-teachers-relax.md
@@ -2,4 +2,4 @@
 "electron-updater": patch
 ---
 
-chore: allow forceDevUpdateConfig also on Linux
+fix: allow forceDevUpdateConfig also on Linux

--- a/.changeset/shaggy-teachers-relax.md
+++ b/.changeset/shaggy-teachers-relax.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+chore: allow forceDevUpdateConfig also on Linux

--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -16,7 +16,7 @@ export class AppImageUpdater extends BaseUpdater {
   }
 
   public isUpdaterActive(): boolean {
-    if (process.env["APPIMAGE"] == null) {
+    if (process.env["APPIMAGE"] == null && !this.forceDevUpdateConfig) {
       if (process.env["SNAP"] == null) {
         this._logger.warn("APPIMAGE env is not defined, current application is not an AppImage")
       } else {


### PR DESCRIPTION
A DX improvement for development on Linux:
- Currently, you may override `appUpdater.forceDevUpdateConfig = true` to test fetching and parsing update config.
- But it works only on macOS and Windows, where `isUpdaterActive` is called [directly on AppUpdater](https://github.com/electron-userland/electron-builder/blob/065c6a456e34e7f8c13cba483d433502b9325168/packages/electron-updater/src/AppUpdater.ts#L331).
- On Linux, `AppImageUpdater` overrides this method and early returns `false` on dev.
- So you have to _also_ set `APPIMAGE=true` env to get the same behavior.
- This PR removes the need for this workaround.