### PR TITLE
fix(mac): skip redundant signing in signApp() for MAS builds. Closes #9507

### DIFF
--- a/.changeset/fix-mas-signing.md
+++ b/.changeset/fix-mas-signing.md
@@ -1,0 +1,7 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): skip redundant signing in signApp() for MAS builds
+
+Fixed MAS builds using wrong provisioning profile by skipping the redundant first signing in `signApp()`. Previously, MAS builds were signed twice - first incorrectly with darwin options, then correctly with MAS options. This caused build failures when the darwin provisioning profile didn't exist.


### PR DESCRIPTION
This PR tries to fix https://github.com/electron-userland/electron-builder/issues/9507 as well as avoiding double signing the app.

> **Note:** This is an alternative fix to #9508, which addresses the same issue by passing correct MAS options to `signApp()` instead of skipping the redundant signing. This PR takes the approach of eliminating the redundant first signing entirely.

## Summary

When building for Mac App Store (MAS), the `signApp()` method was signing the app with incorrect Darwin (Developer ID) settings, because it always passed `null` for `masOptions` to `sign()`. This caused:

1. Wrong provisioning profile being used (`mac.provisioningProfile` instead of `mas.provisioningProfile`)
2. Wrong certificate type being searched for ("Developer ID Application" instead of "3rd Party Mac Developer Application")
3. Build failures in CI when the Darwin provisioning profile doesn't exist
4. Incorrect `platform=darwin` instead of `platform=mas`

## Root Cause

For MAS builds, the app was being signed **twice**:

1. **First signing (WRONG)**: `doPack()` → `signApp()` → `sign(path, null, null, arch)` with `masOptions=null`, causing `isMas=false` and using Darwin settings
2. **Second signing (CORRECT)**: `pack()` → `sign(path, outDir, masBuildOptions, arch)` with proper MAS options, which also creates the `.pkg` installer

The first signing was redundant and used incorrect options. If it failed (e.g., missing Darwin provisioning profile), the build would stop before the correct second signing could run.

## The Fix

Skip signing entirely in `signApp()` for MAS builds, since `pack()` will handle it correctly:

```typescript
protected async signApp(packContext: AfterPackContext, isAsar: boolean): Promise<boolean> {
  // For MAS builds, skip signing here entirely. The pack() method will call sign()
  // with the correct MAS options and also create the .pkg installer.
  if (packContext.electronPlatformName === "mas") {
    return true
  }
  // ... rest of method for darwin builds
}
```

This approach:
- Eliminates redundant double-signing for MAS builds
- Ensures MAS builds use the correct provisioning profile and certificate type
- Relies on `@electron/osx-sign`'s recursive signing to handle nested `.app` bundles

## Test Results

Tested with a [reproduction project](https://github.com/abergs/eb-mas-bug-repro) using different provisioning profiles for `mac` vs `mas` config:

```json
{
  "mac": { "provisioningProfile": "developer_id.provisionprofile" },
  "mas": { "provisioningProfile": "appstore.provisionprofile" }
}
```

### Before Fix (v26.4.0) - Two sign operations, first one wrong

```
• signing file=dist/mas-arm64/App.app platform=darwin provisioningProfile=developer_id.provisionprofile
```

### After Fix - Single correct sign operation

```
• signing file=dist/mas-arm64/App.app platform=mas provisioningProfile=appstore.provisionprofile
```

### Universal builds also fixed

Before: `platform=darwin`, `provisioningProfile=developer_id.provisionprofile`
After: `platform=mas`, `provisioningProfile=appstore.provisionprofile`

### Evidence of double signing

Using a workaround config with `mac.identity: null`, in the current (non PR) build both signing attempts become visible:
 
```
• skipped macOS code signing  reason=identity explicitly is set to null   ← FIRST (from signApp)
• no event listeners found  event=afterSign
• skipped macOS code signing  reason=identity explicitly is set to null   ← SECOND (from pack)
```
The double singing behaviour existed since at least v26.0.12, but possibly earlier. I haven't tested.

## Affected Builds

- `mas` (single-arch and universal)
- `mas-dev` (single-arch and universal)

## Potential Breaking Change: `afterSign` Hook behaviour?

The `afterSign` hook behaviour for MAS builds is affected by this change:

| | Before (buggy) | After (fixed) |
|---|---|---|
| **Hook fires** | After incorrect darwin signing | No signing happened, MAS is signed during Pack |
| **App state when hook runs** | Signed with wrong options | Unsigned |
| **Correct signing** | Happens after hook | Happens after hook |

**Analysis:** The previous behavior was already broken for MAS builds - `afterSign` fired after signing with *incorrect* darwin options, then `pack()` would re-sign with correct MAS options. Users relying on `afterSign` to process a correctly-signed MAS app were already getting incorrect behavior.

**Impact:** Users with `afterSign` hooks that specifically process MAS builds may need to adjust their workflow. However, since the app was incorrectly signed when the hook fired previously, any such hooks were likely not working as intended anyway. Should this be documented somehow?

**Recommendation:** If you have `afterSign` hooks that need to run after MAS signing, consider using the `afterAllArtifactBuild` or `afterPack` hook instead, which runs after all signing and packaging is complete.


Additional notes on afterSign:

In this PR, we keep returning true as to not change the behaviour too much (disabling afterSign hooks from running at all).

However, in a future release we may consider returning `false` - or change when `afterSign hook` is emitted for MAS Builds since they sign during pack?


