### PR TITLE
fix(updater): ignore releases with non-semver tags when collecting full changelog

### DIFF
--- a/.changeset/dry-cloths-travel.md
+++ b/.changeset/dry-cloths-travel.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix(updater): ignore releases with non-semver tags when collecting full changelog

--- a/packages/electron-updater/src/providers/GitHubProvider.ts
+++ b/packages/electron-updater/src/providers/GitHubProvider.ts
@@ -224,7 +224,7 @@ export function computeReleaseNotes(currentVersion: semver.SemVer, isFullChangel
   for (const release of feed.getElements("entry")) {
     // noinspection TypeScriptValidateJSTypes
     const versionRelease = /\/tag\/v?([^/]+)$/.exec(release.element("link").attribute("href"))![1]
-    if (semver.lt(currentVersion, versionRelease)) {
+    if (semver.valid(versionRelease) && semver.lt(currentVersion, versionRelease)) {
       releaseNotes.push({
         version: versionRelease,
         note: getNoteValue(release),


### PR DESCRIPTION
One line change to resolves: #9542