### PR TITLE
fix: support option to override publish trigger (`--policy`) in publish command

### DIFF
--- a/.changeset/long-wasps-divide.md
+++ b/.changeset/long-wasps-divide.md
@@ -1,0 +1,5 @@
+---
+"electron-builder": patch
+---
+
+fix: support option to override `PublishPolicy` in publish command

--- a/packages/electron-builder/src/publish.ts
+++ b/packages/electron-builder/src/publish.ts
@@ -5,6 +5,7 @@ import { Publish } from "app-builder-lib/out/core"
 import { computeSafeArtifactNameIfNeeded } from "app-builder-lib/out/platformPackager"
 import { getConfig } from "app-builder-lib/out/util/config/config"
 import { InvalidConfigurationError, archFromString, log, printErrorAndExit } from "builder-util"
+import { PublishPolicy } from "electron-publish"
 import * as chalk from "chalk"
 import * as path from "path"
 import * as yargs from "yargs"
@@ -36,29 +37,36 @@ export function configurePublishCommand(yargs: yargs.Argv): yargs.Argv {
       description:
         "The path to an electron-builder config. Defaults to `electron-builder.yml` (or `json`, or `json5`, or `js`, or `ts`), see " + chalk.underline("https://goo.gl/YFRJOM"),
     })
+    .option("policy", {
+      alias: ["p"],
+      type: "string",
+      description: `Publish trigger policy, see ${chalk.underline("https://www.electron.build/publish")}`,
+      choices: ["onTag", "onTagOrDraft", "always", "never", undefined as any],
+    })
     .demandOption("files")
 }
 
-export async function publish(args: { files: string[]; version: string | undefined; configurationFilePath: string | undefined }) {
+export async function publish(args: { files: string[]; version: string | undefined; configurationFilePath: string | undefined; policy: PublishPolicy }) {
   const uploadTasks = args.files.map(f => {
     return {
       file: path.resolve(f),
       arch: null,
     }
   })
-  return publishArtifactsWithOptions(uploadTasks, args.version, args.configurationFilePath)
+  return publishArtifactsWithOptions(uploadTasks, args.version, args.configurationFilePath, undefined, { publish: args.policy })
 }
 
 export async function publishArtifactsWithOptions(
   uploadOptions: { file: string; arch: string | null }[],
   buildVersion?: string,
   configurationFilePath?: string,
-  publishConfiguration?: Publish
+  publishConfiguration?: Publish,
+  publishOptions?: PublishOptions
 ) {
   const projectDir = process.cwd()
   const config = await getConfig(projectDir, configurationFilePath || null, { publish: publishConfiguration, detectUpdateChannel: false })
 
-  const buildOptions: BuildOptions = normalizeOptions({ config })
+  const buildOptions: BuildOptions = normalizeOptions({ config, publish: publishOptions?.publish })
   checkBuildRequestOptions(buildOptions)
 
   const uniqueUploads = Array.from(new Set(uploadOptions))


### PR DESCRIPTION
Related:
- https://github.com/electron-userland/electron-builder/issues/4535 
- https://github.com/electron-userland/electron-builder/pull/8150 

---

**Add support for overriding the policy option in the 'publish' command, like the 'build' command:**

```bash
# 'build' command (pack & publish)
electron-builder --publish always

# 'publish' command (only publish)
electron-builder publish --policy always
```

**This change is necessary to override the [intended behavior in the CI environment](https://www.electron.build/publish.html#how-to-publish) (See the following code):**

https://github.com/electron-userland/electron-builder/blob/cf0ac45db79e3e3ff1cef3ad931f7272646d1cb1/packages/app-builder-lib/src/publish/PublishManager.ts#L87-L94

**Currently, the 'publish' command(CLI) has a problem where it cannot read the configuration file path. The following PR resolves issue:**
- https://github.com/electron-userland/electron-builder/issues/9227 