### PR TITLE
chore: wrapping Error in `exec` rejection so as to pass through error code to downstream logic

### DIFF
--- a/.changeset/little-pandas-mix.md
+++ b/.changeset/little-pandas-mix.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+chore: wrapping Error in exec rejection so as to pass through error code to downstream logic

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -10,6 +10,7 @@ import * as path from "path"
 import { install as installSourceMap } from "source-map-support"
 import { getPath7za } from "./7za"
 import { debug, log } from "./log"
+import { wrap } from "module"
 
 if (process.env.JEST_WORKER_ID == null) {
   installSourceMap()
@@ -142,7 +143,11 @@ export function exec(file: string, args?: Array<string> | null, options?: ExecFi
             message += `\n${chalk.red(stderr.toString())}`
           }
 
-          reject(new Error(message))
+          // TODO: switch to ECMA Script 2026 Error class with `cause` property
+          const wrappedError = new Error(message)
+          ;(wrappedError as any).code = code
+          wrappedError.stack = error.stack
+          reject(wrappedError)
         }
       }
     )


### PR DESCRIPTION
This should properly trigger the `hdiutil` retry logic which is keyed off of error code coming back through exec