### PR TITLE
feat(electron-publish): add support for a read/write token to publish to a private gitlab repository

### DIFF
--- a/packages/electron-publish/src/gitlabPublisher.ts
+++ b/packages/electron-publish/src/gitlabPublisher.ts
@@ -36,9 +36,9 @@ export class GitlabPublisher extends HttpPublisher {
   ) {
     super(context, true)
 
-    let token = info.token || null
-    if (isEmptyOrSpaces(token)) {
-      token = process.env.GITLAB_TOKEN || null
+    let token = info.token
+    if (isEmptyOrSpaces(token) || process.env.GITLAB_RELEASE_TOKEN) {
+      token =  process.env.GITLAB_RELEASE_TOKEN ?  process.env.GITLAB_RELEASE_TOKEN : process.env.GITLAB_TOKEN || null
       if (isEmptyOrSpaces(token)) {
         throw new InvalidConfigurationError(`GitLab Personal Access Token is not set, neither programmatically, nor using env "GITLAB_TOKEN"`)
       }


### PR DESCRIPTION
Using the same approach followed by [`GitHubPublisher`](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-publish/src/gitHubPublisher.ts#L52), this PR add support for `GITLAB_RELEASE_TOKEN` token to be used during publishing to a private repository, where the token requires write permissions.