### PR TITLE
fix(asar): enhance symlink check to respect shouldCheckSymlink flag

### DIFF
--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -121,7 +121,7 @@ export class AsarPackager {
       const realPathFile = await fs.realpath(file)
       const realPathRelative = path.relative(fileSet.src, realPathFile)
       const isOutsidePackage = realPathRelative.startsWith("..")
-      if (isOutsidePackage) {
+      if (isOutsidePackage && fileSet.shouldCheckSymlink) {
         log.error({ source: log.filePath(file), realPathFile: log.filePath(realPathFile) }, `unable to copy, file is symlinked outside the package`)
         throw new Error(`Cannot copy file (${path.basename(file)}) symlinked to file (${path.basename(realPathFile)}) outside the package as that violates asar security integrity`)
       }

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -84,6 +84,7 @@ export interface ResolvedFileSet {
   files: Array<string>
   metadata: Map<string, Stats>
   transformedFiles?: Map<number, string | Buffer> | null
+  shouldCheckSymlink?: boolean
 }
 
 // used only for ASAR, if no asar, file transformed on the fly
@@ -203,7 +204,7 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
     const matcher = new FileMatcher(source, destination, mainMatcher.macroExpander, mainMatcher.patterns)
     const copier = new NodeModuleCopyHelper(matcher, platformPackager.info)
     const files = await copier.collectNodeModules(dep, nodeModuleExcludedExts, path.relative(mainMatcher.to, destination))
-    result[index++] = validateFileSet({ src: source, destination, files, metadata: copier.metadata })
+    result[index++] = validateFileSet({ src: source, destination, files, metadata: copier.metadata, shouldCheckSymlink: true })
 
     if (dep.dependencies) {
       for (const c of dep.dependencies) {


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/9025.

Updated the AsarPackager to conditionally check for symlinks outside the package based on the new shouldCheckSymlink property in the ResolvedFileSet interface. This change ensures that the symlink validation logic is only applied when explicitly required, improving flexibility in file handling.


We should only check for symlink files in node_modules. For the "from" field in user-specified files, I think there's no need to check, as it's user-defined.