### PR TITLE
feat: allowing negative patterns to be provided for `signExts` as signing overrides

### DIFF
--- a/.changeset/spicy-mails-sing.md
+++ b/.changeset/spicy-mails-sing.md
@@ -1,0 +1,6 @@
+---
+"electron-builder-squirrel-windows": minor
+"app-builder-lib": minor
+---
+
+feat: allowing negative patterns to be provided for `signExts` as signing overrides

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6827,7 +6827,7 @@
             }
           ],
           "default": null,
-          "description": "Explicit file extensions to also sign. Advanced option."
+          "description": "Explicit file name/extensions (`str.endsWith`) to also sign. Advanced option.\nSupports negative patterns, e.g. example that excludes `.appx` files: `[\"somefilename\", \".dll\", \"!.appx\"]`."
         },
         "signtoolOptions": {
           "anyOf": [

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -61,7 +61,8 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   readonly signAndEditExecutable?: boolean
 
   /**
-   * Explicit file extensions to also sign. Advanced option.
+   * Explicit file name/extensions (`str.endsWith`) to also sign. Advanced option.
+   * Supports negative patterns, e.g. example that excludes `.appx` files: `["somefilename", ".dll", "!.appx"]`.
    * @see https://github.com/electron-userland/electron-builder/issues/7329
    * @default null
    */

--- a/packages/app-builder-lib/src/targets/AppxTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppxTarget.ts
@@ -149,7 +149,7 @@ export default class AppXTarget extends Target {
     }
     this.buildQueueManager.add(async () => {
       await vm.exec(vm.toVmFile(path.join(vendorPath, "windows-10", signToolArch, "makeappx.exe")), makeAppXArgs)
-      await packager.sign(artifactPath)
+      await packager.signIf(artifactPath)
 
       await stageDir.cleanup()
 

--- a/packages/app-builder-lib/src/targets/MsiTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiTarget.ts
@@ -99,7 +99,7 @@ export default class MsiTarget extends Target {
 
     await stageDir.cleanup()
 
-    await packager.sign(artifactPath)
+    await packager.signIf(artifactPath)
 
     await packager.info.emitArtifactBuildCompleted({
       file: artifactPath,

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -359,7 +359,7 @@ export class NsisTarget extends Target {
       defines.UNINSTALLER_OUT_FILE = definesUninstaller.UNINSTALLER_OUT_FILE
 
       await this.executeMakensis(defines, commands, sharedHeader + (await this.computeFinalScript(script, true, archs)))
-      await Promise.all<any>([packager.sign(installerPath), defines.UNINSTALLER_OUT_FILE == null ? Promise.resolve() : unlink(defines.UNINSTALLER_OUT_FILE)])
+      await Promise.all<any>([packager.signIf(installerPath), defines.UNINSTALLER_OUT_FILE == null ? Promise.resolve() : unlink(defines.UNINSTALLER_OUT_FILE)])
 
       const safeArtifactName = computeSafeArtifactNameIfNeeded(installerFilename, () => this.generateGitHubInstallerName(primaryArch, defaultArch))
       let updateInfo: any
@@ -438,7 +438,7 @@ export class NsisTarget extends Target {
     } else {
       await execWine(installerPath, null, [], { env: { __COMPAT_LAYER: "RunAsInvoker" } })
     }
-    await packager.sign(uninstallerPath)
+    await packager.signIf(uninstallerPath)
 
     delete defines.BUILD_UNINSTALLER
     // platform-specific path, not wine

--- a/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -134,7 +134,7 @@ export class CopyElevateHelper {
       const outFile = path.join(appOutDir, "resources", "elevate.exe")
       const promise = copyFile(path.join(it, "elevate.exe"), outFile, false)
       if (target.packager.platformSpecificBuildOptions.signAndEditExecutable !== false) {
-        return promise.then(() => target.packager.sign(outFile))
+        return promise.then(() => target.packager.signIf(outFile))
       }
       return promise
     })

--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -49,7 +49,7 @@ export default class SquirrelWindowsTarget extends Target {
     if (squirrelExe) {
       const filePath = path.join(tmpVendorDirectory, squirrelExe)
       log.debug({ file: filePath }, "signing vendor executable")
-      await this.packager.sign(filePath)
+      await this.packager.signIf(filePath)
     } else {
       log.warn("Squirrel.exe not found in vendor directory, skipping signing")
     }
@@ -67,9 +67,9 @@ export default class SquirrelWindowsTarget extends Target {
     const stubExePath = path.join(appOutDir, `${this.exeName}_ExecutionStub.exe`)
     await fs.promises.copyFile(path.join(vendorDir, "StubExecutable.exe"), stubExePath)
     await execWine(path.join(vendorDir, "WriteZipToSetup.exe"), null, ["--copy-stub-resources", filePath, stubExePath])
-    await this.packager.sign(stubExePath)
+    await this.packager.signIf(stubExePath)
     log.debug({ file: filePath }, "signing app executable")
-    await this.packager.sign(filePath)
+    await this.packager.signIf(filePath)
   }
 
   async build(appOutDir: string, arch: Arch) {
@@ -95,7 +95,7 @@ export default class SquirrelWindowsTarget extends Target {
       await packager.signAndEditResources(artifactPath, arch, installerOutDir)
 
       if (this.options.msi) {
-        await packager.sign(msiArtifactPath)
+        await packager.signIf(msiArtifactPath)
       }
 
       const safeArtifactName = (ext: string) => `${sanitizedName}-Setup-${version}${getArchSuffix(arch)}.${ext}`

--- a/test/src/helpers/CheckingPackager.ts
+++ b/test/src/helpers/CheckingPackager.ts
@@ -23,7 +23,7 @@ export class CheckingWinPackager extends WinPackager {
     const setupFile = this.expandArtifactNamePattern(newClass.options, "exe", arch, "${productName} Setup ${version}.${ext}")
     const installerOutDir = path.join(outDir, `squirrel-windows${getArchSuffix(arch)}`)
     this.effectiveDistOptions = await newClass.computeEffectiveDistOptions(installerOutDir, outDir, setupFile)
-    await this.sign(this.computeAppOutDir(outDir, arch))
+    await this.signIf(this.computeAppOutDir(outDir, arch))
   }
 
   //noinspection JSUnusedLocalSymbols


### PR DESCRIPTION
* Explicit file name/extensions (`str.endsWith`) to also sign. Advanced option that applies to all Windows build artifacts.
* Supports negative patterns, e.g. example that excludes `.appx` files and includes a filename with suffix `somefilename` and all `.dll` files:
   * `["somefilename", ".dll", "!.appx"]`.
* Retains the previous default behavior for `.exe` files
* 
Resolves: https://github.com/electron-userland/electron-builder/issues/8948