### PR TITLE
fix(dmg): `--force` unmount dmg using hdiutil after delay on Resource Lock (code 16)

### DIFF
--- a/.changeset/soft-pets-warn.md
+++ b/.changeset/soft-pets-warn.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix(dmg): --force unmount dmg using hdiutil after 3sec delay when receiving error code 16 (resource is busy)

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -34,7 +34,15 @@ export async function attachAndExecute(dmgPath: string, readWrite: boolean, task
 }
 
 export async function detach(name: string) {
-  return hdiUtil(["detach", "-quiet", name])
+  return hdiUtil(["detach", "-quiet", name]).catch(async e => {
+    if (e.code === 16) {
+      // Resource busy — the volume is currently in use and cannot be unmounted.
+      // Delay then force unmount with verbose output
+      await new Promise(resolve => setTimeout(resolve, 3000))
+      return hdiUtil(["detach", "--force", name])
+    }
+    throw e
+  })
 }
 
 export async function computeBackground(packager: PlatformPackager<any>): Promise<string> {


### PR DESCRIPTION
Use `--force` to unmount dmg when using hdiutil after 3sec delay if receiving error code 16 (resource is busy)