### PR TITLE
chore(tests): update vitest and stabilize archlinux+windows e2e tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,13 +586,46 @@ importers:
         version: 35.7.5
 
   test:
-    dependencies:
+    devDependencies:
+      '@babel/core':
+        specifier: 7.24.9
+        version: 7.24.9
+      '@babel/preset-env':
+        specifier: 7.15.6
+        version: 7.15.6(@babel/core@7.24.9)
+      '@babel/preset-typescript':
+        specifier: ^7.23.3
+        version: 7.28.5(@babel/core@7.24.9)
       '@electron/get':
         specifier: ^3.1.0
         version: 3.1.0
       '@electron/osx-sign':
         specifier: ^1.0.4
         version: 1.3.3
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      '@types/adm-zip':
+        specifier: 0.5.6
+        version: 0.5.6
+      '@types/fs-extra':
+        specifier: ^9.0.11
+        version: 9.0.13
+      '@types/js-yaml':
+        specifier: ^4.0.1
+        version: 4.0.3
+      '@types/request':
+        specifier: ^2.48.12
+        version: 2.48.13
+      '@types/semver':
+        specifier: 7.7.1
+        version: 7.7.1
+      '@types/unzipper':
+        specifier: ^0.10.11
+        version: 0.10.11
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       adm-zip:
         specifier: 0.5.16
         version: 0.5.16
@@ -632,6 +665,9 @@ importers:
       electron-winstaller:
         specifier: 5.4.0
         version: 5.4.0
+      fast-xml-parser:
+        specifier: 5.7.0
+        version: 5.7.0
       fs-extra:
         specifier: ^10.1.0
         version: 10.1.0
@@ -647,6 +683,9 @@ importers:
       resedit:
         specifier: 1.7.0
         version: 1.7.0
+      sanitize-filename:
+        specifier: ^1.6.3
+        version: 1.6.3
       semver:
         specifier: 7.7.2
         version: 7.7.2
@@ -659,51 +698,8 @@ importers:
       unzipper:
         specifier: ^0.12.3
         version: 0.12.3
-      yargs:
-        specifier: ^17.6.2
-        version: 17.7.2
-    devDependencies:
-      '@babel/core':
-        specifier: 7.24.9
-        version: 7.24.9
-      '@babel/preset-env':
-        specifier: 7.15.6
-        version: 7.15.6(@babel/core@7.24.9)
-      '@babel/preset-typescript':
-        specifier: ^7.23.3
-        version: 7.28.5(@babel/core@7.24.9)
-      '@jest/globals':
-        specifier: ^29.7.0
-        version: 29.7.0
-      '@types/adm-zip':
-        specifier: 0.5.6
-        version: 0.5.6
-      '@types/fs-extra':
-        specifier: ^9.0.11
-        version: 9.0.13
-      '@types/js-yaml':
-        specifier: ^4.0.1
-        version: 4.0.3
-      '@types/request':
-        specifier: ^2.48.12
-        version: 2.48.13
-      '@types/semver':
-        specifier: 7.7.1
-        version: 7.7.1
-      '@types/unzipper':
-        specifier: ^0.10.11
-        version: 0.10.11
-      '@types/which':
-        specifier: ^3.0.4
-        version: 3.0.4
-      fast-xml-parser:
-        specifier: 5.7.0
-        version: 5.7.0
-      sanitize-filename:
-        specifier: ^1.6.3
-        version: 1.6.3
       vitest:
-        specifier: ^3.0.4
+        specifier: ^3.2.4
         version: 3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4(vitest@3.2.4))(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1)
       vitest-mock-commonjs:
         specifier: ^1.0.2
@@ -711,6 +707,9 @@ importers:
       which:
         specifier: ^5.0.0
         version: 5.0.0
+      yargs:
+        specifier: ^17.6.2
+        version: 17.7.2
 
 packages:
 

--- a/test/package.json
+++ b/test/package.json
@@ -2,9 +2,20 @@
   "name": "@electron-builder/test",
   "version": "0.0.0",
   "private": true,
-  "dependencies": {
+  "devDependencies": {
+    "@babel/core": "7.24.9",
+    "@babel/preset-env": "7.15.6",
+    "@babel/preset-typescript": "^7.23.3",
     "@electron/get": "^3.1.0",
     "@electron/osx-sign": "^1.0.4",
+    "@jest/globals": "^29.7.0",
+    "@types/adm-zip": "0.5.6",
+    "@types/fs-extra": "^9.0.11",
+    "@types/js-yaml": "^4.0.1",
+    "@types/request": "^2.48.12",
+    "@types/semver": "7.7.1",
+    "@types/unzipper": "^0.10.11",
+    "@types/which": "^3.0.4",
     "adm-zip": "0.5.16",
     "app-builder-lib": "workspace:*",
     "builder-util": "workspace:*",
@@ -18,63 +29,20 @@
     "electron-publish": "workspace:*",
     "electron-updater": "workspace:*",
     "electron-winstaller": "5.4.0",
+    "fast-xml-parser": "5.7.0",
     "fs-extra": "^10.1.0",
     "js-yaml": "^4.1.0",
     "lazy-val": "^1.0.5",
     "path-sort": "^0.1.0",
     "resedit": "1.7.0",
+    "sanitize-filename": "^1.6.3",
     "semver": "7.7.2",
     "stat-mode": "^1.0.0",
     "temp-file": "^3.4.0",
     "unzipper": "^0.12.3",
-    "yargs": "^17.6.2"
-  },
-  "devDependencies": {
-    "@babel/core": "7.24.9",
-    "@babel/preset-env": "7.15.6",
-    "@babel/preset-typescript": "^7.23.3",
-    "@jest/globals": "^29.7.0",
-    "@types/adm-zip": "0.5.6",
-    "@types/fs-extra": "^9.0.11",
-    "@types/js-yaml": "^4.0.1",
-    "@types/request": "^2.48.12",
-    "@types/semver": "7.7.1",
-    "@types/unzipper": "^0.10.11",
-    "@types/which": "^3.0.4",
-    "fast-xml-parser": "5.7.0",
-    "sanitize-filename": "^1.6.3",
-    "vitest": "^3.0.4",
+    "vitest": "^3.2.4",
     "vitest-mock-commonjs": "^1.0.2",
-    "which": "^5.0.0"
-  },
-  "jest": {
-    "snapshotResolver": "<rootDir>/snapshotResolver.js",
-    "testEnvironment": "node",
-    "roots": [
-      "src"
-    ],
-    "transformIgnorePatterns": [
-      "./node_modules",
-      "../node_modules",
-      "../packages"
-    ],
-    "transform": {
-      "^.+\\.ts$": [
-        "esbuild-jest",
-        {
-          "sourcemap": "inline",
-          "loaders": {
-            ".ts": "ts"
-          }
-        }
-      ]
-    },
-    "testPathIgnorePatterns": [
-      "[\\/]{1}helpers[\\/]{1}"
-    ],
-    "testRegex": "\\.[jt]s$",
-    "setupFilesAfterEnv": [
-      "<rootDir>/jestSetup.js"
-    ]
+    "which": "^5.0.0",
+    "yargs": "^17.6.2"
   }
 }

--- a/test/src/updater/blackboxUpdateTest.ts
+++ b/test/src/updater/blackboxUpdateTest.ts
@@ -147,22 +147,32 @@ async function runTest(context: TestContext, target: string, packageManager: str
       const pollInterval = 5 * 1000
       let newVersion: string | undefined
       while (Date.now() < pollDeadline) {
-        const probe = await launchAndWaitForQuit({
-          appPath,
-          timeoutMs: 30 * 1000,
-          updateConfigPath,
-          packageManagerToTest: packageManager,
-          env: { AUTO_UPDATER_TEST: "" }, // disables updater — app prints version and quits
-          // waitForExit: true ensures TestApp.exe is fully released before the next
-          // poll iteration, giving the detached NSIS installer an uncontested window
-          // to overwrite the binary (Windows locks executables while they are running).
-          waitForExit: true,
-        })
-        newVersion = probe.version
-        if (newVersion === NEW_VERSION_NUMBER) {
-          break
+        try {
+          const probe = await launchAndWaitForQuit({
+            appPath,
+            timeoutMs: 30 * 1000,
+            updateConfigPath,
+            packageManagerToTest: packageManager,
+            env: { AUTO_UPDATER_TEST: "" }, // disables updater — app prints version and quits
+            // waitForExit: true ensures TestApp.exe is fully released before the next
+            // poll iteration, giving the detached NSIS installer an uncontested window
+            // to overwrite the binary (Windows locks executables while they are running).
+            waitForExit: true,
+          })
+          newVersion = probe.version
+          if (newVersion === NEW_VERSION_NUMBER) {
+            break
+          }
+          log.info({ installedVersion: newVersion, expected: NEW_VERSION_NUMBER }, "Installer still in progress, retrying...")
+        } catch (err: any) {
+          // NSIS replaces the exe non-atomically: it deletes the old binary before writing the new one,
+          // so there is a brief window where TestApp.exe does not exist on disk.
+          if (err.code === "ENOENT" && (err.syscall === "spawn" || err.syscall?.startsWith("spawn "))) {
+            log.info({ appPath }, "Binary temporarily unavailable (NSIS installer in progress), retrying...")
+          } else {
+            throw err
+          }
         }
-        log.info({ installedVersion: newVersion, expected: NEW_VERSION_NUMBER }, "Installer still in progress, retrying...")
         if (Date.now() + pollInterval < pollDeadline) {
           await new Promise(resolve => setTimeout(resolve, pollInterval))
         }
@@ -369,6 +379,16 @@ async function handleInitialInstallPerOS({ target, dirPath, arch }: { target: st
     // execSync(`sudo pacman -U --noconfirm "${path.join(dirPath, `TestApp.pacman`)}"`, { stdio: "inherit" })
     appPath = path.join("/opt", "TestApp", "TestApp")
   } else if (process.platform === "win32") {
+    // Kill any lingering NSIS installer processes left over from previous test retries.
+    // Without this, ALLOW_ONLY_ONE_INSTALLER_INSTANCE aborts the new installer (mutex conflict),
+    // and lingering mid-replacement processes cause ENOENT at the first probe launch.
+    try {
+      execSync('taskkill /F /IM "TestApp Setup.exe" /T', { stdio: "ignore" })
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    } catch {
+      // no matching process — expected on the first run
+    }
+
     // access installed app's location
     const localProgramsPath = path.join(process.env.LOCALAPPDATA || path.join(homedir(), "AppData", "Local"), "Programs", "TestApp")
     // this is to clear dev environment when not running on an ephemeral GH runner.
@@ -403,6 +423,15 @@ async function handleCleanupPerOS({ target }: { target: string }) {
   } else if (target === "pacman") {
     execSync(`pacman -R --noconfirm testapp`, { stdio: "inherit" })
   } else if (process.platform === "win32") {
+    // Kill any lingering NSIS installer processes before running the uninstaller,
+    // so the uninstaller isn't blocked by a still-running update installer holding file locks.
+    try {
+      execSync('taskkill /F /IM "TestApp Setup.exe" /T', { stdio: "ignore" })
+      await new Promise(resolve => setTimeout(resolve, 500))
+    } catch {
+      // no matching process — ignore
+    }
+
     // access installed app's location
     const localProgramsPath = path.join(process.env.LOCALAPPDATA || path.join(homedir(), "AppData", "Local"), "Programs", "TestApp")
     const uninstaller = path.join(localProgramsPath, "Uninstall TestApp.exe")

--- a/test/src/updater/dockerfile-archlinux
+++ b/test/src/updater/dockerfile-archlinux
@@ -1,10 +1,10 @@
 FROM archlinux:base-20250629.0.373469
 
-RUN pacman -Sy --noconfirm archlinux-keyring \
- && pacman -S --noconfirm gnupg \
- && pacman-key --init \
+RUN pacman-key --init \
  && pacman-key --populate archlinux \
- && pacman-key --refresh-keys \
+ && pacman -Sy --noconfirm archlinux-keyring \
+ && pacman-key --populate archlinux \
+ && pacman -S --noconfirm gnupg \
  && pacman -Syu --noconfirm \
  && pacman -S --noconfirm \
     libxcrypt-compat \
@@ -12,14 +12,8 @@ RUN pacman -Sy --noconfirm archlinux-keyring \
     git \
     nodejs \
     npm \
+    sudo \
     xorg-server-xvfb \
- && pacman -Scc --noconfirm \
- && rm -rf /var/lib/pacman/sync/* /var/cache/pacman/pkg/*
-
-# install prerequisites for building
-RUN pacman -Sy --noconfirm archlinux-keyring \
- && pacman -Syu --noconfirm \
- && pacman -S --noconfirm base-devel git sudo \
  && pacman -Scc --noconfirm \
  && rm -rf /var/lib/pacman/sync/* /var/cache/pacman/pkg/*
 

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -57,7 +57,6 @@ async function main() {
     reporters: ["default", __dirname + "/vitest-smart-reporter.ts"],
 
     maxWorkers: "50%",
-    minWorkers: 1,
 
     // Ensure tests from different files can run in parallel
     // but heavy tests will be serialized by the mutex


### PR DESCRIPTION
- Updates vitest
- Migrates "prod" `dependencies `of `test` package (because none should be production since it isn't deployed/published) to `devDependencies`
- Remove `jest` from `package.json`; it's no longer utilized and dead config.
- Fix unstable test on windows e2e updater from its process still hanging around
- Fix archlinux e2e updater test whose docker image randomly stopped building