### PR TITLE
fix(electron-updater): Do not wrap update command when updating with sudo

### DIFF
--- a/.changeset/sharp-elephants-shout.md
+++ b/.changeset/sharp-elephants-shout.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix(electron-updater): do not use quotes when installing update with sudo

--- a/packages/electron-updater/src/LinuxUpdater.ts
+++ b/packages/electron-updater/src/LinuxUpdater.ts
@@ -31,8 +31,11 @@ export abstract class LinuxUpdater extends BaseUpdater {
     const installComment = `"${name} would like to update"`
     const sudo = this.sudoWithArgs(installComment)
     this._logger.info(`Running as non-root user, using sudo to install: ${sudo}`)
-    // pkexec doesn't want the command to be wrapped in " quotes
-    const wrapper = /pkexec/i.test(sudo[0]) ? "" : `"`
+    let wrapper = `"`
+    // some sudo commands dont want the command to be wrapped in " quotes
+    if (/pkexec/i.test(sudo[0]) || sudo[0] === "sudo") {
+      wrapper = ""
+    }
     return this.spawnSyncLog(sudo[0], [...(sudo.length > 1 ? sudo.slice(1) : []), `${wrapper}/bin/bash`, "-c", `'${commandWithArgs.join(" ")}'${wrapper}`])
   }
 


### PR DESCRIPTION
When updating an application on a system without graphical authentication agents the `sudo` execution fails with `command not found` because the command is wrapped in quotes.

This pull request removes the wrapper quotes when using the `sudo` fallback command if no authentication agent is found.