### PR TITLE
docs: Update recommended tools for icon generation

### DIFF
--- a/pages/icons.md
+++ b/pages/icons.md
@@ -1,4 +1,4 @@
-Recommended tools: [AppIcon Generator](http://www.tweaknow.com/appicongenerator.php), [MakeAppIcon](https://makeappicon.com/), [iConvert Icons](https://iconverticons.com/online/).
+Recommended tools: [AppIcon Generator](http://www.tweaknow.com/appicongenerator.php), [MakeAppIcon](https://makeappicon.com/).
 
 ## macOS
 


### PR DESCRIPTION
Remove link to iConvert Icons as the site now appears to be compromised or repurposed.