### PR TITLE
fix: GitLab auth token differs between fetching channel yaml & API requests

### DIFF
--- a/.changeset/crazy-pandas-cheer.md
+++ b/.changeset/crazy-pandas-cheer.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: GitLab auth token differs between fetching channel yaml & API requests

--- a/packages/electron-updater/src/providers/GitLabProvider.ts
+++ b/packages/electron-updater/src/providers/GitLabProvider.ts
@@ -63,18 +63,27 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
     // Get latest release from GitLab API using the permalink/latest endpoint
     const latestReleaseUrl = newUrlFromBase(`projects/${this.options.projectId}/releases/permalink/latest`, this.baseApiUrl)
 
-    let latestRelease: GitlabReleaseInfo
+    const header = { Accept: "application/json", ...this.setAuthHeaderForToken(this.options.token || null) }
+    let releaseResponse: string | null
     try {
-      const header = { "Content-Type": "application/json", ...this.setAuthHeaderForToken(this.options.token || null) }
-      const releaseResponse = await this.httpRequest(latestReleaseUrl, header, cancellationToken)
-
-      if (!releaseResponse) {
-        throw newError("No latest release found", "ERR_UPDATER_NO_PUBLISHED_VERSIONS")
-      }
-
-      latestRelease = JSON.parse(releaseResponse)
+      releaseResponse = await this.httpRequest(latestReleaseUrl, header, cancellationToken)
     } catch (e: any) {
       throw newError(`Unable to find latest release on GitLab (${latestReleaseUrl}): ${e.stack || e.message}`, "ERR_UPDATER_LATEST_VERSION_NOT_FOUND")
+    }
+
+    if (!releaseResponse) {
+      throw newError("No published releases on GitLab", "ERR_UPDATER_NO_PUBLISHED_VERSIONS")
+    }
+
+    let latestRelease: GitlabReleaseInfo
+    try {
+      latestRelease = JSON.parse(releaseResponse)
+    } catch (e: any) {
+      throw newError(`Unable to parse latest release response from GitLab: ${e.stack || e.message}`, "ERR_UPDATER_LATEST_VERSION_NOT_FOUND")
+    }
+
+    if (latestRelease.upcoming_release) {
+      throw newError("Latest GitLab release is scheduled but not yet published", "ERR_UPDATER_LATEST_VERSION_NOT_FOUND")
     }
 
     const tag = latestRelease.tag_name
@@ -95,7 +104,8 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
       }
 
       channelFileUrl = new URL(channelAsset.direct_asset_url)
-      const headers = this.options.token ? { "PRIVATE-TOKEN": this.options.token } : undefined
+      const authHeaders = this.setAuthHeaderForToken(this.options.token || null)
+      const headers = Object.keys(authHeaders).length ? authHeaders : undefined
 
       try {
         const result = await this.httpRequest(channelFileUrl, headers, cancellationToken)
@@ -138,15 +148,9 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
       result.releaseNotes = latestRelease.description || null
     }
 
-    // Create assets map from GitLab release assets
-    const assetsMap = new Map<string, string>()
-    for (const asset of latestRelease.assets.links) {
-      assetsMap.set(this.normalizeFilename(asset.name), asset.direct_asset_url)
-    }
-
     const gitlabUpdateInfo = {
       tag: tag,
-      assets: assetsMap,
+      assets: this.convertAssetsToMap(latestRelease.assets),
       ...result,
     }
 
@@ -193,7 +197,7 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
       const releaseUrl = newUrlFromBase(`projects/${this.options.projectId}/releases/${encodeURIComponent(releaseId)}`, this.baseApiUrl)
 
       try {
-        const header = { "Content-Type": "application/json", ...this.setAuthHeaderForToken(this.options.token || null) }
+        const header = { Accept: "application/json", ...this.setAuthHeaderForToken(this.options.token || null) }
         const releaseResponse = await this.httpRequest(releaseUrl, header, cancellationToken)
 
         if (releaseResponse) {

--- a/packages/electron-updater/src/providers/GitLabProvider.ts
+++ b/packages/electron-updater/src/providers/GitLabProvider.ts
@@ -79,7 +79,7 @@ export class GitLabProvider extends Provider<GitlabUpdateInfo> {
     try {
       latestRelease = JSON.parse(releaseResponse)
     } catch (e: any) {
-      throw newError(`Unable to parse latest release response from GitLab: ${e.stack || e.message}`, "ERR_UPDATER_LATEST_VERSION_NOT_FOUND")
+      throw newError(`Unable to parse latest release response from GitLab (${latestReleaseUrl}): response was not valid JSON: ${e.stack || e.message}`, "ERR_UPDATER_LATEST_VERSION_NOT_FOUND")
     }
 
     if (latestRelease.upcoming_release) {

--- a/test/src/provider/gitlabProviderTest.ts
+++ b/test/src/provider/gitlabProviderTest.ts
@@ -77,12 +77,24 @@ test("API request URL - uses GitLab releases permalink/latest endpoint", async (
   expect(firstCallPath).toContain(`projects/${MOCK_PROJECT_ID}/releases/permalink/latest`)
 })
 
-// API returns null/empty → ERR_UPDATER_LATEST_VERSION_NOT_FOUND
-test("null API response - throws ERR_UPDATER_LATEST_VERSION_NOT_FOUND", async ({ expect }) => {
+// API returns null/empty → ERR_UPDATER_NO_PUBLISHED_VERSIONS
+test("null API response - throws ERR_UPDATER_NO_PUBLISHED_VERSIONS", async ({ expect }) => {
   const requestSpy = createMockRequest()
   const updater = await createGitlabUpdater(requestSpy)
 
   requestSpy.mockResolvedValueOnce(null)
+
+  await expect(updater.checkForUpdates()).rejects.toMatchObject({ code: "ERR_UPDATER_NO_PUBLISHED_VERSIONS" })
+})
+
+// upcoming_release=true → ERR_UPDATER_LATEST_VERSION_NOT_FOUND (scheduled, not yet published)
+test("upcoming release - throws ERR_UPDATER_LATEST_VERSION_NOT_FOUND", async ({ expect }) => {
+  const requestSpy = createMockRequest()
+  const updater = await createGitlabUpdater(requestSpy)
+
+  const release = mockGitlabRelease(STABLE_VERSION)
+  release.upcoming_release = true
+  requestSpy.mockResolvedValueOnce(JSON.stringify(release))
 
   await expect(updater.checkForUpdates()).rejects.toMatchObject({ code: "ERR_UPDATER_LATEST_VERSION_NOT_FOUND" })
 })
@@ -142,6 +154,12 @@ test("PRIVATE-TOKEN auth - plain token sent as PRIVATE-TOKEN header", async ({ e
 
   const firstCallHeaders = requestSpy.mock.calls[0][0].headers as Record<string, string>
   expect(firstCallHeaders["PRIVATE-TOKEN"]).toBe("glpat-abc123")
+  expect(firstCallHeaders["authorization"]).toBeUndefined()
+
+  // Channel YAML download (second request) must also use PRIVATE-TOKEN, not authorization
+  const secondCallHeaders = requestSpy.mock.calls[1][0].headers as Record<string, string>
+  expect(secondCallHeaders["PRIVATE-TOKEN"]).toBe("glpat-abc123")
+  expect(secondCallHeaders["authorization"]).toBeUndefined()
 })
 
 // Bearer token sent as authorization header when token starts with "Bearer"
@@ -156,6 +174,11 @@ test("Bearer auth - token starting with Bearer sent as authorization header", as
   const firstCallHeaders = requestSpy.mock.calls[0][0].headers as Record<string, string>
   expect(firstCallHeaders["authorization"]).toBe("Bearer gloas-oauth-token")
   expect(firstCallHeaders["PRIVATE-TOKEN"]).toBeUndefined()
+
+  // Channel YAML download (second request) must also use authorization, not PRIVATE-TOKEN
+  const secondCallHeaders = requestSpy.mock.calls[1][0].headers as Record<string, string>
+  expect(secondCallHeaders["authorization"]).toBe("Bearer gloas-oauth-token")
+  expect(secondCallHeaders["PRIVATE-TOKEN"]).toBeUndefined()
 })
 
 // No token → no auth headers on the release API request


### PR DESCRIPTION
In investigating this PR comment (https://github.com/electron-userland/electron-builder/pull/9702#discussion_r3184252771) on test case flow that was missing and cross-referencing with API docs, there are a few fixes that need to be made.

Bug fixes:
- Bearer tokens were always sent as `PRIVATE-TOKEN` on the channel YAML download (second request); now uses `setAuthHeaderForToken` consistently
- `upcoming_release: true` releases are now filtered out correctly — previously, provider would surface a scheduled/unpublished release as an available update. This mirrors logic utilized for Github `draft` releases
- `Content-Type: application/json` on GET requests replaced with `Accept: application/json`
- Null API response now throws `ERR_UPDATER_NO_PUBLISHED_VERSIONS` instead of being swallowed by the outer try-catch block w/ `ERR_UPDATER_LATEST_VERSION_NOT_FOUND`
- Deduplicated inline asset map build in `getLatestVersion` to use existing `convertAssetsToMap`