### PR TITLE
fix: `electronDist` - detect if directory and copy electron from there, short circuit current logic path

### DIFF
--- a/.changeset/three-schools-beam.md
+++ b/.changeset/three-schools-beam.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: electronDist when specified a path to an unpacked electron dir

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         testFiles:
-          - ArtifactPublisherTest,BuildTest,ExtraBuildTest,RepoSlugTest,binDownloadTest,configurationValidationTest,filenameUtilTest,filesTest,globTest,ignoreTest,macroExpanderTest,mainEntryTest,urlUtilTest,extraMetadataTest,linuxArchiveTest,linuxPackagerTest,HoistedNodeModuleTest,MemoLazyTest,HoistTest
+          - ArtifactPublisherTest,BuildTest,ExtraBuildTest,RepoSlugTest,binDownloadTest,configurationValidationTest,filenameUtilTest,filesTest,globTest,ignoreTest,macroExpanderTest,mainEntryTest,urlUtilTest,extraMetadataTest,linuxArchiveTest,linuxPackagerTest,HoistedNodeModuleTest,MemoLazyTest,HoistTest,ExtraBuildResourcesTest
           - snapTest,debTest,fpmTest,protonTest
           - winPackagerTest,winCodeSignTest,webInstallerTest
           - oneClickInstallerTest,assistedInstallerTest

--- a/test/snapshots/ExtraBuildResourcesTest.js.snap
+++ b/test/snapshots/ExtraBuildResourcesTest.js.snap
@@ -84,6 +84,37 @@ exports[`electronDist as path to local folder with electron builds zipped  1`] =
 }
 `;
 
+exports[`electronDist as standard path to node_modules electron 1`] = `
+{
+  "linux": [],
+}
+`;
+
+exports[`electronDist as standard path to node_modules electron 2`] = `
+[
+  "LICENSE.electron.txt",
+  "LICENSES.chromium.html",
+  "Test App ßW",
+  "chrome-sandbox",
+  "chrome_100_percent.pak",
+  "chrome_200_percent.pak",
+  "chrome_crashpad_handler",
+  "icudtl.dat",
+  "libEGL.so",
+  "libGLESv2.so",
+  "libffmpeg.so",
+  "libvk_swiftshader.so",
+  "libvulkan.so.1",
+  "locales",
+  "resources",
+  "resources.pak",
+  "snapshot_blob.bin",
+  "v8_context_snapshot.bin",
+  "version",
+  "vk_swiftshader_icd.json",
+]
+`;
+
 exports[`override targets in the config - only arch 1`] = `
 {
   "win": [

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -152,7 +152,7 @@ test.ifMac("electronDist", ({ expect }) =>
       },
     },
     {},
-    error => expect(error.message).toContain("Failed to resolve electronDist")
+    error => expect(error.message).toContain("Please provide a valid path to the Electron zip file, cache directory, or electron build directory.")
   )
 )
 

--- a/test/src/windows/winCodeSignTest.ts
+++ b/test/src/windows/winCodeSignTest.ts
@@ -112,7 +112,7 @@ test("electronDist", ({ expect }) =>
       },
     },
     {},
-    error => expect(error.message).toContain("Failed to resolve electronDist")
+    error => expect(error.message).toContain("Please provide a valid path to the Electron zip file, cache directory, or electron build directory.")
   ))
 
 test("azure signing without credentials", ({ expect }) =>


### PR DESCRIPTION
Turns out that `ExtraBuildResourcesTest` wasn't running in the CI. Now it will

Fixes: https://github.com/electron-userland/electron-builder/pull/9126#issuecomment-2948662417