### PR TITLE
fix(linux): `productName` should be used as the default value when `executableName` is not set per docs (#9068)

### DIFF
--- a/.changeset/silly-dolls-pretend.md
+++ b/.changeset/silly-dolls-pretend.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(linux): productName should be used as the default value when executableName is not set. (#8766)

--- a/packages/app-builder-lib/src/linuxPackager.ts
+++ b/packages/app-builder-lib/src/linuxPackager.ts
@@ -18,7 +18,7 @@ export class LinuxPackager extends PlatformPackager<LinuxConfiguration> {
     super(info, Platform.LINUX)
 
     const executableName = this.platformSpecificBuildOptions.executableName ?? info.config.executableName
-    this.executableName = executableName == null ? this.appInfo.sanitizedName.toLowerCase() : sanitizeFileName(executableName)
+    this.executableName = executableName == null ? this.appInfo.sanitizedProductName : sanitizeFileName(executableName)
   }
 
   get defaultTarget(): Array<string> {

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -35,7 +35,7 @@ exports[`arm 2`] = `
   "/opt/Test App ßW/LICENSES.chromium.html",
   "/opt/Test App ßW/resources.pak",
   "/opt/Test App ßW/snapshot_blob.bin",
-  "/opt/Test App ßW/testapp",
+  "/opt/Test App ßW/Test App ßW",
   "/opt/Test App ßW/v8_context_snapshot.bin",
   "/opt/Test App ßW/vk_swiftshader_icd.json",
   "/usr/share/",
@@ -43,7 +43,7 @@ exports[`arm 2`] = `
   "/opt/Test App ßW/resources/app.asar",
   "/opt/Test App ßW/resources/apparmor-profile",
   "/usr/share/applications/",
-  "/usr/share/applications/testapp.desktop",
+  "/usr/share/applications/Test App ßW.desktop",
   "/usr/share/doc/",
   "/usr/share/icons/",
   "/usr/share/doc/testapp/",
@@ -57,19 +57,19 @@ exports[`arm 2`] = `
   "/usr/share/icons/hicolor/512x512/",
   "/usr/share/icons/hicolor/64x64/",
   "/usr/share/icons/hicolor/128x128/apps/",
-  "/usr/share/icons/hicolor/128x128/apps/testapp.png",
+  "/usr/share/icons/hicolor/128x128/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/16x16/apps/",
-  "/usr/share/icons/hicolor/16x16/apps/testapp.png",
+  "/usr/share/icons/hicolor/16x16/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/256x256/apps/",
-  "/usr/share/icons/hicolor/256x256/apps/testapp.png",
+  "/usr/share/icons/hicolor/256x256/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/32x32/apps/",
-  "/usr/share/icons/hicolor/32x32/apps/testapp.png",
+  "/usr/share/icons/hicolor/32x32/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/48x48/apps/",
-  "/usr/share/icons/hicolor/48x48/apps/testapp.png",
+  "/usr/share/icons/hicolor/48x48/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/512x512/apps/",
-  "/usr/share/icons/hicolor/512x512/apps/testapp.png",
+  "/usr/share/icons/hicolor/512x512/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/64x64/apps/",
-  "/usr/share/icons/hicolor/64x64/apps/testapp.png",
+  "/usr/share/icons/hicolor/64x64/apps/Test App ßW.png",
 ]
 `;
 
@@ -110,7 +110,7 @@ exports[`arm 5`] = `
   "/opt/Test App ßW/LICENSES.chromium.html",
   "/opt/Test App ßW/resources.pak",
   "/opt/Test App ßW/snapshot_blob.bin",
-  "/opt/Test App ßW/testapp",
+  "/opt/Test App ßW/Test App ßW",
   "/opt/Test App ßW/v8_context_snapshot.bin",
   "/opt/Test App ßW/vk_swiftshader_icd.json",
   "/usr/share/",
@@ -118,7 +118,7 @@ exports[`arm 5`] = `
   "/opt/Test App ßW/resources/app.asar",
   "/opt/Test App ßW/resources/apparmor-profile",
   "/usr/share/applications/",
-  "/usr/share/applications/testapp.desktop",
+  "/usr/share/applications/Test App ßW.desktop",
   "/usr/share/doc/",
   "/usr/share/icons/",
   "/usr/share/doc/testapp/",
@@ -132,19 +132,19 @@ exports[`arm 5`] = `
   "/usr/share/icons/hicolor/512x512/",
   "/usr/share/icons/hicolor/64x64/",
   "/usr/share/icons/hicolor/128x128/apps/",
-  "/usr/share/icons/hicolor/128x128/apps/testapp.png",
+  "/usr/share/icons/hicolor/128x128/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/16x16/apps/",
-  "/usr/share/icons/hicolor/16x16/apps/testapp.png",
+  "/usr/share/icons/hicolor/16x16/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/256x256/apps/",
-  "/usr/share/icons/hicolor/256x256/apps/testapp.png",
+  "/usr/share/icons/hicolor/256x256/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/32x32/apps/",
-  "/usr/share/icons/hicolor/32x32/apps/testapp.png",
+  "/usr/share/icons/hicolor/32x32/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/48x48/apps/",
-  "/usr/share/icons/hicolor/48x48/apps/testapp.png",
+  "/usr/share/icons/hicolor/48x48/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/512x512/apps/",
-  "/usr/share/icons/hicolor/512x512/apps/testapp.png",
+  "/usr/share/icons/hicolor/512x512/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/64x64/apps/",
-  "/usr/share/icons/hicolor/64x64/apps/testapp.png",
+  "/usr/share/icons/hicolor/64x64/apps/Test App ßW.png",
 ]
 `;
 
@@ -282,7 +282,7 @@ exports[`deb 2`] = `
   "/opt/Test App ßW/LICENSES.chromium.html",
   "/opt/Test App ßW/resources.pak",
   "/opt/Test App ßW/snapshot_blob.bin",
-  "/opt/Test App ßW/testapp",
+  "/opt/Test App ßW/Test App ßW",
   "/opt/Test App ßW/v8_context_snapshot.bin",
   "/opt/Test App ßW/vk_swiftshader_icd.json",
   "/usr/share/",
@@ -290,7 +290,7 @@ exports[`deb 2`] = `
   "/opt/Test App ßW/resources/app.asar",
   "/opt/Test App ßW/resources/apparmor-profile",
   "/usr/share/applications/",
-  "/usr/share/applications/testapp.desktop",
+  "/usr/share/applications/Test App ßW.desktop",
   "/usr/share/doc/",
   "/usr/share/icons/",
   "/usr/share/doc/testapp/",
@@ -304,19 +304,19 @@ exports[`deb 2`] = `
   "/usr/share/icons/hicolor/512x512/",
   "/usr/share/icons/hicolor/64x64/",
   "/usr/share/icons/hicolor/128x128/apps/",
-  "/usr/share/icons/hicolor/128x128/apps/testapp.png",
+  "/usr/share/icons/hicolor/128x128/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/16x16/apps/",
-  "/usr/share/icons/hicolor/16x16/apps/testapp.png",
+  "/usr/share/icons/hicolor/16x16/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/256x256/apps/",
-  "/usr/share/icons/hicolor/256x256/apps/testapp.png",
+  "/usr/share/icons/hicolor/256x256/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/32x32/apps/",
-  "/usr/share/icons/hicolor/32x32/apps/testapp.png",
+  "/usr/share/icons/hicolor/32x32/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/48x48/apps/",
-  "/usr/share/icons/hicolor/48x48/apps/testapp.png",
+  "/usr/share/icons/hicolor/48x48/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/512x512/apps/",
-  "/usr/share/icons/hicolor/512x512/apps/testapp.png",
+  "/usr/share/icons/hicolor/512x512/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/64x64/apps/",
-  "/usr/share/icons/hicolor/64x64/apps/testapp.png",
+  "/usr/share/icons/hicolor/64x64/apps/Test App ßW.png",
 ]
 `;
 
@@ -368,7 +368,7 @@ exports[`deb file associations 2`] = `
   "/opt/Test App ßW/LICENSES.chromium.html",
   "/opt/Test App ßW/resources.pak",
   "/opt/Test App ßW/snapshot_blob.bin",
-  "/opt/Test App ßW/testapp",
+  "/opt/Test App ßW/Test App ßW",
   "/opt/Test App ßW/v8_context_snapshot.bin",
   "/opt/Test App ßW/vk_swiftshader_icd.json",
   "/usr/share/",
@@ -376,7 +376,7 @@ exports[`deb file associations 2`] = `
   "/opt/Test App ßW/resources/app.asar",
   "/opt/Test App ßW/resources/apparmor-profile",
   "/usr/share/applications/",
-  "/usr/share/applications/testapp.desktop",
+  "/usr/share/applications/Test App ßW.desktop",
   "/usr/share/doc/",
   "/usr/share/icons/",
   "/usr/share/mime/",
@@ -384,7 +384,7 @@ exports[`deb file associations 2`] = `
   "/usr/share/doc/testapp/changelog.gz",
   "/usr/share/icons/hicolor/",
   "/usr/share/mime/packages/",
-  "/usr/share/mime/packages/testapp.xml",
+  "/usr/share/mime/packages/Test App ßW.xml",
   "/usr/share/icons/hicolor/128x128/",
   "/usr/share/icons/hicolor/16x16/",
   "/usr/share/icons/hicolor/256x256/",
@@ -393,19 +393,19 @@ exports[`deb file associations 2`] = `
   "/usr/share/icons/hicolor/512x512/",
   "/usr/share/icons/hicolor/64x64/",
   "/usr/share/icons/hicolor/128x128/apps/",
-  "/usr/share/icons/hicolor/128x128/apps/testapp.png",
+  "/usr/share/icons/hicolor/128x128/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/16x16/apps/",
-  "/usr/share/icons/hicolor/16x16/apps/testapp.png",
+  "/usr/share/icons/hicolor/16x16/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/256x256/apps/",
-  "/usr/share/icons/hicolor/256x256/apps/testapp.png",
+  "/usr/share/icons/hicolor/256x256/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/32x32/apps/",
-  "/usr/share/icons/hicolor/32x32/apps/testapp.png",
+  "/usr/share/icons/hicolor/32x32/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/48x48/apps/",
-  "/usr/share/icons/hicolor/48x48/apps/testapp.png",
+  "/usr/share/icons/hicolor/48x48/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/512x512/apps/",
-  "/usr/share/icons/hicolor/512x512/apps/testapp.png",
+  "/usr/share/icons/hicolor/512x512/apps/Test App ßW.png",
   "/usr/share/icons/hicolor/64x64/apps/",
-  "/usr/share/icons/hicolor/64x64/apps/testapp.png",
+  "/usr/share/icons/hicolor/64x64/apps/Test App ßW.png",
 ]
 `;
 
@@ -431,7 +431,7 @@ exports[`deb file associations 5`] = `
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
 <mime-type type="application/x-example">
   <glob pattern="*.my-app"/>
-
+    
   <icon name="x-office-document" />
 </mime-type>
 </mime-info>"
@@ -562,9 +562,9 @@ fi
 #
 # Unfortunately, at the moment AppArmor doesn't have a good story for backwards compatibility.
 # https://askubuntu.com/questions/1517272/writing-a-backwards-compatible-apparmor-profile
-APPARMOR_PROFILE_SOURCE='/opt/foo/resources/apparmor-profile'
-APPARMOR_PROFILE_TARGET='/etc/apparmor.d/Boo'
-if test -d "/etc/apparmor.d"; then
+if apparmor_status --enabled > /dev/null 2>&1; then
+  APPARMOR_PROFILE_SOURCE='/opt/foo/resources/apparmor-profile'
+  APPARMOR_PROFILE_TARGET='/etc/apparmor.d/Boo'
   if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
     cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
 

--- a/test/src/linux/debTest.ts
+++ b/test/src/linux/debTest.ts
@@ -104,7 +104,7 @@ test.ifNotWindows("deb file associations", ({ expect }) =>
     {
       packed: async context => {
         const mime = (
-          await execShell(`ar p '${context.outDir}/TestApp_1.1.0_amd64.deb' data.tar.xz | ${await getTarExecutable()} Jx --to-stdout ./usr/share/mime/packages/testapp.xml`, {
+          await execShell(`ar p '${context.outDir}/TestApp_1.1.0_amd64.deb' data.tar.xz | ${await getTarExecutable()} Jx --to-stdout './usr/share/mime/packages/Test App ßW.xml'`, {
             maxBuffer: 10 * 1024 * 1024,
           })
         ).stdout


### PR DESCRIPTION
I have conducted tests in my project and it seems there are no issues.

Fixes: #8766

> The above content is translated by a translation tool. Please ignore any errors in it.