### PR TITLE
fix: use projectDir instead of workspaceRoot for rebuild path

### DIFF
--- a/.changeset/lazy-turkeys-change.md
+++ b/.changeset/lazy-turkeys-change.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: use projectDir instead of workspaceRoot for rebuild path

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -188,7 +188,7 @@ export async function rebuild(config: Configuration, { appDir, projectDir, works
   const {
     frameworkInfo: { version: electronVersion },
   } = options
-  const projectRootPath = workspaceRoot || projectDir || appDir
+  const projectRootPath = projectDir || appDir
   const logInfo = {
     electronVersion,
     arch,

--- a/test/fixtures/test-app-install-app-deps-workspace/package.json
+++ b/test/fixtures/test-app-install-app-deps-workspace/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-app-install-app-deps-workspace",
+  "private": true,
+  "trustedDependencies": [
+    "classic-level"
+  ]
+}

--- a/test/fixtures/test-app-install-app-deps-workspace/packages/bar/package.json
+++ b/test/fixtures/test-app-install-app-deps-workspace/packages/bar/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/bar",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "electron": "35.7.5",
+    "level": "10.0.0"
+  }
+}

--- a/test/fixtures/test-app-install-app-deps-workspace/packages/foo/package.json
+++ b/test/fixtures/test-app-install-app-deps-workspace/packages/foo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@test/foo",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "electron": "35.7.5",
+    "level": "10.0.0"
+  }
+}

--- a/test/src/installAppDepsWorkspaceIntegrationTest.ts
+++ b/test/src/installAppDepsWorkspaceIntegrationTest.ts
@@ -1,0 +1,107 @@
+import { isEmptyOrSpaces } from "builder-util"
+import { copy, outputFile, readJson, writeJson } from "fs-extra"
+import { execFile } from "child_process"
+import * as path from "path"
+import { TmpDir } from "temp-file"
+import { promisify } from "util"
+import * as which from "which"
+
+const hasBun = !isEmptyOrSpaces(which.sync("bun", { nothrow: true }))
+const hasPnpm = !isEmptyOrSpaces(which.sync("pnpm", { nothrow: true }))
+const fixtureDir = path.join(__dirname, "..", "fixtures", "test-app-install-app-deps-workspace")
+const electronBuilderCli = path.join(__dirname, "..", "..", "packages", "electron-builder", "cli.js")
+const execFileAsync = promisify(execFile)
+
+async function setPostinstallScripts(rootDir: string) {
+  for (const packageName of ["foo", "bar"]) {
+    const packageJsonPath = path.join(rootDir, "packages", packageName, "package.json")
+    const packageJson = await readJson(packageJsonPath)
+    packageJson.scripts = {
+      ...(packageJson.scripts || {}),
+      postinstall: `node ${electronBuilderCli} install-app-deps`,
+    }
+    await writeJson(packageJsonPath, packageJson, { spaces: 2 })
+  }
+}
+
+async function configureBunWorkspace(rootDir: string) {
+  const rootPackageJsonPath = path.join(rootDir, "package.json")
+  const rootPackageJson = await readJson(rootPackageJsonPath)
+  rootPackageJson.workspaces = ["packages/*"]
+  await writeJson(rootPackageJsonPath, rootPackageJson, { spaces: 2 })
+}
+
+async function configurePnpmWorkspace(rootDir: string) {
+  await outputFile(path.join(rootDir, "pnpm-workspace.yaml"), 'packages:\n  - "packages/*"\n')
+}
+
+describe.ifNotWindows("install-app-deps workspace integration", () => {
+  test.runIf(hasBun)("bun workspace postinstall uses package-local projectRootPath and avoids classic-level rebuild", async ({ expect }) => {
+    const tmpDir = new TmpDir("install-app-deps-bun-integration")
+    const rootDir = await tmpDir.createTempDir({ prefix: "test-project" })
+
+    try {
+      await copy(fixtureDir, rootDir)
+      await configureBunWorkspace(rootDir)
+      await setPostinstallScripts(rootDir)
+
+      const fooDir = path.join(rootDir, "packages", "foo")
+      const barDir = path.join(rootDir, "packages", "bar")
+      const { stdout, stderr } = await execFileAsync("bun", ["install", "--verbose"], {
+        cwd: rootDir,
+        env: {
+          ...process.env,
+          DEBUG: "electron-rebuild",
+        },
+        maxBuffer: 40 * 1024 * 1024,
+      })
+      const output = `${stdout}\n${stderr}`
+
+      expect(output).toContain('[Scripts] Starting scripts for "@test/foo"')
+      expect(output).toContain('[Scripts] Starting scripts for "@test/bar"')
+      expect(output).toContain(`projectRootPath: '${fooDir}'`)
+      expect(output).toContain(`projectRootPath: '${barDir}'`)
+      expect(output).toContain(`scanning: ${path.join(fooDir, "node_modules")}`)
+      expect(output).toContain(`scanning: ${path.join(barDir, "node_modules")}`)
+      expect(output).not.toContain(`scanning: ${path.join(rootDir, "node_modules")}`)
+      expect(output).not.toContain("moduleName=classic-level")
+      expect(output).not.toContain("node-gyp failed to rebuild")
+    } finally {
+      await tmpDir.cleanup()
+    }
+  })
+
+  test.runIf(hasPnpm)("pnpm workspace postinstall uses package-local projectRootPath and avoids classic-level rebuild", async ({ expect }) => {
+    const tmpDir = new TmpDir("install-app-deps-pnpm-integration")
+    const rootDir = await tmpDir.createTempDir({ prefix: "test-project" })
+
+    try {
+      await copy(fixtureDir, rootDir)
+      await configurePnpmWorkspace(rootDir)
+      await setPostinstallScripts(rootDir)
+
+      const fooDir = path.join(rootDir, "packages", "foo")
+      const barDir = path.join(rootDir, "packages", "bar")
+      const { stdout, stderr } = await execFileAsync("pnpm", ["install"], {
+        cwd: rootDir,
+        env: {
+          ...process.env,
+          DEBUG: "electron-rebuild",
+        },
+        maxBuffer: 40 * 1024 * 1024,
+      })
+      const output = `${stdout}\n${stderr}`
+
+      expect(output).toContain("packages/foo postinstall$")
+      expect(output).toContain("packages/bar postinstall$")
+      expect(output).toContain(`projectRootPath: '${fooDir}'`)
+      expect(output).toContain(`projectRootPath: '${barDir}'`)
+      expect(output).toContain(`scanning: ${path.join(fooDir, "node_modules")}`)
+      expect(output).toContain(`scanning: ${path.join(barDir, "node_modules")}`)
+      expect(output).not.toContain("rebuilding classic-level with args")
+      expect(output).not.toContain("node-gyp failed to rebuild")
+    } finally {
+      await tmpDir.cleanup()
+    }
+  })
+})


### PR DESCRIPTION
WIP - some edgecases

---

Using `workspaceRoot` by default for rebuild path causes issues, as demonstrated in the added test fixtures where multiple monorepos are trying to rebuild `classic-level` with `electron-builder install-app-deps`, but clobber eachother due to the incorrect scoping.

(If you revert the fix I added in `yarn.ts` you'll see how those tests now fail, with both bun/pnpm using their "isolated installation" strategies)

Test cases are added a little oddly as integration tests using the cli directly to try to keep the environment as realistic and similar to the error case as I currently face in my real repo.

This change doesn't seem to regress #9376, as rebuilderTest still passes.
