### PR TITLE
feat: Add Package Previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,19 @@
+name: Publish Any Commit
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install node, pnpm and other dependencies
+        uses: ./.github/actions/pnpm
+
+      - name: Build
+        run: pnpm compile
+
+      - run: pnpm dlx pkg-pr-new publish --pnpm ./packages/*


### PR DESCRIPTION
This PR uses GitHub Actions to build the packages on PRs once workflows are approved to run. This allows other users to use changes from the PRs before they are approved and merged.

---

**For maintainers:**

This requires the [pkg-pr-new](https://github.com/apps/pkg-pr-new) app to be installed on this repository before this can be merged.