### PR TITLE
fix: add quotation marks around variable in AppArmor profile

### DIFF
--- a/.changeset/brown-boxes-know.md
+++ b/.changeset/brown-boxes-know.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add quotation marks around variable in AppArmor profile

--- a/packages/app-builder-lib/templates/linux/apparmor-profile.tpl
+++ b/packages/app-builder-lib/templates/linux/apparmor-profile.tpl
@@ -1,7 +1,7 @@
 abi <abi/4.0>,
 include <tunables/global>
 
-profile ${executable} "/opt/${sanitizedProductName}/${executable}" flags=(unconfined) {
+profile "${executable}" "/opt/${sanitizedProductName}/${executable}" flags=(unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.


### PR DESCRIPTION
fixes #9230