### PR TITLE
fix: Use `spawn` without `shell: true` for node module collection

### DIFF
--- a/.changeset/heavy-hats-wonder.md
+++ b/.changeset/heavy-hats-wonder.md
@@ -1,5 +1,9 @@
 ---
 "app-builder-lib": patch
+"builder-util": patch
+"builder-util-runtime": patch
+"dmg-builder": patch
+"electron-updater": patch
 ---
 
 fix: remove `shell: true` from node_modules collector so as to prevent shell console logging from malforming the json output

--- a/.changeset/heavy-hats-wonder.md
+++ b/.changeset/heavy-hats-wonder.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: remove `shell: true` from node_modules collector so as to prevent shell console logging from malforming the json output

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -214,7 +214,11 @@ async function importCerts(keychainFile: string, paths: Array<string>, keyPasswo
 }
 
 export async function sign(opts: SignOptions): Promise<void> {
-  return retry(() => signAsync(opts), 3, 5000, 5000)
+  return retry(() => signAsync(opts), {
+    retries: 3,
+    interval: 5000,
+    backoff: 5000,
+  })
 }
 
 export let findIdentityRawResult: Promise<Array<string>> | null = null

--- a/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsCodeSign.ts
@@ -21,17 +21,22 @@ export async function signWindows(options: WindowsSignOptions, packager: WinPack
 }
 
 function signWithRetry(signer: () => Promise<boolean>): Promise<boolean> {
-  return retry(signer, 3, 1000, 1000, 0, (e: any) => {
-    const message = e.message
-    if (
-      // https://github.com/electron-userland/electron-builder/issues/1414
-      message?.includes("Couldn't resolve host name") ||
-      // https://github.com/electron-userland/electron-builder/issues/8615
-      message?.includes("being used by another process.")
-    ) {
-      log.warn({ error: message }, "attempt to sign failed, another attempt will be made")
-      return true
-    }
-    return false
+  return retry(signer, {
+    retries: 3,
+    interval: 1000,
+    backoff: 1000,
+    shouldRetry: (e: any) => {
+      const message = e.message
+      if (
+        // https://github.com/electron-userland/electron-builder/issues/1414
+        message?.includes("Couldn't resolve host name") ||
+        // https://github.com/electron-userland/electron-builder/issues/8615
+        message?.includes("being used by another process.")
+      ) {
+        log.warn({ error: message }, "attempt to sign failed, another attempt will be made")
+        return true
+      }
+      return false
+    },
   })
 }

--- a/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
@@ -449,13 +449,11 @@ export class WindowsSignToolManager implements SignManager {
       }
     }
 
-    await retry(
-      () => vm.exec(tool, args, { timeout, env }),
-      2,
-      15000,
-      10000,
-      0,
-      (e: any) => {
+    await retry(() => vm.exec(tool, args, { timeout, env }), {
+      retries: 2,
+      interval: 15000,
+      backoff: 10000,
+      shouldRetry: (e: any) => {
         if (
           e.message.includes("The file is being used by another process") ||
           e.message.includes("The specified timestamp server either could not be reached") ||
@@ -465,8 +463,8 @@ export class WindowsSignToolManager implements SignManager {
           return true
         }
         return false
-      }
-    )
+      },
+    })
   }
 }
 

--- a/packages/app-builder-lib/src/node-module-collector/index.ts
+++ b/packages/app-builder-lib/src/node-module-collector/index.ts
@@ -3,26 +3,27 @@ import { PnpmNodeModulesCollector } from "./pnpmNodeModulesCollector"
 import { YarnNodeModulesCollector } from "./yarnNodeModulesCollector"
 import { detectPackageManager, PM, getPackageManagerCommand } from "./packageManager"
 import { NodeModuleInfo } from "./types"
+import { TmpDir } from "temp-file"
 
-export async function getCollectorByPackageManager(rootDir: string) {
+export async function getCollectorByPackageManager(rootDir: string, tempDirManager: TmpDir) {
   const manager: PM = detectPackageManager(rootDir)
   switch (manager) {
     case PM.PNPM:
       if (await PnpmNodeModulesCollector.isPnpmProjectHoisted(rootDir)) {
-        return new NpmNodeModulesCollector(rootDir)
+        return new NpmNodeModulesCollector(rootDir, tempDirManager)
       }
-      return new PnpmNodeModulesCollector(rootDir)
+      return new PnpmNodeModulesCollector(rootDir, tempDirManager)
     case PM.NPM:
-      return new NpmNodeModulesCollector(rootDir)
+      return new NpmNodeModulesCollector(rootDir, tempDirManager)
     case PM.YARN:
-      return new YarnNodeModulesCollector(rootDir)
+      return new YarnNodeModulesCollector(rootDir, tempDirManager)
     default:
-      return new NpmNodeModulesCollector(rootDir)
+      return new NpmNodeModulesCollector(rootDir, tempDirManager)
   }
 }
 
-export async function getNodeModules(rootDir: string): Promise<NodeModuleInfo[]> {
-  const collector = await getCollectorByPackageManager(rootDir)
+export async function getNodeModules(rootDir: string, tempDirManager: TmpDir): Promise<NodeModuleInfo[]> {
+  const collector = await getCollectorByPackageManager(rootDir, tempDirManager)
   return collector.getNodeModules()
 }
 

--- a/packages/app-builder-lib/src/node-module-collector/index.ts
+++ b/packages/app-builder-lib/src/node-module-collector/index.ts
@@ -3,20 +3,12 @@ import { PnpmNodeModulesCollector } from "./pnpmNodeModulesCollector"
 import { YarnNodeModulesCollector } from "./yarnNodeModulesCollector"
 import { detectPackageManager, PM, getPackageManagerCommand } from "./packageManager"
 import { NodeModuleInfo } from "./types"
-import { exec } from "builder-util"
-
-async function isPnpmProjectHoisted(rootDir: string) {
-  const command = getPackageManagerCommand(PM.PNPM)
-  const config = await exec(command, ["config", "list"], { cwd: rootDir })
-  const lines = Object.fromEntries(config.split("\n").map(line => line.split("=").map(s => s.trim())))
-  return lines["node-linker"] === "hoisted"
-}
 
 export async function getCollectorByPackageManager(rootDir: string) {
   const manager: PM = detectPackageManager(rootDir)
   switch (manager) {
     case PM.PNPM:
-      if (await isPnpmProjectHoisted(rootDir)) {
+      if (await PnpmNodeModulesCollector.isPnpmProjectHoisted(rootDir)) {
         return new NpmNodeModulesCollector(rootDir)
       }
       return new PnpmNodeModulesCollector(rootDir)

--- a/packages/app-builder-lib/src/node-module-collector/index.ts
+++ b/packages/app-builder-lib/src/node-module-collector/index.ts
@@ -7,7 +7,7 @@ import { exec } from "builder-util"
 
 async function isPnpmProjectHoisted(rootDir: string) {
   const command = getPackageManagerCommand(PM.PNPM)
-  const config = await exec(command, ["config", "list"], { cwd: rootDir, shell: true })
+  const config = await exec(command, ["config", "list"], { cwd: rootDir })
   const lines = Object.fromEntries(config.split("\n").map(line => line.split("=").map(s => s.trim())))
   return lines["node-linker"] === "hoisted"
 }

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -37,7 +37,7 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
   protected async getDependenciesTree(): Promise<T> {
     const command = getPackageManagerCommand(this.installOptions.manager)
     const args = this.getArgs()
-    const dependencies = await exec(command, args, { cwd: this.rootDir, maxBuffer: 1024 * 1024 * 10 })
+    const dependencies = await exec(command, args, { cwd: this.rootDir })
     return this.parseDependenciesTree(dependencies)
   }
 

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -129,7 +129,7 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
   }
 
   async streamCollectorCommandToJsonFile(command: string, args: string[], cwd: string) {
-    const tempFile = await this.tmpDir.getTempFile({ prefix: command, suffix: "output.json" })
+    const tempFile = await this.tmpDir.getTempFile({ prefix: path.basename(command, path.extname(command)), suffix: "output.json" })
 
     await new Promise<void>((resolve, reject) => {
       const outStream = createWriteStream(tempFile)

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -134,7 +134,7 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
       suffix: "output.json",
     })
 
-    const isCmdWithSpaces = process.platform === "win32" && path.extname(command).toLowerCase() === ".cmd" && command.includes(" ")
+    const isCmdWithSpaces = process.platform === "win32" && path.extname(command).toLowerCase() === ".cmd"
 
     const tempBatFile = isCmdWithSpaces
       ? await this.tmpDir.getTempFile({

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -15,7 +15,7 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
   protected productionGraph: DependencyGraph = {}
 
   static async safeExec(command: string, args: string[], cwd: string): Promise<string> {
-    const payload = await execAsync([`"${command}"`, ...args].join(" "), { cwd, maxBuffer: 50 * 1024 * 1024 }) // 50MB buffer, some projects can have extremely large dependency trees
+    const payload = await execAsync([`"${command}"`, ...args].join(" "), { cwd, maxBuffer: 1000 * 1024 * 1024 }) // 1000MB buffer LOL, some projects can have extremely large dependency trees
     return payload.stdout.trim()
   }
 

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -15,7 +15,7 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
   protected productionGraph: DependencyGraph = {}
 
   static async safeExec(command: string, args: string[], cwd: string): Promise<string> {
-    const payload = await execAsync([`"${command}"`, ...args].join(" "), { cwd, maxBuffer: 1024 * 1024 * 1024 }) // 1GB buffer, some projects can have extremely large dependency trees
+    const payload = await execAsync([`"${command}"`, ...args].join(" "), { cwd, maxBuffer: 50 * 1024 * 1024 }) // 50MB buffer, some projects can have extremely large dependency trees
     return payload.stdout.trim()
   }
 

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -37,10 +37,7 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
   protected async getDependenciesTree(): Promise<T> {
     const command = getPackageManagerCommand(this.installOptions.manager)
     const args = this.getArgs()
-    const dependencies = await exec(command, args, {
-      cwd: this.rootDir,
-      shell: true,
-    })
+    const dependencies = await exec(command, args, { cwd: this.rootDir, maxBuffer: 1024 * 1024 * 10 })
     return this.parseDependenciesTree(dependencies)
   }
 

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -58,8 +58,8 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
         try {
           return this.parseDependenciesTree(dependencies)
         } catch (error: any) {
-          log.error({ message: error.message || error.stack, shellOutput: dependencies }, "error parsing dependencies tree")
-          throw new Error(`Failed to parse dependencies tree: ${error.message || error.stack}`)
+          log.debug({ message: error.message || error.stack, shellOutput: dependencies }, "error parsing dependencies tree")
+          throw new Error(`Failed to parse dependencies tree: ${error.message || error.stack}. Use DEBUG=electron-builder env var to see the dependency query output.`)
         }
       },
       {

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -64,7 +64,7 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
       },
       {
         retries: 2,
-        interval: 500,
+        interval: 1000,
         shouldRetry: async (error: any) => {
           if (!(await exists(tempOutputFile))) {
             log.error({ error: error.message || error.stack, tempOutputFile }, "error getting dependencies tree, unable to find output; retrying")

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -14,6 +14,11 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
   protected allDependencies: Map<string, T> = new Map()
   protected productionGraph: DependencyGraph = {}
 
+  static async safeExec(command: string, args: string[], cwd: string): Promise<string> {
+    const payload = await execAsync([`"${command}"`, ...args].join(" "), { cwd, maxBuffer: 1024 * 1024 * 1024 }) // 1GB buffer, some projects can have extremely large dependency trees
+    return payload.stdout.trim()
+  }
+
   constructor(private readonly rootDir: string) {}
 
   public async getNodeModules(): Promise<NodeModuleInfo[]> {
@@ -117,10 +122,5 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
       }
     }
     result.sort((a, b) => a.name.localeCompare(b.name))
-  }
-
-  static async safeExec(command: string, args: string[], cwd: string): Promise<string> {
-    const payload = await execAsync([`"${command}"`, ...args].join(" "), { cwd })
-    return payload.stdout.trim()
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -67,12 +67,12 @@ export abstract class NodeModulesCollector<T extends Dependency<T, OptionalsType
         interval: 500,
         shouldRetry: async (error: any) => {
           if (!(await exists(tempOutputFile))) {
-            log.warn({ error: error.message || error.stack, tempOutputFile }, "error getting dependencies tree, unable to find output; retrying")
+            log.error({ error: error.message || error.stack, tempOutputFile }, "error getting dependencies tree, unable to find output; retrying")
             return true
           }
           const dependencies = await fs.readFile(tempOutputFile, { encoding: "utf8" })
           if (dependencies.trim().length === 0) {
-            log.warn({ error: error.message || error.stack, tempOutputFile }, "dependency tree output file is empty, retrying")
+            log.error({ error: error.message || error.stack, tempOutputFile }, "dependency tree output file is empty, retrying")
             return true
           }
           return false

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -3,7 +3,6 @@ import { PM } from "./packageManager"
 import { NpmDependency } from "./types"
 
 export class NpmNodeModulesCollector extends NodeModulesCollector<NpmDependency, string> {
-
   public readonly installOptions = { manager: PM.NPM, lockfile: "package-lock.json" }
 
   protected getArgs(): string[] {

--- a/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/npmNodeModulesCollector.ts
@@ -3,9 +3,6 @@ import { PM } from "./packageManager"
 import { NpmDependency } from "./types"
 
 export class NpmNodeModulesCollector extends NodeModulesCollector<NpmDependency, string> {
-  constructor(rootDir: string) {
-    super(rootDir)
-  }
 
   public readonly installOptions = { manager: PM.NPM, lockfile: "package-lock.json" }
 

--- a/packages/app-builder-lib/src/node-module-collector/packageManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/packageManager.ts
@@ -25,7 +25,7 @@ function resolveCommand(pm: PM): string {
   }
 
   try {
-    return path.basename(which.sync(fallback))
+    return which.sync(fallback)
   } catch {
     // If `which` fails (not found), still return the fallback string
     return fallback

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -2,10 +2,17 @@ import { log } from "builder-util"
 import * as fs from "fs"
 import * as path from "path"
 import { NodeModulesCollector } from "./nodeModulesCollector"
-import { PM } from "./packageManager"
+import { getPackageManagerCommand, PM } from "./packageManager"
 import { Dependency, PnpmDependency } from "./types"
 
 export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependency, PnpmDependency> {
+  static async isPnpmProjectHoisted(rootDir: string) {
+    const command = getPackageManagerCommand(PM.PNPM)
+    const config = await NodeModulesCollector.safeExec(command, ["config", "list"], rootDir)
+    const lines = Object.fromEntries(config.split("\n").map(line => line.split("=").map(s => s.trim())))
+    return lines["node-linker"] === "hoisted"
+  }
+
   constructor(rootDir: string) {
     super(rootDir)
   }

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -13,10 +13,6 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
     return lines["node-linker"] === "hoisted"
   }
 
-  constructor(rootDir: string) {
-    super(rootDir)
-  }
-
   public readonly installOptions = { manager: PM.PNPM, lockfile: "pnpm-lock.yaml" }
 
   protected getArgs(): string[] {

--- a/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/yarnNodeModulesCollector.ts
@@ -2,10 +2,6 @@ import { NpmNodeModulesCollector } from "./npmNodeModulesCollector"
 import { PM } from "./packageManager"
 
 export class YarnNodeModulesCollector extends NpmNodeModulesCollector {
-  constructor(rootDir: string) {
-    super(rootDir)
-  }
-
   // note: do not override instance-var `pmCommand`. We explicitly use npm for the json payload
   public readonly installOptions = { manager: PM.YARN, lockfile: "yarn.lock" }
 }

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -181,12 +181,12 @@ export async function computeNodeModuleFileSets(platformPackager: PlatformPackag
   const projectDir = platformPackager.info.projectDir
   const appDir = platformPackager.info.appDir
 
-  let deps = await getNodeModules(appDir)
+  let deps = await getNodeModules(appDir, platformPackager.info.tempDirManager)
   if (projectDir !== appDir && deps.length === 0) {
     const packageJson = require(path.join(appDir, "package.json"))
     if (Object.keys(packageJson.dependencies || {}).length > 0) {
       log.debug({ projectDir, appDir }, "no node_modules in app dir, trying to find in project dir")
-      deps = await getNodeModules(projectDir)
+      deps = await getNodeModules(projectDir, platformPackager.info.tempDirManager)
     }
   }
 

--- a/packages/builder-util-runtime/src/retry.ts
+++ b/packages/builder-util-runtime/src/retry.ts
@@ -2,7 +2,7 @@ import { CancellationToken } from "./CancellationToken"
 
 export async function retry<T>(
   task: () => Promise<T>,
-  options: { retries: number; interval: number; backoff: number; attempt: number; shouldRetry?: (e: any) => boolean | Promise<boolean> }
+  options: { retries: number; interval: number; backoff?: number; attempt?: number; shouldRetry?: (e: any) => boolean | Promise<boolean> }
 ): Promise<T> {
   const { retries: retryCount, interval, backoff = 0, attempt = 0, shouldRetry } = options
   const cancellationToken = new CancellationToken()

--- a/packages/builder-util-runtime/src/retry.ts
+++ b/packages/builder-util-runtime/src/retry.ts
@@ -1,13 +1,17 @@
 import { CancellationToken } from "./CancellationToken"
 
-export async function retry<T>(task: () => Promise<T>, retryCount: number, interval: number, backoff = 0, attempt = 0, shouldRetry?: (e: any) => boolean): Promise<T> {
+export async function retry<T>(
+  task: () => Promise<T>,
+  options: { retries: number; interval: number; backoff: number; attempt: number; shouldRetry?: (e: any) => boolean | Promise<boolean> }
+): Promise<T> {
+  const { retries: retryCount, interval, backoff = 0, attempt = 0, shouldRetry } = options
   const cancellationToken = new CancellationToken()
   try {
     return await task()
   } catch (error: any) {
-    if ((shouldRetry?.(error) ?? true) && retryCount > 0 && !cancellationToken.cancelled) {
+    if ((await Promise.resolve(shouldRetry?.(error) ?? true)) && retryCount > 0 && !cancellationToken.cancelled) {
       await new Promise(resolve => setTimeout(resolve, interval + backoff * attempt))
-      return await retry(task, retryCount - 1, interval, backoff, attempt + 1, shouldRetry)
+      return await retry(task, { ...options, retries: retryCount - 1, attempt: attempt + 1 })
     } else {
       throw error
     }

--- a/packages/builder-util-runtime/src/retry.ts
+++ b/packages/builder-util-runtime/src/retry.ts
@@ -2,10 +2,9 @@ import { CancellationToken } from "./CancellationToken"
 
 export async function retry<T>(
   task: () => Promise<T>,
-  options: { retries: number; interval: number; backoff?: number; attempt?: number; shouldRetry?: (e: any) => boolean | Promise<boolean> }
+  options: { retries: number; interval: number; backoff?: number; attempt?: number; cancellationToken?: CancellationToken; shouldRetry?: (e: any) => boolean | Promise<boolean> }
 ): Promise<T> {
-  const { retries: retryCount, interval, backoff = 0, attempt = 0, shouldRetry } = options
-  const cancellationToken = new CancellationToken()
+  const { retries: retryCount, interval, backoff = 0, attempt = 0, shouldRetry, cancellationToken = new CancellationToken() } = options
   try {
     return await task()
   } catch (error: any) {

--- a/packages/builder-util/src/log.ts
+++ b/packages/builder-util/src/log.ts
@@ -69,7 +69,12 @@ export class Logger {
 
   private _doLog(message: string | Error, fields: Fields | null, level: LogLevel) {
     if (this.shouldDisableNonErrorLoggingVitest) {
-      if (["warn", "error"].includes(level)) {
+      if (
+        [
+          // "warn", // is actually a bit too noisy
+          "error",
+        ].includes(level)
+      ) {
         // log error message to console so VITEST can capture stacktrace as well
         console.log(message, fields)
       }

--- a/packages/builder-util/src/log.ts
+++ b/packages/builder-util/src/log.ts
@@ -68,7 +68,11 @@ export class Logger {
   }
 
   private _doLog(message: string | Error, fields: Fields | null, level: LogLevel) {
-    if (this.shouldDisableNonErrorLoggingVitest && level !== "error") {
+    if (this.shouldDisableNonErrorLoggingVitest) {
+      if (["warn", "error"].includes(level)) {
+        // log error message to console so VITEST can capture stacktrace as well
+        console.log(message, fields)
+      }
       return // ignore info/warn message during VITEST workflow if debug flag is disabled
     }
 

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -1,5 +1,5 @@
 import { appBuilderPath } from "app-builder-bin"
-import { retry as _retry, Nullish, safeStringifyJson } from "builder-util-runtime"
+import { retry, Nullish, safeStringifyJson } from "builder-util-runtime"
 import * as chalk from "chalk"
 import { ChildProcess, execFile, ExecFileOptions, SpawnOptions } from "child_process"
 import { spawn as _spawn } from "cross-spawn"
@@ -15,7 +15,7 @@ if (process.env.JEST_WORKER_ID == null) {
   installSourceMap()
 }
 
-export { safeStringifyJson } from "builder-util-runtime"
+export { safeStringifyJson, retry } from "builder-util-runtime"
 export { TmpDir } from "temp-file"
 export * from "./arch"
 export { Arch, archFromString, ArchType, defaultArchFromString, getArchCliNames, getArchSuffix, toLinuxArchString } from "./arch"
@@ -409,25 +409,3 @@ export async function executeAppBuilder(
   }
 }
 
-export async function retry<T>(
-  task: () => Promise<T>,
-  options: {
-    retries: number
-    interval: number
-    backoff?: number
-    attempt?: number // no need to set explicitly, left optional to be handled internally during recursion
-    shouldRetry?: (e: any) => boolean | Promise<boolean>
-  }
-): Promise<T> {
-  const { retries: retryCount, interval, backoff, attempt, shouldRetry } = options
-  return await _retry(task, {
-    retries: retryCount,
-    interval,
-    backoff: backoff ?? 0,
-    attempt: attempt ?? 0,
-    shouldRetry: e => {
-      log.info(`Above command failed, retrying ${retryCount} more times`)
-      return shouldRetry?.(e) ?? true
-    },
-  })
-}

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -408,4 +408,3 @@ export async function executeAppBuilder(
     return retry(runCommand, { retries: maxRetries, interval: 1000 })
   }
 }
-

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -121,14 +121,7 @@ export function exec(file: string, args?: Array<string> | null, options?: ExecFi
           }
           resolve(stdout.toString())
         } else {
-          const code = (error as any).code
-          // https://github.com/npm/npm/issues/17624
-          if (code === 1 && (file.toLowerCase().endsWith("npm") || file.toLowerCase().endsWith("npm.cmd")) && args?.includes("list") && args?.includes("--silent")) {
-            log.debug({ file, code, message: error.message }, "`npm list` returned non-zero exit code, but it is expected (https://github.com/npm/npm/issues/17624)")
-            resolve(stdout.toString())
-            return
-          }
-          let message = chalk.red(removePassword(`Exit code: ${code}. ${error.message}`))
+          let message = chalk.red(removePassword(`Exit code: ${(error as any).code}. ${error.message}`))
           if (stdout.length !== 0) {
             if (file.endsWith("wine")) {
               stdout = stdout.toString()
@@ -143,7 +136,7 @@ export function exec(file: string, args?: Array<string> | null, options?: ExecFi
           }
 
           // TODO: switch to ECMA Script 2026 Error class with `cause` property to return stack trace
-          reject(new ExecError(file, code, message, "", `${error.code || ExecError.code}`))
+          reject(new ExecError(file, (error as any).code, message, "", `${error.code || ExecError.code}`))
         }
       }
     )

--- a/packages/dmg-builder/src/hdiuil.ts
+++ b/packages/dmg-builder/src/hdiuil.ts
@@ -52,5 +52,10 @@ const shouldRetry = (args: string[]) => (error: any) => {
 }
 
 export async function hdiUtil(args: string[]): Promise<string | null> {
-  return retry(() => exec("hdiutil", args), 5, 5000, 2000, 0, shouldRetry(args))
+  return retry(() => exec("hdiutil", args), {
+    retries: 5,
+    interval: 5000,
+    backoff: 2000,
+    shouldRetry: shouldRetry(args),
+  })
 }

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -758,14 +758,17 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
     const tempUpdateFile = await createTempUpdateFile(`temp-${updateFileName}`, cacheDir, log)
     try {
       await taskOptions.task(tempUpdateFile, downloadOptions, packageFile, removeFileIfAny)
-      await retry(
-        () => rename(tempUpdateFile, updateFile),
-        60,
-        500,
-        0,
-        0,
-        error => error instanceof Error && /^EBUSY:/.test(error.message)
-      )
+      await retry(() => rename(tempUpdateFile, updateFile), {
+        retries: 60,
+        interval: 500,
+        shouldRetry: (error: Error) => {
+          if (error instanceof Error && /^EBUSY:/.test(error.message)) {
+            return true
+          }
+          log.warn(`Cannot rename temp file to final file: ${error.message || error.stack}`)
+          return false
+        },
+      })
     } catch (e: any) {
       await removeFileIfAny()
 

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -136,7 +136,7 @@ export async function assertPack(expect: ExpectStatic, fixtureName: string, pack
       }
 
       if (checkOptions.isInstallDepsBefore) {
-        const pm = await getCollectorByPackageManager(projectDir)
+        const pm = await getCollectorByPackageManager(projectDir, tmpDir)
         const pmOptions = pm.installOptions
 
         const destLockfile = path.join(projectDir, pmOptions.lockfile)

--- a/test/src/linux/fpmTest.ts
+++ b/test/src/linux/fpmTest.ts
@@ -2,7 +2,7 @@ import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 
 // "apk" is very slow, don't test for now
-test.ifDevOrLinuxCi("targets", ({ expect }) =>
+test.ifDevOrLinuxCi("targets", { timeout: 120 * 1000 }, ({ expect }) =>
   app(expect, {
     targets: Platform.LINUX.createTarget(["sh", "freebsd", "pacman", "zip", "7z"]),
     config: {

--- a/test/src/linux/fpmTest.ts
+++ b/test/src/linux/fpmTest.ts
@@ -2,7 +2,7 @@ import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 
 // "apk" is very slow, don't test for now
-test.ifDevOrLinuxCi("targets", { timeout: 5 * 60 * 1000 }, ({ expect }) =>
+test.ifDevOrLinuxCi("targets", { timeout: 10 * 60 * 1000 }, ({ expect }) =>
   app(expect, {
     targets: Platform.LINUX.createTarget(["sh", "freebsd", "pacman", "zip", "7z"]),
     config: {

--- a/test/src/linux/fpmTest.ts
+++ b/test/src/linux/fpmTest.ts
@@ -2,7 +2,7 @@ import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 
 // "apk" is very slow, don't test for now
-test.ifDevOrLinuxCi("targets", { timeout: 120 * 1000 }, ({ expect }) =>
+test.ifDevOrLinuxCi("targets", { timeout: 3 * 60 * 1000 }, ({ expect }) =>
   app(expect, {
     targets: Platform.LINUX.createTarget(["sh", "freebsd", "pacman", "zip", "7z"]),
     config: {

--- a/test/src/linux/fpmTest.ts
+++ b/test/src/linux/fpmTest.ts
@@ -2,7 +2,7 @@ import { Platform } from "electron-builder"
 import { app } from "../helpers/packTester"
 
 // "apk" is very slow, don't test for now
-test.ifDevOrLinuxCi("targets", { timeout: 3 * 60 * 1000 }, ({ expect }) =>
+test.ifDevOrLinuxCi("targets", { timeout: 5 * 60 * 1000 }, ({ expect }) =>
   app(expect, {
     targets: Platform.LINUX.createTarget(["sh", "freebsd", "pacman", "zip", "7z"]),
     config: {


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/9020.

Research is here: https://github.com/electron-userland/electron-builder/issues/9020#issuecomment-3006486452

TLDR; having `shell: true` can result in malformed JSON because console could log something during profile loading. We need to remove the `shell: true`, but `.cmd` and spaces in the path are not supported when not an explicit executable on Windows. This is a particular caveat of Windows requiring a workaround

Solution:
- cross-platform
- JSON-safe without console Profile log noise (e.g. shell: false)
- supports .cmd/.bat/.exe and no-extension file paths
- works with paths containing spaces
- automatic temp .bat creation only when necessary


Might fix OOM: https://github.com/electron-userland/electron-builder/issues/9147 since we're now piping `spawn` to a writable stream to a file, which we then read in later. This allows more efficient memory utilization during the shell execution (no `maxBuffer` preallocated to handle 1GB for instance`, and ability to backpressure file operations), then it's read into memory using readFile.