### PR TITLE
fix: add support for pnpm 11

### DIFF
--- a/.changeset/swift-steaks-say.md
+++ b/.changeset/swift-steaks-say.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add support for pnpm v11

--- a/packages/app-builder-lib/src/codeSign/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/macCodeSign.ts
@@ -158,10 +158,7 @@ export async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink
 
   // https://github.com/electron-userland/electron-builder/issues/3685
   // use constant file
-  const keychainFile = path.join(
-    process.env.APP_BUILDER_TMP_DIR || tmpdir(),
-    `${createHash("sha256").update(currentDir).update("app-builder").digest("hex")}.keychain`
-  )
+  const keychainFile = path.join(process.env.APP_BUILDER_TMP_DIR || tmpdir(), `${createHash("sha256").update(currentDir).update("app-builder").digest("hex")}.keychain`)
   // noinspection JSUnusedLocalSymbols
 
   await removeKeychain(keychainFile, false).catch(_ => {

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -1,12 +1,36 @@
+import { Lazy } from "lazy-val"
 import { LogMessageByKey } from "./moduleManager"
 import { NodeModulesCollector } from "./nodeModulesCollector"
-import { PM } from "./packageManager"
+import { getPackageManagerCommand, PM } from "./packageManager"
 import { PnpmDependency } from "./types"
 
 export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependency, PnpmDependency> {
   public readonly installOptions = {
     manager: PM.PNPM,
     lockfile: "pnpm-lock.yaml",
+  }
+
+  // Raw backing field — all entries from `pnpm list --json`
+  private _allWorkspacePackages: PnpmDependency[] = []
+  // Cached after parseDependenciesTree resolves the Lazy; 0 = safe default (treated as < v11)
+  private _pnpmMajorVersion = 0
+  // Runs `pnpm --version` once and caches the major version number
+  private readonly pnpmVersion = new Lazy<number>(async () => {
+    const result = await this.asyncExec(getPackageManagerCommand(PM.PNPM), ["--version"])
+    const major = parseInt((result.stdout ?? "0").split(".")[0], 10)
+    return isNaN(major) ? 0 : major
+  })
+
+  /**
+   * Returns the workspace packages to iterate over, gated by detected pnpm version:
+   * - pnpm v11+: multi-entry workspace output → return the full parsed array
+   * - pnpm < v11 / non-workspace / detection failure: single-tree behavior → return only [0]
+   */
+  private get allWorkspacePackages(): PnpmDependency[] {
+    if (this._pnpmMajorVersion >= 11) {
+      return this._allWorkspacePackages
+    }
+    return this._allWorkspacePackages.slice(0, 1)
   }
 
   protected getArgs(): string[] {
@@ -80,31 +104,48 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
     this.productionGraph[dependencyId] = { dependencies: collectedDependencies }
   }
 
-  protected async collectAllDependencies(tree: PnpmDependency) {
-    // Collect regular dependencies
+  protected async collectAllDependencies(_tree: PnpmDependency, _appPackageName: string): Promise<void> {
+    for (const root of this.allWorkspacePackages) {
+      await this.collectDepsRecursively(root)
+    }
+  }
+
+  private async collectDepsRecursively(tree: PnpmDependency): Promise<void> {
     for (const [key, value] of Object.entries(tree.dependencies || {})) {
       if ((value?.dedupedDependenciesCount ?? 0) > 0) {
         continue
       }
       const pkg = await this.locateFromDepOrRoot(key, value.path, value.version)
       this.allDependencies.set(`${key}@${value.version}`, { ...value, path: pkg?.packageDir ?? value.path })
-      await this.collectAllDependencies(value)
+      await this.collectDepsRecursively(value)
     }
 
-    // Collect optional dependencies if they exist
     for (const [key, value] of Object.entries(tree.optionalDependencies || {})) {
       if ((value?.dedupedDependenciesCount ?? 0) > 0) {
         continue
       }
       const pkg = await this.locateFromDepOrRoot(key, value.path, value.version)
       this.allDependencies.set(`${key}@${value.version}`, { ...value, path: pkg?.packageDir ?? value.path })
-      await this.collectAllDependencies(value)
+      await this.collectDepsRecursively(value)
     }
   }
 
-  protected parseDependenciesTree(jsonBlob: string): PnpmDependency {
-    // pnpm returns an array of dependency trees
-    const dependencyTree: PnpmDependency[] = this.extractJsonFromPollutedOutput<PnpmDependency[]>(jsonBlob)
+  protected override getTreeFromWorkspaces(tree: PnpmDependency, packageName: string): PnpmDependency {
+    // pnpm v10 workspace: app is nested as a dependency of root — handled by base class
+    const result = super.getTreeFromWorkspaces(tree, packageName)
+    if (result !== tree) {
+      return result
+    }
+    // pnpm v11 workspace: each workspace package is a separate top-level array entry;
+    // non-workspace (single-tree): find returns the one entry or undefined → falls back to tree
+    const match = this.allWorkspacePackages.find(pkg => pkg.name === packageName || pkg.from === packageName)
+    return match ?? tree
+  }
+
+  protected async parseDependenciesTree(jsonBlob: string): Promise<PnpmDependency> {
+    const dependencyTree = this.extractJsonFromPollutedOutput<PnpmDependency[]>(jsonBlob)
+    this._allWorkspacePackages = dependencyTree
+    this._pnpmMajorVersion = await this.pnpmVersion.value
     return dependencyTree[0]
   }
 }

--- a/test/fixtures/test-app-yarn-several-workspace/pnpm-workspace.yaml
+++ b/test/fixtures/test-app-yarn-several-workspace/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
-  - "packages/*"
+  - packages/*
+allowBuilds:
+  electron: true

--- a/test/snapshots/HoistedNodeModuleTest.js.snap
+++ b/test/snapshots/HoistedNodeModuleTest.js.snap
@@ -28474,6 +28474,83 @@ exports[`node_module collectors > pnpm shamefully-hoist=true 2`] = `
 }
 `;
 
+exports[`node_module collectors > pnpm v11 workspace 1`] = `
+{
+  "linux": [],
+}
+`;
+
+exports[`node_module collectors > pnpm v11 workspace 2`] = `
+{
+  "files": {
+    "index.html": {
+      "offset": 24710,
+      "size": 850,
+    },
+    "index.js": {
+      "offset": 25550,
+      "size": 2510,
+    },
+    "node_modules": {
+      "files": {
+        "debug": {
+          "files": {
+            "LICENSE": {
+              "offset": 0,
+              "size": 1140,
+            },
+            "package.json": {
+              "offset": 1140,
+              "size": 910,
+            },
+            "src": {
+              "files": {
+                "browser.js": {
+                  "offset": 2050,
+                  "size": 6110,
+                },
+                "common.js": {
+                  "offset": 8160,
+                  "size": 6920,
+                },
+                "index.js": {
+                  "offset": 15070,
+                  "size": 320,
+                },
+                "node.js": {
+                  "offset": 15390,
+                  "size": 4730,
+                },
+              },
+            },
+          },
+        },
+        "ms": {
+          "files": {
+            "index.js": {
+              "offset": 20110,
+              "size": 3030,
+            },
+            "license.md": {
+              "offset": 23140,
+              "size": 1080,
+            },
+            "package.json": {
+              "offset": 24220,
+              "size": 500,
+            },
+          },
+        },
+      },
+    },
+    "package.json": {
+      "offset": 28060,
+      "size": 290,
+    },
+  },
+}
+`;
+
 exports[`node_module collectors > pnpm workspace with native module 1`] = `
 {
   "linux": [],

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -6,6 +6,7 @@ import { appTwoThrows, assertPack, linuxDirTarget, modifyPackageJson, verifyAsar
 import { ELECTRON_VERSION } from "./helpers/testConfig"
 import { copy, mkdir, outputFile, readJson, rm, symlink, writeJson } from "fs-extra"
 import { assertThat } from "./helpers/fileAssert"
+import { dump } from "js-yaml"
 
 describe.ifNotWindows("node_module collectors", () => {
   test("yarn workspace", ({ expect }) =>
@@ -636,6 +637,40 @@ describe.ifNotWindows("node_module collectors", () => {
                 electron: ELECTRON_VERSION,
               }
             }),
+          ])
+        },
+        packed: context => verifyAsarFileTree(expect, context.getResources(Platform.LINUX)),
+      }
+    ))
+
+  // https://github.com/electron-userland/electron-builder/issues/9711
+  test("pnpm v11 workspace", ({ expect }) =>
+    assertPack(
+      expect,
+      "test-app-yarn-several-workspace",
+      {
+        targets: linuxDirTarget,
+        projectDir: "packages/test-app",
+      },
+      {
+        storeDepsLockfileSnapshot: true,
+        packageManager: PM.PNPM,
+        projectDirCreated: async projectDir => {
+          return Promise.all([
+            modifyPackageJson(projectDir, data => {
+              data.packageManager = "pnpm@11.0.9"
+            }),
+            modifyPackageJson(path.join(projectDir, "packages", "test-app"), data => {
+              data.dependencies = {
+                debug: "4.4.3",
+              }
+              data.devDependencies = {
+                electron: ELECTRON_VERSION,
+              }
+            }),
+            // pnpm v11 requires explicit build script approval via allowBuilds in pnpm-workspace.yaml
+            // (replaces the removed onlyBuiltDependencies / neverBuiltDependencies settings)
+            outputFile(path.join(projectDir, "pnpm-workspace.yaml"), dump({ packages: ["packages/*"], allowBuilds: { electron: true } })),
           ])
         },
         packed: context => verifyAsarFileTree(expect, context.getResources(Platform.LINUX)),


### PR DESCRIPTION
- Fixes pnpm v11 workspace builds producing empty bundles (`Error: Cannot find module`) due to a breaking change in `pnpm list --json` output format
- pnpm v11 returns one array entry **per workspace package**; v10 returned the root entry with workspace packages nested as dependencies — electron-builder assumed the old layout and collected zero dependencies
- Detects pnpm major version via a `Lazy<number>` and exposes a version-aware `allWorkspacePackages` getter that returns the full multi-entry array for v11 and single-tree behavior for v10/non-workspace
- Adds a regression test using `pnpm@11.0.9` in a workspace fixture, including the required `allowBuilds: { electron: true }` in `pnpm-workspace.yaml` (pnpm v11 replaced `onlyBuiltDependencies` with this)