### PR TITLE
chore(toolset): add additional config validations for app-builder-lib and dmg-builder

### DIFF
--- a/.changeset/five-rocks-like.md
+++ b/.changeset/five-rocks-like.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"dmg-builder": patch
+---
+
+chore: add more validations, incl. compression levels, vendor toolsets, and invalid configs

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -466,6 +466,19 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
       }
     }
 
+    const projectDir = await this.info.getWorkspaceRoot()
+    const blockExternalLoadPath = (p: string | null | undefined, label: string) => {
+      if (p && path.isAbsolute(p)) {
+        if (!p.startsWith(projectDir + path.sep) && p !== projectDir) {
+          log.error({ path: p, label }, "entitlements path is outside the workspace directory")
+          throw new InvalidConfigurationError(`Entitlements ${label} must be located inside the workspace directory`)
+        }
+      }
+    }
+    blockExternalLoadPath(customSignOptions.entitlements, "entitlements")
+    blockExternalLoadPath(customSignOptions.entitlementsInherit, "entitlementsInherit")
+    blockExternalLoadPath(customSignOptions.entitlementsLoginHelper, "entitlementsLoginHelper")
+
     const requirements = isMas || this.platformSpecificBuildOptions.requirements == null ? undefined : await this.getResource(this.platformSpecificBuildOptions.requirements)
 
     // harden by default for mac builds. Only harden mas builds if explicitly true (backward compatibility)

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -1,5 +1,6 @@
 import { exists, log, retry, TmpDir } from "builder-util"
 import * as childProcess from "child_process"
+import { randomBytes } from "crypto"
 import * as fs from "fs-extra"
 import { createWriteStream } from "fs-extra"
 import { Lazy } from "lazy-val"
@@ -363,12 +364,12 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
       // We create a temporary .bat file that calls the script-like file with the provided arguments. The .bat file will be executed by cmd.exe.
       // Note: This is a workaround for Windows command execution quirks when using `shell: true`
       const tempBatFile = await this.tempDirManager.getTempFile({
-        prefix: execName,
+        prefix: execName + "-" + randomBytes(8).toString("hex"),
         suffix: ".bat",
       })
       const escapedCommand = command.replace(/"/g, `""`)
       const batScript = `@echo off\r\n"${escapedCommand}" %*\r\n` // <-- CRLF required for .bat
-      await fs.writeFile(tempBatFile, batScript, { encoding: "utf8" })
+      await fs.writeFile(tempBatFile, batScript, { encoding: "utf8", mode: 0o600 })
       command = "cmd.exe"
       args = ["/c", `"${tempBatFile}"`, ...args]
     }

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -7,6 +7,14 @@ import { CompressionLevel } from "../core"
 import { getLinuxToolsPath } from "../toolsets/linux"
 import { TarOptionsWithAliasesAsync } from "tar/dist/commonjs/options"
 
+const ALLOWED_7Z_FILTERS = new Set(["BCJ", "BCJ2", "ARM", "ARMT", "IA64", "PPC", "SPARC", "DELTA"])
+
+function validateCompressionLevel(level: string): void {
+  if (!/^[0-9]$/.test(level)) {
+    throw new Error(`ELECTRON_BUILDER_COMPRESSION_LEVEL must be a single digit 0-9, got: "${level}"`)
+  }
+}
+
 /** @internal */
 export async function tar(compression: CompressionLevel | any, format: string, outFile: string, dirToArchive: string, isMacApp: boolean, tempDirManager: TmpDir): Promise<void> {
   const tarFile = await tempDirManager.getTempFile({ suffix: ".tar" })
@@ -89,9 +97,11 @@ export function compute7zCompressArgs(format: string, options: ArchiveOptions = 
   const args = debug7zArgs("a")
 
   let isLevelSet = false
-  if (process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL != null) {
+  const compressionLevel = process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL
+  if (compressionLevel != null) {
+    validateCompressionLevel(compressionLevel)
     storeOnly = false
-    args.push(`-mx=${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL}`)
+    args.push(`-mx=${compressionLevel}`)
     isLevelSet = true
   }
 
@@ -131,8 +141,12 @@ export function compute7zCompressArgs(format: string, options: ArchiveOptions = 
 
     // https://www.7-zip.org/7z.html
     // Filters: BCJ, BCJ2, ARM, ARMT, IA64, PPC, SPARC, ...
-    if (process.env.ELECTRON_BUILDER_7Z_FILTER) {
-      args.push(`-mf=${process.env.ELECTRON_BUILDER_7Z_FILTER}`)
+    const sevenZFilter = process.env.ELECTRON_BUILDER_7Z_FILTER
+    if (sevenZFilter) {
+      if (!ALLOWED_7Z_FILTERS.has(sevenZFilter.toUpperCase())) {
+        throw new Error(`ELECTRON_BUILDER_7Z_FILTER must be one of: ${[...ALLOWED_7Z_FILTERS].join(", ")}`)
+      }
+      args.push(`-mf=${sevenZFilter}`)
     }
 
     // args valid only for 7z
@@ -165,9 +179,11 @@ export function computeZipCompressArgs(options: ArchiveOptions = {}) {
     args.push("-v")
   }
 
-  if (process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL != null) {
+  const compressionLevelZip = process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL
+  if (compressionLevelZip != null) {
+    validateCompressionLevel(compressionLevelZip)
     storeOnly = false
-    args.push(`-${process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL}`)
+    args.push(`-${compressionLevelZip}`)
   } else if (!storeOnly) {
     // https://github.com/electron-userland/electron-builder/pull/3032
     args.push("-" + (options.compression === "maximum" ? "9" : "7"))

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -36,7 +36,7 @@ import { Defines } from "./Defines"
 import { addCustomMessageFileInclude, createAddLangsMacro, LangConfigurator } from "./nsisLang"
 import { computeLicensePage } from "./nsisLicense"
 import { NsisOptions, PortableOptions } from "./nsisOptions"
-import { NsisScriptGenerator } from "./nsisScriptGenerator"
+import { NsisScriptGenerator, nsisEscapeString } from "./nsisScriptGenerator"
 import { AppPackageHelper, NSIS_PATH, NSIS_RESOURCES_PATH, NsisTargetOptions, nsisTemplatesDir, UninstallerReader } from "./nsisUtil"
 
 const debug = _debug("electron-builder:nsis")
@@ -452,18 +452,18 @@ export class NsisTarget extends Target {
     const localeId = this.options.language || "1033"
     const appInfo = this.packager.appInfo
     const versionKey = [
-      `/LANG=${localeId} ProductName "${appInfo.productName}"`,
-      `/LANG=${localeId} ProductVersion "${appInfo.version}"`,
-      `/LANG=${localeId} LegalCopyright "${appInfo.copyright}"`,
-      `/LANG=${localeId} FileDescription "${appInfo.description}"`,
-      `/LANG=${localeId} FileVersion "${appInfo.buildVersion}"`,
+      `/LANG=${localeId} ProductName "${nsisEscapeString(appInfo.productName)}"`,
+      `/LANG=${localeId} ProductVersion "${nsisEscapeString(appInfo.version)}"`,
+      `/LANG=${localeId} LegalCopyright "${nsisEscapeString(appInfo.copyright)}"`,
+      `/LANG=${localeId} FileDescription "${nsisEscapeString(appInfo.description)}"`,
+      `/LANG=${localeId} FileVersion "${nsisEscapeString(appInfo.buildVersion)}"`,
     ]
     if (short) {
-      versionKey[1] = `/LANG=${localeId} ProductVersion "${appInfo.shortVersion}"`
-      versionKey[4] = `/LANG=${localeId} FileVersion "${appInfo.shortVersion}"`
+      versionKey[1] = `/LANG=${localeId} ProductVersion "${nsisEscapeString(appInfo.shortVersion!)}"`
+      versionKey[4] = `/LANG=${localeId} FileVersion "${nsisEscapeString(appInfo.shortVersion!)}"`
     }
-    use(this.packager.platformSpecificBuildOptions.legalTrademarks, it => versionKey.push(`/LANG=${localeId} LegalTrademarks "${it}"`))
-    use(appInfo.companyName, it => versionKey.push(`/LANG=${localeId} CompanyName "${it}"`))
+    use(this.packager.platformSpecificBuildOptions.legalTrademarks, it => versionKey.push(`/LANG=${localeId} LegalTrademarks "${nsisEscapeString(it)}"`))
+    use(appInfo.companyName, it => versionKey.push(`/LANG=${localeId} CompanyName "${nsisEscapeString(it)}"`))
     return versionKey
   }
 
@@ -741,9 +741,12 @@ export class NsisTarget extends Target {
             }
 
             const icon = `"${installedIconPath}"`
-            const commandText = `"Open with ${packager.appInfo.productName}"`
+            const commandText = `"Open with ${nsisEscapeString(packager.appInfo.productName)}"`
             const command = '"$appExe $\\"%1$\\""'
-            registerFileAssociationsScript.insertMacro("APP_ASSOCIATE", `"${ext}" "${item.name || ext}" "${item.description || ""}" ${icon} ${commandText} ${command}`)
+            registerFileAssociationsScript.insertMacro(
+              "APP_ASSOCIATE",
+              `"${nsisEscapeString(ext)}" "${nsisEscapeString(item.name || ext)}" "${nsisEscapeString(item.description || "")}" ${icon} ${commandText} ${command}`
+            )
           }
         }
         scriptGenerator.macro("registerFileAssociations", registerFileAssociationsScript)

--- a/packages/app-builder-lib/src/targets/nsis/nsisScriptGenerator.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisScriptGenerator.ts
@@ -1,3 +1,5 @@
+import { log } from "builder-util"
+
 export class NsisScriptGenerator {
   private readonly lines: Array<string> = []
 
@@ -18,7 +20,8 @@ export class NsisScriptGenerator {
   }
 
   file(outputName: string | null, file: string) {
-    this.lines.push(`File${outputName == null ? "" : ` "/oname=${outputName}"`} "${file}"`)
+    const safeName = outputName == null ? null : nsisEscapeString(outputName)
+    this.lines.push(`File${safeName == null ? "" : ` "/oname=${safeName}"`} "${file}"`)
   }
 
   insertMacro(name: string, parameters: string) {
@@ -41,6 +44,17 @@ export class NsisScriptGenerator {
   build() {
     return this.lines.join("\n") + "\n"
   }
+}
+
+export function nsisEscapeString(s: string): string {
+  const escaped = s
+    .replace(/\r\n|\r|\n/g, " ") // newlines break NSIS string literals
+    .replace(/\$/g, "$$$$") // $ → $$ (prevents NSIS variable expansion)
+    .replace(/"/g, '$\\"') // " → $\" (NSIS escape for double-quote)
+  if (escaped !== s) {
+    log.debug({ original: s, final: escaped }, "nsis was escaped")
+  }
+  return escaped
 }
 
 function getVarNameForFlag(flagName: string): string {

--- a/packages/app-builder-lib/src/util/macroExpander.ts
+++ b/packages/app-builder-lib/src/util/macroExpander.ts
@@ -1,4 +1,4 @@
-import { InvalidConfigurationError } from "builder-util"
+import { InvalidConfigurationError, log } from "builder-util"
 import { Nullish } from "builder-util-runtime"
 import { AppInfo } from "../appInfo"
 
@@ -51,6 +51,9 @@ export function expandMacro(pattern: string, arch: string | Nullish, appInfo: Ap
           const envValue = process.env[envName]
           if (envValue == null) {
             throw new InvalidConfigurationError(`cannot expand pattern "${pattern}": env ${envName} is not defined`, "ERR_ELECTRON_BUILDER_ENV_NOT_DEFINED")
+          }
+          if (/TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL/i.test(envName)) {
+            log.warn({ envName, pattern }, "macro expansion includes an env var that may contain a secret — verify this is intentional")
           }
           return envValue
         }

--- a/packages/app-builder-lib/src/util/resolve.ts
+++ b/packages/app-builder-lib/src/util/resolve.ts
@@ -1,6 +1,7 @@
 import { InvalidConfigurationError } from "builder-util"
 import { log } from "builder-util/out/log"
 import debug from "debug"
+import { realpath } from "fs/promises"
 import * as path from "path"
 import * as requireMaybe from "../../helpers/dynamic-import"
 
@@ -22,7 +23,15 @@ export async function resolveFunction<T>(type: string | undefined, executor: T |
   let p = executor as string
   if (p.startsWith(".")) {
     p = path.resolve(p)
-    const relative = path.relative(rootSearchDir, p)
+    let realP = p
+    let realRoot = rootSearchDir
+    try {
+      realP = await realpath(p)
+      realRoot = await realpath(rootSearchDir)
+    } catch {
+      // path may not exist yet; fall back to lexical check
+    }
+    const relative = path.relative(realRoot, realP)
     if (relative.startsWith("..") || path.isAbsolute(relative)) {
       throw new InvalidConfigurationError(`Hook module path "${executor}" resolves outside the workspace root ("${rootSearchDir}")`)
     }

--- a/packages/dmg-builder/src/dmgLicense.ts
+++ b/packages/dmg-builder/src/dmgLicense.ts
@@ -1,9 +1,9 @@
 import { PlatformPackager } from "app-builder-lib"
 import { getLicenseFiles } from "app-builder-lib/out/util/license"
-import { log } from "builder-util"
+import { deepAssign, log } from "builder-util"
 import { dmgLicenseFromJSON } from "dmg-license"
 import { readFile, readJson } from "fs-extra"
-import { load } from "js-yaml"
+import { CORE_SCHEMA, load } from "js-yaml"
 import { getLicenseButtonsFile } from "./licenseButtons"
 
 // License Specifications
@@ -40,20 +40,13 @@ export async function addLicenseToDmg(packager: PlatformPackager<any>, dmgPath: 
 
   for (const button of licenseButtonFiles) {
     const filepath = button.file
-    const label = filepath.endsWith(".yml") ? load(await readFile(filepath, "utf-8")) : await readJson(filepath)
+    const label: any = filepath.endsWith(".yml") ? load(await readFile(filepath, "utf-8"), { schema: CORE_SCHEMA }) : await readJson(filepath)
     if (label.description) {
       // to support original button file format
       label.message = label.description
       delete label.description
     }
-    jsonFile.labels.push(
-      Object.assign(
-        {
-          lang: button.langWithRegion.replace("_", "-"),
-        },
-        label
-      )
-    )
+    jsonFile.labels.push(deepAssign({ lang: button.langWithRegion.replace("_", "-") }, label))
   }
 
   await dmgLicenseFromJSON(dmgPath, jsonFile, {

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -1,6 +1,7 @@
 import { DmgOptions, MacPackager, PlatformPackager } from "app-builder-lib"
 import { downloadBuilderToolset } from "app-builder-lib/out/util/electronGet"
-import { exec, executeFinally, exists, isEmptyOrSpaces, TmpDir } from "builder-util"
+import { exec, executeFinally, exists, InvalidConfigurationError, isEmptyOrSpaces, log, TmpDir } from "builder-util"
+import { stat } from "fs/promises"
 import { writeFile } from "fs-extra"
 import * as path from "path"
 import { DmgBuildConfig } from "./dmg"
@@ -17,7 +18,21 @@ export function getDmgTemplatePath() {
 async function getDmgVendorPath(): Promise<string> {
   const customDmgbuildPath = process.env.CUSTOM_DMGBUILD_PATH?.trim()
   if (customDmgbuildPath) {
-    return path.resolve(customDmgbuildPath)
+    const resolvedPath = path.resolve(customDmgbuildPath)
+    let dmgbuildStat: Awaited<ReturnType<typeof stat>>
+    try {
+      dmgbuildStat = await stat(resolvedPath)
+    } catch (e: any) {
+      if (e.code === "ENOENT") {
+        throw new Error(`CUSTOM_DMGBUILD_PATH "${resolvedPath}" does not exist`)
+      }
+      throw e
+    }
+    if (!dmgbuildStat.isFile()) {
+      throw new Error(`CUSTOM_DMGBUILD_PATH "${resolvedPath}" is not a regular file`)
+    }
+    log.warn({ path: resolvedPath }, "using CUSTOM_DMGBUILD_PATH override for dmgbuild binary")
+    return resolvedPath
   }
 
   // https://github.com/electron-userland/electron-builder-binaries/releases/tag/dmg-builder%401.2.0
@@ -180,6 +195,16 @@ export async function customizeDmg({ appPath, artifactPath, volumeName, specific
   if (!isEmptyOrSpaces(settings.background)) {
     const size = await getImageSizeUsingSips(settings.background)
     settings.window = { position: { x: 400, y: Math.round((1440 - size.height) / 2) }, size, ...settings.window }
+  }
+
+  const workspaceRoot = await packager.info.getWorkspaceRoot()
+  for (const item of settings.contents ?? []) {
+    if (item.type === "file" && item.path && path.isAbsolute(item.path)) {
+      if (!item.path.startsWith(workspaceRoot + path.sep) && item.path !== appPath) {
+        log.error({ contentPath: item.path }, "dmg.contents path is outside the workspace root — verify this is intentional")
+        throw new InvalidConfigurationError(`dmg.contents path "${item.path}" is outside the workspace root`)
+      }
+    }
   }
 
   const settingsFile = await packager.getTempFile(".json")

--- a/packages/dmg-builder/src/licenseButtons.ts
+++ b/packages/dmg-builder/src/licenseButtons.ts
@@ -3,7 +3,7 @@ import { getLicenseAssets } from "app-builder-lib/out/util/license"
 import { log } from "builder-util"
 import { readFile } from "fs-extra"
 import * as iconv from "iconv-lite"
-import { load } from "js-yaml"
+import { CORE_SCHEMA, load } from "js-yaml"
 import { serializeString } from "./dmgUtil"
 import { getDefaultButtons } from "./licenseDefaultButtons"
 
@@ -34,7 +34,7 @@ export async function getLicenseButtons(licenseButtonFiles: Array<LicenseButtons
     }
 
     try {
-      const fileData = load(await readFile(item.file, "utf-8")) as any
+      const fileData = load(await readFile(item.file, "utf-8"), { schema: CORE_SCHEMA }) as any
       const buttonsStr =
         labelToHex(fileData.lang, item.lang, item.langWithRegion) +
         labelToHex(fileData.agree, item.lang, item.langWithRegion) +

--- a/test/src/windows/nsisScriptGeneratorTest.ts
+++ b/test/src/windows/nsisScriptGeneratorTest.ts
@@ -1,0 +1,33 @@
+import { nsisEscapeString } from "app-builder-lib/src/targets/nsis/nsisScriptGenerator"
+
+describe("nsisEscapeString", () => {
+  test("leaves plain strings unchanged", ({ expect }) => {
+    expect(nsisEscapeString("Hello World")).toBe("Hello World")
+  })
+
+  test("replaces LF newline with space", ({ expect }) => {
+    expect(nsisEscapeString("line1\nline2")).toBe("line1 line2")
+  })
+
+  test("replaces CRLF newline with space", ({ expect }) => {
+    expect(nsisEscapeString("line1\r\nline2")).toBe("line1 line2")
+  })
+
+  test("replaces standalone CR with space", ({ expect }) => {
+    expect(nsisEscapeString("line1\rline2")).toBe("line1 line2")
+  })
+
+  test("escapes dollar sign to prevent variable expansion", ({ expect }) => {
+    expect(nsisEscapeString("price $9.99")).toBe("price $$9.99")
+  })
+
+  test("escapes double quote", ({ expect }) => {
+    expect(nsisEscapeString('say "hello"')).toBe('say $\\"hello$\\"')
+  })
+
+  test("handles combined special characters", ({ expect }) => {
+    expect(nsisEscapeString('Copyright © 2024 "Acme" $Corp\r\nAll rights reserved')).toBe(
+      'Copyright © 2024 $\\"Acme$\\" $$Corp All rights reserved'
+    )
+  })
+})


### PR DESCRIPTION
- add `nsisEscapeString` utility to validate and/or escape app metadata and file-association strings
- validates `ELECTRON_BUILDER_COMPRESSION_LEVEL` (must be 0–9) and against expected compression algorithm enum via `ELECTRON_BUILDER_7Z_FILTER` 
-  Windows temporary node_modules collector `.bat` uses randomized name and restricted file permissions
- Mac packaging: block entitlement files outside project workspace
- `resolve` hooks follow symlinks before workspace boundary check
- dmg license and buttons use explicit YAML schema on `load()`
- validate `CUSTOM_DMGBUILD_PATH` exists and is a regular file before use