### PR TITLE
chore: Increase timeout for macOS test job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -247,7 +247,7 @@ jobs:
 
   test-mac:
     runs-on: macos-26
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Test suite takes longer now that we added macIconTest to it as well, and each test case has to activate its own corepack environment.