### PR TITLE
chore(builder-util): add engines field to package.json

### DIFF
--- a/.changeset/cool-seas-juggle.md
+++ b/.changeset/cool-seas-juggle.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+chore(builder-util): add engines field to package.json

--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -41,6 +41,6 @@
     "@types/tiny-async-pool": "^1.0.5"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=16"
   }
 }

--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -39,5 +39,8 @@
     "@types/js-yaml": "4.0.3",
     "@types/source-map-support": "0.5.4",
     "@types/tiny-async-pool": "^1.0.5"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/builder-util/package.json
+++ b/packages/builder-util/package.json
@@ -41,6 +41,6 @@
     "@types/tiny-async-pool": "^1.0.5"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
This makes it easier for consumers to know what to expect as far as compatibility goes. Both human consumers and static analysis tools.
