### PR TITLE
fix(yarn): check for dependencies in both projectDir and appDir during installation

### DIFF
--- a/.changeset/rude-donuts-bathe.md
+++ b/.changeset/rude-donuts-bathe.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(yarn): check for dependencies in both projectDir and appDir during installation

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -21,7 +21,7 @@ export async function installOrRebuild(config: Configuration, { appDir, projectD
   let isDependenciesInstalled = false
 
   for (const fileOrDir of ["node_modules", ".pnp.js"]) {
-    if (await pathExists(path.join(projectDir, fileOrDir)) || await pathExists(path.join(appDir, fileOrDir))) {
+    if ((await pathExists(path.join(projectDir, fileOrDir))) || (await pathExists(path.join(appDir, fileOrDir)))) {
       isDependenciesInstalled = true
 
       break

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -21,7 +21,7 @@ export async function installOrRebuild(config: Configuration, { appDir, projectD
   let isDependenciesInstalled = false
 
   for (const fileOrDir of ["node_modules", ".pnp.js"]) {
-    if (await pathExists(path.join(appDir, fileOrDir))) {
+    if (await pathExists(path.join(projectDir, fileOrDir)) || await pathExists(path.join(appDir, fileOrDir))) {
       isDependenciesInstalled = true
 
       break


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/6448

In a workspace setup, the `node_modules` inside the app directory often doesn't exist, while the one in the project directory does. Therefore, we can add an additional check to verify the existence of `node_modules` in the project directory.