### PR TITLE
chore: migrate fpm packaging from app builder

### DIFF
--- a/.changeset/late-drinks-drive.md
+++ b/.changeset/late-drinks-drive.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: migrate fpm packaging from app builder

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -268,7 +268,7 @@ export default class FpmTarget extends Target {
       })
     }
 
-    await this.executeFpm(target, fpmConfiguration, resourceDir, env)
+    await this.executeFpm(target, fpmConfiguration, env)
 
     let info: ArtifactCreated = {
       file: artifactPath,
@@ -290,7 +290,7 @@ export default class FpmTarget extends Target {
     await packager.info.emitArtifactBuildCompleted(info)
   }
 
-  private async executeFpm(target: string, fpmConfiguration: FpmConfiguration, resourceDir: string, env: { SZA_PATH: string; SZA_COMPRESSION_LEVEL: string; TZ?: string }) {
+  private async executeFpm(target: string, fpmConfiguration: FpmConfiguration, env: any) {
     const fpmArgs = ["-s", "dir", "--force", "-t", target]
     if (process.env.FPM_DEBUG === "true") {
       fpmArgs.push("--debug")
@@ -305,11 +305,10 @@ export default class FpmTarget extends Target {
 
     fpmArgs.push(...this.configureTargetSpecificOptions(target, fpmConfiguration.compression ?? "xz"))
     fpmArgs.push(...fpmConfiguration.args)
+
     const fpmPath = await getFpmPath()
-    await exec(fpmPath, fpmArgs, {
-      cwd: resourceDir,
-      env,
-    }).catch(e => {
+
+    await exec(fpmPath, fpmArgs, { env }).catch(e => {
       if (e.message.includes("Need executable 'rpmbuild' to convert dir to rpm")) {
         const hint = "to build rpm, executable rpmbuild is required, please install rpm package on your system. "
         if (process.platform === "darwin") {

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -255,6 +255,7 @@ export default class FpmTarget extends Target {
       ...process.env,
       SZA_PATH: await getPath7za(),
       SZA_COMPRESSION_LEVEL: packager.compression === "store" ? "0" : "9",
+      SZA_ARCHIVE_TYPE: "xz",
     }
 
     // rpmbuild wants directory rpm with some default config files. Even if we can use dylibbundler, path to such config files are not changed (we need to replace in the binary)
@@ -308,6 +309,15 @@ export default class FpmTarget extends Target {
     await exec(fpmPath, fpmArgs, {
       cwd: resourceDir,
       env,
+    }).catch(e => {
+      if (e.message.includes("Need executable 'rpmbuild' to convert dir to rpm")) {
+        const hint = "to build rpm, executable rpmbuild is required, please install rpm package on your system. "
+        if (process.platform === "darwin") {
+          log.error(null, hint + "(brew install rpm)")
+        }
+        log.error(null, hint + "(sudo apt-get install rpm)")
+      }
+      throw e
     })
   }
 

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -361,15 +361,8 @@ export default class FpmTarget extends Target {
 
   private configureTargetSpecificOptions(target: string, compression: string): string[] {
     switch (target) {
-      case "rpm": {
-        let args = ["--rpm-os", "linux"]
-        if (compression == "xz") {
-          args = [...args, "--rpm-compression", "xzmt"]
-        } else {
-          args = [...args, "--rpm-compression", compression]
-        }
-        return args
-      }
+      case "rpm":
+        return ["--rpm-os", "linux", "--rpm-compression", compression == "xz" ? "xzmt" : compression]
       case "deb":
         return ["--deb-compression", compression]
       case "pacman":

--- a/packages/app-builder-lib/src/targets/tools.ts
+++ b/packages/app-builder-lib/src/targets/tools.ts
@@ -1,4 +1,4 @@
-import path from "path"
+import * as path from "path"
 import { getBinFromUrl } from "../binDownload"
 
 export function getLinuxToolsPath() {

--- a/packages/app-builder-lib/src/targets/tools.ts
+++ b/packages/app-builder-lib/src/targets/tools.ts
@@ -4,3 +4,23 @@ export function getLinuxToolsPath() {
   //noinspection SpellCheckingInspection
   return getBinFromUrl("linux-tools", "mac-10.12.3", "SQ8fqIRVXuQVWnVgaMTDWyf2TLAJjJYw3tRSqQJECmgF6qdM7Kogfa6KD49RbGzzMYIFca9Uw3MdsxzOPRWcYw==")
 }
+
+export async function getFpmPath() {
+  if (process.platform === "win32" || process.env.USE_SYSTEM_FPM === "true") {
+    return "fpm"
+  }
+  if (process.platform === "linux") {
+    let checksum: string
+    let archSuffix: string
+    if (process.arch == "x64") {
+      checksum = "fcKdXPJSso3xFs5JyIJHG1TfHIRTGDP0xhSBGZl7pPZlz4/TJ4rD/q3wtO/uaBBYeX0qFFQAFjgu1uJ6HLHghA=="
+      archSuffix = "-x86_64"
+    } else {
+      checksum = "OnzvBdsHE5djcXcAT87rwbnZwS789ZAd2ehuIO42JWtBAHNzXKxV4o/24XFX5No4DJWGO2YSGQttW+zn7d/4rQ=="
+      archSuffix = "-x86"
+    }
+    return `${await getBinFromUrl("fpm", "1.9.3-2.3.1-linux" + archSuffix, checksum)}/fpm`
+  } else {
+    return `${await getBinFromUrl("fpm", "1.9.3-20150715-2.2.2-mac", "oXfq+0H2SbdrbMik07mYloAZ8uHrmf6IJk+Q3P1kwywuZnKTXSaaeZUJNlWoVpRDWNu537YxxpBQWuTcF+6xfw==")}/fpm`
+  }
+}

--- a/packages/app-builder-lib/src/targets/tools.ts
+++ b/packages/app-builder-lib/src/targets/tools.ts
@@ -1,3 +1,4 @@
+import path from "path"
 import { getBinFromUrl } from "../binDownload"
 
 export function getLinuxToolsPath() {
@@ -6,8 +7,9 @@ export function getLinuxToolsPath() {
 }
 
 export async function getFpmPath() {
+  const exec = "fpm"
   if (process.platform === "win32" || process.env.USE_SYSTEM_FPM === "true") {
-    return "fpm"
+    return exec
   }
   if (process.platform === "linux") {
     let checksum: string
@@ -19,8 +21,7 @@ export async function getFpmPath() {
       checksum = "OnzvBdsHE5djcXcAT87rwbnZwS789ZAd2ehuIO42JWtBAHNzXKxV4o/24XFX5No4DJWGO2YSGQttW+zn7d/4rQ=="
       archSuffix = "-x86"
     }
-    return `${await getBinFromUrl("fpm", "1.9.3-2.3.1-linux" + archSuffix, checksum)}/fpm`
-  } else {
-    return `${await getBinFromUrl("fpm", "1.9.3-20150715-2.2.2-mac", "oXfq+0H2SbdrbMik07mYloAZ8uHrmf6IJk+Q3P1kwywuZnKTXSaaeZUJNlWoVpRDWNu537YxxpBQWuTcF+6xfw==")}/fpm`
+    return path.join(await getBinFromUrl("fpm", "1.9.3-2.3.1-linux" + archSuffix, checksum), exec)
   }
+  return path.join(await getBinFromUrl("fpm", "1.9.3-20150715-2.2.2-mac", "oXfq+0H2SbdrbMik07mYloAZ8uHrmf6IJk+Q3P1kwywuZnKTXSaaeZUJNlWoVpRDWNu537YxxpBQWuTcF+6xfw=="), exec)
 }


### PR DESCRIPTION
Fairly straight-forward translation of https://github.com/develar/app-builder/blob/master/pkg/package-format/fpm/fpm.go

This will make it much easier to update fpm and innately test within electron-builder's CI/CD without interspersed updates of app-builder project.