### PR TITLE
feat(linux): add installDirectory config option

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -709,6 +709,14 @@
         "icon": {
           "type": "string"
         },
+        "installDirectory": {
+          "default": "/opt/${productName}",
+          "description": "Installation directory.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "maintainer": {
           "type": [
             "null",
@@ -2394,6 +2402,14 @@
         },
         "icon": {
           "type": "string"
+        },
+        "installDirectory": {
+          "default": "/opt/${productName}",
+          "description": "Installation directory.",
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "maintainer": {
           "type": [

--- a/packages/app-builder-lib/src/options/linuxOptions.ts
+++ b/packages/app-builder-lib/src/options/linuxOptions.ts
@@ -112,6 +112,12 @@ export interface LinuxTargetSpecificOptions extends CommonLinuxOptions, TargetSp
   readonly icon?: string
 
   /**
+   * Installation directory.
+   * @default /opt/${productName}
+   */
+  readonly installDirectory?: string | null
+
+  /**
    * The package category.
    */
   readonly packageCategory?: string | null

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -15,7 +15,7 @@ import { computeEnv } from "../util/bundledTool"
 import { hashFile } from "../util/hash"
 import { isMacOsSierra } from "../util/macosVersion"
 import { getTemplatePath } from "../util/pathManager"
-import { installPrefix, LinuxTargetHelper } from "./LinuxTargetHelper"
+import { LinuxTargetHelper } from "./LinuxTargetHelper"
 import { getFpmPath, getLinuxToolsPath } from "../toolsets/linux"
 
 interface FpmOptions {
@@ -51,12 +51,13 @@ export default class FpmTarget extends Target {
     const defaultTemplatesDir = getTemplatePath("linux")
 
     const packager = this.packager
+    const installDirectory = this.helper.getInstallDirectory(this.options)
     const templateOptions = {
+      ...packager.platformSpecificBuildOptions,
       // old API compatibility
       executable: packager.executableName,
-      sanitizedProductName: packager.appInfo.sanitizedProductName,
       productFilename: packager.appInfo.productFilename,
-      ...packager.platformSpecificBuildOptions,
+      installDirectory,
     }
 
     function getResource(value: string | Nullish, defaultFile: string) {
@@ -232,7 +233,8 @@ export default class FpmTarget extends Target {
 
     use(options.fpm, it => args.push(...it))
 
-    args.push(`${appOutDir}/=${installPrefix}/${appInfo.sanitizedProductName}`)
+    const installDirectory = this.helper.getInstallDirectory(this.options)
+    args.push(`${appOutDir}/=${installDirectory}`)
     for (const icon of await this.helper.icons) {
       const extWithDot = path.extname(icon.file)
       const sizeName = extWithDot === ".svg" ? "scalable" : `${icon.size}x${icon.size}`

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -6,8 +6,6 @@ import { LinuxPackager } from "../linuxPackager"
 import { LinuxTargetSpecificOptions } from "../options/linuxOptions"
 import { IconInfo } from "../platformPackager"
 
-export const installPrefix = "/opt"
-
 export class LinuxTargetHelper {
   private readonly iconPromise = new Lazy(() => this.computeDesktopIcons())
 
@@ -23,6 +21,11 @@ export class LinuxTargetHelper {
 
   get mimeTypeFiles(): Promise<string | null> {
     return this.mimeTypeFilesPromise.value
+  }
+
+  getInstallDirectory(options: LinuxTargetSpecificOptions): string {
+    const installDirectory = this.packager.expandMacro(options.installDirectory ?? "/opt/${productName}", null)
+    return installDirectory.replace(/(?<=.)\/+$/, "")
   }
 
   private async computeMimeTypeFiles(): Promise<string | null> {
@@ -114,7 +117,8 @@ export class LinuxTargetHelper {
 
     const executableArgs = targetSpecificOptions.executableArgs
     if (exec == null) {
-      exec = `${installPrefix}/${appInfo.sanitizedProductName}/${packager.executableName}`
+      const installDirectory = this.getInstallDirectory(targetSpecificOptions)
+      exec = `${installDirectory}/${packager.executableName}`
       if (!/^[/0-9A-Za-z._-]+$/.test(exec)) {
         exec = `"${exec}"`
       }

--- a/packages/app-builder-lib/templates/linux/after-install.tpl
+++ b/packages/app-builder-lib/templates/linux/after-install.tpl
@@ -5,17 +5,17 @@ if type update-alternatives >/dev/null 2>&1; then
     if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
         rm -f '/usr/bin/${executable}'
     fi
-    update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100 || ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+    update-alternatives --install '/usr/bin/${executable}' '${executable}' '${installDirectory}/${executable}' 100 || ln -sf '${installDirectory}/${executable}' '/usr/bin/${executable}'
 else
-    ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+    ln -sf '${installDirectory}/${executable}' '/usr/bin/${executable}'
 fi
 
 # Check if user namespaces are supported by the kernel and working with a quick test:
 if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
     # Use SUID chrome-sandbox only on systems without user namespaces:
-    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+    chmod 4755 '${installDirectory}/chrome-sandbox' || true
 else
-    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+    chmod 0755 '${installDirectory}/chrome-sandbox' || true
 fi
 
 if hash update-mime-database 2>/dev/null; then
@@ -37,7 +37,7 @@ fi
 # Unfortunately, at the moment AppArmor doesn't have a good story for backwards compatibility.
 # https://askubuntu.com/questions/1517272/writing-a-backwards-compatible-apparmor-profile
 if apparmor_status --enabled > /dev/null 2>&1; then
-  APPARMOR_PROFILE_SOURCE='/opt/${sanitizedProductName}/resources/apparmor-profile'
+  APPARMOR_PROFILE_SOURCE='${installDirectory}/resources/apparmor-profile'
   APPARMOR_PROFILE_TARGET='/etc/apparmor.d/${executable}'
   if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
     cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"

--- a/packages/app-builder-lib/templates/linux/apparmor-profile.tpl
+++ b/packages/app-builder-lib/templates/linux/apparmor-profile.tpl
@@ -1,7 +1,7 @@
 abi <abi/4.0>,
 include <tunables/global>
 
-profile "${executable}" "/opt/${sanitizedProductName}/${executable}" flags=(unconfined) {
+profile "${executable}" "${installDirectory}/${executable}" flags=(unconfined) {
   userns,
 
   # Site-specific additions and overrides. See local/README for details.


### PR DESCRIPTION
Allow the installation directory used in Linux builds - which still defaults to being /opt/${appInfo.sanitizedProductName} - to be configured.