### PR TITLE
Fixed the call to “download-artifact” when ELECTRON_BUILDER_CACHE is …

### DIFF
--- a/packages/app-builder-lib/src/binDownload.ts
+++ b/packages/app-builder-lib/src/binDownload.ts
@@ -51,7 +51,7 @@ export function getBin(cacheKey: string, url?: string | null, checksum?: string 
     return promise
   }
 
-  promise = doGetBin(cacheName, url, checksum)
+  promise = doGetBin(cacheKey, url, checksum)
   versionToPromise.set(cacheName, promise)
   return promise
 }


### PR DESCRIPTION
There is an issue with the PR #9151 on the call to `doGetBin` in `binDownload.ts`. This function is now called with `cacheName`, which produces an invalid value when `ELECTRON_BUILDER_CACHE` is set.
For example, if `ELECTRON_BUILDER_CACHE="~cache"`, the following command is called and fails: `app-builder.exe download-artifact --name ~cachewinCodeSign`; and the following directory is created: `~cache/~cachewinCodeSign/590582919`.