### PR TITLE
chore: Increase days before issues and PRs are marked stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. Remove stale label or comment, or this will be closed in 30 days.'
-          stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment, or this will be closed in 30 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
-          days-before-stale: 30
-          days-before-close: 30
+          days-before-stale: 60
+          days-before-close: 60
           operations-per-run: 100


### PR DESCRIPTION
Updated stale issue and PR settings to 60 days.
Utilizing whatever default message stalebot typically uses

CC @esimkowitz 🙂 