### PR TITLE
feat(nsis): added supports for uninstall components page

### DIFF
--- a/.changeset/thin-geckos-dream.md
+++ b/.changeset/thin-geckos-dream.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+feat(nsis): added supports for uninstall components page

--- a/packages/app-builder-lib/templates/nsis/installer.nsi
+++ b/packages/app-builder-lib/templates/nsis/installer.nsi
@@ -10,6 +10,13 @@ Var oldMenuDirectory
 !include "multiUser.nsh"
 !include "allowOnlyOneInstallerInstance.nsh"
 
+!ifdef BUILD_UNINSTALLER
+  !ifmacrodef customUnInstallSection
+    !define MUI_COMPONENTSPAGE_NODESC
+    !insertmacro MUI_UNPAGE_COMPONENTS
+  !endif
+!endif
+
 !ifdef INSTALL_MODE_PER_ALL_USERS
   !ifdef BUILD_UNINSTALLER
     RequestExecutionLevel user

--- a/packages/app-builder-lib/templates/nsis/uninstaller.nsh
+++ b/packages/app-builder-lib/templates/nsis/uninstaller.nsh
@@ -131,7 +131,12 @@ Function un.restoreFiles
     Exch $R0
 FunctionEnd
 
-Section "un.install"
+!ifndef UNINSTALL_SECTION_NAME
+  !define UNINSTALL_SECTION_NAME "Uninstall"
+!endif
+
+Section "un.${UNINSTALL_SECTION_NAME}"
+  SectionIn RO
   # for assisted installer we check it here to show progress
   !ifndef ONE_CLICK
     ${IfNot} ${Silent}
@@ -243,3 +248,7 @@ Section "un.install"
     !insertmacro quitSuccess
   !endif
 SectionEnd
+
+!ifmacrodef customUnInstallSection
+  !insertmacro customUnInstallSection
+!endif

--- a/pages/nsis.md
+++ b/pages/nsis.md
@@ -29,7 +29,7 @@ Two options are available — [include](#NsisOptions-include) and [script](#Nsis
 Keep in mind — if you customize NSIS script, you should always state about it in the issue reports. And don't expect that your issue will be resolved.
 
 1. Add file `build/installer.nsh`.
-2. Define wanted macro to customise: `customHeader`, `preInit`, `customInit`, `customUnInit`, `customInstall`, `customUnInstall`, `customRemoveFiles`, `customInstallMode`, `customWelcomePage`, `customUnWelcomePage`.
+2. Define wanted macro to customise: `customHeader`, `preInit`, `customInit`, `customUnInit`, `customInstall`, `customUnInstall`, `customRemoveFiles`, `customInstallMode`, `customWelcomePage`, `customUnWelcomePage`, `customUnInstallSection`.
 
     !!! example
         ```nsis
@@ -64,6 +64,13 @@ Keep in mind — if you customize NSIS script, you should always state about it 
           !define MUI_WELCOMEPAGE_TITLE "custom title for uninstaller welcome page"
           !define MUI_WELCOMEPAGE_TEXT "custom text for uninstaller welcome page $\r$\n more"
           !insertmacro MUI_UNPAGE_WELCOME
+        !macroend
+
+        !macro customUnInstallSection
+          Section /o "un.Some cool checkbox"
+            ; You can add some uninstall section as component page
+            ; If defined, then always run after `customUnInstall`
+          SectionEnd
         !macroend
         ```
 


### PR DESCRIPTION
- Added support for uninstall components page.
- Uninstall section is RO (readonly)
- Uninstall section can be rename via `UNINSTALL_SECTION_NAME` definition

Example (installer.nsh):
```nsis
!define UNINSTALL_SECTION_NAME "Odinstalovat prohlížeč"

!macro customUnInstallSection
  Section /o "un.Vymazat data aplikace"
    RMDir /r "$APPDATA\${PRODUCT_NAME}"
  SectionEnd
!macroend
; ...
```  
![2025-06-13 19 25 26](https://github.com/user-attachments/assets/42aaaecf-6c2a-4545-9ac3-82c1808d4c27)
