### PR TITLE
chore(deploy): entering alpha release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,20 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "app-builder-lib": "26.0.14",
+    "builder-util": "26.0.13",
+    "builder-util-runtime": "9.3.2",
+    "dmg-builder": "26.0.14",
+    "electron-builder": "26.0.14",
+    "electron-builder-squirrel-windows": "26.0.14",
+    "electron-forge-maker-appimage": "26.0.14",
+    "electron-forge-maker-nsis": "26.0.14",
+    "electron-forge-maker-nsis-web": "26.0.14",
+    "electron-forge-maker-snap": "26.0.14",
+    "electron-publish": "26.0.13",
+    "electron-updater": "6.6.3",
+    "@electron-builder/test": "0.0.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
In order to adopt fixes of the latest `electron/*` packages, we need to bump the required `engine` to node >22.12. Entering `alpha` release mode to enable merging additional breaking changes requiring a major semver bump as well