### PR TITLE
feat: allow target specific build options to override top-level publish configuration

### DIFF
--- a/.changeset/tiny-places-dream.md
+++ b/.changeset/tiny-places-dream.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: allow platform specific build options to override top-level publish configuration

--- a/packages/app-builder-lib/src/publish/PublishManager.ts
+++ b/packages/app-builder-lib/src/publish/PublishManager.ts
@@ -35,7 +35,7 @@ import { isCI } from "ci-info"
 import * as path from "path"
 import { WriteStream as TtyWriteStream } from "tty"
 import * as url from "url"
-import { AppInfo, ArtifactCreated, Configuration, Platform, PlatformSpecificBuildOptions, Target } from "../index"
+import { AppInfo, ArtifactCreated, Configuration, Platform, PlatformSpecificBuildOptions, Target, TargetSpecificOptions } from "../index"
 import { Packager } from "../packager"
 import { PlatformPackager } from "../platformPackager"
 import { expandMacro } from "../util/macroExpander"
@@ -125,7 +125,7 @@ export class PublishManager implements PublishContext {
         }
       }
 
-      const publishConfig = await getAppUpdatePublishConfiguration(packager, event.arch, this.isPublish)
+      const publishConfig = await getAppUpdatePublishConfiguration(packager, null, event.arch, this.isPublish)
       if (publishConfig != null) {
         await writeFile(path.join(packager.getResourcesDir(event.appOutDir), "app-update.yml"), serializeToYaml(publishConfig))
       }
@@ -254,7 +254,12 @@ export class PublishManager implements PublishContext {
   }
 }
 
-export async function getAppUpdatePublishConfiguration(packager: PlatformPackager<any>, arch: Arch, errorIfCannot: boolean) {
+export async function getAppUpdatePublishConfiguration(
+  packager: PlatformPackager<any>,
+  targetSpecificOptions: TargetSpecificOptions | Nullish,
+  arch: Arch,
+  errorIfCannot: boolean
+): Promise<PublishConfiguration | null> {
   const publishConfigs = await getPublishConfigsForUpdateInfo(packager, await getPublishConfigs(packager, null, arch, errorIfCannot), arch)
   if (publishConfigs == null || publishConfigs.length === 0) {
     return null

--- a/packages/app-builder-lib/src/targets/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/AppImageTarget.ts
@@ -49,7 +49,7 @@ export default class AppImageTarget extends Target {
     const c = await Promise.all([
       this.desktopEntry.value,
       this.helper.icons,
-      getAppUpdatePublishConfiguration(packager, arch, false /* in any case validation will be done on publish */),
+      getAppUpdatePublishConfiguration(packager, options, arch, false /* in any case validation will be done on publish */),
       getNotLocalizedLicenseFile(options.license, this.packager, ["txt", "html"]),
       createStageDir(this, packager, arch),
     ])

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -140,10 +140,10 @@ export default class FpmTarget extends Target {
     const resourceDir = packager.getResourcesDir(linuxDistType)
 
     const publishConfig = this.supportsAutoUpdate(target)
-      ? await getAppUpdatePublishConfiguration(packager, arch, false /* in any case validation will be done on publish */)
+      ? await getAppUpdatePublishConfiguration(packager, this.options, arch, false /* in any case validation will be done on publish step */)
       : null
     if (publishConfig != null) {
-      log.info({ resourceDir: log.filePath(resourceDir) }, `adding autoupdate files for: ${target}. (Beta feature)`)
+      log.info({ resourceDir: log.filePath(resourceDir) }, `adding autoupdate files for: ${target}`)
       await outputFile(path.join(resourceDir, "app-update.yml"), serializeToYaml(publishConfig))
       // Extra file needed for auto-updater to detect installation method
       await outputFile(path.join(resourceDir, "package-type"), target)


### PR DESCRIPTION
Enables per-target level enable/disable of `publish` feature to determine if package-type file should be produced on deb/fpm/linux packages. (usage of `deb.publish=null` to override publishing on deb)

Resolves https://github.com/electron-userland/electron-builder/issues/8838