### PR TITLE
fix(nsis): implement custom function to handle /D parameter with spaces

### DIFF
--- a/.changeset/famous-berries-clap.md
+++ b/.changeset/famous-berries-clap.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): implement custom function to handle /D parameter with spaces


### PR DESCRIPTION
Added a new macro `GetDParameter` to improve handling of the /D command line parameter in NSIS scripts. This function extracts the installation path correctly even when it contains spaces, ensuring compatibility with the NSIS requirements for the /D parameter.

fix #7946 

test results:

![image](https://github.com/user-attachments/assets/1da9610b-6575-4db5-8651-48d2104655fd)
![image](https://github.com/user-attachments/assets/05201632-ea8c-41f7-b059-3f4c01ff6357)
