### PR TITLE
fix: fix argument names mismatch in publish command to make it work

### DIFF
--- a/.changeset/rotten-bags-carry.md
+++ b/.changeset/rotten-bags-carry.md
@@ -1,0 +1,5 @@
+---
+"electron-builder": patch
+---
+
+fix: fix argument names mismatch in publish command to make it work

--- a/packages/electron-builder/src/publish.ts
+++ b/packages/electron-builder/src/publish.ts
@@ -15,6 +15,7 @@ export function configurePublishCommand(yargs: yargs.Argv): yargs.Argv {
   // https://github.com/yargs/yargs/issues/760
   // demandOption is required to be set
   return yargs
+    .version(false)
     .parserConfiguration({
       "camel-case-expansion": false,
     })

--- a/packages/electron-builder/src/publish.ts
+++ b/packages/electron-builder/src/publish.ts
@@ -31,7 +31,7 @@ export function configurePublishCommand(yargs: yargs.Argv): yargs.Argv {
       description: "The app/build version used when searching for an upload release (used by some Publishers)",
     })
     .option("config", {
-      alias: ["c"],
+      alias: ["c", "configurationFilePath"],
       type: "string",
       description:
         "The path to an electron-builder config. Defaults to `electron-builder.yml` (or `json`, or `json5`, or `js`, or `ts`), see " + chalk.underline("https://goo.gl/YFRJOM"),


### PR DESCRIPTION
Fixes:
- https://github.com/electron-userland/electron-builder/issues/9005 

Caused by:
- https://github.com/electron-userland/electron-builder/pull/8596 

---

**Fixes mismatched argument names:**

`config` ↔ `configurationFilePath`

**Resolves conflicts caused by the reserved word 'version' in [yargs](https://github.com/yargs/yargs), and removes warning messages (Output before fix):**

```bash
$ npx electron-builder publish -f foobar.dmg
(node:7826) Warning: "version" is a reserved word.
Please do one of the following:
- Disable version with `yargs.version(false)` if using "version" as an option
- Use the built-in `yargs.version` method instead (if applicable)
- Use a different option key
https://yargs.js.org/docs/#api-reference-version
```
