### PR TITLE
fix: detect wrong package manager for two package.json structure

### DIFF
--- a/.changeset/tough-walls-bathe.md
+++ b/.changeset/tough-walls-bathe.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix detect wrong package manager for two package.json structure

--- a/packages/app-builder-lib/src/node-module-collector/index.ts
+++ b/packages/app-builder-lib/src/node-module-collector/index.ts
@@ -1,13 +1,12 @@
 import { NpmNodeModulesCollector } from "./npmNodeModulesCollector"
 import { PnpmNodeModulesCollector } from "./pnpmNodeModulesCollector"
 import { YarnNodeModulesCollector } from "./yarnNodeModulesCollector"
-import { detectPackageManager, PM, getPackageManagerCommand } from "./packageManager"
+import { detectPackageManagerByLockfile, detectPackageManagerByEnv, PM, getPackageManagerCommand } from "./packageManager"
 import { NodeModuleInfo } from "./types"
 import { TmpDir } from "temp-file"
 
-export async function getCollectorByPackageManager(rootDir: string, tempDirManager: TmpDir) {
-  const manager: PM = detectPackageManager(rootDir)
-  switch (manager) {
+export async function getCollectorByPackageManager(pm: PM, rootDir: string, tempDirManager: TmpDir) {
+  switch (pm) {
     case PM.PNPM:
       if (await PnpmNodeModulesCollector.isPnpmProjectHoisted(rootDir)) {
         return new NpmNodeModulesCollector(rootDir, tempDirManager)
@@ -22,9 +21,22 @@ export async function getCollectorByPackageManager(rootDir: string, tempDirManag
   }
 }
 
-export async function getNodeModules(rootDir: string, tempDirManager: TmpDir): Promise<NodeModuleInfo[]> {
-  const collector = await getCollectorByPackageManager(rootDir, tempDirManager)
+export async function getNodeModules(pm: PM, rootDir: string, tempDirManager: TmpDir): Promise<NodeModuleInfo[]> {
+  const collector = await getCollectorByPackageManager(pm, rootDir, tempDirManager)
   return collector.getNodeModules()
 }
 
-export { detectPackageManager, PM, getPackageManagerCommand }
+export function detectPackageManager(dirs: string[]): PM {
+  let pm: PM | null = null;
+
+  for (const dir of dirs) {
+    pm = detectPackageManagerByLockfile(dir)
+    if (pm) {
+      return pm
+    }
+  }
+
+  return detectPackageManagerByEnv('pnpm') || detectPackageManagerByEnv('yarn') || detectPackageManagerByEnv('npm') || PM.NPM
+}
+
+export { PM, getPackageManagerCommand }

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -84,7 +84,7 @@ export async function installDependencies(config: Configuration, { appDir, proje
   const arch = options.arch || process.arch
   const additionalArgs = options.additionalArgs
 
-  const pm = detectPackageManager(projectDir)
+  const pm = detectPackageManager([projectDir])
   log.info({ pm, platform, arch, projectDir, appDir }, `installing production dependencies`)
   const execArgs = ["install"]
   if (pm === PM.YARN_BERRY) {

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -16,7 +16,7 @@ import * as path from "path"
 import pathSorter from "path-sort"
 import { NtExecutable, NtExecutableResource } from "resedit"
 import { TmpDir } from "temp-file"
-import { getCollectorByPackageManager } from "app-builder-lib/out/node-module-collector"
+import { getCollectorByPackageManager, detectPackageManager } from "app-builder-lib/out/node-module-collector"
 import { promisify } from "util"
 import { CSC_LINK, WIN_CSC_LINK } from "./codeSignData"
 import { assertThat } from "./fileAssert"
@@ -136,10 +136,11 @@ export async function assertPack(expect: ExpectStatic, fixtureName: string, pack
       }
 
       if (checkOptions.isInstallDepsBefore) {
-        const pm = await getCollectorByPackageManager(projectDir, tmpDir)
-        const pmOptions = pm.installOptions
+        const pm = detectPackageManager([projectDir])
+        const collector = await getCollectorByPackageManager(pm, projectDir, tmpDir)
+        const collectorOptions = collector.installOptions
 
-        const destLockfile = path.join(projectDir, pmOptions.lockfile)
+        const destLockfile = path.join(projectDir, collectorOptions.lockfile)
 
         const shouldUpdateLockfiles = !!process.env.UPDATE_LOCKFILE_FIXTURES && !!checkOptions.storeDepsLockfileSnapshot
         // check for lockfile fixture so we can use `--frozen-lockfile`


### PR DESCRIPTION
When using yarn to manage a two package.json structure, if pnpm is installed globally (i.e., the PNPM_HOME environment variable exists), it may result in the package manager being detected incorrectly.