### PR TITLE
fix: only use hardlinks during unit tests to avoid breaking debian builds where /opt is on a different drive

### DIFF
--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -20,7 +20,6 @@
     "app-builder-bin": "5.0.0-alpha.12",
     "builder-util-runtime": "workspace:*",
     "chalk": "^4.1.2",
-    "ci-info": "^4.2.0",
     "cross-spawn": "^7.0.6",
     "debug": "^4.3.4",
     "fs-extra": "^10.1.0",

--- a/packages/builder-util/src/fs.ts
+++ b/packages/builder-util/src/fs.ts
@@ -151,7 +151,7 @@ export async function walk(initialDirPath: string, filter?: Filter | null, consu
 // performance optimization. only enable hard links during unit tests on non-Windows platforms by default
 // This is to optimize disk space and speed during tests, while avoiding potential issues with hard links in distribution builds
 // https://github.com/electron-userland/electron-builder/issues/5721
-const _isUseHardLink = process.platform !== "win32" && process.env.USE_HARD_LINKS !== "false" && process.env.VITEST == null
+const _isUseHardLink = process.platform !== "win32" && (process.env.USE_HARD_LINKS === "true" || process.env.VITEST != null)
 
 export function copyFile(src: string, dest: string, isEnsureDir = true) {
   return (isEnsureDir ? mkdir(path.dirname(dest), { recursive: true }) : Promise.resolve()).then(() => copyOrLinkFile(src, dest, null, false))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,6 @@ importers:
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
-      ci-info:
-        specifier: ^4.2.0
-        version: 4.2.0
       cross-spawn:
         specifier: ^7.0.6
         version: 7.0.6


### PR DESCRIPTION
Resolves  #5721 