### PR TITLE
docs: replace difference to built-in autoUpdater

### DIFF
--- a/pages/auto-update.md
+++ b/pages/auto-update.md
@@ -28,7 +28,7 @@ All these targets are default, custom configuration is not required. (Though it 
 
 The `electron-updater` package offers a different functionality compared to Electron's built-in auto-updater. Here are the differences:
 
-* A dedicated release server is not required.
+* Linux is supported (not only macOS and Windows).
 * Code signature validation not only on macOS, but also on Windows.
 * All required metadata files and artifacts are produced and published automatically.
 * Download progress and [staged rollouts](#staged-rollouts) supported on all platforms.


### PR DESCRIPTION
A dedicated release server is not needed anymore (https://www.electronjs.org/docs/latest/tutorial/updates#using-cloud-object-storage-serverless) but a major existing difference is that only electron-updater supports Linux.