### PR TITLE
feat: generate minimumSystemVersion into latest.yml from platformat config

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1952,6 +1952,13 @@
           ],
           "description": "The mime types in addition to specified in the file associations. Use it if you don't want to register a new mime type, but reuse existing."
         },
+        "minimumSystemVersion": {
+          "description": "The minimum system version required to install the application.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "packageCategory": {
           "description": "backward compatibility + to allow specify fpm-only category for all possible fpm targets in one place",
           "type": [
@@ -6446,6 +6453,13 @@
             "string"
           ]
         },
+        "minimumSystemVersion": {
+          "description": "The minimum system version required to install the application.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "protocols": {
           "anyOf": [
             {
@@ -7314,6 +7328,13 @@
         }
       ],
       "description": "MAS (Mac Application Store) development options (`mas-dev` target)."
+    },
+    "minimumSystemVersion": {
+      "description": "The minimum system version required to install the application.",
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "msi": {
       "anyOf": [

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -199,6 +199,11 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions, Fil
   cscKeyPassword?: string | null
 
   readonly defaultArch?: string
+
+  /**
+   * The minimum system version required to install the application.
+   */
+  readonly minimumSystemVersion?: string | null
 }
 
 export interface ReleaseInfo {

--- a/packages/app-builder-lib/src/publish/updateInfoBuilder.ts
+++ b/packages/app-builder-lib/src/publish/updateInfoBuilder.ts
@@ -169,7 +169,9 @@ export async function createUpdateInfoTasks(event: ArtifactCreated, _publishConf
 async function createUpdateInfo(version: string, event: ArtifactCreated, releaseInfo: ReleaseInfo): Promise<UpdateInfo> {
   const customUpdateInfo = event.updateInfo
   const url = path.basename(event.file)
+  console.log("customUpdateInfo xxxxxxxxxxxxxxx", JSON.stringify(customUpdateInfo, null, 2))
   const sha512 = (customUpdateInfo == null ? null : customUpdateInfo.sha512) || (await hashFile(event.file))
+  const minimumSystemVersion = customUpdateInfo == null ? null : customUpdateInfo.minimumSystemVersion
   const files = [{ url, sha512 }]
   const result: UpdateInfo = {
     // @ts-ignore
@@ -180,6 +182,7 @@ async function createUpdateInfo(version: string, event: ArtifactCreated, release
     path: url /* backward compatibility, electron-updater 1.x - electron-updater 2.15.0 */,
     // @ts-ignore
     sha512 /* backward compatibility, electron-updater 1.x - electron-updater 2.15.0 */,
+    minimumSystemVersion,
     ...(releaseInfo as UpdateInfo),
   }
 

--- a/packages/app-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/app-builder-lib/src/targets/ArchiveTarget.ts
@@ -79,6 +79,10 @@ export class ArchiveTarget extends Target {
         }
       }
 
+      if (this.packager.platformSpecificBuildOptions.minimumSystemVersion) {
+        updateInfo.minimumSystemVersion = this.packager.platformSpecificBuildOptions.minimumSystemVersion
+      }
+
       await packager.info.emitArtifactBuildCompleted({
         updateInfo,
         file: artifactPath,

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -371,6 +371,10 @@ export class NsisTarget extends Target {
         updateInfo.isAdminRightsRequired = true
       }
 
+      if (updateInfo != null && this.packager.platformSpecificBuildOptions.minimumSystemVersion) {
+        updateInfo.minimumSystemVersion = this.packager.platformSpecificBuildOptions.minimumSystemVersion
+      }
+
       await packager.info.emitArtifactBuildCompleted({
         file: installerPath,
         updateInfo,

--- a/packages/builder-util-runtime/src/updateInfo.ts
+++ b/packages/builder-util-runtime/src/updateInfo.ts
@@ -78,7 +78,7 @@ export interface UpdateInfo {
    * The minimum version of system required for the app to run. Sample value: macOS `23.1.0`, Windows `10.0.22631`.
    * Same with os.release() value, this is a kernel version.
    */
-  readonly minimumSystemVersion?: string
+  readonly minimumSystemVersion?: string | null
 }
 
 export interface WindowsUpdateInfo extends UpdateInfo {


### PR DESCRIPTION
Currently, it is not possible to configure `minimumSystemVersion`, and it has to be manually added to the `latest.yml` file, which is very inconvenient. Therefore, this configuration should be added.