### PR TITLE
feat: add excludeReBuildModules option to configuration and scheme

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1825,6 +1825,20 @@
             "string"
           ]
         },
+        "excludeReBuildModules": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The modules to exclude from the rebuild."
+        },
         "executableArgs": {
           "anyOf": [
             {
@@ -2527,6 +2541,20 @@
             "string"
           ]
         },
+        "excludeReBuildModules": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The modules to exclude from the rebuild."
+        },
         "executableName": {
           "description": "The executable name. Defaults to `productName`.",
           "type": [
@@ -3158,6 +3186,20 @@
             "null",
             "string"
           ]
+        },
+        "excludeReBuildModules": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The modules to exclude from the rebuild."
         },
         "executableName": {
           "description": "The executable name. Defaults to `productName`.",
@@ -6381,6 +6423,20 @@
             "string"
           ]
         },
+        "excludeReBuildModules": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The modules to exclude from the rebuild."
+        },
         "executableName": {
           "description": "The executable name. Defaults to `productName`.",
           "type": [
@@ -7152,6 +7208,20 @@
         "null",
         "string"
       ]
+    },
+    "excludeReBuildModules": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The modules to exclude from the rebuild."
     },
     "executableName": {
       "description": "The executable name. Defaults to `productName`.",

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -192,6 +192,11 @@ export interface CommonConfiguration {
    * [Experimental] Configuration for concurrent builds.
    */
   readonly concurrency?: Concurrency | null
+
+  /**
+   * The modules to exclude from the rebuild.
+   */
+  readonly excludeReBuildModules?: Array<string> | null
 }
 
 export interface Configuration extends CommonConfiguration, PlatformSpecificBuildOptions, Hooks {

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -199,6 +199,11 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions, Fil
   cscKeyPassword?: string | null
 
   readonly defaultArch?: string
+
+  /**
+   * The modules to exclude from the rebuild.
+   */
+  readonly excludeReBuildModules?: Array<string> | null
 }
 
 export interface ReleaseInfo {

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -181,6 +181,7 @@ export async function rebuild(config: Configuration, { appDir, projectDir }: Dir
     arch,
     platform,
     buildFromSource,
+    ignoreModules: config.excludeReBuildModules || undefined,
     projectRootPath: projectDir,
     mode: (config.nativeRebuilder as RebuildMode) || "sequential",
     disablePreGypCopy: true,

--- a/test/fixtures/lockfiles/BuildTest/exclude some modules from rebuild.txt
+++ b/test/fixtures/lockfiles/BuildTest/exclude some modules from rebuild.txt
@@ -1,0 +1,59 @@
+{
+  "name": "TestApp",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "TestApp",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "3.1.0",
+        "selection-hook": "0.9.9"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/selection-hook": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/selection-hook/-/selection-hook-0.9.9.tgz",
+      "integrity": "sha512-CZfyBpPnq0Qx0uyCQxeZJxtiikOo83sHJSsdZJ8DgJs6OOf9yBUTgGoV/H304UDsXVPUQe6Oc1QUN860+S2pow==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-gyp-build": "^4.7.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    }
+  }
+}

--- a/test/snapshots/BuildTest.js.snap
+++ b/test/snapshots/BuildTest.js.snap
@@ -205,6 +205,220 @@ exports[`electron version from electron-prebuilt dependency 1`] = `
 }
 `;
 
+exports[`exclude some modules from rebuild 1`] = `
+{
+  "win": [],
+}
+`;
+
+exports[`exclude some modules from rebuild 2`] = `
+{
+  "files": {
+    "app": {
+      "files": {
+        "package.json": {
+          "files": {
+            "readme.md": {
+              "size": "<size>",
+            },
+          },
+        },
+        "readme.md": {
+          "size": "<size>",
+        },
+      },
+    },
+    "index.html": {
+      "size": "<size>",
+    },
+    "index.js": {
+      "size": "<size>",
+    },
+    "node_modules": {
+      "files": {
+        "debug": {
+          "files": {
+            "LICENSE": {
+              "size": "<size>",
+            },
+            "Makefile": {
+              "size": "<size>",
+            },
+            "node.js": {
+              "size": "<size>",
+            },
+            "package.json": {
+              "size": "<size>",
+            },
+            "src": {
+              "files": {
+                "browser.js": {
+                  "size": "<size>",
+                },
+                "debug.js": {
+                  "size": "<size>",
+                },
+                "index.js": {
+                  "size": "<size>",
+                },
+                "node.js": {
+                  "size": "<size>",
+                },
+              },
+            },
+          },
+        },
+        "ms": {
+          "files": {
+            "index.js": {
+              "size": "<size>",
+            },
+            "license.md": {
+              "size": "<size>",
+            },
+            "package.json": {
+              "size": "<size>",
+            },
+          },
+        },
+        "node-gyp-build": {
+          "files": {
+            "LICENSE": {
+              "size": "<size>",
+            },
+            "SECURITY.md": {
+              "size": "<size>",
+            },
+            "bin.js": {
+              "size": "<size>",
+            },
+            "build-test.js": {
+              "size": "<size>",
+            },
+            "index.js": {
+              "size": "<size>",
+            },
+            "node-gyp-build.js": {
+              "size": "<size>",
+            },
+            "optional.js": {
+              "size": "<size>",
+            },
+            "package.json": {
+              "size": "<size>",
+            },
+          },
+        },
+        "selection-hook": {
+          "files": {
+            "LICENSE": {
+              "size": "<size>",
+              "unpacked": true,
+            },
+            "index.js": {
+              "size": "<size>",
+              "unpacked": true,
+            },
+            "package.json": {
+              "size": "<size>",
+              "unpacked": true,
+            },
+            "prebuilds": {
+              "files": {
+                "win32-x64": {
+                  "files": {
+                    "selection-hook.node": {
+                      "size": "<size>",
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+            "src": {
+              "files": {
+                "windows": {
+                  "files": {
+                    "lib": {
+                      "files": {
+                        "clipboard.h": {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "string_pool.h": {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                        "utils.h": {
+                          "size": "<size>",
+                          "unpacked": true,
+                        },
+                      },
+                      "unpacked": true,
+                    },
+                  },
+                  "unpacked": true,
+                },
+              },
+              "unpacked": true,
+            },
+          },
+          "unpacked": true,
+        },
+      },
+    },
+    "package.json": {
+      "size": "<size>",
+    },
+  },
+}
+`;
+
+exports[`exclude some modules from rebuild 3`] = `
+[
+  "app.asar",
+  "app.asar.unpacked/node_modules/selection-hook/LICENSE",
+  "app.asar.unpacked/node_modules/selection-hook/index.js",
+  {
+    "content": "{
+  "name": "selection-hook",
+  "version": "0.9.9",
+  "description": "Text selection monitoring of native Node.js module with N-API across applications",
+  "author": "0xfullex",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/0xfullex/selection-hook"
+  },
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "MIT",
+  "dependencies": {
+    "node-gyp-build": "^4.7.1"
+  },
+  "devDependencies": {
+    "node-addon-api": "^5.1.0",
+    "node-gyp": "^9.3.1",
+    "prebuildify": "^6.0.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "gypfile": true,
+  "os": [
+    "win32"
+  ]
+}",
+    "name": "app.asar.unpacked/node_modules/selection-hook/package.json",
+  },
+  "app.asar.unpacked/node_modules/selection-hook/src/windows/lib/clipboard.h",
+  "app.asar.unpacked/node_modules/selection-hook/src/windows/lib/string_pool.h",
+  "app.asar.unpacked/node_modules/selection-hook/src/windows/lib/utils.h",
+  "app.asar.unpacked/node_modules/selection-hook/prebuilds/win32-x64/selection-hook.node",
+]
+`;
+
 exports[`hooks as file - cjs 1`] = `
 {
   "linux": [

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -383,6 +383,33 @@ test.ifDevOrLinuxCi("win smart unpack", ({ expect }) => {
   )
 })
 
+test.ifDevOrWinCi("exclude some modules from rebuild", ({ expect }) => {
+  return app(
+    expect,
+    {
+      targets: Platform.WINDOWS.createTarget(DIR_TARGET, Arch.x64),
+      config: {
+        npmRebuild: true,
+        excludeReBuildModules: ["selection-hook"],
+      }
+    },
+    {
+      isInstallDepsBefore: true,
+      projectDirCreated: async (projectDir, tmpDir) => {
+        await modifyPackageJson(projectDir, data => {
+          data.dependencies = {
+            debug: "3.1.0",
+            "selection-hook": "0.9.9",
+          }
+        })
+      },
+      packed: async context => {
+        await verifySmartUnpack(expect, context.getResources(Platform.WINDOWS))
+      },
+    }
+  )
+})
+
 test.ifDevOrWinCi("smart unpack local module with dll file", ({ expect }) => {
   return app(
     expect,

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -396,6 +396,7 @@ test.ifDevOrWinCi("exclude some modules from rebuild", ({ expect }) => {
     {
       isInstallDepsBefore: true,
       projectDirCreated: async (projectDir, tmpDir) => {
+        process.env.npm_config_user_agent = "npm"
         await modifyPackageJson(projectDir, data => {
           data.dependencies = {
             debug: "3.1.0",


### PR DESCRIPTION
Introduced a new configuration option `excludeReBuildModules` to allow users to specify modules that should be excluded from the rebuild process. This option is now available in the `CommonConfiguration` and `PlatformSpecificBuildOptions` interfaces, as well as in the scheme.json file.