### PR TITLE
fix: prevent install-app-deps infinite recursion in npm workspaces

### DIFF
--- a/.changeset/brave-workspace-recursion.md
+++ b/.changeset/brave-workspace-recursion.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: include workspaceRoot when checking for installed dependencies in installOrRebuild to prevent infinite npm install recursion when install-app-deps runs from a workspace member's postinstall in npm workspaces

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -27,8 +27,9 @@ export async function installOrRebuild(
   }
   let isDependenciesInstalled = false
 
+  const dirsToCheck = [projectDir, appDir, workspaceRoot].filter((d): d is string => !!d)
   for (const fileOrDir of ["node_modules", ".pnp.js"]) {
-    if ((await pathExists(path.join(projectDir, fileOrDir))) || (await pathExists(path.join(appDir, fileOrDir)))) {
+    if ((await Promise.all(dirsToCheck.map(d => pathExists(path.join(d, fileOrDir))))).some(Boolean)) {
       isDependenciesInstalled = true
 
       break

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -27,7 +27,7 @@ export async function installOrRebuild(
   }
   let isDependenciesInstalled = false
 
-  const dirsToCheck = [projectDir, appDir, workspaceRoot].filter((d): d is string => !!d)
+  const dirsToCheck = [...new Set([projectDir, appDir, workspaceRoot].filter((d): d is string => !!d))]
   for (const fileOrDir of ["node_modules", ".pnp.js"]) {
     if ((await Promise.all(dirsToCheck.map(d => pathExists(path.join(d, fileOrDir))))).some(Boolean)) {
       isDependenciesInstalled = true


### PR DESCRIPTION
fix #9678

## Summary

- Fix infinite `npm install` recursion when `install-app-deps` runs from a workspace member's `postinstall` in an npm-workspaces setup.
- Include `workspaceRoot` in the `node_modules` / `.pnp.js` existence check inside `installOrRebuild` so hoisted dependencies are recognized.

## Repro

Repo: https://github.com/ian-oneleet/electron-builder-infinite-recursion-bug

Structure: root `package.json` declares `workspaces: ["app"]`; `app/package.json` has `"postinstall": "electron-builder install-app-deps"` and an empty `dependencies`.

Running `npm install` at the root spawns `npm install` processes endlessly.

## Root cause

In `packages/app-builder-lib/src/util/yarn.ts` (`installOrRebuild`), the check for whether deps are already installed only looked at `projectDir` and `appDir`:

```ts
for (const fileOrDir of ["node_modules", ".pnp.js"]) {
  if ((await pathExists(path.join(projectDir, fileOrDir))) || (await pathExists(path.join(appDir, fileOrDir)))) {
    isDependenciesInstalled = true
    break
  }
}
```

Under npm workspaces, `node_modules` is hoisted to the workspace root, so neither `app/node_modules` nor `projectDir/node_modules` exists. `isDependenciesInstalled` stays `false`, `installDependencies` spawns `npm install` in `appDir`, which re-triggers the `postinstall` script and re-enters `electron-builder install-app-deps` — infinite recursion. The empty `dependencies` array is irrelevant; the recursion is driven by the `postinstall` lifecycle hook.

`workspaceRoot` is already correctly resolved upstream (via `determinePackageManagerEnv` / `npm prefix -w`) and passed into `installOrRebuild`, but it wasn't being consulted here.

## Fix

Also check `workspaceRoot` for `node_modules` / `.pnp.js`. When the workspace root has dependencies installed (which it does when this path is reached via a workspace member's `postinstall`), `installOrRebuild` now correctly takes the `rebuild` branch — which is the intended behavior of `install-app-deps`: rebuild native modules for Electron, not re-install from scratch.

### Why this is safe

- **Workspace + postinstall recursion (the bug):** `workspaceRoot/node_modules` exists (npm just installed it, that's why postinstall fired) → recognized as installed → `rebuild` runs → recursion broken.
- **Fresh clone, manual `electron-builder install-app-deps`:** none of `projectDir`, `appDir`, `workspaceRoot` has `node_modules` → still installs, as before.
- **Two-package.json layout (separate dev / prod deps):** `appDir !== projectDir` triggers `forceInstall = true` in `install-app-deps.ts`, which bypasses this check entirely → still installs the app's prod deps, as before.

## Test plan

- [ ] Clone https://github.com/ian-oneleet/electron-builder-infinite-recursion-bug
- [ ] Point its `electron-builder` dependency at this branch's build
- [ ] Run `npm install` at the workspace root
- [ ] Verify no recursive `npm install` spawning, `install-app-deps` reaches the rebuild path and exits cleanly
- [ ] Regression check: traditional two-`package.json` layout (root + `app/`) still installs prod deps in `app/`
- [ ] Regression check: fresh clone with no `node_modules` anywhere still installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)