### PR TITLE
fix: correct broken links in builder.ts and cli.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ const Platform = builder.Platform
 builder.build({
   targets: Platform.MAC.createTarget(),
   config: {
-   "//": "build options, see https://goo.gl/QQXmcV"
+   "//": "build options, see https://www.electron.build/"
   }
 })
   .then(() => {

--- a/packages/electron-builder/src/builder.ts
+++ b/packages/electron-builder/src/builder.ts
@@ -222,19 +222,19 @@ export function configureBuildCommand(yargs: yargs.Argv): yargs.Argv {
     .option("mac", {
       group: buildGroup,
       alias: ["m", "o", "macos"],
-      description: `Build for macOS, accepts target list (see ${chalk.underline("https://goo.gl/5uHuzj")}).`,
+      description: `Build for macOS, accepts target list (see ${chalk.underline("https://www.electron.build/mac")}).`,
       type: "array",
     })
     .option("linux", {
       group: buildGroup,
       alias: "l",
-      description: `Build for Linux, accepts target list (see ${chalk.underline("https://goo.gl/4vwQad")})`,
+      description: `Build for Linux, accepts target list (see ${chalk.underline("https://www.electron.build/linux")})`,
       type: "array",
     })
     .option("win", {
       group: buildGroup,
       alias: ["w", "windows"],
-      description: `Build for Windows, accepts target list (see ${chalk.underline("https://goo.gl/jYsTEJ")})`,
+      description: `Build for Windows, accepts target list (see ${chalk.underline("https://www.electron.build/win")})`,
       type: "array",
     })
     .option("x64", {
@@ -270,7 +270,7 @@ export function configureBuildCommand(yargs: yargs.Argv): yargs.Argv {
     .option("publish", {
       group: publishGroup,
       alias: "p",
-      description: `Publish artifacts, see ${chalk.underline("https://goo.gl/tSFycD")}`,
+      description: `Publish artifacts, see ${chalk.underline("https://www.electron.build/publish")}`,
       choices: ["onTag", "onTagOrDraft", "always", "never", undefined as any],
     })
     .option("prepackaged", {
@@ -287,7 +287,7 @@ export function configureBuildCommand(yargs: yargs.Argv): yargs.Argv {
       alias: ["c"],
       group: buildGroup,
       description:
-        "The path to an electron-builder config. Defaults to `electron-builder.yml` (or `json`, or `json5`, or `js`, or `ts`), see " + chalk.underline("https://goo.gl/YFRJOM"),
+        "The path to an electron-builder config. Defaults to `electron-builder.yml` (or `json`, or `json5`, or `js`, or `ts`), see " + chalk.underline("https://www.electron.build/configuration"),
     })
     .group(["help", "version"], "Other:")
     .example("electron-builder -mwl", "build for macOS, Windows and Linux")

--- a/pages/cli.md
+++ b/pages/cli.md
@@ -11,11 +11,11 @@ Commands:
 
 Building:
   --mac, -m, -o, --macos   Build for macOS, accepts target list (see
-                           https://goo.gl/5uHuzj).                       [array]
+                           https://www.electron.build/mac)               [array]
   --linux, -l              Build for Linux, accepts target list (see
-                           https://goo.gl/4vwQad)                        [array]
+                           https://www.electron.build/linux)             [array]
   --win, -w, --windows     Build for Windows, accepts target list (see
-                           https://goo.gl/jYsTEJ)                        [array]
+                           https://www.electron.build/win)               [array]
   --x64                    Build for x64                               [boolean]
   --ia32                   Build for ia32                              [boolean]
   --armv7l                 Build for armv7l                            [boolean]
@@ -32,7 +32,7 @@ Building:
 
 Publishing:
   --publish, -p  Publish artifacts (to GitHub Releases), see
-                 https://goo.gl/tSFycD
+                 https://www.electron.build/publish
                 [choices: "onTag", "onTagOrDraft", "always", "never", undefined]
 
 
@@ -49,7 +49,7 @@ Options:
   -f, --files    The file(s) to upload to your publisher      [array] [required]
   -c, --config   The path to an electron-builder config. Defaults to
                  `electron-builder.yml` (or `json`, or `json5`, or `js`, or
-                 `ts`), see https://goo.gl/YFRJOM                       [string]
+                 `ts`), see https://www.electron.build/configuration   [string]
 
 Other:
   --help     Show help                                                 [boolean]


### PR DESCRIPTION
* Fixes broken or outdated links in `cli.md` and `builder.ts`
* Makes sure all CLI and builder references point to the correct URLs