### PR TITLE
chore(test): optimizing e2e test runner distribution across a bigger matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -170,25 +170,25 @@ jobs:
         test_config:
           - file: dockerfile-archlinux
             env:
-              ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: pacman
+              PACKAGE_MANAGER_TO_TEST: pacman
           - file: dockerfile-rpm
             env:
-              ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: dnf
+              PACKAGE_MANAGER_TO_TEST: dnf
           - file: dockerfile-rpm
             env:
-              ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: zypper
+              PACKAGE_MANAGER_TO_TEST: zypper
           - file: dockerfile-rpm
             env:
-              ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: yum
+              PACKAGE_MANAGER_TO_TEST: yum
           - file: dockerfile-rpm
             env:
-              ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: rpm
+              PACKAGE_MANAGER_TO_TEST: rpm
           - file: dockerfile-debian
             env:
-              ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: apt
+              PACKAGE_MANAGER_TO_TEST: apt
           - file: dockerfile-debian
             env:
-              ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: dpkg
+              PACKAGE_MANAGER_TO_TEST: dpkg
           - file: dockerfile-appimage
             env:
               RUN_APP_IMAGE_TEST: true
@@ -213,7 +213,7 @@ jobs:
         env:
           TEST_FILES: blackboxUpdateTest,linuxUpdaterTest
           DEBUG: electron-updater,electron-builder
-          ADDITIONAL_DOCKER_ARGS: "-e ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER=${{ matrix.test_config.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER }} -e RUN_APP_IMAGE_TEST=${{ matrix.test_config.env.RUN_APP_IMAGE_TEST || false }}"
+          ADDITIONAL_DOCKER_ARGS: "-e PACKAGE_MANAGER_TO_TEST=${{ matrix.test_config.env.PACKAGE_MANAGER_TO_TEST }} -e RUN_APP_IMAGE_TEST=${{ matrix.test_config.env.RUN_APP_IMAGE_TEST || false }}"
 
 
   test-windows:

--- a/test/src/helpers/launchAppCrossPlatform.ts
+++ b/test/src/helpers/launchAppCrossPlatform.ts
@@ -17,9 +17,17 @@ interface LaunchOptions {
   env?: Record<string, string>
   expectedVersion?: string
   updateConfigPath: string
+  packageManagerToTest: string
 }
 
-export async function launchAndWaitForQuit({ appPath, timeoutMs = 20000, env = {}, expectedVersion, updateConfigPath }: LaunchOptions): Promise<LaunchResult> {
+export async function launchAndWaitForQuit({
+  appPath,
+  timeoutMs = 20000,
+  env = {},
+  expectedVersion,
+  updateConfigPath,
+  packageManagerToTest,
+}: LaunchOptions): Promise<LaunchResult> {
   let child: ChildProcess
   const versionRegex = /APP_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)/
 
@@ -32,6 +40,7 @@ export async function launchAndWaitForQuit({ appPath, timeoutMs = 20000, env = {
         ...process.env,
         AUTO_UPDATER_TEST: "1",
         AUTO_UPDATER_TEST_CONFIG_PATH: updateConfigPath,
+        ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: packageManagerToTest,
         ...localEnv,
       },
     })


### PR DESCRIPTION
The tests are running too slow for rpm because it's running tests across 4 different package manager, whereas the others are 1 or 2. Splitting them up to run across additional nodes