### PR TITLE
feat(github): Add `tagNamePrefix` option

### DIFF
--- a/.changeset/chatty-points-shop.md
+++ b/.changeset/chatty-points-shop.md
@@ -1,0 +1,7 @@
+---
+"app-builder-lib": patch
+"builder-util-runtime": patch
+"electron-publish": patch
+---
+
+feat(github): Add `tagNamePrefix` option and deprecate `vPrefixedTagName`

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -1603,6 +1603,10 @@
           "default": true,
           "description": "Whether to use `v`-prefixed tag name.",
           "type": "boolean"
+        },
+        "tagNamePrefix": {
+          "description": "Sets the prefix of the tag name that comes before the semver number. Overrides vPrefixedTagName.",
+          "type": "string"
         }
       },
       "required": [

--- a/packages/app-builder-lib/src/publish/PublishManager.ts
+++ b/packages/app-builder-lib/src/publish/PublishManager.ts
@@ -5,6 +5,7 @@ import {
   GenericServerOptions,
   getS3LikeProviderBaseUrl,
   GithubOptions,
+  githubTagPrefix,
   githubUrl,
   KeygenOptions,
   Nullish,
@@ -385,7 +386,7 @@ export function computeDownloadUrl(publishConfiguration: PublishConfiguration, f
   let baseUrl
   if (publishConfiguration.provider === "github") {
     const gh = publishConfiguration as GithubOptions
-    baseUrl = `${githubUrl(gh)}/${gh.owner}/${gh.repo}/releases/download/${gh.vPrefixedTagName === false ? "" : "v"}${packager.appInfo.version}`
+    baseUrl = `${githubUrl(gh)}/${gh.owner}/${gh.repo}/releases/download/${githubTagPrefix(gh)}${packager.appInfo.version}`
   } else {
     baseUrl = getS3LikeProviderBaseUrl(publishConfiguration)
   }

--- a/packages/builder-util-runtime/src/index.ts
+++ b/packages/builder-util-runtime/src/index.ts
@@ -26,6 +26,7 @@ export {
   getS3LikeProviderBaseUrl,
   GithubOptions,
   githubUrl,
+  githubTagPrefix,
   GitlabOptions,
   KeygenOptions,
   PublishConfiguration,

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -98,8 +98,16 @@ export interface GithubOptions extends PublishConfiguration {
   /**
    * Whether to use `v`-prefixed tag name.
    * @default true
+   * @deprecated please use #tagNamePrefix instead.
    */
   readonly vPrefixedTagName?: boolean
+
+  /**
+   * If defined, sets the prefix of the tag name that comes before the semver number.
+   * e.g. "v" in "v1.2.3" or "test" of "test1.2.3".
+   * Overrides `vPrefixedTagName`
+   */
+  readonly tagNamePrefix?: string
 
   /**
    * The host (including the port if need).
@@ -141,6 +149,16 @@ export interface GithubOptions extends PublishConfiguration {
 /** @private */
 export function githubUrl(options: GithubOptions, defaultHost = "github.com") {
   return `${options.protocol || "https"}://${options.host || defaultHost}`
+}
+
+export function githubTagPrefix(options: GithubOptions) {
+  if (options.tagNamePrefix) {
+    return options.tagNamePrefix
+  }
+  if (options.vPrefixedTagName ?? true) {
+    return 'v'
+  }
+  return ''
 }
 
 /**

--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -1,5 +1,5 @@
 import { Arch, Fields, httpExecutor, InvalidConfigurationError, isEmptyOrSpaces, isEnvTrue, isTokenCharValid, log } from "builder-util"
-import { configureRequestOptions, GithubOptions, HttpError, parseJson } from "builder-util-runtime"
+import { configureRequestOptions, GithubOptions, HttpError, parseJson, githubTagPrefix } from "builder-util-runtime"
 import { ClientRequest } from "http"
 import { Lazy } from "lazy-val"
 import * as mime from "mime"
@@ -65,7 +65,7 @@ export class GitHubPublisher extends HttpPublisher {
       throw new InvalidConfigurationError(`Version must not start with "v": ${version}`)
     }
 
-    this.tag = info.vPrefixedTagName === false ? version : `v${version}`
+    this.tag = githubTagPrefix(info) + version
 
     if (isEnvTrue(process.env.EP_DRAFT)) {
       this.releaseType = "draft"


### PR DESCRIPTION
This adds support for an optional `tagNamePrefix` setting in `GithubOptions`. This is joined by the a new `githubTagPrefix()` function that handles the creation of any prefix that should be prepended to the version number. When present, `tagNamePrefix` will override any `vPrefixedTagName` value.

This allows users of github updates to use any tag prefix they like. This makes the updater more adaptable and more easily used in monorepo projects that may use multiple different tag prefixes to mark the versions of different packages within the repo.