### PR TITLE
fix: deleting default macOS appPlist keys using extendInfo

### DIFF
--- a/.changeset/fifty-laws-jog.md
+++ b/.changeset/fifty-laws-jog.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: delete default macOS appPlist keys using extendInfo when set Nullish

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -582,6 +582,9 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
     if (extendInfo != null) {
       Object.assign(appPlist, extendInfo)
     }
+    for (const [k, v] of Object.entries(appPlist)) {
+      if (v === null || v === undefined) delete appPlist[k]
+    }
   }
 
   protected async signApp(packContext: AfterPackContext, isAsar: boolean): Promise<boolean> {

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -81,6 +81,8 @@ test.ifMac("one-package", ({ expect }) =>
                 LSItemContentTypes: ["public.folder"],
               },
             ],
+            // test unsetting a default electron plist value
+            NSMicrophoneUsageDescription: undefined,
           },
           minimumSystemVersion: "10.12.0",
           fileAssociations: [


### PR DESCRIPTION
Explicitly delete nullish values from macOS `appPlist`, because it seems that the `plist` library handles nullish values differently than the previous implementation (before https://github.com/electron-userland/electron-builder/pull/8890)

Resolves https://github.com/electron-userland/electron-builder/issues/9480

I confirmed this fix with local patch on a real app built on macOS, and added test coverage.
The test passes as is, and fails if I comment out the code change :heavy_check_mark: 