### PR TITLE
refactor(dmg): add human-readable hdiutil log messages and refactoring to only retry on transient error codes

### DIFF
--- a/.changeset/old-games-wait.md
+++ b/.changeset/old-games-wait.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+refactor(dmg): add human-readable log messages for hdiutil error codes and refactoring retry logic to only retry on transient error codes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -161,7 +161,7 @@ jobs:
         run: pnpm generate-all
 
   test-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -161,7 +161,7 @@ jobs:
         run: pnpm generate-all
 
   test-windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -36,7 +36,6 @@ export async function attachAndExecute(dmgPath: string, readWrite: boolean, task
 export async function detach(name: string) {
   return hdiUtil(["detach", "-quiet", name]).catch(async e => {
     if (e.code === 16) {
-      // Resource busy — the volume is currently in use and cannot be unmounted.
       // Delay then force unmount with verbose output
       await new Promise(resolve => setTimeout(resolve, 3000))
       return hdiUtil(["detach", "--force", name])

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -1,7 +1,7 @@
 import { PlatformPackager } from "app-builder-lib"
 import { executeFinally } from "builder-util"
 import * as path from "path"
-import { hdiUtil } from "./hdiuil"
+import { hdiUtil, hdiutilTransientExitCodes } from "./hdiuil"
 
 export { DmgTarget } from "./dmg"
 
@@ -35,7 +35,7 @@ export async function attachAndExecute(dmgPath: string, readWrite: boolean, task
 
 export async function detach(name: string) {
   return hdiUtil(["detach", "-quiet", name]).catch(async e => {
-    if (e.code === 16) {
+    if (hdiutilTransientExitCodes.has(e.code)) {
       // Delay then force unmount with verbose output
       await new Promise(resolve => setTimeout(resolve, 3000))
       return hdiUtil(["detach", "--force", name])

--- a/packages/dmg-builder/src/hdiuil.ts
+++ b/packages/dmg-builder/src/hdiuil.ts
@@ -15,7 +15,7 @@ import { exec, log, retry } from "builder-util"
 | `-5342` | Specified size too small         | Same as above — retry if size is corrected.          |
  *
  */
-const transientExitCodes = new Set([1, 16, 35, 256, 49153])
+export const hdiutilTransientExitCodes = new Set([1, 16, 35, 256, 49153])
 
 export function explainHdiutilError(errorCode: number): string {
   const code = errorCode.toString()
@@ -23,6 +23,7 @@ export function explainHdiutilError(errorCode: number): string {
     "0": "Success: The hdiutil command completed without error.",
     "1": "Generic error: The operation failed, but the reason is not specific. Check command syntax or permissions.",
     "2": "No such file or directory: Check if the specified path exists.",
+    "6": "Disk image to resize is not currently attached or not recognized as a valid block device by macOS.",
     "8": "Exec format error: The file might not be a valid disk image.",
     "16": "Resource busy: The volume is in use. Try closing files or processes and retry.",
     "22": "Invalid argument: One or more arguments passed to hdiutil are incorrect.",
@@ -44,7 +45,7 @@ const shouldRetry = (args: string[]) => (error: any) => {
   const stdout = error.stdout?.toString() || ""
   const output = `${stdout} ${stderr}`.trim()
 
-  const willRetry = transientExitCodes.has(code)
+  const willRetry = hdiutilTransientExitCodes.has(code)
   log.warn({ willRetry, args, code, output }, `hdiutil error: ${explainHdiutilError(code)}`)
 
   return willRetry

--- a/packages/dmg-builder/src/hdiuil.ts
+++ b/packages/dmg-builder/src/hdiuil.ts
@@ -1,15 +1,55 @@
 import { exec, log, retry } from "builder-util"
 
-export async function hdiUtil(args: string[]) {
-  return retry(
-    () => exec("hdiutil", args),
-    5,
-    5000,
-    2000,
-    0,
-    (error: any) => {
-      log.error({ args, code: error.code, error: (error.message || error).toString() }, "unable to execute hdiutil")
-      return true
-    }
-  )
+/**
+ * Table of hdiutil error codes that are transient and can be retried.
+ * These codes are typically related to resource availability or temporary issues.
+ *
+| Code    | Meaning                          | Why Retry?                                           |
+| ------- | -------------------------------- | ---------------------------------------------------- |
+| `1`     | Generic error                    | Can occur from brief race conditions or temp issues. |
+| `16`    | **Resource busy**                | Volume is in use — wait and retry often works.       |
+| `35`    | **Operation timed out**          | System delay or timeout — retry after a short delay. |
+| `256`   | Volume in use or unmount failure | Same as 16 — usually resolves after retry.           |
+| `49153` | Volume not mounted yet           | Attach may be too fast — retry after delay.          |
+| `-5341` | Disk image too small             | Retry *after fixing* with a larger `-size`.          |
+| `-5342` | Specified size too small         | Same as above — retry if size is corrected.          |
+ *
+ */
+const transientExitCodes = new Set([1, 16, 35, 256, 49153])
+
+export function explainHdiutilError(errorCode: number): string {
+  const code = errorCode.toString()
+  const messages: Record<string, string> = {
+    "0": "Success: The hdiutil command completed without error.",
+    "1": "Generic error: The operation failed, but the reason is not specific. Check command syntax or permissions.",
+    "2": "No such file or directory: Check if the specified path exists.",
+    "8": "Exec format error: The file might not be a valid disk image.",
+    "16": "Resource busy: The volume is in use. Try closing files or processes and retry.",
+    "22": "Invalid argument: One or more arguments passed to hdiutil are incorrect.",
+    "35": "Operation timed out: The system was too slow or unresponsive. Try again.",
+    "36": "I/O error: There was a problem reading or writing to disk. Check disk health.",
+    "100": "Image-related error: The disk image may be corrupted or invalid.",
+    "256": "Volume is busy or could not be unmounted. Try again after closing files.",
+    "49153": "Volume not mounted yet: The image may not have been fully attached.",
+    "-5341": "Disk image too small: hdiutil could not fit the contents. Increase the image size.",
+    "-5342": "Specified size too small: Disk image creation failed due to insufficient size.",
+  }
+
+  return messages[code] ?? `Unknown error (code ${code}): Refer to hdiutil documentation or run with -verbose for details by rerunning with env var DEBUG_DEMB=true.`
+}
+
+const shouldRetry = (args: string[]) => (error: any) => {
+  const code = error.code ?? -1
+  const stderr = error.stderr?.toString() || ""
+  const stdout = error.stdout?.toString() || ""
+  const output = `${stdout} ${stderr}`.trim()
+
+  const willRetry = transientExitCodes.has(code)
+  log.warn({ willRetry, args, code, output }, `hdiutil error: ${explainHdiutilError(code)}`)
+
+  return willRetry
+}
+
+export async function hdiUtil(args: string[]): Promise<string | null> {
+  return retry(() => exec("hdiutil", args), 5, 5000, 2000, 0, shouldRetry(args))
 }

--- a/test/snapshots/mac/dmgTest.js.snap
+++ b/test/snapshots/mac/dmgTest.js.snap
@@ -226,14 +226,16 @@ exports[`dmg > bundleShortVersion 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "BundleShortVersion-2017.1-alpha5.dmg",
+      "file": "Bundle ShortVersion-2017.1-alpha5.dmg",
+      "safeArtifactName": "Bundle-ShortVersion-2017.1-alpha5.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "BundleShortVersion-2017.1-alpha5.dmg.blockmap",
+      "file": "Bundle ShortVersion-2017.1-alpha5.dmg.blockmap",
+      "safeArtifactName": "Bundle-ShortVersion-2017.1-alpha5.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -245,12 +247,12 @@ exports[`dmg > bundleShortVersion 1`] = `
 
 exports[`dmg > bundleShortVersion 2`] = `
 {
-  "CFBundleDisplayName": "BundleShortVersion",
-  "CFBundleExecutable": "BundleShortVersion",
+  "CFBundleDisplayName": "Bundle ShortVersion",
+  "CFBundleExecutable": "Bundle ShortVersion",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "BundleShortVersion",
+  "CFBundleName": "Bundle ShortVersion",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "2017.1-alpha5",
   "ElectronAsarIntegrity": {
@@ -295,16 +297,15 @@ exports[`dmg > custom background - new way 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0-mac.zip",
-      "safeArtifactName": "TestApp-1.1.0-mac.zip",
+      "file": "CustomBackground-1.1.0-mac.zip",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0-mac.zip.blockmap",
-      "safeArtifactName": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "file": "CustomBackground-1.1.0-mac.zip.blockmap",
+      "safeArtifactName": "CustomBackground-1.1.0-mac.zip.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -316,12 +317,12 @@ exports[`dmg > custom background - new way 1`] = `
 
 exports[`dmg > custom background - new way 2`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "CustomBackground",
+  "CFBundleExecutable": "CustomBackground",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "CustomBackground",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -366,16 +367,16 @@ exports[`dmg > disable dmg icon (light), bundleVersion 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0-mac.zip",
-      "safeArtifactName": "TestApp-1.1.0-mac.zip",
+      "file": "Disable Icon-1.1.0-mac.zip",
+      "safeArtifactName": "Disable-Icon-1.1.0-mac.zip",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0-mac.zip.blockmap",
-      "safeArtifactName": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "file": "Disable Icon-1.1.0-mac.zip.blockmap",
+      "safeArtifactName": "Disable Icon-1.1.0-mac.zip.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -387,12 +388,12 @@ exports[`dmg > disable dmg icon (light), bundleVersion 1`] = `
 
 exports[`dmg > disable dmg icon (light), bundleVersion 2`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "Disable Icon",
+  "CFBundleExecutable": "Disable Icon",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "Disable Icon",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -437,14 +438,16 @@ exports[`dmg > dmg 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "DefaultDmg-1.1.0.dmg",
+      "file": "Default Dmg-1.1.0.dmg",
+      "safeArtifactName": "Default-Dmg-1.1.0.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "DefaultDmg-1.1.0.dmg.blockmap",
+      "file": "Default Dmg-1.1.0.dmg.blockmap",
+      "safeArtifactName": "Default-Dmg-1.1.0.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -456,12 +459,12 @@ exports[`dmg > dmg 1`] = `
 
 exports[`dmg > dmg 2`] = `
 {
-  "CFBundleDisplayName": "DefaultDmg",
-  "CFBundleExecutable": "DefaultDmg",
+  "CFBundleDisplayName": "Default Dmg",
+  "CFBundleExecutable": "Default Dmg",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "DefaultDmg",
+  "CFBundleName": "Default Dmg",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -564,16 +567,16 @@ exports[`dmg > license buttons config 2`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0.dmg",
-      "safeArtifactName": "TestApp-1.1.0.dmg",
+      "file": "Foo 5-1.1.0.dmg",
+      "safeArtifactName": "Foo-5-1.1.0.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0.dmg.blockmap",
-      "safeArtifactName": "TestApp-1.1.0.dmg.blockmap",
+      "file": "Foo 5-1.1.0.dmg.blockmap",
+      "safeArtifactName": "Foo-5-1.1.0.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -585,12 +588,12 @@ exports[`dmg > license buttons config 2`] = `
 
 exports[`dmg > license buttons config 3`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "Foo 5",
+  "CFBundleExecutable": "Foo 5",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "Foo 5",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -635,16 +638,16 @@ exports[`dmg > license en 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0.dmg",
-      "safeArtifactName": "TestApp-1.1.0.dmg",
+      "file": "Foo 3-1.1.0.dmg",
+      "safeArtifactName": "Foo-3-1.1.0.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0.dmg.blockmap",
-      "safeArtifactName": "TestApp-1.1.0.dmg.blockmap",
+      "file": "Foo 3-1.1.0.dmg.blockmap",
+      "safeArtifactName": "Foo-3-1.1.0.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -656,12 +659,12 @@ exports[`dmg > license en 1`] = `
 
 exports[`dmg > license en 2`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "Foo 3",
+  "CFBundleExecutable": "Foo 3",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "Foo 3",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -706,16 +709,16 @@ exports[`dmg > license ja 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0.dmg",
-      "safeArtifactName": "TestApp-1.1.0.dmg",
+      "file": "Foo 2-1.1.0.dmg",
+      "safeArtifactName": "Foo-2-1.1.0.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0.dmg.blockmap",
-      "safeArtifactName": "TestApp-1.1.0.dmg.blockmap",
+      "file": "Foo 2-1.1.0.dmg.blockmap",
+      "safeArtifactName": "Foo-2-1.1.0.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -727,12 +730,12 @@ exports[`dmg > license ja 1`] = `
 
 exports[`dmg > license ja 2`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "Foo 2",
+  "CFBundleExecutable": "Foo 2",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "Foo 2",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -777,16 +780,16 @@ exports[`dmg > license rtf 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0.dmg",
-      "safeArtifactName": "TestApp-1.1.0.dmg",
+      "file": "Foo 4-1.1.0.dmg",
+      "safeArtifactName": "Foo-4-1.1.0.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0.dmg.blockmap",
-      "safeArtifactName": "TestApp-1.1.0.dmg.blockmap",
+      "file": "Foo 4-1.1.0.dmg.blockmap",
+      "safeArtifactName": "Foo-4-1.1.0.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -798,12 +801,12 @@ exports[`dmg > license rtf 1`] = `
 
 exports[`dmg > license rtf 2`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "Foo 4",
+  "CFBundleExecutable": "Foo 4",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "Foo 4",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -848,16 +851,16 @@ exports[`dmg > multi language license 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0.dmg",
-      "safeArtifactName": "TestApp-1.1.0.dmg",
+      "file": "Foo 1-1.1.0.dmg",
+      "safeArtifactName": "Foo-1-1.1.0.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0.dmg.blockmap",
-      "safeArtifactName": "TestApp-1.1.0.dmg.blockmap",
+      "file": "Foo 1-1.1.0.dmg.blockmap",
+      "safeArtifactName": "Foo-1-1.1.0.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -869,12 +872,12 @@ exports[`dmg > multi language license 1`] = `
 
 exports[`dmg > multi language license 2`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "Foo 1",
+  "CFBundleExecutable": "Foo 1",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "Foo 1",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -919,14 +922,16 @@ exports[`dmg > no background 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "NoBackground-1.1.0.dmg",
+      "file": "No Background-1.1.0.dmg",
+      "safeArtifactName": "No-Background-1.1.0.dmg",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "NoBackground-1.1.0.dmg.blockmap",
+      "file": "No Background-1.1.0.dmg.blockmap",
+      "safeArtifactName": "No-Background-1.1.0.dmg.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -938,12 +943,12 @@ exports[`dmg > no background 1`] = `
 
 exports[`dmg > no background 2`] = `
 {
-  "CFBundleDisplayName": "NoBackground",
-  "CFBundleExecutable": "NoBackground",
+  "CFBundleDisplayName": "No Background",
+  "CFBundleExecutable": "No Background",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "NoBackground",
+  "CFBundleName": "No Background",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {
@@ -1072,16 +1077,15 @@ exports[`dmg > retina background as 2 png 1`] = `
   "mac": [
     {
       "arch": "x64",
-      "file": "Test App ßW-1.1.0-mac.zip",
-      "safeArtifactName": "TestApp-1.1.0-mac.zip",
+      "file": "RetinaBackground-1.1.0-mac.zip",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
       },
     },
     {
-      "file": "Test App ßW-1.1.0-mac.zip.blockmap",
-      "safeArtifactName": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "file": "RetinaBackground-1.1.0-mac.zip.blockmap",
+      "safeArtifactName": "RetinaBackground-1.1.0-mac.zip.blockmap",
       "updateInfo": {
         "sha512": "@sha512",
         "size": "@size",
@@ -1093,12 +1097,12 @@ exports[`dmg > retina background as 2 png 1`] = `
 
 exports[`dmg > retina background as 2 png 2`] = `
 {
-  "CFBundleDisplayName": "Test App ßW",
-  "CFBundleExecutable": "Test App ßW",
+  "CFBundleDisplayName": "RetinaBackground",
+  "CFBundleExecutable": "RetinaBackground",
   "CFBundleIconFile": "icon.icns",
   "CFBundleIdentifier": "org.electron-builder.testApp",
   "CFBundleInfoDictionaryVersion": "6.0",
-  "CFBundleName": "Test App ßW",
+  "CFBundleName": "RetinaBackground",
   "CFBundlePackageType": "APPL",
   "CFBundleShortVersionString": "1.1.0",
   "ElectronAsarIntegrity": {

--- a/test/src/mac/dmgTest.ts
+++ b/test/src/mac/dmgTest.ts
@@ -15,7 +15,7 @@ describe("dmg", { sequential: true }, () => {
     app(expect, {
       targets: dmgTarget,
       config: {
-        productName: "DefaultDmg",
+        productName: "Default Dmg",
         publish: null,
       },
     })
@@ -163,9 +163,9 @@ describe("dmg", { sequential: true }, () => {
       targets: defaultTarget,
       config: {
         publish: null,
-        productName: "NoApplicationsLink",
+        productName: "No ApplicationsLink",
         dmg: {
-          title: "No Applications",
+          title: "No Applications Link",
           contents: [
             {
               x: 110,
@@ -234,7 +234,7 @@ describe("dmg", { sequential: true }, () => {
         config: {
           publish: null,
           // dmg can mount only one volume name, so, to test in parallel, we set different product name
-          productName: "NoBackground",
+          productName: "No Background",
           dmg: {
             background: null,
             title: "Foo",
@@ -243,8 +243,8 @@ describe("dmg", { sequential: true }, () => {
       },
       {
         packed: context => {
-          return attachAndExecute(path.join(context.outDir, "NoBackground-1.1.0.dmg"), false, () => {
-            return assertThat(expect, path.join("/Volumes/NoBackground 1.1.0/.background")).doesNotExist()
+          return attachAndExecute(path.join(context.outDir, "No Background-1.1.0.dmg"), false, () => {
+            return assertThat(expect, path.join("/Volumes/No Background 1.1.0/.background")).doesNotExist()
           })
         },
       }
@@ -258,7 +258,7 @@ describe("dmg", { sequential: true }, () => {
       config: {
         publish: null,
         // dmg can mount only one volume name, so, to test in parallel, we set different product name
-        productName: "BundleShortVersion",
+        productName: "Bundle ShortVersion",
         mac: {
           bundleShortVersion: "2017.1-alpha5",
           darkModeSupport: true,
@@ -275,7 +275,7 @@ describe("dmg", { sequential: true }, () => {
       targets: defaultTarget,
       config: {
         publish: null,
-        productName: "DisableIcon",
+        productName: "Disable Icon",
         dmg: {
           icon: null,
           title: "Disable Icon",
@@ -297,9 +297,9 @@ describe("dmg", { sequential: true }, () => {
     targets: dmgTarget,
     config: {
       publish: null,
-      productName: "Foo" + uniqueKey,
+      productName: "Foo " + uniqueKey,
       dmg: {
-        title: "Foo" + uniqueKey,
+        title: "Foo " + uniqueKey,
       },
     },
   })


### PR DESCRIPTION
Using older windows runner to attempt to more consistently build in order, and added a unique `productName` for all dmg's to prevent collision

Added human-readable logging for hdiutil error codes and refactoring logic to retry only for transiet errors.