### PR TITLE
chore: bump `engine` node requirement to >21.12

### DIFF
--- a/.changeset/beige-lamps-march.md
+++ b/.changeset/beige-lamps-march.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": major
+"electron-builder": major
+---
+
+chore: bump `engine` node requirement to >22.12 to update to latest `electron/XX` packages (in order to support Electron 36)

--- a/packages/app-builder-lib/package.json
+++ b/packages/app-builder-lib/package.json
@@ -15,7 +15,7 @@
     "directory": "packages/app-builder-lib"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=22.12.0"
   },
   "keywords": [
     "electron",

--- a/packages/electron-builder/package.json
+++ b/packages/electron-builder/package.json
@@ -16,7 +16,7 @@
     "directory": "packages/electron-builder"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=22.12.0"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
This is necessary in order to update to latest `electron/XX` packages (in order to support Electron 36)

This only bumps the requirements for `app-builder-lib` and `electron-builder` packages, this does not change the requirements for `electron-updater` (which remains node >12 for now)