### PR TITLE
fix: pnpm "Invalid string length" errors during node module collection

### DIFF
--- a/.changeset/good-lights-smell.md
+++ b/.changeset/good-lights-smell.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: pnpm "Invalid string length" errors during node module collection

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -11,7 +11,7 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
   }
 
   protected getArgs(): string[] {
-    return ["list", "--prod", "--json", "--depth", "Infinity", "--long"]
+    return ["list", "--prod", "--json", "--depth", "Infinity"]
   }
 
   private async getProductionDependencies(depTree: PnpmDependency): Promise<{ path: string; dependencies: Record<string, string>; optionalDependencies: Record<string, string> }> {


### PR DESCRIPTION
Closes #9469 

electron-builder calls `pnpm list --prod --json --depth Infinity --long` to collect node modules with pnpm. My project has many dependencies, so this command fails with the following error:

```
{
  "error": {
    "code": "pnpm",
    "message": "Invalid string length"
  }
}
```

Removing `--long` resolves this error. This flag adds the following fields to the output:
- `description`
- `license`
- `author`
- `homepage`
- `repository`

electron-builder doesn't appear to consume any of these fields, so `--long` can safely be removed.