### PR TITLE
feat(electron-updater): add GitLab provider

### DIFF
--- a/.changeset/funny-bottles-occur.md
+++ b/.changeset/funny-bottles-occur.md
@@ -1,0 +1,6 @@
+---
+"builder-util-runtime": major
+"electron-updater": major
+---
+
+feat(electron-updater): add GitLab provider support

--- a/.changeset/funny-bottles-occur.md
+++ b/.changeset/funny-bottles-occur.md
@@ -1,6 +1,6 @@
 ---
-"builder-util-runtime": major
-"electron-updater": major
+"builder-util-runtime": patch
+"electron-updater": patch
 ---
 
 feat(electron-updater): add GitLab provider support

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -357,8 +357,8 @@ function parseUrl(url: string, options: RequestOptions): URL {
     return new URL(url)
   } else {
     // Relative URL - construct base URL from original options
+    const hostname = options.hostname
     const protocol = options.protocol || "https:"
-    const hostname = options.hostname || "localhost"
     const port = options.port ? `:${options.port}` : ""
     const baseUrl = `${protocol}//${hostname}${port}`
     return new URL(url, baseUrl)

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -352,10 +352,10 @@ export interface DownloadCallOptions {
 }
 
 function parseUrl(url: string, options: RequestOptions): URL {
-  if (url.startsWith("http://") || url.startsWith("https://")) {
-    // Absolute URL
+  try {
+    // Would throw exception if url is not absolute
     return new URL(url)
-  } else {
+  } catch {
     // Relative URL - construct base URL from original options
     const hostname = options.hostname
     const protocol = options.protocol || "https:"

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -319,7 +319,7 @@ Please double check that your authentication token is correct. Due to security r
     const newOptions = configureRequestOptionsFromUrl(redirectUrl, { ...options })
     const headers = newOptions.headers
     if (headers?.authorization) {
-      const parsedNewUrl = new URL(redirectUrl)
+      const parsedNewUrl = parseUrl(redirectUrl, options)
       if (parsedNewUrl.hostname.endsWith(".amazonaws.com") || parsedNewUrl.searchParams.has("X-Amz-Credential")) {
         delete headers.authorization
       }
@@ -351,9 +351,24 @@ export interface DownloadCallOptions {
   destination: string | null
 }
 
+function parseUrl(url: string, options: RequestOptions): URL {
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    // Absolute URL
+    return new URL(url)
+  } else {
+    // Relative URL - construct base URL from original options
+    const protocol = options.protocol || "https:"
+    const hostname = options.hostname || "localhost"
+    const port = options.port ? `:${options.port}` : ""
+    const baseUrl = `${protocol}//${hostname}${port}`
+    return new URL(url, baseUrl)
+  }
+}
+
 export function configureRequestOptionsFromUrl(url: string, options: RequestOptions) {
   const result = configureRequestOptions(options)
-  configureRequestUrl(new URL(url), result)
+  const parsedUrl = parseUrl(url, options)
+  configureRequestUrl(parsedUrl, result)
   return result
 }
 

--- a/packages/builder-util-runtime/src/index.ts
+++ b/packages/builder-util-runtime/src/index.ts
@@ -26,6 +26,7 @@ export {
   getS3LikeProviderBaseUrl,
   GithubOptions,
   githubUrl,
+  GitlabOptions,
   KeygenOptions,
   PublishConfiguration,
   PublishProvider,

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -167,12 +167,6 @@ export interface GitlabOptions extends PublishConfiguration {
   readonly host?: string | null
 
   /**
-   * The protocol. GitLab supports both `https` and `http`.
-   * @default https
-   */
-  readonly protocol?: "https" | "http" | null
-
-  /**
    * The access token to support auto-update from private GitLab repositories. Never specify it in the configuration files. Only for [setFeedURL](./auto-update.md#appupdatersetfeedurloptions).
    */
   readonly token?: string | null

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -1,12 +1,13 @@
 import { OutgoingHttpHeaders } from "http"
 import { Nullish } from "."
 
-export type PublishProvider = "github" | "s3" | "spaces" | "generic" | "custom" | "snapStore" | "keygen" | "bitbucket"
+export type PublishProvider = "github" | "gitlab" | "s3" | "spaces" | "generic" | "custom" | "snapStore" | "keygen" | "bitbucket"
 
 // typescript-json-schema generates only PublishConfiguration if it is specified in the list, so, it is not added here
 export type AllPublishOptions =
   | string
   | GithubOptions
+  | GitlabOptions
   | S3Options
   | SpacesOptions
   | GenericServerOptions
@@ -140,6 +141,47 @@ export interface GithubOptions extends PublishConfiguration {
 /** @private */
 export function githubUrl(options: GithubOptions, defaultHost = "github.com") {
   return `${options.protocol || "https"}://${options.host || defaultHost}`
+}
+
+/**
+ * [GitLab](https://docs.gitlab.com/ee/user/project/releases/) options.
+ *
+ * GitLab [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) is required for private repositories. You can generate one by going to your GitLab profile settings.
+ * Define `GITLAB_TOKEN` environment variable.
+ */
+export interface GitlabOptions extends PublishConfiguration {
+  /**
+   * The provider. Must be `gitlab`.
+   */
+  readonly provider: "gitlab"
+
+  /**
+   * The GitLab project ID or namespace/project-name.
+   */
+  readonly projectId: string | number
+
+  /**
+   * The host (including the port if needed).
+   * @default gitlab.com
+   */
+  readonly host?: string | null
+
+  /**
+   * The protocol. GitLab supports both `https` and `http`.
+   * @default https
+   */
+  readonly protocol?: "https" | "http" | null
+
+  /**
+   * The access token to support auto-update from private GitLab repositories. Never specify it in the configuration files. Only for [setFeedURL](./auto-update.md#appupdatersetfeedurloptions).
+   */
+  readonly token?: string | null
+
+  /**
+   * The channel.
+   * @default latest
+   */
+  readonly channel?: string | null
 }
 
 /**

--- a/packages/electron-updater/src/providerFactory.ts
+++ b/packages/electron-updater/src/providerFactory.ts
@@ -6,6 +6,7 @@ import {
   GenericServerOptions,
   getS3LikeProviderBaseUrl,
   GithubOptions,
+  GitlabOptions,
   KeygenOptions,
   newError,
   PublishConfiguration,
@@ -14,6 +15,7 @@ import { AppUpdater } from "./AppUpdater"
 import { BitbucketProvider } from "./providers/BitbucketProvider"
 import { GenericProvider } from "./providers/GenericProvider"
 import { GitHubProvider } from "./providers/GitHubProvider"
+import { GitLabProvider } from "./providers/GitLabProvider"
 import { KeygenProvider } from "./providers/KeygenProvider"
 import { PrivateGitHubProvider } from "./providers/PrivateGitHubProvider"
 import { Provider, ProviderRuntimeOptions } from "./providers/Provider"
@@ -42,6 +44,9 @@ export function createClient(data: PublishConfiguration | AllPublishOptions, upd
 
     case "bitbucket":
       return new BitbucketProvider(data as BitbucketOptions, updater, runtimeOptions)
+
+    case "gitlab":
+      return new GitLabProvider(data as GitlabOptions, updater, runtimeOptions)
 
     case "keygen":
       return new KeygenProvider(data as KeygenOptions, updater, runtimeOptions)

--- a/packages/electron-updater/src/providers/GitLabProvider.ts
+++ b/packages/electron-updater/src/providers/GitLabProvider.ts
@@ -1,0 +1,193 @@
+import { CancellationToken, GitlabOptions, HttpError, newError, UpdateFileInfo, UpdateInfo } from "builder-util-runtime"
+import { URL } from "url"
+import { AppUpdater } from "../AppUpdater"
+import { ResolvedUpdateFileInfo } from "../types"
+import { getChannelFilename, newBaseUrl, newUrlFromBase } from "../util"
+import { getFileList, parseUpdateInfo, Provider, ProviderRuntimeOptions } from "./Provider"
+
+interface GitlabUpdateInfo extends UpdateInfo {
+  tag: string
+  assets: Map<string, string> // filename -> download URL mapping
+}
+
+interface GitlabReleaseInfo {
+  name: string
+  tag_name: string
+  description: string
+  created_at: string
+  released_at: string
+  upcoming_release: boolean
+  assets: {
+    count: number
+    sources: Array<{
+      format: string
+      url: string
+    }>
+    links: Array<{
+      id: number
+      name: string
+      url: string
+      direct_asset_url: string
+      link_type: string
+    }>
+  }
+}
+
+export class GitLabProvider extends Provider<GitlabUpdateInfo> {
+  private readonly baseApiUrl: URL
+
+  constructor(
+    private readonly options: GitlabOptions,
+    private readonly updater: AppUpdater,
+    runtimeOptions: ProviderRuntimeOptions
+  ) {
+    super({
+      ...runtimeOptions,
+      // GitLab might not support multiple range requests efficiently
+      isUseMultipleRangeRequest: false,
+    })
+
+    const defaultHost = "gitlab.com"
+    const host = options.host || defaultHost
+    const protocol = options.protocol || "https"
+
+    this.baseApiUrl = newBaseUrl(`${protocol}://${host}/api/v4`)
+  }
+
+  private get channel(): string {
+    const result = this.updater.channel || this.options.channel
+    return result == null ? this.getDefaultChannelName() : this.getCustomChannelName(result)
+  }
+
+  async getLatestVersion(): Promise<GitlabUpdateInfo> {
+    const cancellationToken = new CancellationToken()
+
+    // Get latest release from GitLab API using the permalink/latest endpoint
+    const latestReleaseUrl = newUrlFromBase(`projects/${this.options.projectId}/releases/permalink/latest`, this.baseApiUrl)
+
+    let latestRelease: GitlabReleaseInfo
+    try {
+      const releaseResponse = await this.httpRequest(
+        latestReleaseUrl,
+        {
+          accept: "application/json",
+          "PRIVATE-TOKEN": this.options.token || "",
+        },
+        cancellationToken
+      )
+
+      if (!releaseResponse) {
+        throw newError("No latest release found", "ERR_UPDATER_NO_PUBLISHED_VERSIONS")
+      }
+
+      latestRelease = JSON.parse(releaseResponse)
+    } catch (e: any) {
+      throw newError(`Unable to find latest release on GitLab (${latestReleaseUrl}): ${e.stack || e.message}`, "ERR_UPDATER_LATEST_VERSION_NOT_FOUND")
+    }
+
+    const tag = latestRelease.tag_name
+
+    // Look for channel file in release assets
+    let rawData: string | null = null
+    let channelFile = ""
+    let channelFileUrl: URL | null = null
+
+    const fetchChannelData = async (channelName: string): Promise<string> => {
+      channelFile = getChannelFilename(channelName)
+
+      // Find the channel file in GitLab release assets
+      const channelAsset = latestRelease.assets.links.find(asset => asset.name === channelFile)
+
+      if (!channelAsset) {
+        throw newError(`Cannot find ${channelFile} in the latest release assets`, "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND")
+      }
+
+      channelFileUrl = new URL(channelAsset.direct_asset_url)
+      const headers = this.options.token ? { "PRIVATE-TOKEN": this.options.token } : undefined
+
+      try {
+        const result = await this.httpRequest(channelFileUrl, headers, cancellationToken)
+        if (!result) {
+          throw newError(`Empty response from ${channelFileUrl}`, "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND")
+        }
+        return result
+      } catch (e: any) {
+        if (e instanceof HttpError && e.statusCode === 404) {
+          throw newError(`Cannot find ${channelFile} in the latest release artifacts (${channelFileUrl}): ${e.stack || e.message}`, "ERR_UPDATER_CHANNEL_FILE_NOT_FOUND")
+        }
+        throw e
+      }
+    }
+
+    try {
+      rawData = await fetchChannelData(this.channel)
+    } catch (e: any) {
+      // If custom channel fails, try default channel as fallback
+      if (this.channel !== this.getDefaultChannelName()) {
+        rawData = await fetchChannelData(this.getDefaultChannelName())
+      } else {
+        throw e
+      }
+    }
+
+    if (!rawData) {
+      throw newError(`Unable to parse channel data from ${channelFile}`, "ERR_UPDATER_INVALID_UPDATE_INFO")
+    }
+
+    const result = parseUpdateInfo(rawData, channelFile, channelFileUrl!)
+
+    // Set release name from GitLab if not present
+    if (result.releaseName == null) {
+      result.releaseName = latestRelease.name
+    }
+
+    // Set release notes from GitLab description if not present
+    if (result.releaseNotes == null) {
+      result.releaseNotes = latestRelease.description || null
+    }
+
+    // Create assets map from GitLab release assets
+    const assetsMap = new Map<string, string>()
+    for (const asset of latestRelease.assets.links) {
+      assetsMap.set(asset.name, asset.direct_asset_url)
+    }
+
+    return {
+      tag: tag,
+      assets: assetsMap,
+      ...result,
+    }
+  }
+
+  resolveFiles(updateInfo: GitlabUpdateInfo): Array<ResolvedUpdateFileInfo> {
+    return getFileList(updateInfo).map((fileInfo: UpdateFileInfo) => {
+      // GitLab assets may have spaces replaced with dashes
+      const possibleNames = [
+        fileInfo.url, // Original filename
+        fileInfo.url.replace(/ /g, "-"), // Spaces replaced with dashes
+      ]
+
+      let assetUrl: string | undefined
+      for (const name of possibleNames) {
+        assetUrl = updateInfo.assets.get(name)
+        if (assetUrl) break
+      }
+
+      if (!assetUrl) {
+        throw newError(
+          `Cannot find asset "${fileInfo.url}" in GitLab release assets. Available assets: ${Array.from(updateInfo.assets.keys()).join(", ")}`,
+          "ERR_UPDATER_ASSET_NOT_FOUND"
+        )
+      }
+
+      return {
+        url: new URL(assetUrl),
+        info: fileInfo,
+      }
+    })
+  }
+
+  toString(): string {
+    return `GitLab (projectId: ${this.options.projectId}, channel: ${this.channel})`
+  }
+}

--- a/packages/electron-updater/src/providers/GitLabProvider.ts
+++ b/packages/electron-updater/src/providers/GitLabProvider.ts
@@ -51,9 +51,8 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
 
     const defaultHost = "gitlab.com"
     const host = options.host || defaultHost
-    const protocol = options.protocol || "https"
 
-    this.baseApiUrl = newBaseUrl(`${protocol}://${host}/api/v4`)
+    this.baseApiUrl = newBaseUrl(`https://${host}/api/v4`)
   }
 
   private get channel(): string {

--- a/packages/electron-updater/src/providers/GitLabProvider.ts
+++ b/packages/electron-updater/src/providers/GitLabProvider.ts
@@ -17,20 +17,22 @@ interface GitlabReleaseInfo {
   created_at: string
   released_at: string
   upcoming_release: boolean
-  assets: {
-    count: number
-    sources: Array<{
-      format: string
-      url: string
-    }>
-    links: Array<{
-      id: number
-      name: string
-      url: string
-      direct_asset_url: string
-      link_type: string
-    }>
-  }
+  assets: GitlabReleaseAsset
+}
+
+interface GitlabReleaseAsset {
+  count: number
+  sources: Array<{
+    format: string
+    url: string
+  }>
+  links: Array<{
+    id: number
+    name: string
+    url: string
+    direct_asset_url: string
+    link_type: string
+  }>
 }
 
 export class GitLabProvider extends Provider<GitlabUpdateInfo> {
@@ -167,11 +169,8 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
         fileInfo.url.replace(/ /g, "-"), // Spaces replaced with dashes
       ]
 
-      let assetUrl: string | undefined
-      for (const name of possibleNames) {
-        assetUrl = updateInfo.assets.get(name)
-        if (assetUrl) break
-      }
+      const matchingAssetName = possibleNames.find(name => updateInfo.assets.has(name))
+      const assetUrl = matchingAssetName ? updateInfo.assets.get(matchingAssetName) : undefined
 
       if (!assetUrl) {
         throw newError(

--- a/packages/electron-updater/src/providers/GitLabProvider.ts
+++ b/packages/electron-updater/src/providers/GitLabProvider.ts
@@ -150,7 +150,7 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
     // Create assets map from GitLab release assets
     const assetsMap = new Map<string, string>()
     for (const asset of latestRelease.assets.links) {
-      assetsMap.set(asset.name, asset.direct_asset_url)
+      assetsMap.set(asset.name.replace(/ /g, "-"), asset.direct_asset_url)
     }
 
     return {

--- a/test/snapshots/updater/nsisUpdaterTest.js.snap
+++ b/test/snapshots/updater/nsisUpdaterTest.js.snap
@@ -377,6 +377,80 @@ exports[`file url github private 2`] = `
 ]
 `;
 
+exports[`file url gitlab 1`] = `
+{
+  "assets": Map {
+    "myApp-1.4.19.exe" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/5380695460839605bb43ca57876c65ce/myApp-1.4.19.exe",
+    "latest.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/f6761055faa67eafb151341367e7c891/latest.yml",
+    "builder-debug.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/c1d7c1a1abf0c9a8ebb660cdfe6085fb/builder-debug.yml",
+  },
+  "files": [
+    {
+      "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
+      "size": 71956233,
+      "url": "myApp-1.4.19.exe",
+    },
+  ],
+  "path": "myApp-1.4.19.exe",
+  "releaseDate": "2023-09-24T10:10:44.654Z",
+  "releaseName": "v1.4.19",
+  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
+
+
+### Bug Fixes
+
+* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
+
+
+
+",
+  "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
+  "tag": "v1.4.19",
+  "version": "1.4.19",
+}
+`;
+
+exports[`file url gitlab 2`] = `
+{
+  "assets": Map {
+    "myApp-1.4.19.exe" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/5380695460839605bb43ca57876c65ce/myApp-1.4.19.exe",
+    "latest.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/f6761055faa67eafb151341367e7c891/latest.yml",
+    "builder-debug.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/c1d7c1a1abf0c9a8ebb660cdfe6085fb/builder-debug.yml",
+  },
+  "files": [
+    {
+      "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
+      "size": 71956233,
+      "url": "myApp-1.4.19.exe",
+    },
+  ],
+  "path": "myApp-1.4.19.exe",
+  "releaseDate": "2023-09-24T10:10:44.654Z",
+  "releaseName": "v1.4.19",
+  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
+
+
+### Bug Fixes
+
+* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
+
+
+
+",
+  "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
+  "tag": "v1.4.19",
+  "version": "1.4.19",
+}
+`;
+
+exports[`file url gitlab 3`] = `
+[
+  "checking-for-update",
+  "update-available",
+  "update-downloaded",
+]
+`;
+
 exports[`file url keygen 1`] = `
 {
   "files": [
@@ -436,6 +510,71 @@ exports[`github allowPrerelease=true 1`] = `
   "sha512": "@sha512",
   "tag": "v2.0.0",
   "version": "2.0.0",
+}
+`;
+
+exports[`gitlab - manual download 1`] = `
+{
+  "assets": {},
+  "files": [
+    {
+      "sha512": "@sha512",
+      "size": "@size",
+      "url": "myApp-1.4.19.exe",
+    },
+  ],
+  "path": "myApp-1.4.19.exe",
+  "releaseDate": "@releaseDate",
+  "releaseName": "v1.4.19",
+  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
+
+
+### Bug Fixes
+
+* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
+
+
+
+",
+  "sha512": "@sha512",
+  "tag": "v1.4.19",
+  "version": "1.4.19",
+}
+`;
+
+exports[`gitlab - manual download 2`] = `
+[
+  "checking-for-update",
+  "update-available",
+]
+`;
+
+exports[`gitlab checkForUpdates 1`] = `
+{
+  "assets": {},
+  "files": [
+    {
+      "sha512": "@sha512",
+      "size": "@size",
+      "url": "myApp-1.4.19.exe",
+    },
+  ],
+  "path": "myApp-1.4.19.exe",
+  "releaseDate": "@releaseDate",
+  "releaseName": "v1.4.19",
+  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
+
+
+### Bug Fixes
+
+* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
+
+
+
+",
+  "sha512": "@sha512",
+  "tag": "v1.4.19",
+  "version": "1.4.19",
 }
 `;
 

--- a/test/snapshots/updater/nsisUpdaterTest.js.snap
+++ b/test/snapshots/updater/nsisUpdaterTest.js.snap
@@ -380,66 +380,48 @@ exports[`file url github private 2`] = `
 exports[`file url gitlab 1`] = `
 {
   "assets": Map {
-    "myApp-1.4.19.exe" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/5380695460839605bb43ca57876c65ce/myApp-1.4.19.exe",
-    "latest.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/f6761055faa67eafb151341367e7c891/latest.yml",
-    "builder-debug.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/c1d7c1a1abf0c9a8ebb660cdfe6085fb/builder-debug.yml",
+    "gitlab-electron-updater-test-Setup-1.0.0.exe" => "https://gitlab.com/-/project/71361100/uploads/e091e17d4af22a810eb3364850efee91/gitlab-electron-updater-test_Setup_1.0.0.exe",
+    "latest.yml" => "https://gitlab.com/-/project/71361100/uploads/3d114468f4225779109ea1dc462fcc47/latest.yml",
+    "gitlab-electron-updater-test-Setup-1.0.0.exe.blockmap" => "https://gitlab.com/-/project/71361100/uploads/351b843d22eea25c79909c6b8eb94bd5/gitlab-electron-updater-test_Setup_1.0.0.exe.blockmap",
   },
   "files": [
     {
-      "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
-      "size": 71956233,
-      "url": "myApp-1.4.19.exe",
+      "sha512": "xQVjQm2Jpo+88NyCdSoyNlgSj+hDj7oP5A5endhg1x+7sjanRcicQj62SIV7u9GIusYyy+9bDsxDBdyVHo4bEg==",
+      "size": 78217306,
+      "url": "gitlab-electron-updater-test-Setup-1.0.0.exe",
     },
   ],
-  "path": "myApp-1.4.19.exe",
-  "releaseDate": "2023-09-24T10:10:44.654Z",
-  "releaseName": "v1.4.19",
-  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
-
-
-### Bug Fixes
-
-* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
-
-
-
-",
-  "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
-  "tag": "v1.4.19",
-  "version": "1.4.19",
+  "path": "gitlab-electron-updater-test-Setup-1.0.0.exe",
+  "releaseDate": "2025-07-04T09:14:24.881Z",
+  "releaseName": "Release v1.0.0",
+  "releaseNotes": "Automated release for v1.0.0",
+  "sha512": "xQVjQm2Jpo+88NyCdSoyNlgSj+hDj7oP5A5endhg1x+7sjanRcicQj62SIV7u9GIusYyy+9bDsxDBdyVHo4bEg==",
+  "tag": "v1.0.0",
+  "version": "1.0.0",
 }
 `;
 
 exports[`file url gitlab 2`] = `
 {
   "assets": Map {
-    "myApp-1.4.19.exe" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/5380695460839605bb43ca57876c65ce/myApp-1.4.19.exe",
-    "latest.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/f6761055faa67eafb151341367e7c891/latest.yml",
-    "builder-debug.yml" => "https://gitlab.com/daihere1993/electron-cicd-gitlab/uploads/c1d7c1a1abf0c9a8ebb660cdfe6085fb/builder-debug.yml",
+    "gitlab-electron-updater-test-Setup-1.0.0.exe" => "https://gitlab.com/-/project/71361100/uploads/e091e17d4af22a810eb3364850efee91/gitlab-electron-updater-test_Setup_1.0.0.exe",
+    "latest.yml" => "https://gitlab.com/-/project/71361100/uploads/3d114468f4225779109ea1dc462fcc47/latest.yml",
+    "gitlab-electron-updater-test-Setup-1.0.0.exe.blockmap" => "https://gitlab.com/-/project/71361100/uploads/351b843d22eea25c79909c6b8eb94bd5/gitlab-electron-updater-test_Setup_1.0.0.exe.blockmap",
   },
   "files": [
     {
-      "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
-      "size": 71956233,
-      "url": "myApp-1.4.19.exe",
+      "sha512": "xQVjQm2Jpo+88NyCdSoyNlgSj+hDj7oP5A5endhg1x+7sjanRcicQj62SIV7u9GIusYyy+9bDsxDBdyVHo4bEg==",
+      "size": 78217306,
+      "url": "gitlab-electron-updater-test-Setup-1.0.0.exe",
     },
   ],
-  "path": "myApp-1.4.19.exe",
-  "releaseDate": "2023-09-24T10:10:44.654Z",
-  "releaseName": "v1.4.19",
-  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
-
-
-### Bug Fixes
-
-* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
-
-
-
-",
-  "sha512": "LnjTKVyKKiUKk+EF/4iT5EyxiNORnyHEGvkL+h6FNU58MLcMGJCqiLondvi3T+MxV7fo5oh4950rjSuSfj95dw==",
-  "tag": "v1.4.19",
-  "version": "1.4.19",
+  "path": "gitlab-electron-updater-test-Setup-1.0.0.exe",
+  "releaseDate": "2025-07-04T09:14:24.881Z",
+  "releaseName": "Release v1.0.0",
+  "releaseNotes": "Automated release for v1.0.0",
+  "sha512": "xQVjQm2Jpo+88NyCdSoyNlgSj+hDj7oP5A5endhg1x+7sjanRcicQj62SIV7u9GIusYyy+9bDsxDBdyVHo4bEg==",
+  "tag": "v1.0.0",
+  "version": "1.0.0",
 }
 `;
 
@@ -520,25 +502,16 @@ exports[`gitlab - manual download 1`] = `
     {
       "sha512": "@sha512",
       "size": "@size",
-      "url": "myApp-1.4.19.exe",
+      "url": "gitlab-electron-updater-test-Setup-1.0.0.exe",
     },
   ],
-  "path": "myApp-1.4.19.exe",
+  "path": "gitlab-electron-updater-test-Setup-1.0.0.exe",
   "releaseDate": "@releaseDate",
-  "releaseName": "v1.4.19",
-  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
-
-
-### Bug Fixes
-
-* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
-
-
-
-",
+  "releaseName": "Release v1.0.0",
+  "releaseNotes": "Automated release for v1.0.0",
   "sha512": "@sha512",
-  "tag": "v1.4.19",
-  "version": "1.4.19",
+  "tag": "v1.0.0",
+  "version": "1.0.0",
 }
 `;
 
@@ -556,25 +529,16 @@ exports[`gitlab checkForUpdates 1`] = `
     {
       "sha512": "@sha512",
       "size": "@size",
-      "url": "myApp-1.4.19.exe",
+      "url": "gitlab-electron-updater-test-Setup-1.0.0.exe",
     },
   ],
-  "path": "myApp-1.4.19.exe",
+  "path": "gitlab-electron-updater-test-Setup-1.0.0.exe",
   "releaseDate": "@releaseDate",
-  "releaseName": "v1.4.19",
-  "releaseNotes": "## [1.4.19](https://gitlab.com/daihere1993/electron-cicd-gitlab/compare/v1.4.18...v1.4.19) (2023-09-24)
-
-
-### Bug Fixes
-
-* test ([0264068](https://gitlab.com/daihere1993/electron-cicd-gitlab/commit/02640686b6016cfbb2b8d4a1b76a7bff268ec8c2))
-
-
-
-",
+  "releaseName": "Release v1.0.0",
+  "releaseNotes": "Automated release for v1.0.0",
   "sha512": "@sha512",
-  "tag": "v1.4.19",
-  "version": "1.4.19",
+  "tag": "v1.0.0",
+  "version": "1.0.0",
 }
 `;
 

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -95,7 +95,7 @@ test("file url gitlab", config, async ({ expect }) => {
   const updater = await createNsisUpdater()
   const options: GitlabOptions = {
     provider: "gitlab",
-    projectId: 50484362, // electron-cicd-gitlab - has latest.yml and proper installers
+    projectId: 71361100,
   }
   updater.updateConfigPath = await writeUpdateConfig(options)
   updater.signals.updateDownloaded(info => {
@@ -111,7 +111,7 @@ test("gitlab checkForUpdates", config, async ({ expect }) => {
   const updater = await createNsisUpdater("0.0.1")
   updater.updateConfigPath = await writeUpdateConfig<GitlabOptions>({
     provider: "gitlab",
-    projectId: 50484362, // electron-cicd-gitlab - has latest.yml and proper installers
+    projectId: 71361100,
   })
 
   const actualEvents: Array<string> = []
@@ -131,7 +131,7 @@ test("gitlab - manual download", config, async ({ expect }) => {
   const updater = await createNsisUpdater("0.0.1")
   updater.updateConfigPath = await writeUpdateConfig<GitlabOptions>({
     provider: "gitlab",
-    projectId: 50484362, // electron-cicd-gitlab - has latest.yml and proper installers
+    projectId: 71361100,
   })
   updater.autoDownload = false
 

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -1,4 +1,4 @@
-import { BitbucketOptions, GenericServerOptions, GithubOptions, KeygenOptions, S3Options, SpacesOptions } from "builder-util-runtime"
+import { BitbucketOptions, GenericServerOptions, GithubOptions, GitlabOptions, KeygenOptions, S3Options, SpacesOptions } from "builder-util-runtime"
 import { BitbucketPublisher } from "electron-publish"
 import { UpdateCheckResult } from "electron-updater"
 import { outputFile } from "fs-extra"
@@ -89,6 +89,61 @@ test.ifEnv(process.env.BITBUCKET_TOKEN)("file url bitbucket", config, async ({ e
   updater.addAuthHeader(BitbucketPublisher.convertAppPassword(options.owner, process.env.BITBUCKET_TOKEN!))
   updater.updateConfigPath = await writeUpdateConfig(options)
   await validateDownload(expect, updater)
+})
+
+test("file url gitlab", config, async ({ expect }) => {
+  const updater = await createNsisUpdater()
+  const options: GitlabOptions = {
+    provider: "gitlab",
+    projectId: 50484362, // electron-cicd-gitlab - has latest.yml and proper installers
+  }
+  updater.updateConfigPath = await writeUpdateConfig(options)
+  updater.signals.updateDownloaded(info => {
+    expect(info.downloadedFile).not.toBeNull()
+
+    delete (info as any).downloadedFile
+    expect(info).toMatchSnapshot()
+  })
+  await validateDownload(expect, updater)
+})
+
+test("gitlab checkForUpdates", config, async ({ expect }) => {
+  const updater = await createNsisUpdater("0.0.1")
+  updater.updateConfigPath = await writeUpdateConfig<GitlabOptions>({
+    provider: "gitlab",
+    projectId: 50484362, // electron-cicd-gitlab - has latest.yml and proper installers
+  })
+
+  const actualEvents: Array<string> = []
+  const expectedEvents = ["checking-for-update", "update-available"] as const
+  for (const eventName of expectedEvents) {
+    updater.addListener(eventName, () => {
+      actualEvents.push(eventName)
+    })
+  }
+
+  const updateCheckResult = await updater.checkForUpdates()
+  expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
+  expect(actualEvents).toEqual(expectedEvents)
+})
+
+test("gitlab - manual download", config, async ({ expect }) => {
+  const updater = await createNsisUpdater("0.0.1")
+  updater.updateConfigPath = await writeUpdateConfig<GitlabOptions>({
+    provider: "gitlab",
+    projectId: 50484362, // electron-cicd-gitlab - has latest.yml and proper installers
+  })
+  updater.autoDownload = false
+
+  const actualEvents = trackEvents(updater)
+
+  const updateCheckResult = await updater.checkForUpdates()
+  expect(removeUnstableProperties(updateCheckResult?.updateInfo)).toMatchSnapshot()
+  // noinspection JSIgnoredPromiseFromCall
+  expect(updateCheckResult?.downloadPromise).toBeNull()
+  expect(actualEvents).toMatchSnapshot()
+
+  await assertThat(expect, path.join((await updater.downloadUpdate())[0])).isFile()
 })
 
 test.skip("DigitalOcean Spaces", config, async ({ expect }) => {


### PR DESCRIPTION
### 🔧 **Usage Example**
```typescript
autoUpdater.setFeedURL({
  provider: 'gitlab',
  projectId: 12345,
  token: process.env.GITLAB_TOKEN // for private repos
})
```

### 🧪 **Testing**
- [x] Integration tests added
- [x] Follows existing provider patterns  
- [x] Works with GitLab.com and self-hosted instances

### 📚 **Documentation**
Let me know, if need to update.