### PR TITLE
feat: add buildUniversalInstaller option to NSIS portable configuration

### DIFF
--- a/.changeset/sweet-jeans-brake.md
+++ b/.changeset/sweet-jeans-brake.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+feat: add buildUniversalInstaller option to NSIS portable configuration

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -5164,6 +5164,11 @@
             "string"
           ]
         },
+        "buildUniversalInstaller": {
+          "default": true,
+          "description": "Disable building an universal installer of the archs specified in the target configuration",
+          "type": "boolean"
+        },
         "customNsisBinary": {
           "anyOf": [
             {

--- a/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisOptions.ts
@@ -231,6 +231,12 @@ export interface PortableOptions extends TargetSpecificOptions, CommonNsisOption
    * The image to show while the portable executable is extracting. This image must be a bitmap (`.bmp`) image.
    */
   readonly splashImage?: string | null
+
+  /**
+   * Disable building an universal installer of the archs specified in the target configuration
+   * @default true
+   */
+  readonly buildUniversalInstaller?: boolean
 }
 
 /**


### PR DESCRIPTION
When using `electron-builder --win --x64 --arm64` to build NSIS, we can set buildUniversalInstaller to false to avoid generating a universal setup EXE. However, a universal portable EXE is still generated. Add a configuration to control whether to generate the universal portable EXE.