### PR TITLE
fix: update regex for multipart content-type parsing in multipleRange

### DIFF
--- a/.changeset/purple-tigers-guess.md
+++ b/.changeset/purple-tigers-guess.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: update regex for multipart content-type parsing in multipleRange

--- a/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
@@ -95,7 +95,7 @@ function doExecuteTasks(differentialDownloader: DifferentialDownloader, options:
     }
 
     const contentType = safeGetHeader(response, "content-type")
-    const m = /^multipart\/.+?(?:; boundary=(?:(?:"(.+)")|(?:([^\s]+))))$/i.exec(contentType)
+    const m = /^multipart\/.+?\s*;\s*boundary=(?:"([^"]+)"|([^\s";]+))\s*$/i.exec(contentType)
     if (m == null) {
       reject(new Error(`Content-Type "multipart/byteranges" is expected, but got "${contentType}"`))
       return


### PR DESCRIPTION
The `Content-Type` response is as follows: `Content-Type: multipart/byteranges; boundary=799ddd5a-943e-4e22-981d-e32596ca39d2`. The `boundary` can have a space before it or no space at all. 
Here's the rfc:
https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1
![image](https://github.com/user-attachments/assets/16508142-3700-4297-ad64-57d121a153b5)

**Issue**

Currently, the check only accounts for cases where there is a space. If some servers return a response without a space, it will cause incremental downloads to fail.

**Error Info**
```
17:13:29.256 > Full: 92,770.98 KB, To download: 19,742.1 KB (21%)
17:13:29.633 > Cannot download differentially, fallback to full download: Error: Content-Type "multipart/byteranges" is expected, but got "multipart/byteranges;boundary=e888c103-165d-4ec1-9b6f-eca722ac9b10"
    at ClientRequest.<anonymous> (C:\Users\payne\AppData\Local\Programs\Cherry Studio\resources\app.asar\node_modules\electron-updater\out\differentialDownloader\multipleRangeDownloader.js:80:20)
    at ClientRequest.emit (node:events:531:35)
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:2:114720)
    at SimpleURLLoaderWrapper.emit (node:events:519:28)
17:13:34.288 > New version 1.2.9 has been downloaded to C:\Users\payne\AppData\Local\cherrystudio-updater\pending\Cherry-Studio-1.2.9-x64-setup.exe
```

**How to fix**

```
Welcome to Node.js v22.14.0.
Type ".help" for more information.
> /^multipart\/.+?\s*;\s*boundary=(?:"([^"]+)"|([^\s";]+))\s*$/i.exec("multipart/byteranges;boundary=799ddd5a-943e-4e22-981d-e32596ca39d2")
[
  'multipart/byteranges;boundary=799ddd5a-943e-4e22-981d-e32596ca39d2',
  undefined,
  '799ddd5a-943e-4e22-981d-e32596ca39d2',
  index: 0,
  input: 'multipart/byteranges;boundary=799ddd5a-943e-4e22-981d-e32596ca39d2',
  groups: undefined
]
> /^multipart\/.+?\s*;\s*boundary=(?:"([^"]+)"|([^\s";]+))\s*$/i.exec("multipart/byteranges; boundary=799ddd5a-943e-4e22-981d-e32596ca39d2")
[
  'multipart/byteranges; boundary=799ddd5a-943e-4e22-981d-e32596ca39d2',
  undefined,
  '799ddd5a-943e-4e22-981d-e32596ca39d2',
  index: 0,
  input: 'multipart/byteranges; boundary=799ddd5a-943e-4e22-981d-e32596ca39d2',
  groups: undefined
]
```

might fix https://github.com/electron-userland/electron-builder/issues/9063