### PR TITLE
refactor: update package manager detection and improve type handling

### DIFF
--- a/.changeset/blue-icons-push.md
+++ b/.changeset/blue-icons-push.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+refactor: update package manager detection and improve type handling

--- a/packages/app-builder-lib/src/node-module-collector/index.ts
+++ b/packages/app-builder-lib/src/node-module-collector/index.ts
@@ -1,7 +1,7 @@
 import { NpmNodeModulesCollector } from "./npmNodeModulesCollector"
 import { PnpmNodeModulesCollector } from "./pnpmNodeModulesCollector"
 import { YarnNodeModulesCollector } from "./yarnNodeModulesCollector"
-import { detectPackageManager, PM } from "./packageManager"
+import { detectPackageManager, PM, getPackageManagerCommand } from "./packageManager"
 import { NodeModuleInfo } from "./types"
 import { exec } from "builder-util"
 
@@ -34,4 +34,4 @@ export async function getNodeModules(rootDir: string): Promise<NodeModuleInfo[]>
   return collector.getNodeModules()
 }
 
-export { detectPackageManager, PM }
+export { detectPackageManager, PM, getPackageManagerCommand }

--- a/packages/app-builder-lib/src/node-module-collector/index.ts
+++ b/packages/app-builder-lib/src/node-module-collector/index.ts
@@ -1,7 +1,7 @@
 import { NpmNodeModulesCollector } from "./npmNodeModulesCollector"
 import { PnpmNodeModulesCollector } from "./pnpmNodeModulesCollector"
 import { YarnNodeModulesCollector } from "./yarnNodeModulesCollector"
-import { detect, PM, getPackageManagerVersion } from "./packageManager"
+import { detectPackageManager, PM } from "./packageManager"
 import { NodeModuleInfo } from "./types"
 import { exec } from "builder-util"
 
@@ -13,16 +13,16 @@ async function isPnpmProjectHoisted(rootDir: string) {
 }
 
 export async function getCollectorByPackageManager(rootDir: string) {
-  const manager: PM = await detect({ cwd: rootDir })
+  const manager: PM = detectPackageManager(rootDir)
   switch (manager) {
-    case "pnpm":
+    case PM.PNPM:
       if (await isPnpmProjectHoisted(rootDir)) {
         return new NpmNodeModulesCollector(rootDir)
       }
       return new PnpmNodeModulesCollector(rootDir)
-    case "npm":
+    case PM.NPM:
       return new NpmNodeModulesCollector(rootDir)
-    case "yarn":
+    case PM.YARN:
       return new YarnNodeModulesCollector(rootDir)
     default:
       return new NpmNodeModulesCollector(rootDir)
@@ -34,4 +34,4 @@ export async function getNodeModules(rootDir: string): Promise<NodeModuleInfo[]>
   return collector.getNodeModules()
 }
 
-export { detect, getPackageManagerVersion, PM }
+export { detectPackageManager, PM }

--- a/packages/app-builder-lib/src/node-module-collector/packageManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/packageManager.ts
@@ -69,6 +69,14 @@ function detectPackageManagerByEnv(): PM {
   return PM.NPM
 }
 
+export function getPackageManagerCommand(pm: PM) {
+  let cmd = pm
+  if (pm === PM.YARN_BERRY || process.env.FORCE_YARN === "true") {
+    cmd = PM.YARN
+  }
+  return `${cmd}${process.platform === "win32" ? ".cmd" : ""}`
+}
+
 export function detectPackageManager(cwd: string) {
   const isYarnLockFileExists = fs.existsSync(path.join(cwd, "yarn.lock"))
   const isPnpmLockFileExists = fs.existsSync(path.join(cwd, "pnpm-lock.yaml"))

--- a/packages/app-builder-lib/src/node-module-collector/packageManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/packageManager.ts
@@ -1,95 +1,84 @@
-// copy from https://github.com/egoist/detect-package-manager/blob/main/src/index.ts
-// and merge https://github.com/egoist/detect-package-manager/pull/9 to support Monorepo
-import { resolve, dirname } from "path"
-import { exec, exists } from "builder-util"
+import * as path from "path"
+import * as fs from "fs"
 
-export type PM = "npm" | "yarn" | "pnpm" | "bun"
-
-const cache = new Map()
-const globalInstallationCache = new Map<string, boolean>()
-const lockfileCache = new Map<string, PM>()
-
-/**
- * Check if a global pm is available
- */
-function hasGlobalInstallation(pm: PM): Promise<boolean> {
-  const key = `has_global_${pm}`
-  if (globalInstallationCache.has(key)) {
-    return Promise.resolve(globalInstallationCache.get(key)!)
-  }
-
-  return exec(pm, ["--version"], { shell: true })
-    .then(res => {
-      return /^\d+.\d+.\d+$/.test(res)
-    })
-    .then(value => {
-      globalInstallationCache.set(key, value)
-      return value
-    })
-    .catch(() => false)
+export enum PM {
+  NPM = "npm",
+  YARN = "yarn",
+  PNPM = "pnpm",
+  YARN_BERRY = "yarn-berry",
 }
 
-function getTypeofLockFile(cwd = process.cwd()): Promise<PM> {
-  const key = `lockfile_${cwd}`
-  if (lockfileCache.has(key)) {
-    return Promise.resolve(lockfileCache.get(key)!)
-  }
+export function detectPackageManager(cwd: string): PM {
+  if (process.env.npm_config_user_agent) {
+    const userAgent = process.env.npm_config_user_agent
 
-  return Promise.all([
-    exists(resolve(cwd, "yarn.lock")),
-    exists(resolve(cwd, "package-lock.json")),
-    exists(resolve(cwd, "pnpm-lock.yaml")),
-    exists(resolve(cwd, "bun.lockb")),
-  ]).then(([isYarn, _, isPnpm, isBun]) => {
-    let value: PM
-
-    if (isYarn) {
-      value = "yarn"
-    } else if (isPnpm) {
-      value = "pnpm"
-    } else if (isBun) {
-      value = "bun"
-    } else {
-      value = "npm"
+    if (userAgent.includes("pnpm")) {
+      return PM.PNPM
     }
 
-    cache.set(key, value)
-    return value
-  })
-}
+    if (userAgent.includes("yarn")) {
+      if (userAgent.includes("yarn/")) {
+        const version = userAgent.match(/yarn\/(\d+)\./)
+        if (version && parseInt(version[1]) >= 2) {
+          return PM.YARN_BERRY
+        }
+      }
+      return PM.YARN
+    }
 
-export const detect = async ({ cwd, includeGlobalBun }: { cwd?: string; includeGlobalBun?: boolean } = {}) => {
-  let type = await getTypeofLockFile(cwd)
-  if (type) {
-    return type
-  }
-
-  let tmpCwd = cwd || "."
-  for (let i = 1; i <= 5; i++) {
-    tmpCwd = dirname(tmpCwd)
-    type = await getTypeofLockFile(tmpCwd)
-    if (type) {
-      return type
+    if (userAgent.includes("npm")) {
+      return PM.NPM
     }
   }
 
-  if (await hasGlobalInstallation("yarn")) {
-    return "yarn"
-  }
-  if (await hasGlobalInstallation("pnpm")) {
-    return "yarn"
+  if (process.env.npm_execpath) {
+    const execPath = process.env.npm_execpath.toLowerCase()
+
+    if (execPath.includes("pnpm")) {
+      return PM.PNPM
+    }
+
+    if (execPath.includes("yarn")) {
+      if (execPath.includes("berry") || process.env.YARN_VERSION?.startsWith("2.") || process.env.YARN_VERSION?.startsWith("3.")) {
+        return PM.YARN_BERRY
+      }
+      return PM.YARN
+    }
+
+    if (execPath.includes("npm")) {
+      return PM.NPM
+    }
   }
 
-  if (includeGlobalBun && (await hasGlobalInstallation("bun"))) {
-    return "bun"
+  if (process.env.PNPM_HOME) {
+    return PM.PNPM
   }
-  return "npm"
+
+  if (process.env.YARN_REGISTRY) {
+    if (process.env.YARN_VERSION?.startsWith("2.") || process.env.YARN_VERSION?.startsWith("3.")) {
+      return PM.YARN_BERRY
+    }
+    return PM.YARN
+  }
+
+  if (process.env.npm_package_json) {
+    return PM.NPM
+  }
+
+  return getPackageManagerCommandByLockFile(cwd)
 }
 
-export function getPackageManagerVersion(pm: PM) {
-  return exec(pm, ["--version"], { shell: true }).then(res => res.trim())
-}
+function getPackageManagerCommandByLockFile(cwd: string) {
+  const yarnLockFile = path.join(cwd, "yarn.lock")
+  const pnpmLockFile = path.join(cwd, "pnpm-lock.yaml")
 
-export function clearCache() {
-  return cache.clear()
+  if (fs.existsSync(yarnLockFile)) {
+    return PM.YARN
+  }
+
+  if (fs.existsSync(pnpmLockFile)) {
+    return PM.PNPM
+  }
+
+  return PM.NPM
 }

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -86,8 +86,7 @@ async function installDependencies(config: Configuration, { appDir, projectDir }
   const pm = detectPackageManager(projectDir)
   log.info({ pm, platform, arch, projectDir, appDir }, `installing production dependencies`)
   const execArgs = ["install"]
-  const isYarnBerry = pm === PM.YARN_BERRY
-  if (!isYarnBerry) {
+  if (pm === PM.YARN_BERRY) {
     if (process.env.NPM_NO_BIN_LINKS === "true") {
       execArgs.push("--no-bin-links")
     }

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -7,7 +7,7 @@ import { homedir } from "os"
 import * as path from "path"
 import { Configuration } from "../configuration"
 import { executeAppBuilderAndWriteJson } from "./appBuilder"
-import { PM, detectPackageManager } from "../node-module-collector"
+import { PM, detectPackageManager, getPackageManagerCommand } from "../node-module-collector"
 import { NodeModuleDirInfo } from "./packageDependencies"
 import { rebuild as remoteRebuild } from "./rebuild/rebuild"
 
@@ -96,7 +96,7 @@ async function installDependencies(config: Configuration, { appDir, projectDir }
     execArgs.push("--prefer-offline")
   }
 
-  const execPath = getPackageToolPath(pm)
+  const execPath = getPackageManagerCommand(pm)
 
   if (additionalArgs != null) {
     execArgs.push(...additionalArgs)
@@ -129,15 +129,6 @@ export async function nodeGypRebuild(platform: NodeJS.Platform, arch: string, fr
   }
   await spawn(nodeGyp, args, { env: getGypEnv(frameworkInfo, platform, arch, true) })
 }
-
-function getPackageToolPath(pm: PM) {
-  let cmd = pm
-  if (process.env.FORCE_YARN === "true") {
-    cmd = PM.YARN
-  }
-  return `${cmd}${process.platform === "win32" ? ".cmd" : ""}`
-}
-
 export interface RebuildOptions {
   frameworkInfo: DesktopFrameworkInfo
   productionDeps: Lazy<Array<NodeModuleDirInfo>>

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -365,7 +365,7 @@ test.ifDevOrLinuxCi("win smart unpack", ({ expect }) => {
       isInstallDepsBefore: true,
       projectDirCreated: async projectDir => {
         p = projectDir
-        await outputFile(path.join(projectDir, "package-lock.json"), "")
+        process.env.npm_config_user_agent = "npm"
         return packageJson(it => {
           it.dependencies = {
             debug: "3.1.0",
@@ -441,8 +441,8 @@ test.ifDevOrLinuxCi("posix smart unpack", ({ expect }) =>
     },
     {
       isInstallDepsBefore: true,
-      projectDirCreated: async projectDir => {
-        await outputFile(path.join(projectDir, "package-lock.json"), "")
+      projectDirCreated: projectDir => {
+        process.env.npm_config_user_agent = "npm"
         return packageJson(it => {
           it.dependencies = {
             debug: "4.1.1",
@@ -450,7 +450,7 @@ test.ifDevOrLinuxCi("posix smart unpack", ({ expect }) =>
             keytar: "7.9.0",
             three: "0.160.0",
           }
-        })
+        })(projectDir)
       },
       packed: async context => {
         expect(context.packager.appInfo.copyright).toBe("Copyright © 2018 Foo Bar")

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -363,8 +363,9 @@ test.ifDevOrLinuxCi("win smart unpack", ({ expect }) => {
     },
     {
       isInstallDepsBefore: true,
-      projectDirCreated: projectDir => {
+      projectDirCreated: async projectDir => {
         p = projectDir
+        await outputFile(path.join(projectDir, "package-lock.json"), "")
         return packageJson(it => {
           it.dependencies = {
             debug: "3.1.0",
@@ -440,14 +441,17 @@ test.ifDevOrLinuxCi("posix smart unpack", ({ expect }) =>
     },
     {
       isInstallDepsBefore: true,
-      projectDirCreated: packageJson(it => {
-        it.dependencies = {
-          debug: "4.1.1",
-          "edge-cs": "1.2.1",
-          keytar: "7.9.0",
-          three: "0.160.0",
-        }
-      }),
+      projectDirCreated: async projectDir => {
+        await outputFile(path.join(projectDir, "package-lock.json"), "")
+        return packageJson(it => {
+          it.dependencies = {
+            debug: "4.1.1",
+            "edge-cs": "1.2.1",
+            keytar: "7.9.0",
+            three: "0.160.0",
+          }
+        })
+      },
       packed: async context => {
         expect(context.packager.appInfo.copyright).toBe("Copyright © 2018 Foo Bar")
         await verifySmartUnpack(expect, context.getResources(Platform.LINUX), async asarFs => {

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -178,7 +178,7 @@ describe("isInstallDepsBefore=true", { sequential: true }, () => {
       },
       {
         isInstallDepsBefore: true,
-        projectDirCreated: projectDir => {
+        projectDirCreated: async projectDir => {
           const subAppDir = path.join(projectDir, "packages", "test-app")
           return modifyPackageJson(subAppDir, data => {
             data.name = "@scope/xxx-app"

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -145,6 +145,7 @@ describe("isInstallDepsBefore=true", { sequential: true }, () => {
       {
         isInstallDepsBefore: true,
         projectDirCreated: async projectDir => {
+          await outputFile(path.join(projectDir, "package-lock.json"), "")
           await modifyPackageJson(projectDir, data => {
             data.dependencies = {
               debug: "4.1.1",
@@ -207,7 +208,7 @@ describe("isInstallDepsBefore=true", { sequential: true }, () => {
       },
       {
         isInstallDepsBefore: true,
-        projectDirCreated: projectDir => {
+        projectDirCreated: async projectDir => {
           return Promise.all([
             modifyPackageJson(projectDir, data => {
               //noinspection SpellCheckingInspection
@@ -241,15 +242,17 @@ describe("isInstallDepsBefore=true", { sequential: true }, () => {
       },
       {
         isInstallDepsBefore: true,
-        projectDirCreated: projectDir =>
-          modifyPackageJson(projectDir, data => {
+        projectDirCreated: async projectDir => {
+          await outputFile(path.join(projectDir, "package-lock.json"), "")
+          return modifyPackageJson(projectDir, data => {
             //noinspection SpellCheckingInspection
             data.dependencies = {
               "ci-info": "2.0.0",
               // this contains string-width-cjs 4.2.3
               "@isaacs/cliui": "8.0.2",
             }
-          }),
+          })
+        },
         packed: context => {
           return assertThat(expect, path.join(context.getResources(Platform.LINUX), "app", "node_modules")).doesNotExist()
         },
@@ -269,12 +272,14 @@ describe("isInstallDepsBefore=true", { sequential: true }, () => {
       },
       {
         isInstallDepsBefore: true,
-        projectDirCreated: projectDir =>
-          modifyPackageJson(projectDir, data => {
+        projectDirCreated: async projectDir => {
+          await outputFile(path.join(projectDir, "package-lock.json"), "")
+          return modifyPackageJson(projectDir, data => {
             data.dependencies = {
               "ci-info": "2.0.0",
             }
-          }),
+          })
+        },
         packed: async context => {
           const nodeModulesNode = (await readAsar(path.join(context.getResources(Platform.LINUX), "app.asar"))).getNode("node_modules")
           expect(removeUnstableProperties(nodeModulesNode)).toMatchSnapshot()

--- a/test/src/ignoreTest.ts
+++ b/test/src/ignoreTest.ts
@@ -90,7 +90,8 @@ test.ifNotCiMac.sequential("ignore node_modules dev dep", ({ expect }) =>
     },
     {
       isInstallDepsBefore: true,
-      projectDirCreated: projectDir => {
+      projectDirCreated: async projectDir => {
+        await outputFile(path.join(projectDir, "package-lock.json"), "")
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.devDependencies = {
@@ -119,7 +120,8 @@ test.ifDevOrLinuxCi.sequential("copied sub node_modules of the rootDir/node_modu
     },
     {
       isInstallDepsBefore: true,
-      projectDirCreated: projectDir => {
+      projectDirCreated: async projectDir => {
+        await outputFile(path.join(projectDir, "package-lock.json"), "")
         return Promise.all([
           modifyPackageJson(projectDir, data => {
             data.dependencies = {


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/8970#issuecomment-2830421527

- Replaced the `detect` and `getPackageManagerVersion` functions with a new `detectPackageManager` function for better clarity and type safety.
- Updated the `PM` type to an enum for improved maintainability.
- Adjusted the logic in `getCollectorByPackageManager` and `installDependencies` to utilize the new detection method.
- Cleaned up unused code and comments in `packageManager.ts` and `yarn.ts` files.