### PR TITLE
feat: customNsisResources override in nsis options

### DIFF
--- a/.changeset/four-cheetahs-wash.md
+++ b/.changeset/four-cheetahs-wash.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Add customNsisResources override to nsis options

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -460,7 +460,7 @@
           ]
         },
         "url": {
-          "default": "https://github.com/electron-userland/electron-builder-binaries/releases/download",
+          "default": "https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z",
           "type": [
             "null",
             "string"
@@ -476,6 +476,29 @@
       },
       "required": [
         "url"
+      ],
+      "type": "object"
+    },
+    "CustomNsisResources": {
+      "additionalProperties": false,
+      "properties": {
+        "checksum": {
+          "default": "Dqd6g+2buwwvoG1Vyf6BHR1b+25QMmPcwZx40atOT57gH27rkjOei1L0JTldxZu4NFoEmW4kJgZ3DlSWVON3+Q==",
+          "type": "string"
+        },
+        "url": {
+          "default": "https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z",
+          "type": "string"
+        },
+        "version": {
+          "default": "3.4.1",
+          "type": "string"
+        }
+      },
+      "required": [
+        "checksum",
+        "url",
+        "version"
       ],
       "type": "object"
     },
@@ -3914,6 +3937,17 @@
           ],
           "description": "Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)"
         },
+        "customNsisResources": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CustomNsisResources"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Allows you to provide your own `nsis-resources`"
+        },
         "deleteAppDataOnUninstall": {
           "default": false,
           "description": "*one-click installer only.* Whether to delete app data on uninstall.",
@@ -4219,6 +4253,17 @@
             }
           ],
           "description": "Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)"
+        },
+        "customNsisResources": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CustomNsisResources"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Allows you to provide your own `nsis-resources`"
         },
         "deleteAppDataOnUninstall": {
           "default": false,
@@ -5174,6 +5219,17 @@
             }
           ],
           "description": "Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)"
+        },
+        "customNsisResources": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CustomNsisResources"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Allows you to provide your own `nsis-resources`"
         },
         "guid": {
           "description": "See [GUID vs Application Name](./nsis.md#guid-vs-application-name).",

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -20,7 +20,6 @@ import _debug from "debug"
 import * as fs from "fs"
 import { readFile, stat, unlink } from "fs-extra"
 import * as path from "path"
-import { getBinFromUrl } from "../../binDownload"
 import { Target } from "../../core"
 import { DesktopShortcutCreationPolicy, getEffectiveOptions } from "../../options/CommonWindowsInstallerConfiguration"
 import { chooseNotNull, computeSafeArtifactNameIfNeeded, normalizeExt } from "../../platformPackager"
@@ -38,15 +37,12 @@ import { addCustomMessageFileInclude, createAddLangsMacro, LangConfigurator } fr
 import { computeLicensePage } from "./nsisLicense"
 import { NsisOptions, PortableOptions } from "./nsisOptions"
 import { NsisScriptGenerator } from "./nsisScriptGenerator"
-import { AppPackageHelper, NSIS_PATH, NsisTargetOptions, nsisTemplatesDir, UninstallerReader } from "./nsisUtil"
+import { AppPackageHelper, NSIS_PATH, NSIS_RESOURCES_PATH, NsisTargetOptions, nsisTemplatesDir, UninstallerReader } from "./nsisUtil"
 
 const debug = _debug("electron-builder:nsis")
 
 // noinspection SpellCheckingInspection
 const ELECTRON_BUILDER_NS_UUID = UUID.parse("50e065bc-3134-11e6-9bab-38c9862bdaf3")
-
-// noinspection SpellCheckingInspection
-const nsisResourcePathPromise = () => getBinFromUrl("nsis-resources", "3.4.1", "Dqd6g+2buwwvoG1Vyf6BHR1b+25QMmPcwZx40atOT57gH27rkjOei1L0JTldxZu4NFoEmW4kJgZ3DlSWVON3+Q==")
 
 const USE_NSIS_BUILT_IN_COMPRESSOR = false
 
@@ -666,7 +662,7 @@ export class NsisTarget extends Target {
 
     const pluginArch = this.isUnicodeEnabled ? "x86-unicode" : "x86-ansi"
     taskManager.add(async () => {
-      scriptGenerator.addPluginDir(pluginArch, path.join(await nsisResourcePathPromise(), "plugins", pluginArch))
+      scriptGenerator.addPluginDir(pluginArch, path.join(await NSIS_RESOURCES_PATH(), "plugins", pluginArch))
     })
 
     taskManager.add(async () => {

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -3,7 +3,7 @@ import { TargetSpecificOptions } from "../../core"
 
 export interface CustomNsisBinary {
   /**
-   * @default https://github.com/electron-userland/electron-builder-binaries/releases/download
+   * @default https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z
    */
   readonly url: string | null
 
@@ -24,6 +24,22 @@ export interface CustomNsisBinary {
    * In your custom nsis scripts, you can leverage this functionality via `LogSet` and `LogText`
    */
   readonly debugLogging?: boolean | null
+}
+export interface CustomNsisResources {
+  /**
+   * @default https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-resources-3.4.1/nsis-resources-3.4.1.7z
+   */
+  readonly url: string
+
+  /**
+   * @default Dqd6g+2buwwvoG1Vyf6BHR1b+25QMmPcwZx40atOT57gH27rkjOei1L0JTldxZu4NFoEmW4kJgZ3DlSWVON3+Q==
+   */
+  readonly checksum: string
+
+  /**
+   * @default 3.4.1
+   */
+  readonly version: string
 }
 export interface CommonNsisOptions {
   /**
@@ -53,6 +69,11 @@ export interface CommonNsisOptions {
    * Allows you to provide your own `makensis`, such as one with support for debug logging via LogSet and LogText. (Logging also requires option `debugLogging = true`)
    */
   readonly customNsisBinary?: CustomNsisBinary | null
+
+  /**
+   * Allows you to provide your own `nsis-resources`
+   */
+  readonly customNsisResources?: CustomNsisResources | null
 }
 
 export interface NsisOptions extends CommonNsisOptions, CommonWindowsInstallerConfiguration, TargetSpecificOptions {

--- a/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -38,6 +38,16 @@ export const NSIS_PATH = () => {
   })
 }
 
+export const NSIS_RESOURCES_PATH = () => {
+  return NsisTargetOptions.then((options: NsisOptions) => {
+    if (options.customNsisResources) {
+      const { checksum, url, version } = options.customNsisResources
+      return getBinFromCustomLoc("nsis-resources", version, url, checksum)
+    }
+    return getBinFromUrl("nsis-resources", "3.4.1", "Dqd6g+2buwwvoG1Vyf6BHR1b+25QMmPcwZx40atOT57gH27rkjOei1L0JTldxZu4NFoEmW4kJgZ3DlSWVON3+Q==")
+  })
+}
+
 export interface PackArchResult {
   fileInfo: PackageFileInfo
   unpackedSize: number


### PR DESCRIPTION
Prior to this change `customNsisBinary` could be used to override the url of `nsis-*.7z` from the `electron-builder-binaries` repo to a custom location. However, there was no option to change the url of the `nsis-resources-*.7z` file.

With this chcange the url of the NSIS resources could also be overriden.