### PR TITLE
chore(test): Adding tests that verify the full flow of install+update (live/blackbox test)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,6 +73,7 @@ jobs:
           - winPackagerTest,winCodeSignTest,webInstallerTest
           - oneClickInstallerTest,assistedInstallerTest
           - concurrentBuildsTest
+          - blackboxUpdateTest
     steps:
       - name: Checkout code repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -171,6 +172,7 @@ jobs:
           - appxTest,msiTest,portableTest,assistedInstallerTest,protonTest
           - BuildTest,oneClickInstallerTest,winPackagerTest,nsisUpdaterTest,webInstallerTest
           - concurrentBuildsTest
+          - blackboxUpdateTest
     steps:
       - name: Checkout code repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -199,6 +201,7 @@ jobs:
           - winPackagerTest,winCodeSignTest,BuildTest
           - masTest,dmgTest,filesTest,macPackagerTest,differentialUpdateTest,macArchiveTest
           - concurrentBuildsTest
+          - blackboxUpdateTest
     steps:
       - name: Checkout code repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/test/fixtures/test-app/app/index.js
+++ b/test/fixtures/test-app/app/index.js
@@ -12,7 +12,7 @@ process.on("unhandledRejection", console.error)
 console.log(`APP_VERSION: ${app.getVersion()}`)
 
 const updateConfigPath = process.env.AUTO_UPDATER_TEST_CONFIG_PATH?.trim()
-const shouldTestAutoUpdater = process.env.AUTO_UPDATER_TEST
+const shouldTestAutoUpdater =!!process.env.AUTO_UPDATER_TEST?.trim() && updateConfigPath
 const root = path.dirname(process.execPath)
 const _appUpdateConfigPath = path.resolve(process.platform === "darwin" ? `${root}/../Resources` : `${root}/resources`, "app-update.yml")
 
@@ -28,7 +28,7 @@ async function init() {
 }
 
 function isReady() {
-  if (!!shouldTestAutoUpdater) {
+  if (shouldTestAutoUpdater) {
     autoUpdater._appUpdateConfigPath = _appUpdateConfigPath
     autoUpdater.updateConfigPath = updateConfigPath
     autoUpdater.logger = console
@@ -37,6 +37,19 @@ function isReady() {
     autoUpdater.checkForUpdates()
     autoUpdater.on("update-downloaded", () => {
       setTimeout(() => autoUpdater.quitAndInstall(false, true), 1000)
+    })
+    autoUpdater.on("update-not-available", () => {
+      console.log("Update not available")
+      app.quit()
+    })
+    autoUpdater.on("error", error => {
+      console.error("Error in auto-updater:", error)
+    })
+    autoUpdater.on("checking-for-update", () => {
+      console.log("Checking for update...")
+    })
+    autoUpdater.on("update-available", () => {
+      console.log("Update available")
     })
   }
 }

--- a/test/fixtures/test-app/app/index.js
+++ b/test/fixtures/test-app/app/index.js
@@ -7,8 +7,13 @@ const app = electron.app
 console.log(`APP_VERSION: ${app.getVersion()}`);
 
 app.on("ready", () => {
-  if (process.env.AUTO_UPDATER_TEST) {
-    autoUpdater.updateConfigPath = process.env.AUTO_UPDATER_TEST_CONFIG_PATH?.trim();
+  const updateConfigPath = process.env.AUTO_UPDATER_TEST_CONFIG_PATH?.trim();
+  const shouldTestAutoUpdater = process.env.AUTO_UPDATER_TEST;
+  console.log(`AUTO_UPDATER_TEST: ${shouldTestAutoUpdater}`);
+  console.log(`AUTO_UPDATER_TEST_CONFIG_PATH: ${updateConfigPath}`);
+
+  if (shouldTestAutoUpdater) {
+    autoUpdater.updateConfigPath = updateConfigPath;
     autoUpdater.checkForUpdates();
     autoUpdater.on("update-downloaded", () => {
       setTimeout(() => autoUpdater.quitAndInstall(false, true), 1000);

--- a/test/fixtures/test-app/app/index.js
+++ b/test/fixtures/test-app/app/index.js
@@ -1,22 +1,42 @@
 "use strict"
 
-const electron = require('electron')
-const autoUpdater = require("electron-updater")
+const electron = require("electron")
+const { autoUpdater } = require("electron-updater")
+const path = require("path")
 
 const app = electron.app
-console.log(`APP_VERSION: ${app.getVersion()}`);
 
-app.on("ready", () => {
-  const updateConfigPath = process.env.AUTO_UPDATER_TEST_CONFIG_PATH?.trim();
-  const shouldTestAutoUpdater = process.env.AUTO_UPDATER_TEST;
-  console.log(`AUTO_UPDATER_TEST: ${shouldTestAutoUpdater}`);
-  console.log(`AUTO_UPDATER_TEST_CONFIG_PATH: ${updateConfigPath}`);
+process.on("uncaughtException", console.error)
+process.on("unhandledRejection", console.error)
 
-  if (shouldTestAutoUpdater) {
-    autoUpdater.updateConfigPath = updateConfigPath;
-    autoUpdater.checkForUpdates();
-    autoUpdater.on("update-downloaded", () => {
-      setTimeout(() => autoUpdater.quitAndInstall(false, true), 1000);
-    });
+console.log(`APP_VERSION: ${app.getVersion()}`)
+
+const updateConfigPath = process.env.AUTO_UPDATER_TEST_CONFIG_PATH?.trim()
+const shouldTestAutoUpdater = process.env.AUTO_UPDATER_TEST
+const root = path.dirname(process.execPath)
+const _appUpdateConfigPath = path.resolve(process.platform === "darwin" ? `${root}/../Resources` : `${root}/resources`, "app-update.yml")
+
+console.log(`Should test autoupdate: ${shouldTestAutoUpdater}`)
+console.log(`Autoupdate config path: ${updateConfigPath}`)
+console.log(`App app-update.yml configuration: ${_appUpdateConfigPath}`)
+
+async function init() {
+  if (!app.isReady()) {
+    await app.whenReady()
   }
-});
+  console.log("APP_VERSION:", app.getVersion())
+  isReady()
+}
+init()
+
+function isReady() {
+  console.log("App is ready")
+  if (!!shouldTestAutoUpdater) {
+    autoUpdater._appUpdateConfigPath = _appUpdateConfigPath
+    autoUpdater.updateConfigPath = updateConfigPath
+    autoUpdater.checkForUpdates()
+    autoUpdater.on("update-downloaded", () => {
+      setTimeout(() => autoUpdater.quitAndInstall(false, true), 1000)
+    })
+  }
+}

--- a/test/fixtures/test-app/app/index.js
+++ b/test/fixtures/test-app/app/index.js
@@ -24,19 +24,27 @@ async function init() {
   if (!app.isReady()) {
     await app.whenReady()
   }
-  console.log("APP_VERSION:", app.getVersion())
   isReady()
 }
-init()
 
 function isReady() {
-  console.log("App is ready")
   if (!!shouldTestAutoUpdater) {
     autoUpdater._appUpdateConfigPath = _appUpdateConfigPath
     autoUpdater.updateConfigPath = updateConfigPath
+    autoUpdater.logger = console
+    autoUpdater.autoDownload = true
+
     autoUpdater.checkForUpdates()
     autoUpdater.on("update-downloaded", () => {
       setTimeout(() => autoUpdater.quitAndInstall(false, true), 1000)
     })
   }
 }
+
+init()
+  .then(() => {
+    console.log("App initialized")
+  })
+  .catch(error => {
+    console.error("Error initializing app:", error)
+  })

--- a/test/fixtures/test-app/app/index.js
+++ b/test/fixtures/test-app/app/index.js
@@ -1,32 +1,17 @@
 "use strict"
 
 const electron = require('electron')
+const autoUpdater = require("electron-updater")
+
 const app = electron.app
-const BrowserWindow = electron.BrowserWindow
+console.log(`APP_VERSION: ${app.getVersion()}`);
 
-let mainWindow
-
-function createWindow () {
-  mainWindow = new BrowserWindow({width: 800, height: 600})
-  mainWindow.loadURL('file://' + __dirname + '/index.html')
-
-  mainWindow.webContents.openDevTools()
-
-  mainWindow.on('closed', function() {
-    mainWindow = null
-  });
-}
-
-app.on('ready', createWindow)
-
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') {
-    app.quit()
+app.on("ready", () => {
+  if (process.env.AUTO_UPDATER_TEST) {
+    autoUpdater.updateConfigPath = process.env.AUTO_UPDATER_TEST_CONFIG_PATH?.trim();
+    autoUpdater.checkForUpdates();
+    autoUpdater.on("update-downloaded", () => {
+      setTimeout(() => autoUpdater.quitAndInstall(false, true), 1000);
+    });
   }
-})
-
-app.on('activate', function () {
-  if (mainWindow === null) {
-    createWindow()
-  }
-})
+});

--- a/test/snapshots/updater/blackboxUpdateTest.js.snap
+++ b/test/snapshots/updater/blackboxUpdateTest.js.snap
@@ -1,0 +1,173 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Electron autoupdate from 1.0.0 to 1.0.1 (live test) > mac 1`] = `
+{
+  "mac": [
+    {
+      "file": "latest-mac.yml",
+      "fileContent": {
+        "files": [
+          {
+            "sha512": "@sha512",
+            "size": "@size",
+            "url": "TestApp-1.0.0-arm64-mac.zip",
+          },
+        ],
+        "path": "TestApp-1.0.0-arm64-mac.zip",
+        "releaseDate": "@releaseDate",
+        "sha512": "@sha512",
+        "version": "1.0.0",
+      },
+    },
+    {
+      "arch": "arm64",
+      "file": "TestApp-1.0.0-arm64-mac.zip",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    {
+      "file": "TestApp-1.0.0-arm64-mac.zip.blockmap",
+      "safeArtifactName": "TestApp-1.0.0-arm64-mac.zip.blockmap",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Electron autoupdate from 1.0.0 to 1.0.1 (live test) > mac 2`] = `
+{
+  "CFBundleDisplayName": "TestApp",
+  "CFBundleExecutable": "TestApp",
+  "CFBundleIconFile": "icon.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "TestApp",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.0.0",
+  "ElectronAsarIntegrity": {
+    "Resources/default_app.asar": {
+      "algorithm": "SHA256",
+      "hash": "hash",
+    },
+  },
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSEnvironment": {
+    "MallocNanoZone": "0",
+  },
+  "NSAppTransportSecurity": {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": {
+      "127.0.0.1": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSBluetoothAlwaysUsageDescription": "This app needs access to Bluetooth",
+  "NSBluetoothPeripheralUsageDescription": "This app needs access to Bluetooth",
+  "NSHighResolutionCapable": true,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
+exports[`Electron autoupdate from 1.0.0 to 1.0.1 (live test) > mac 3`] = `
+{
+  "mac": [
+    {
+      "file": "latest-mac.yml",
+      "fileContent": {
+        "files": [
+          {
+            "sha512": "@sha512",
+            "size": "@size",
+            "url": "TestApp-1.0.1-arm64-mac.zip",
+          },
+        ],
+        "path": "TestApp-1.0.1-arm64-mac.zip",
+        "releaseDate": "@releaseDate",
+        "sha512": "@sha512",
+        "version": "1.0.1",
+      },
+    },
+    {
+      "arch": "arm64",
+      "file": "TestApp-1.0.1-arm64-mac.zip",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    {
+      "file": "TestApp-1.0.1-arm64-mac.zip.blockmap",
+      "safeArtifactName": "TestApp-1.0.1-arm64-mac.zip.blockmap",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`Electron autoupdate from 1.0.0 to 1.0.1 (live test) > mac 4`] = `
+{
+  "CFBundleDisplayName": "TestApp",
+  "CFBundleExecutable": "TestApp",
+  "CFBundleIconFile": "icon.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "TestApp",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.0.1",
+  "ElectronAsarIntegrity": {
+    "Resources/default_app.asar": {
+      "algorithm": "SHA256",
+      "hash": "hash",
+    },
+  },
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSEnvironment": {
+    "MallocNanoZone": "0",
+  },
+  "NSAppTransportSecurity": {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": {
+      "127.0.0.1": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSBluetoothAlwaysUsageDescription": "This app needs access to Bluetooth",
+  "NSBluetoothPeripheralUsageDescription": "This app needs access to Bluetooth",
+  "NSHighResolutionCapable": true,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;

--- a/test/src/helpers/launchAppCrossPlatform.ts
+++ b/test/src/helpers/launchAppCrossPlatform.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcess } from "child_process"
+import { ChildProcess, spawn } from "child_process"
 import os from "os"
 import path from "path"
 
@@ -14,18 +14,10 @@ interface LaunchOptions {
   timeoutMs?: number
   env?: Record<string, string>
   expectedVersion?: string
-  waitForVersionLog?: boolean
   updateConfigPath: string
 }
 
-export async function launchAndWaitForQuit({
-  appPath,
-  timeoutMs = 20000,
-  env = {},
-  expectedVersion,
-  updateConfigPath,
-  waitForVersionLog = true,
-}: LaunchOptions): Promise<LaunchResult> {
+export async function launchAndWaitForQuit({ appPath, timeoutMs = 20000, env = {}, expectedVersion, updateConfigPath }: LaunchOptions): Promise<LaunchResult> {
   return new Promise((resolve, reject) => {
     let child: ChildProcess
 
@@ -93,7 +85,6 @@ export async function launchAndWaitForQuit({
           resolved = true
           resolveResult(resolve, version, 0, stdoutChunks, stderrChunks)
         }
-        child.kill() // best-effort cleanup
       }
     })
 

--- a/test/src/helpers/launchAppCrossPlatform.ts
+++ b/test/src/helpers/launchAppCrossPlatform.ts
@@ -1,0 +1,125 @@
+import { spawn, ChildProcess } from "child_process"
+import os from "os"
+import path from "path"
+
+interface LaunchResult {
+  version?: string
+  exitCode: number | null
+  stdout: string
+  stderr: string
+}
+
+interface LaunchOptions {
+  appPath: string
+  timeoutMs?: number
+  env?: Record<string, string>
+  expectVersion?: string
+  waitForVersionLog?: boolean
+  updateConfigPath: string
+}
+
+export async function launchAndWaitForQuit({
+  appPath,
+  timeoutMs = 20000,
+  env = {},
+  expectVersion,
+  updateConfigPath,
+  waitForVersionLog = true,
+}: LaunchOptions): Promise<LaunchResult> {
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess
+
+    const platform = os.platform()
+    const versionRegex = /APP_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)/
+    const finalEnv = {
+      ...process.env,
+      AUTO_UPDATER_TEST: "1",
+      AUTO_UPDATER_TEST_CONFIG_PATH: updateConfigPath,
+      ...env,
+    }
+
+    const stdoutChunks: string[] = []
+    const stderrChunks: string[] = []
+
+    function spawnApp(command: string, args: string[] = []) {
+      return spawn(command, args, {
+        detached: true,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: finalEnv,
+      })
+    }
+
+    try {
+      switch (platform) {
+        case "darwin": {
+          const binary = path.join(appPath, "Contents", "MacOS", path.basename(appPath, ".app"))
+          child = spawnApp(binary)
+          break
+        }
+        case "win32": {
+          const powershellCmd = `Start-Process -FilePath '${appPath}' -Wait`
+          child = spawn("powershell.exe", ["-NoProfile", "-Command", powershellCmd], {
+            stdio: ["ignore", "pipe", "pipe"],
+            env: finalEnv,
+          })
+          break
+        }
+        case "linux": {
+          child = spawnApp(appPath)
+          break
+        }
+        default:
+          throw new Error(`Unsupported platform: ${platform}`)
+      }
+    } catch (err) {
+      return reject(err)
+    }
+
+    let version: string | undefined
+    let resolved = false
+
+    child.stdout?.on("data", data => {
+      const line = data.toString()
+      stdoutChunks.push(line)
+      const match = line.match(versionRegex)
+      if (match) {
+        version = match[1].trim()
+        if (expectVersion && version !== expectVersion) {
+          reject(new Error(`Expected version ${expectVersion}, got ${version}`))
+        }
+      }
+    })
+
+    child.stderr?.on("data", data => {
+      stderrChunks.push(data.toString())
+    })
+
+    child.on("error", err => {
+      if (!resolved) {
+        resolved = true
+        reject(err)
+      }
+    })
+
+    child.on("exit", code => {
+      if (!resolved) {
+        resolved = true
+        resolve({
+          version,
+          exitCode: code,
+          stdout: stdoutChunks.join(""),
+          stderr: stderrChunks.join(""),
+        })
+      }
+    })
+
+    setTimeout(() => {
+      if (!resolved) {
+        resolved = true
+        reject(new Error(`Timeout after ${timeoutMs}ms\nSTDOUT:\n${stdoutChunks.join("")}\nSTDERR:\n${stderrChunks.join("")}`))
+        child.kill()
+      }
+    }, timeoutMs)
+  })
+}

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -45,6 +45,7 @@ export interface AssertPackOptions {
   readonly signedWin?: boolean
 
   readonly isInstallDepsBefore?: boolean
+  readonly storeDepsLockfileSnapshot?: boolean
 
   readonly publish?: PublishPolicy
 
@@ -137,7 +138,7 @@ export async function assertPack(expect: ExpectStatic, fixtureName: string, pack
 
         const destLockfile = path.join(projectDir, pmOptions.lockfile)
 
-        const shouldUpdateLockfiles = !!process.env.UPDATE_LOCKFILE_FIXTURES
+        const shouldUpdateLockfiles = !!process.env.UPDATE_LOCKFILE_FIXTURES && !!checkOptions.storeDepsLockfileSnapshot
         // check for lockfile fixture so we can use `--frozen-lockfile`
         if ((await exists(testFixtureLockfile)) && !shouldUpdateLockfiles) {
           await copyFile(testFixtureLockfile, destLockfile)
@@ -155,7 +156,7 @@ export async function assertPack(expect: ExpectStatic, fixtureName: string, pack
         })
 
         // save lockfile fixture
-        if (!(await exists(testFixtureLockfile)) || shouldUpdateLockfiles) {
+        if (!(await exists(testFixtureLockfile)) && shouldUpdateLockfiles) {
           const fixtureDir = path.dirname(testFixtureLockfile)
           if (!(await exists(fixtureDir))) {
             await mkdir(fixtureDir)

--- a/test/src/helpers/updaterTestUtil.ts
+++ b/test/src/helpers/updaterTestUtil.ts
@@ -87,3 +87,7 @@ export function trackEvents(updater: AppUpdater) {
   }
   return actualEvents
 }
+export const OLD_VERSION_NUMBER = "1.0.0"
+export const NEW_VERSION_NUMBER = "1.0.1"
+
+export const testAppCacheDirName = "testapp-updater"

--- a/test/src/updater/blackboxUpdateTest.ts
+++ b/test/src/updater/blackboxUpdateTest.ts
@@ -139,21 +139,16 @@ describe("Electron autoupdate from 1.0.0 to 1.0.1 (live test)", () => {
 
       const oldExePath = app2(oldAppDir, targetArch)
 
-      const appVersion = async (expectVersion: string) => await launchAndWaitForQuit({ appPath: oldExePath, updateConfigPath, expectVersion })
-      await appVersion(OLD_VERSION_NUMBER)
+      const appVersion = async (expectedVersion: string) => await launchAndWaitForQuit({ appPath: oldExePath, updateConfigPath, expectedVersion })
+
+      console.log("Verified old version", await appVersion(OLD_VERSION_NUMBER))
 
       // Wait for quitAndInstall to take effect
       await wait(18000) // increase if updates are slower
 
-      // Relaunch app and verify new version
-      // const versionAfter = await launchAppCrossPlatform("open", [oldExePath], updateConfigPath)
-      await appVersion(NEW_VERSION_NUMBER)
-
-      // await appVersion(NEW_VERSION_NUMBER)
-
-      // const verifyNoUpdateSameVersion = await launchAppCrossPlatform("open", [oldExePath], updateConfigPath)
-      // expect(await appVersion()).toBe(NEW_VERSION_NUMBER)
+      console.log("Verified new version", await appVersion(NEW_VERSION_NUMBER))
     })
+    await tmpDir.cleanup()
   })
 })
 

--- a/test/src/updater/blackboxUpdateTest.ts
+++ b/test/src/updater/blackboxUpdateTest.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, ExpectStatic } from "vitest"
+import { ChildProcessWithoutNullStreams, spawn } from "child_process"
+import path from "path"
+import { Platform, Arch, Configuration } from "electron-builder"
+import fs, { outputJson } from "fs-extra"
+import { NEW_VERSION_NUMBER, OLD_VERSION_NUMBER } from "../helpers/updaterTestUtil"
+import { getBinFromUrl } from "app-builder-lib/out/binDownload"
+import { GenericServerOptions, Nullish } from "builder-util-runtime"
+import { doSpawn, getArchSuffix, TmpDir } from "builder-util/out/util"
+import { writeUpdateConfig } from "../helpers/updaterTestUtil"
+import { PackedContext, assertPack, modifyPackageJson } from "../helpers/packTester"
+import { ELECTRON_VERSION } from "../helpers/testConfig"
+import { fileURLToPath } from "url"
+
+async function doBuild(
+  expect: ExpectStatic,
+  outDirs: Array<string>,
+  targets: Map<Platform, Map<Arch, Array<string>>>,
+  tmpDir: TmpDir,
+  isWindows: boolean,
+  extraConfig?: Configuration | null
+) {
+  async function buildApp(
+    version: string,
+    targets: Map<Platform, Map<Arch, Array<string>>>,
+    extraConfig: Configuration | Nullish,
+    packed: (context: PackedContext) => Promise<any>
+  ) {
+    await assertPack(
+      expect,
+      "test-app",
+      {
+        targets,
+        config: {
+          extraMetadata: {
+            version,
+          },
+          ...extraConfig,
+          compression: "store",
+          publish: {
+            provider: "s3",
+            bucket: "develar",
+            path: "test",
+          },
+        },
+      },
+      {
+        isInstallDepsBefore: true,
+        signed: true,
+        signedWin: isWindows,
+        packed,
+        projectDirCreated: projectDir =>
+          Promise.all([
+            modifyPackageJson(projectDir, data => {
+              data.devDependencies = {
+                ...(data.devDependencies || {}),
+                electron: ELECTRON_VERSION,
+              }
+              data.dependencies = {
+                ...(data.devDependencies || {}),
+                "electron-updater": `file:${__dirname}/../../../packages/electron-updater/out`,
+                "builder-util-runtime": `file:${__dirname}/../../../packages/builder-util-runtime/out`,
+              }
+            }),
+          ]),
+      }
+    )
+  }
+
+  const build = (version: string) =>
+    buildApp(version, targets, extraConfig, async context => {
+      // move dist temporarily out of project dir so each downloader can reference it
+      const newDir = await tmpDir.getTempDir({ prefix: version })
+      await fs.move(context.outDir, newDir)
+      outDirs.push(newDir)
+    })
+  try {
+    await build(OLD_VERSION_NUMBER)
+    await build(NEW_VERSION_NUMBER)
+  } catch (e: any) {
+    await tmpDir.cleanup()
+    throw e
+  }
+}
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function launchAppAndGetVersion(executablePath: string, updateConfigPath?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = doSpawn(executablePath, [], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        AUTO_UPDATER_TEST: "1",
+        AUTO_UPDATER_TEST_CONFIG_PATH: updateConfigPath,
+      },
+    }) as ChildProcessWithoutNullStreams
+
+    let stdout = ""
+
+    child.stdout.on("data", data => {
+      const str = data.toString()
+      stdout += str
+
+      const match = str.match(/APP_VERSION:\s*(\d+\.\d+\.\d+)/)
+      if (match) {
+        resolve(match[1])
+        child.kill()
+      }
+    })
+
+    child.stderr.on("data", data => {
+      console.error("stderr:", data.toString())
+    })
+
+    child.on("exit", code => {
+      if (!stdout.includes("APP_VERSION")) {
+        reject(new Error("App exited without logging version."))
+      }
+    })
+
+    setTimeout(() => reject(new Error("Timeout: App did not log version")), 15000)
+  })
+}
+
+describe("Electron autoupdate from 1.0.0 to 1.0.1 (live test)", () => {
+  test.ifEnv(process.env.CSC_KEY_PASSWORD && process.platform === "darwin")("mac", async () => {
+    const tmpDir = new TmpDir("windows-auto-update")
+    const outDirs: string[] = []
+
+    // 1. Build both versions
+    await doBuild(expect, outDirs, Platform.current().createTarget(["zip"], Arch.x64), tmpDir, process.platform === "win32")
+
+    const oldAppDir = outDirs[0]
+    const newAppDir = outDirs[1]
+
+    console.error("Old app dir:", oldAppDir)
+    console.error("New app dir:", newAppDir)
+    const app = (dir: string, version: string) => path.join(dir, "mac", `TestApp.app`, "Contents", "MacOS", "TestApp")
+
+    await runTestWithinServer(async (rootDirectory: string, updateConfigPath: string) => {
+      // Move app update to the root directory of the server
+      await fs.copy(newAppDir, rootDirectory, { recursive: true, overwrite: true })
+
+      const oldExePath = app(oldAppDir, OLD_VERSION_NUMBER)
+      const versionBefore = await launchAppAndGetVersion(oldExePath, updateConfigPath)
+      expect(versionBefore).toBe(OLD_VERSION_NUMBER)
+
+      // Wait for quitAndInstall to take effect
+      await wait(8000) // increase if updates are slower
+
+      // Relaunch app and verify new version
+      const versionAfter = await launchAppAndGetVersion(oldExePath, undefined)
+      expect(versionAfter).toBe(NEW_VERSION_NUMBER)
+    })
+  })
+})
+
+async function runTestWithinServer(doTest: (rootDirectory: string, updateConfigPath: string) => Promise<void>) {
+  const tmpDir = new TmpDir("blackbox-update-test")
+  const root = await tmpDir.getTempDir({ prefix: "root" })
+
+  const port = 8000 + Math.floor(((Math.random() / Math.random()) * 1000) % 65535)
+  const serverBin = await getBinFromUrl("ran", "0.1.3", "imfA3LtT6umMM0BuQ29MgO3CJ9uleN5zRBi3sXzcTbMOeYZ6SQeN7eKr3kXZikKnVOIwbH+DDO43wkiR/qTdkg==")
+  const httpServerProcess = doSpawn(path.join(serverBin, process.platform, "ran"), [`-root=${root}`, `-port=${port}`, "-gzip=false", "-listdir=true"])
+
+  const updateConfig = await writeUpdateConfig<GenericServerOptions>({
+    provider: "generic",
+    url: `http://127.0.0.1:${port}`,
+  })
+
+  return await new Promise<void>((resolve, reject) => {
+    httpServerProcess.on("error", reject)
+    doTest(root, updateConfig).then(resolve).catch(reject)
+  }).then(
+    v => {
+      httpServerProcess.kill()
+      return v
+    },
+    e => {
+      httpServerProcess.kill()
+      throw e
+    }
+  )
+}

--- a/test/src/updater/differentialUpdateTest.ts
+++ b/test/src/updater/differentialUpdateTest.ts
@@ -2,30 +2,16 @@ import { Arch, Configuration, Platform } from "app-builder-lib"
 import { getBinFromUrl } from "app-builder-lib/out/binDownload"
 import { doSpawn, getArchSuffix } from "builder-util"
 import { GenericServerOptions, Nullish, S3Options } from "builder-util-runtime"
-import { AppImageUpdater, BaseUpdater, MacUpdater, NoOpLogger, NsisUpdater } from "electron-updater"
+import { AppImageUpdater, BaseUpdater, MacUpdater, NsisUpdater } from "electron-updater"
 import { EventEmitter } from "events"
 import { move } from "fs-extra"
 import * as path from "path"
 import { TmpDir } from "temp-file"
 import { TestAppAdapter } from "../helpers/TestAppAdapter"
 import { PackedContext, assertPack, removeUnstableProperties } from "../helpers/packTester"
-import { tuneTestUpdater, writeUpdateConfig } from "../helpers/updaterTestUtil"
+import { NEW_VERSION_NUMBER, OLD_VERSION_NUMBER, testAppCacheDirName, tuneTestUpdater, writeUpdateConfig } from "../helpers/updaterTestUtil"
 import { mockForNodeRequire } from "vitest-mock-commonjs"
 import { ExpectStatic } from "vitest"
-
-/*
-
-rm -rf ~/Documents/onshape-desktop-shell/node_modules/electron-updater && cp -R ~/Documents/electron-builder/packages/electron-updater ~/Documents/onshape-desktop-shell/node_modules/electron-updater && rm -rf ~/Documents/onshape-desktop-shell/node_modules/electron-updater/src && rm -rf ~/Documents/onshape-desktop-shell/node_modules/builder-util-runtime && cp -R ~/Documents/electron-builder/packages/builder-util-runtime ~/Documents/onshape-desktop-shell/node_modules/builder-util-runtime && rm -rf ~/Documents/onshape-desktop-shell/node_modules/builder-util-runtime/src
-
-*/
-// %USERPROFILE%\AppData\Roaming\Onshape
-
-// mkdir -p ~/minio-data/onshape
-// minio server ~/minio-data
-
-const OLD_VERSION_NUMBER = "1.0.0"
-
-const testAppCacheDirName = "testapp-updater"
 
 async function doBuild(
   expect: ExpectStatic,
@@ -75,7 +61,7 @@ async function doBuild(
     })
   try {
     await build(OLD_VERSION_NUMBER)
-    await build("1.0.1")
+    await build(NEW_VERSION_NUMBER)
   } catch (e: any) {
     await tmpDir.cleanup()
     throw e
@@ -156,7 +142,7 @@ test.ifMac("Mac universal", ({ expect }) => testMac(expect, Arch.universal))
 // only run on arm64 macs, otherwise of course no files can be found to be updated to (due to arch mismatch)
 test.ifMac.ifEnv(process.arch === "arm64")("Mac arm64", ({ expect }) => testMac(expect, Arch.arm64))
 
-async function checkResult(expect: ExpectStatic, updater: BaseUpdater) {
+export async function checkResult(expect: ExpectStatic, updater: BaseUpdater) {
   // disable automatic install otherwise mac updater will permanently wait on mocked electron's native updater to receive update (mocked server can't install)
   updater.autoInstallOnAppQuit = false
 
@@ -207,7 +193,6 @@ async function testBlockMap(expect: ExpectStatic, oldDir: string, newDir: string
 
   // Mac uses electron's native autoUpdater to serve updates to, we mock here since electron API isn't available within jest runtime
   const mockNativeUpdater = new TestNativeUpdater()
-
   mockForNodeRequire("electron", {
     autoUpdater: mockNativeUpdater,
   })
@@ -226,7 +211,7 @@ async function testBlockMap(expect: ExpectStatic, oldDir: string, newDir: string
         platform: platform.nodeName as any,
         isUseDifferentialDownload: true,
       })
-      updater.logger = new NoOpLogger()
+      updater.logger = console
 
       const currentUpdaterCacheDirName = (await updater.configOnDisk.value).updaterCacheDirName
       if (currentUpdaterCacheDirName == null) {

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -4,32 +4,48 @@ import { UpdateCheckResult } from "electron-updater"
 import { outputFile } from "fs-extra"
 import { tmpdir } from "os"
 import * as path from "path"
+import { ExpectStatic } from "vitest"
 import { assertThat } from "../helpers/fileAssert"
 import { removeUnstableProperties } from "../helpers/packTester"
 import { createNsisUpdater, trackEvents, validateDownload, writeUpdateConfig } from "../helpers/updaterTestUtil"
-import { ExpectStatic } from "vitest"
 
 const config = { retry: 3 }
 
-test.ifWindows("test nsis updater: full install", config, async ({ expect }) => {
-  const updater = await createNsisUpdater("1.0.1")
-  updater.updateConfigPath = await writeUpdateConfig<GithubOptions>({
-    provider: "github",
-    owner: "mmaietta",
-    repo: "electron-builder-test",
-  })
-  const updateCheckResult = await validateDownload(expect, updater)
-  expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
-  expect(updateCheckResult?.downloadPromise).toBeDefined()
-  const files = await updateCheckResult?.downloadPromise
-  expect(files!.length).toEqual(1)
-  const installer = files![0]
-  expect(installer.endsWith(".exe")).toBeTruthy()
-  await assertThat(expect, installer).isFile()
+// test.ifWindows("test nsis updater: full install", config, async ({ expect }) => {
+//   let appPath1: string
+//   await appTwo(
+//     expect,
+//     {
+//       targets: Platform.WINDOWS.createTarget("nsis", Arch.x64),
+//     },
+//     {
+//       packed: async (context) => {
+//         appPath1 = context.getAppPath(Platform.WINDOWS, Arch.x64)
+//         // Install the app
+//         const installerPath = path.join(appPath1, "TestApp-1.0.0.exe")
+//         return Promise.resolve()
+//       }
+//     }
+//   )
 
-  const didInstall = updater.quitAndInstall(true, false)
-  expect(didInstall).toBe(true)
-})
+//   const updater = await createNsisUpdater("1.0.1")
+//   updater.updateConfigPath = await writeUpdateConfig<GithubOptions>({
+//     provider: "github",
+//     owner: "mmaietta",
+//     repo: "electron-builder-test",
+//   })
+//   const updateCheckResult = await validateDownload(expect, updater)
+//   expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
+//   expect(updateCheckResult?.downloadPromise).toBeDefined()
+//   const files = await updateCheckResult?.downloadPromise
+//   expect(files!.length).toEqual(1)
+//   const installer = files![0]
+//   expect(installer.endsWith(".exe")).toBeTruthy()
+//   await assertThat(expect, installer).isFile()
+
+//   const didInstall = updater.quitAndInstall(true, false)
+//   expect(didInstall).toBe(true)
+// })
 
 test("downgrade (disallowed, beta)", config, async ({ expect }) => {
   const updater = await createNsisUpdater("1.5.2-beta.4")

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
 


### PR DESCRIPTION
This is new functionality in the test suite that I pulled from learnings from the electron/universal project

Notes:
- The test app checks for env vars to determine on whether it should check for updates using the native installer
- Serves update file/directory via `ran` (similar to differentialUpdateTest, but that mocks the updater to verify differential blockmaps explicitly)
- Test app logs current app version to console, which is then intercepted by the `blackboxUpdateTest` for verification of the current app version, and then the updated app version (same file path)
- Sets up Mac and Windows installers.
- In progress: Linux Updaters