### PR TITLE
fix: skip Netlify PR deploy workflow on forks

### DIFF
--- a/.github/workflows/pr-netlify.yml
+++ b/.github/workflows/pr-netlify.yml
@@ -14,6 +14,8 @@ jobs:
   deploy:
     name: 'Deploy PR'
     runs-on: ubuntu-latest
+    # Only run on the main repository, not on forks
+    if: github.repository == 'electron-userland/electron-builder'
 
     steps:
       - name: Checkout code repository


### PR DESCRIPTION
Forks don't have access to the required secrets (NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID), so the workflow fails.