### PR TITLE
fix: auto-update powershell script

### DIFF
--- a/.changeset/hot-cars-attack.md
+++ b/.changeset/hot-cars-attack.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: auto-update powershell script


### PR DESCRIPTION
After the `Get-AuthenticodeSignature` command fails, in the error handler there is an additional `ConvertTo-Json test` command that should be called in the same way as `Get-AuthenticodeSignature`. Without this, `Get-AuthenticodeSignature` could fail simply due to the workarounds used (using `shell:true` `chcp 65001 >NUL` https://github.com/electron-userland/electron-builder/pull/7230 and resetting `PSModulePath` https://github.com/electron-userland/electron-builder/pull/8051), which is unintended behavior. 

After this fix, when the workarounds fail, the `ConvertTo-Json test` command will also fail (with the message `Ignoring signature validation due to unsupported PowerShell version`) and the update will be installed.
