### PR TITLE
chore: harden function resolution, utilize deepAssign helper utility, and escape node module collector command

### DIFF
--- a/.changeset/five-rocks-like.md
+++ b/.changeset/five-rocks-like.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: adding hardening to resolving scripts to be within the workspace directory, utilize deepAssign helper utility, and escape command used within node module collector

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -160,7 +160,7 @@ export async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink
   // use constant file
   const keychainFile = path.join(
     process.env.APP_BUILDER_TMP_DIR || tmpdir(),
-    `${createHash("sha256").update(currentDir).update("app-builder").update(randomBytes(16)).digest("hex")}.keychain`
+    `${createHash("sha256").update(currentDir).update("app-builder").digest("hex")}.keychain`
   )
   // noinspection JSUnusedLocalSymbols
 

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -158,7 +158,10 @@ export async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink
 
   // https://github.com/electron-userland/electron-builder/issues/3685
   // use constant file
-  const keychainFile = path.join(process.env.APP_BUILDER_TMP_DIR || tmpdir(), `${createHash("sha256").update(currentDir).update("app-builder").digest("hex")}.keychain`)
+  const keychainFile = path.join(
+    process.env.APP_BUILDER_TMP_DIR || tmpdir(),
+    `${createHash("sha256").update(currentDir).update("app-builder").update(randomBytes(16)).digest("hex")}.keychain`
+  )
   // noinspection JSUnusedLocalSymbols
 
   await removeKeychain(keychainFile, false).catch(_ => {

--- a/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
+++ b/packages/app-builder-lib/src/codeSign/windowsSignToolManager.ts
@@ -190,7 +190,7 @@ export class WindowsSignToolManager implements SignManager {
     const name = this.packager.appInfo.productName
     const site = await this.packager.appInfo.computePackageUrl()
 
-    const customSign = await resolveFunction(this.packager.appInfo.type, options.options.signtoolOptions?.sign, "sign")
+    const customSign = await resolveFunction(this.packager.appInfo.type, options.options.signtoolOptions?.sign, "sign", await this.packager.info.getWorkspaceRoot())
 
     const cscInfo = await this.cscInfo.value
     if (cscInfo) {

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -266,7 +266,7 @@ async function unpack(prepareOptions: PrepareApplicationStageDirectoryOptions, d
 
   let resolvedDist: string | null = null
   try {
-    const electronDistHook: any = await resolveFunction(packager.appInfo.type, electronDist, "electronDist")
+    const electronDistHook: any = await resolveFunction(packager.appInfo.type, electronDist, "electronDist", await packager.info.getWorkspaceRoot())
     resolvedDist = typeof electronDistHook === "function" ? await Promise.resolve(electronDistHook(prepareOptions)) : electronDistHook
   } catch (error: any) {
     log.warn({ error }, "Failed to resolve electronDist, using default unpack logic")

--- a/packages/app-builder-lib/src/index.ts
+++ b/packages/app-builder-lib/src/index.ts
@@ -91,7 +91,12 @@ export function build(options: PackagerOptions & PublishOptions, packager: Packa
   process.once("SIGINT", sigIntHandler)
 
   const promise = packager.build().then(async buildResult => {
-    const afterAllArtifactBuild = await resolveFunction(packager.appInfo.type, buildResult.configuration.afterAllArtifactBuild, "afterAllArtifactBuild")
+    const afterAllArtifactBuild = await resolveFunction(
+      packager.appInfo.type,
+      buildResult.configuration.afterAllArtifactBuild,
+      "afterAllArtifactBuild",
+      await packager.getWorkspaceRoot()
+    )
     if (afterAllArtifactBuild != null) {
       const newArtifacts = asArray(await Promise.resolve(afterAllArtifactBuild(buildResult)))
       if (newArtifacts.length === 0 || !publishManager.isPublish) {

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -336,8 +336,8 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
         : filter.map(it => {
             try {
               return new RegExp(it)
-            } catch {
-              throw new InvalidConfigurationError(`Invalid regex filter pattern: ${it}`)
+            } catch (e: any) {
+              throw new InvalidConfigurationError(`Invalid regex filter pattern: ${it}. ${e.message}`)
             }
           })
 

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -330,7 +330,16 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
       filter = filter.length === 0 ? null : [filter]
     }
 
-    const filterRe = filter == null ? null : filter.map(it => new RegExp(it))
+    const filterRe =
+      filter == null
+        ? null
+        : filter.map(it => {
+            try {
+              return new RegExp(it)
+            } catch {
+              throw new InvalidConfigurationError(`Invalid regex filter pattern: ${it}`)
+            }
+          })
 
     let binaries = options.binaries || undefined
     if (binaries) {
@@ -478,7 +487,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
 
   //noinspection JSMethodCanBeStatic
   protected async doSign(opts: SignOptions, customSignOptions: MacConfiguration, identity: Identity | null): Promise<void> {
-    const customSign = await resolveFunction(this.appInfo.type, customSignOptions.sign, "sign")
+    const customSign = await resolveFunction(this.appInfo.type, customSignOptions.sign, "sign", await this.info.getWorkspaceRoot())
 
     const { app, platform, type, provisioningProfile } = opts
     log.info(
@@ -579,7 +588,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
 
     const extendInfo = this.platformSpecificBuildOptions.extendInfo
     if (extendInfo != null) {
-      Object.assign(appPlist, extendInfo)
+      deepAssign(appPlist, extendInfo)
     }
     for (const [k, v] of Object.entries(appPlist)) {
       if (v === null || v === undefined) {

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -366,7 +366,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
         prefix: execName,
         suffix: ".bat",
       })
-      const escapedCommand = command.replace(/"/g, '""')
+      const escapedCommand = command.replace(/"/g, `""`)
       const batScript = `@echo off\r\n"${escapedCommand}" %*\r\n` // <-- CRLF required for .bat
       await fs.writeFile(tempBatFile, batScript, { encoding: "utf8" })
       command = "cmd.exe"

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -366,7 +366,8 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
         prefix: execName,
         suffix: ".bat",
       })
-      const batScript = `@echo off\r\n"${command}" %*\r\n` // <-- CRLF required for .bat
+      const escapedCommand = command.replace(/"/g, '""')
+      const batScript = `@echo off\r\n"${escapedCommand}" %*\r\n` // <-- CRLF required for .bat
       await fs.writeFile(tempBatFile, batScript, { encoding: "utf8" })
       command = "cmd.exe"
       args = ["/c", `"${tempBatFile}"`, ...args]

--- a/packages/app-builder-lib/src/packager.ts
+++ b/packages/app-builder-lib/src/packager.ts
@@ -289,16 +289,17 @@ export class Packager {
 
   private async addPackagerEventHandlers() {
     const { type } = this.appInfo
-    this.eventEmitter.on("artifactBuildStarted", await resolveFunction(type, this.config.artifactBuildStarted, "artifactBuildStarted"), "user")
-    this.eventEmitter.on("artifactBuildCompleted", await resolveFunction(type, this.config.artifactBuildCompleted, "artifactBuildCompleted"), "user")
+    const root = await this.getWorkspaceRoot()
+    this.eventEmitter.on("artifactBuildStarted", await resolveFunction(type, this.config.artifactBuildStarted, "artifactBuildStarted", root), "user")
+    this.eventEmitter.on("artifactBuildCompleted", await resolveFunction(type, this.config.artifactBuildCompleted, "artifactBuildCompleted", root), "user")
 
-    this.eventEmitter.on("appxManifestCreated", await resolveFunction(type, this.config.appxManifestCreated, "appxManifestCreated"), "user")
-    this.eventEmitter.on("msiProjectCreated", await resolveFunction(type, this.config.msiProjectCreated, "msiProjectCreated"), "user")
+    this.eventEmitter.on("appxManifestCreated", await resolveFunction(type, this.config.appxManifestCreated, "appxManifestCreated", root), "user")
+    this.eventEmitter.on("msiProjectCreated", await resolveFunction(type, this.config.msiProjectCreated, "msiProjectCreated", root), "user")
 
-    this.eventEmitter.on("beforePack", await resolveFunction(type, this.config.beforePack, "beforePack"), "user")
-    this.eventEmitter.on("afterExtract", await resolveFunction(type, this.config.afterExtract, "afterExtract"), "user")
-    this.eventEmitter.on("afterPack", await resolveFunction(type, this.config.afterPack, "afterPack"), "user")
-    this.eventEmitter.on("afterSign", await resolveFunction(type, this.config.afterSign, "afterSign"), "user")
+    this.eventEmitter.on("beforePack", await resolveFunction(type, this.config.beforePack, "beforePack", root), "user")
+    this.eventEmitter.on("afterExtract", await resolveFunction(type, this.config.afterExtract, "afterExtract", root), "user")
+    this.eventEmitter.on("afterPack", await resolveFunction(type, this.config.afterPack, "afterPack", root), "user")
+    this.eventEmitter.on("afterSign", await resolveFunction(type, this.config.afterSign, "afterSign", root), "user")
   }
 
   onAfterPack(handler: PackagerEvents["afterPack"]): Packager {
@@ -625,7 +626,7 @@ export class Packager {
       return
     }
 
-    const beforeBuild = await resolveFunction(this.appInfo.type, config.beforeBuild, "beforeBuild")
+    const beforeBuild = await resolveFunction(this.appInfo.type, config.beforeBuild, "beforeBuild", await this.getWorkspaceRoot())
     if (beforeBuild != null) {
       const performDependenciesInstallOrRebuild = await beforeBuild({
         appDir: this.appDir,

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -53,7 +53,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
     const filter = this.filter
     const metadata = this.metadata
 
-    const onNodeModuleFile = await resolveFunction(this.packager.appInfo.type, this.packager.config.onNodeModuleFile, "onNodeModuleFile")
+    const onNodeModuleFile = await resolveFunction(this.packager.appInfo.type, this.packager.config.onNodeModuleFile, "onNodeModuleFile", await this.packager.getWorkspaceRoot())
 
     const result: Array<string | undefined> = []
     const queue: Array<string> = []

--- a/packages/app-builder-lib/src/util/resolve.ts
+++ b/packages/app-builder-lib/src/util/resolve.ts
@@ -1,3 +1,4 @@
+import { InvalidConfigurationError } from "builder-util"
 import { log } from "builder-util/out/log"
 import debug from "debug"
 import * as path from "path"
@@ -12,7 +13,7 @@ export async function resolveModule<T>(type: string | undefined, name: string): 
   }
 }
 
-export async function resolveFunction<T>(type: string | undefined, executor: T | string, name: string): Promise<T> {
+export async function resolveFunction<T>(type: string | undefined, executor: T | string, name: string, rootSearchDir?: string): Promise<T> {
   if (executor == null || typeof executor !== "string") {
     // is already function or explicitly ignored by user
     return executor
@@ -21,6 +22,12 @@ export async function resolveFunction<T>(type: string | undefined, executor: T |
   let p = executor as string
   if (p.startsWith(".")) {
     p = path.resolve(p)
+    if (rootSearchDir != null) {
+      const relative = path.relative(rootSearchDir, p)
+      if (relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new InvalidConfigurationError(`Hook module path "${executor}" resolves outside the project directory`)
+      }
+    }
   }
 
   try {

--- a/packages/app-builder-lib/src/util/resolve.ts
+++ b/packages/app-builder-lib/src/util/resolve.ts
@@ -13,7 +13,7 @@ export async function resolveModule<T>(type: string | undefined, name: string): 
   }
 }
 
-export async function resolveFunction<T>(type: string | undefined, executor: T | string, name: string, rootSearchDir?: string): Promise<T> {
+export async function resolveFunction<T>(type: string | undefined, executor: T | string, name: string, rootSearchDir: string): Promise<T> {
   if (executor == null || typeof executor !== "string") {
     // is already function or explicitly ignored by user
     return executor
@@ -22,11 +22,9 @@ export async function resolveFunction<T>(type: string | undefined, executor: T |
   let p = executor as string
   if (p.startsWith(".")) {
     p = path.resolve(p)
-    if (rootSearchDir != null) {
-      const relative = path.relative(rootSearchDir, p)
-      if (relative.startsWith("..") || path.isAbsolute(relative)) {
-        throw new InvalidConfigurationError(`Hook module path "${executor}" resolves outside the project directory`)
-      }
+    const relative = path.relative(rootSearchDir, p)
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      throw new InvalidConfigurationError(`Hook module path "${executor}" resolves outside the workspace root ("${rootSearchDir}")`)
     }
   }
 


### PR DESCRIPTION
This PR hardens user hook/function resolution to reduce the chance of resolving arbitrary paths outside the workspace, improves some configuration handling, and tightens Windows command execution in the node module collector.

Changes:
- Add workspace-root bounding to `resolveFunction and thread workspace root through hook resolution call sites to make sure all hooks are within the current project.
- Escape embedded quotes when generating the Windows .bat wrapper used by the node module collector.
- Improve macOS packaging behaviors: validate `signIgnore` regexes and switch `extendInfo` merging to `deepAssign`