### PR TITLE
Expanding ${arch} macro properly for mac.binaries in case of native node packages

### DIFF
--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -71,9 +71,6 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
   }
   
   expandArch(pattern: string, arch?: Arch | null): string[] {
-    if(!arch) {
-      return [pattern];
-    }
     if(arch === Arch.arm64) {
       return [doExpandMacro(pattern, null, this.appInfo, {}, false)]
     }
@@ -323,15 +320,15 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
       binaries = (await Promise.all(
         binaries.flatMap(async destination => {
           const expandedDestination = this.expandArch(destination, arch);
-          return await Promise.all(expandedDestination.map(async destination => {
-            if (await statOrNull(destination)) {
-              return destination
+          return await Promise.all(expandedDestination.map(async d => {
+            if (await statOrNull(d)) {
+              return d
             }
-            return path.resolve(appPath, destination)
+            return path.resolve(appPath, d)
           }))
         })
       )).flat();
-      log.info({ binaries }, "signing additional user-defined binaries")
+      log.info({ binaries, arch: arch == null ? null : Arch[arch] }, "signing additional user-defined binaries for arch")
     }
     const customSignOptions: MasConfiguration | MacConfiguration = (isMas ? masOptions : this.platformSpecificBuildOptions) || this.platformSpecificBuildOptions
 

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -310,7 +310,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
       // Accept absolute paths for external binaries, else resolve relative paths from the artifact's app Contents path.
       binaries = await Promise.all(
         binaries.map(async destination => {
-          const expandedDestination = this.expandMacro(destination);
+          const expandedDestination = this.expandMacro(destination, arch == null ? null : Arch[arch], { "/*": "{,/**/*}" });
           if (await statOrNull(expandedDestination)) {
             return expandedDestination
           }


### PR DESCRIPTION
We have this issue where we pack `realm.node` that needs signing. 
Our CI either builds universal or arm64 + x64 archs. 

It was not possible to say which file to sign in `mac.binaries`, as it is under `app.asar.unpacked` or `app-x64.asar.unpacked` and then for universal arch it should double the paths as we need to sign both `app-arm64.asar.unpacked` and `app-x64.asar.unpacked`

This fixes the issue, we have tested with:
```
electron-builder --mac zip:universal --universal --publish always --config electron/electron-fym.yml
```
and
```
electron-builder -lm --publish always --config electron/electron-fym.yml
```

with configuration
<img width="1630" height="236" alt="CleanShot 2025-08-29 at 12 22 04@2x" src="https://github.com/user-attachments/assets/332af0a7-f2d4-47c2-96e9-9d18969c806b" />
