### PR TITLE
fix(squirrel-windows): update loadingGif handling to prioritize user-defined option

### DIFF
--- a/.changeset/lovely-geckos-chew.md
+++ b/.changeset/lovely-geckos-chew.md
@@ -1,0 +1,5 @@
+---
+"electron-builder-squirrel-windows": patch
+---
+
+fix(squirrel-windows): update loadingGif handling to prioritize user-defined option

--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -203,7 +203,9 @@ export default class SquirrelWindowsTarget extends Target {
       options.remoteReleases = this.options.remoteReleases
     }
 
-    if (!("loadingGif" in options)) {
+    if (this.options.loadingGif) {
+      options.loadingGif = path.resolve(packager.projectDir, this.options.loadingGif)
+    } else {
       const resourceList = await packager.resourceList
       if (resourceList.includes("install-spinner.gif")) {
         options.loadingGif = path.join(packager.buildResourcesDir, "install-spinner.gif")


### PR DESCRIPTION
fix https://github.com/electron-userland/electron-builder/issues/9184