### PR TITLE
fix: two failed linux updater tests

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2290,7 +2290,7 @@
               "type": "null"
             }
           ],
-          "description": "Package dependencies.\n`rpm` defaults to `[\"gtk3\", \"libnotify\", \"nss\", \"libXScrnSaver\", \"(libXtst or libXtst6)\", \"xdg-utils\", \"at-spi2-core\", \"(libuuid or libuuid1)\"]`\n`pacman` defaults to `[\"c-ares\", \"ffmpeg\", \"gtk3\", \"http-parser\", \"libevent\", \"libvpx\", \"libxslt\", \"libxss\", \"minizip\", \"nss\", \"re2\", \"snappy\", \"libnotify\", \"libappindicator-gtk3\"]`"
+          "description": "Package dependencies.\n`rpm` defaults to `[\"gtk3\", \"libnotify\", \"nss\", \"libXScrnSaver\", \"(libXtst or libXtst6)\", \"xdg-utils\", \"at-spi2-core\", \"(libuuid or libuuid1)\"]`\n`pacman` defaults to `[\"c-ares\", \"ffmpeg\", \"gtk3\", \"libevent\", \"libvpx\", \"libxslt\", \"libxss\", \"minizip\", \"nss\", \"re2\", \"snappy\", \"libnotify\", \"libappindicator-gtk3\"]`"
         },
         "description": {
           "description": "As [description](./configuration.md#description) from application package.json, but allows you to specify different for Linux.",

--- a/packages/app-builder-lib/src/options/linuxOptions.ts
+++ b/packages/app-builder-lib/src/options/linuxOptions.ts
@@ -99,7 +99,7 @@ export interface LinuxTargetSpecificOptions extends CommonLinuxOptions, TargetSp
   /**
    * Package dependencies.
    * `rpm` defaults to `["gtk3", "libnotify", "nss", "libXScrnSaver", "(libXtst or libXtst6)", "xdg-utils", "at-spi2-core", "(libuuid or libuuid1)"]`
-   * `pacman` defaults to `["c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk3"]`
+   * `pacman` defaults to `["c-ares", "ffmpeg", "gtk3", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk3"]`
    */
   readonly depends?: Array<string> | null
 

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -359,7 +359,7 @@ export default class FpmTarget extends Target {
         ]
 
       case "pacman":
-        return ["c-ares", "ffmpeg", "gtk3", "http-parser", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk3"]
+        return ["c-ares", "ffmpeg", "gtk3", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk3"]
 
       default:
         return []


### PR DESCRIPTION
```
warning: cannot resolve "http-parser", a dependency of "testapp"
error: failed to prepare transaction (could not satisfy dependencies)

FAIL   node  test/src/updater/blackboxUpdateTest.ts > Electron autoupdate (fresh install & update) > linux > arch - (pacman)
FAIL   node  test/src/updater/linuxUpdaterTest.ts > test arch download and install (pacman)
```

Root cause: [Arch Linux removed the http-parser package](https://archlinux.org/todo/move-to-llhttp-from-http-parser/), but our Pacman metadata still declares it as a required dependency. Reinstall attempts during the Arch updater tests therefore fail with “unable to satisfy dependency ‘http-parser’”, causing both the blackbox pacman autoupdate test and the Linux pacman updater unit test to error out. 

Fix: I can not find our project depends on `http-parser`, so the easiest way to fix is just remove it.

@mmaietta if we do depend on `http-parser`, then we may need switch to `llhttp` instead.