### PR TITLE
fix(nsis): undefined vars when customCheckAppRunning is defined

### DIFF
--- a/.changeset/old-spies-lick.md
+++ b/.changeset/old-spies-lick.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): undefined vars when `customCheckAppRunning` is defined

--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -33,12 +33,12 @@
   Var /GLOBAL CmdPath
   Var /GLOBAL FindPath
   Var /GLOBAL PowerShellPath
+  StrCpy $CmdPath "$SYSDIR\cmd.exe"
+  StrCpy $FindPath "$SYSDIR\find.exe"
+  StrCpy $PowerShellPath "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
   !ifmacrodef customCheckAppRunning
     !insertmacro customCheckAppRunning
   !else
-    StrCpy $CmdPath "$SYSDIR\cmd.exe"
-    StrCpy $FindPath "$SYSDIR\find.exe"
-    StrCpy $PowerShellPath "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe"
     !insertmacro IS_POWERSHELL_AVAILABLE
     !insertmacro _CHECK_APP_RUNNING
   !endif


### PR DESCRIPTION
Currently, if your NSIS script defines `customCheckAppRunning`, building fails with `Variable "CmdPath" not referenced or never set, wasting memory!`. PR fixes this by not always declaring the unused variables.