### PR TITLE
chore(test): run Windows auto-update e2e tests via Parallels VM on macOS

### DIFF
--- a/packages/app-builder-lib/src/vm/ParallelsVm.ts
+++ b/packages/app-builder-lib/src/vm/ParallelsVm.ts
@@ -33,7 +33,6 @@ export async function parseVmList(debugLogger: DebugLogger) {
   return result
 }
 
-/** @internal */
 export class ParallelsVmManager extends VmManager {
   private startPromise: Promise<any>
 

--- a/test/fixtures/test-app/app/index.js
+++ b/test/fixtures/test-app/app/index.js
@@ -9,8 +9,8 @@ const BrowserWindow = electron.BrowserWindow
 
 let mainWindow
 
-process.on("uncaughtException", console.error)
-process.on("unhandledRejection", console.error)
+process.on("uncaughtException", err => console.log("uncaughtException:", err))
+process.on("unhandledRejection", err => console.log("unhandledRejection:", err))
 
 console.log(`APP_VERSION: ${app.getVersion()}`)
 console.log('Running from:', app.getAppPath())
@@ -36,7 +36,15 @@ async function init() {
 async function isReady() {
   console.log(`APP_VERSION: ${app.getVersion()}`)
 
-  createWindow()
+  if (!shouldTestAutoUpdater) {
+    // Probe mode: version already printed; quit without creating any windows
+    app.quit()
+    return
+  }
+
+  // No window in auto-update mode — renderer crashes in headless VMs (no GPU/display)
+  // trigger window-all-closed → app.quit() mid-download. electron-updater runs
+  // entirely in the main process and needs no visible window.
 
   // test native module loading
   const db = new sqlite3.Database(":memory:")
@@ -61,7 +69,12 @@ async function isReady() {
 
     // autoUpdater._appUpdateConfigPath = _appUpdateConfigPath
     autoUpdater.updateConfigPath = updateConfigPath
-    autoUpdater.logger = console
+    autoUpdater.logger = {
+      info: (...args) => console.log("[updater]", ...args),
+      warn: (...args) => console.log("[updater warn]", ...args),
+      error: (...args) => console.log("[updater error]", ...args),
+      debug: () => {},
+    }
     autoUpdater.autoRunAppAfterInstall = false
 
     autoUpdater.on("checking-for-update", () => {
@@ -81,10 +94,12 @@ async function isReady() {
       app.quit()
     })
     autoUpdater.on("error", error => {
-      console.error("Error in auto-updater:", error)
+      console.log("Error in auto-updater:", error)
       app.quit()
     })
-    autoUpdater.checkForUpdates()
+    autoUpdater.checkForUpdates().catch(err => {
+      console.log("checkForUpdates rejected (handled via error event):", err?.message)
+    })
   } else {
     // Not in auto-update test mode — quit immediately after printing version so polling probes are cheap
     app.quit()
@@ -116,7 +131,10 @@ function createWindow() {
 }
 
 app.on('window-all-closed', function () {
-  app.quit()
+  if (!shouldTestAutoUpdater) {
+    app.quit()
+  }
+  // In auto-update mode the updater runs headlessly — a renderer crash must not abort it.
 })
 
 init()
@@ -124,5 +142,5 @@ init()
     console.log("App initialized")
   })
   .catch(error => {
-    console.error("Error initializing app:", error)
+    console.log("Error initializing app:", error)
   })

--- a/test/snapshots/globTest.js.snap
+++ b/test/snapshots/globTest.js.snap
@@ -15,16 +15,16 @@ exports[`asarUnpack and files ignore 2`] = `
     },
     "index.js": {
       "offset": 490,
-      "size": 3680,
+      "size": 4560,
     },
     "package.json": {
-      "offset": 4170,
+      "offset": 5040,
       "size": 230,
     },
     "path": {
       "files": {
         "app.asar": {
-          "offset": 4390,
+          "offset": 5270,
           "size": 720,
         },
       },
@@ -20136,16 +20136,16 @@ exports[`unpackDir 2`] = `
     },
     "index.js": {
       "offset": 490,
-      "size": 3680,
+      "size": 4560,
     },
     "package.json": {
-      "offset": 4170,
+      "offset": 5050,
       "size": 230,
     },
     "path": {
       "files": {
         "app.asar": {
-          "offset": 4400,
+          "offset": 5270,
           "size": 720,
         },
       },

--- a/test/src/helpers/launchAppCrossPlatform.ts
+++ b/test/src/helpers/launchAppCrossPlatform.ts
@@ -1,4 +1,5 @@
 import { isEmptyOrSpaces } from "builder-util"
+import type { VmManager } from "app-builder-lib/out/vm/vm"
 import { ChildProcess, spawn } from "child_process"
 import * as fs from "fs"
 import * as http from "http"
@@ -6,7 +7,23 @@ import * as net from "net"
 import os from "os"
 import path from "path"
 
-export function createLocalServer(root: string): Promise<{ server: http.Server; port: number }> {
+/**
+ * Returns the macOS host's IP address on the Parallels virtual network.
+ * The VM reaches the host via this address (not 127.0.0.1).
+ */
+export function getParallelsHostIP(): string | undefined {
+  const interfaces = os.networkInterfaces()
+  for (const [name, addrs] of Object.entries(interfaces)) {
+    // Older Parallels uses prl* interfaces; newer versions use bridge* (e.g. bridge100)
+    if (name.startsWith("prl") || name.startsWith("bridge")) {
+      const addr = addrs?.find(a => a.family === "IPv4" && !a.internal)
+      if (addr) return addr.address
+    }
+  }
+  return undefined
+}
+
+export function createLocalServer(root: string, bindAddress = "127.0.0.1"): Promise<{ server: http.Server; port: number }> {
   const server = http.createServer((req, res) => {
     const pathname = decodeURIComponent(new URL(req.url!, "http://localhost").pathname).replace(/^\/+/, "")
     const filePath = path.resolve(root, pathname)
@@ -78,7 +95,7 @@ export function createLocalServer(root: string): Promise<{ server: http.Server; 
 
   return new Promise((resolve, reject) => {
     server.once("error", reject)
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, bindAddress, () => {
       const { port } = server.address() as net.AddressInfo
       resolve({ server, port })
     })
@@ -108,6 +125,7 @@ interface LaunchResult {
 
 interface LaunchOptions {
   appPath: string
+  vm?: VmManager
   timeoutMs?: number
   env?: Record<string, string>
   expectedVersion?: string
@@ -118,6 +136,7 @@ interface LaunchOptions {
 
 export async function launchAndWaitForQuit({
   appPath,
+  vm,
   timeoutMs = 20000,
   env = {},
   expectedVersion,
@@ -141,6 +160,33 @@ export async function launchAndWaitForQuit({
         ...localEnv,
       },
     })
+  }
+
+  // VM-based execution: prlctl exec runs synchronously (blocks until the process exits),
+  // so we build a PowerShell command that sets env vars and runs the app, then parse stdout.
+  if (vm) {
+    const vmConfigPath = vm.toVmFile(updateConfigPath)
+    const envVars: Record<string, string> = {
+      AUTO_UPDATER_TEST: "1",
+      AUTO_UPDATER_TEST_CONFIG_PATH: vmConfigPath,
+      ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER: packageManagerToTest,
+      ...env,
+    }
+    const setters = Object.entries(envVars)
+      .map(([k, v]) => `$env:${k}='${v.replace(/'/g, "''")}'`)
+      .join("; ")
+    // 2>&1 merges TestApp.exe's stderr into PowerShell's stdout stream so
+    // console.error calls (including electron-updater errors) are captured.
+    const psCommand = `${setters}; & '${appPath.replace(/'/g, "''")}' 2>&1`
+
+    const output = await vm.exec("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", psCommand], { timeout: timeoutMs })
+
+    const match = output.match(versionRegex)
+    const version = match?.[1]?.trim()
+    if (expectedVersion && version && version !== expectedVersion) {
+      throw new Error(`Expected version ${expectedVersion}, got ${version}`)
+    }
+    return { version, exitCode: 0, stdout: output, stderr: "" }
   }
 
   const platform = os.platform()

--- a/test/src/helpers/launchAppCrossPlatform.ts
+++ b/test/src/helpers/launchAppCrossPlatform.ts
@@ -11,6 +11,20 @@ import path from "path"
  * Returns the macOS host's IP address on the Parallels virtual network.
  * The VM reaches the host via this address (not 127.0.0.1).
  */
+/**
+ * Converts a macOS path under the user home directory to its Parallels UNC form.
+ * Files in `~/` are reachable via `\\Mac\Home\...` (always shared) without needing
+ * "All Disks" sharing. Paths outside the home dir fall back to `\\Mac\Host\...`.
+ */
+export function toVmHomePath(macPath: string): string {
+  const home = os.homedir()
+  const rel = path.relative(home, macPath)
+  if (!rel.startsWith("..")) {
+    return "\\\\Mac\\Home\\" + rel.replace(/\//g, "\\")
+  }
+  return "\\\\Mac\\Host\\" + macPath.replace(/\//g, "\\")
+}
+
 export function getParallelsHostIP(): string | undefined {
   const interfaces = os.networkInterfaces()
   for (const [name, addrs] of Object.entries(interfaces)) {
@@ -165,7 +179,7 @@ export async function launchAndWaitForQuit({
   // VM-based execution: prlctl exec runs synchronously (blocks until the process exits),
   // so we build a PowerShell command that sets env vars and runs the app, then parse stdout.
   if (vm) {
-    const vmConfigPath = vm.toVmFile(updateConfigPath)
+    const vmConfigPath = toVmHomePath(updateConfigPath)
     const envVars: Record<string, string> = {
       AUTO_UPDATER_TEST: "1",
       AUTO_UPDATER_TEST_CONFIG_PATH: vmConfigPath,

--- a/test/src/rebuilderTest.ts
+++ b/test/src/rebuilderTest.ts
@@ -1,6 +1,6 @@
 import { Configuration, Platform } from "app-builder-lib"
 import { PM } from "app-builder-lib/out/node-module-collector"
-import { exists } from "builder-util/src/util"
+import { exists } from "builder-util/out/util"
 import path from "path"
 import { assertPack, linuxDirTarget, modifyPackageJson } from "./helpers/packTester"
 import { ELECTRON_VERSION } from "./helpers/testConfig"

--- a/test/src/updater/blackboxUpdateTest.ts
+++ b/test/src/updater/blackboxUpdateTest.ts
@@ -12,18 +12,12 @@ import { copy, existsSync, move, outputFile, readJsonSync, remove } from "fs-ext
 import { homedir } from "os"
 import path from "path"
 import { ExpectStatic, TestContext, TestOptions } from "vitest"
-import { createLocalServer, getParallelsHostIP, launchAndWaitForQuit } from "../helpers/launchAppCrossPlatform"
+import { createLocalServer, getParallelsHostIP, launchAndWaitForQuit, toVmHomePath } from "../helpers/launchAppCrossPlatform"
 import { assertPack, EXTENDED_TIMEOUT, modifyPackageJson, PackedContext } from "../helpers/packTester"
 import { ELECTRON_VERSION } from "../helpers/testConfig"
 import { NEW_VERSION_NUMBER, OLD_VERSION_NUMBER, writeUpdateConfig } from "../helpers/updaterTestUtil"
 
-const windowsVm = await (async () => {
-  try {
-    return await getWindowsVm(new DebugLogger(false))
-  } catch {
-    return undefined
-  }
-})()
+const windowsVmPromise: Promise<VmManager | undefined> = getWindowsVm(new DebugLogger(false)).catch(() => undefined)
 
 async function sha256File(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -56,8 +50,11 @@ const winCodeSignVersions: ToolsetConfig["winCodeSign"][] = ["0.0.0", "1.0.0", "
 
 for (const winCodeSign of winCodeSignVersions) {
   describe(`winCodeSign: ${winCodeSign}`, optionsForFlakyE2E, () => {
-    describe.heavy.ifWindows("windows", optionsForFlakyE2E, () => {
+    describe.heavy("windows", optionsForFlakyE2E, () => {
       test("nsis", async context => {
+        if (process.platform !== "win32" && (await windowsVmPromise) == null) {
+          context.skip()
+        }
         await runTest(context, "nsis", "", Arch.x64, { winCodeSign })
       })
     })
@@ -124,14 +121,14 @@ const packageManagerMap: {
 
 async function runTest(context: TestContext, target: string, packageManager: string, arch: Arch = Arch.x64, toolsets: ToolsetConfig = {}) {
   const { expect } = context
-  const vm = windowsVm
+  const vm = await windowsVmPromise
   if (vm && target === "nsis") {
     console.log("Running Windows test via Parallels VM")
   }
 
   const tmpDir = new TmpDir("auto-update")
   const outDirs: ApplicationUpdatePaths[] = []
-  await doBuild(expect, outDirs, target, arch, tmpDir, windowsVm != null, { toolsets })
+  await doBuild(expect, outDirs, target, arch, tmpDir, process.platform === "win32" || (target === "nsis" && vm != null), { toolsets })
 
   const oldAppDir = outDirs[0]
   const newAppDir = outDirs[1]
@@ -524,7 +521,7 @@ async function handleInitialInstallPerOS({ target, dirPath, arch, vm }: { target
     ].join("\n")
 
     await outputFile(scriptPath, psScript)
-    const winScriptPath = vm.toVmFile(scriptPath)
+    const winScriptPath = toVmHomePath(scriptPath)
     try {
       const installResult = await vm.exec("powershell.exe", ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", winScriptPath], { timeout: 300000 })
       console.log("Installer output:", installResult)
@@ -575,11 +572,13 @@ async function runTestWithinServer(doTest: (rootDirectory: string, updateConfigP
   const root = await tmpDir.getTempDir({ prefix: "server-root" })
 
   // When a VM is in use, the update server must be reachable from inside the VM.
-  // Parallels exposes the macOS host via the prl* interface IP — bind to all
-  // interfaces so that IP is accessible, and use it in the config URL.
-  const bindAddress = vm ? "0.0.0.0" : "127.0.0.1"
-  const { server, port } = await createLocalServer(root, bindAddress)
-  const serverHost = vm ? (getParallelsHostIP() ?? "127.0.0.1") : "127.0.0.1"
+  // Bind to the Parallels host IP specifically so the server is accessible from the VM
+  // without exposing it on all interfaces.
+  const serverHost = vm ? getParallelsHostIP() : "127.0.0.1"
+  if (vm && !serverHost) {
+    throw new Error("Cannot determine Parallels host IP for update server — no prl*/bridge* interface found")
+  }
+  const { server, port } = await createLocalServer(root, serverHost!)
 
   const serverConfig: GenericServerOptions = { provider: "generic", url: `http://${serverHost}:${port}` }
   let updateConfig: string

--- a/test/src/updater/blackboxUpdateTest.ts
+++ b/test/src/updater/blackboxUpdateTest.ts
@@ -1,20 +1,41 @@
 import { ToolsetConfig } from "app-builder-lib"
-import { PM } from "app-builder-lib/src/node-module-collector"
+import { PM } from "app-builder-lib/out/node-module-collector"
+import { getWindowsVm, VmManager } from "app-builder-lib/out/vm/vm"
 import { GenericServerOptions, Nullish } from "builder-util-runtime"
-import { archFromString, getArchSuffix, isEmptyOrSpaces, log, spawn, TmpDir } from "builder-util/out/util"
+import { archFromString, DebugLogger, getArchSuffix, isEmptyOrSpaces, log, serializeToYaml, spawn, TmpDir } from "builder-util/out/util"
 import { execFileSync, execSync } from "child_process"
+import { createHash, randomUUID } from "crypto"
 import { Arch, Configuration, Platform } from "electron-builder"
 import { DebUpdater, PacmanUpdater, RpmUpdater } from "electron-updater"
-import { copy, existsSync, move, outputFile, readJsonSync } from "fs-extra"
+import { createReadStream } from "fs"
+import { copy, existsSync, move, outputFile, readJsonSync, remove } from "fs-extra"
 import { homedir } from "os"
 import path from "path"
 import { ExpectStatic, TestContext, TestOptions } from "vitest"
-import { createLocalServer, launchAndWaitForQuit } from "../helpers/launchAppCrossPlatform"
+import { createLocalServer, getParallelsHostIP, launchAndWaitForQuit } from "../helpers/launchAppCrossPlatform"
 import { assertPack, EXTENDED_TIMEOUT, modifyPackageJson, PackedContext } from "../helpers/packTester"
 import { ELECTRON_VERSION } from "../helpers/testConfig"
 import { NEW_VERSION_NUMBER, OLD_VERSION_NUMBER, writeUpdateConfig } from "../helpers/updaterTestUtil"
 
-const optionsForFlakyE2E: TestOptions = { sequential: true, retry: 1, timeout: EXTENDED_TIMEOUT }
+const windowsVm = await (async () => {
+  try {
+    return await getWindowsVm(new DebugLogger(false))
+  } catch {
+    return undefined
+  }
+})()
+
+async function sha256File(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256")
+    createReadStream(filePath)
+      .on("data", chunk => hash.update(chunk))
+      .on("end", () => resolve(hash.digest("hex")))
+      .on("error", reject)
+  })
+}
+
+const optionsForFlakyE2E: TestOptions = { sequential: true, retry: 0, timeout: EXTENDED_TIMEOUT }
 // Linux Tests MUST be run in docker containers for proper ephemeral testing environment (e.g. fresh install + update + relaunch)
 // Currently this test logic does not handle uninstalling packages (yet)
 describe.ifMac.heavy("mac", optionsForFlakyE2E, () => {
@@ -103,19 +124,23 @@ const packageManagerMap: {
 
 async function runTest(context: TestContext, target: string, packageManager: string, arch: Arch = Arch.x64, toolsets: ToolsetConfig = {}) {
   const { expect } = context
+  const vm = windowsVm
+  if (vm && target === "nsis") {
+    console.log("Running Windows test via Parallels VM")
+  }
 
   const tmpDir = new TmpDir("auto-update")
   const outDirs: ApplicationUpdatePaths[] = []
-  await doBuild(expect, outDirs, target, arch, tmpDir, process.platform === "win32", { toolsets })
+  await doBuild(expect, outDirs, target, arch, tmpDir, windowsVm != null, { toolsets })
 
   const oldAppDir = outDirs[0]
   const newAppDir = outDirs[1]
 
   const dirPath = oldAppDir.dir
   // Setup tests by installing the previous version
-  const appPath = await handleInitialInstallPerOS({ target, dirPath, arch })
+  const appPath = await handleInitialInstallPerOS({ target, dirPath, arch, vm })
 
-  if (!existsSync(appPath)) {
+  if (!vm && !existsSync(appPath)) {
     throw new Error(`App not found: ${appPath}`)
   }
 
@@ -131,25 +156,30 @@ async function runTest(context: TestContext, target: string, packageManager: str
       // installation completes — the polling loop below handles that case.
       const result = await launchAndWaitForQuit({
         appPath,
+        vm,
         timeoutMs: 5 * 60 * 1000,
         updateConfigPath,
         expectedVersion: OLD_VERSION_NUMBER,
         packageManagerToTest: packageManager,
         waitForExit: true,
       })
-      log.debug(result, "Test App version")
+      log.info({ version: result.version, stdout: result.stdout }, "Initial launch completed")
       expect(result.version).toMatch(OLD_VERSION_NUMBER)
+      if (!result.stdout.includes("Update downloaded")) {
+        throw new Error(`Update phase did not complete — quitAndInstall was never triggered.\nFull stdout:\n${result.stdout}`)
+      }
 
       // Poll until the installed binary reports the new version.
       // We disable AUTO_UPDATER_TEST so the probe app quits immediately after printing its version
       // (no update cycle triggered), which also prevents a second installer from running in parallel.
-      const pollDeadline = Date.now() + 3 * 60 * 1000
+      const pollDeadline = Date.now() + 6 * 60 * 1000
       const pollInterval = 5 * 1000
       let newVersion: string | undefined
       while (Date.now() < pollDeadline) {
         try {
           const probe = await launchAndWaitForQuit({
             appPath,
+            vm,
             timeoutMs: 30 * 1000,
             updateConfigPath,
             packageManagerToTest: packageManager,
@@ -178,7 +208,7 @@ async function runTest(context: TestContext, target: string, packageManager: str
         }
       }
       expect(newVersion).toMatch(NEW_VERSION_NUMBER)
-    })
+    }, vm)
   } catch (error: any) {
     log.error({ error: error.message }, "Blackbox Updater Test failed to run")
     queuedError = error
@@ -212,7 +242,7 @@ async function doBuild(
   isWindows: boolean,
   extraConfig?: Configuration | null
 ) {
-  const currentPlatform = Platform.current()
+  const currentPlatform = isWindows ? Platform.WINDOWS : Platform.current()
   async function buildApp({
     version,
     target,
@@ -343,7 +373,7 @@ async function doBuild(
   }
 }
 
-async function handleInitialInstallPerOS({ target, dirPath, arch }: { target: string; dirPath: string; arch: Arch }): Promise<string> {
+async function handleInitialInstallPerOS({ target, dirPath, arch, vm }: { target: string; dirPath: string; arch: Arch; vm?: VmManager }): Promise<string> {
   let appPath: string
   if (target === "AppImage") {
     appPath = path.join(dirPath, `TestApp.AppImage`)
@@ -406,6 +436,103 @@ async function handleInitialInstallPerOS({ target, dirPath, arch }: { target: st
     execFileSync(installerPath, ["/S"], { stdio: "inherit" })
 
     appPath = path.join(localProgramsPath, "TestApp.exe")
+  } else if (target === "nsis" && vm) {
+    // Running on macOS host with Parallels VM — install and locate app inside the VM.
+    try {
+      await vm.exec("taskkill", ["/F", "/IM", "TestApp Setup.exe", "/T"])
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    } catch {
+      // no matching process — expected on the first run
+    }
+    // Query LOCALAPPDATA once; used for both the uninstaller check and the install path.
+    const localAppData = (await vm.exec("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", "[Environment]::GetFolderPath('LocalApplicationData')"])).trim()
+    const uninstallerPath = `${localAppData}\\Programs\\TestApp\\Uninstall TestApp.exe`
+    try {
+      await vm.exec(uninstallerPath, ["/S", "/C", "exit"])
+      await new Promise(resolve => setTimeout(resolve, 5000))
+    } catch {
+      // no previous installation — expected on first run
+    }
+    // Use HTTP to deliver the installer: getParallelsHostIP() returns the Mac's bridge IP
+    // (e.g. 10.211.55.2) which is reachable from the VM. \\Mac\Home\ hangs on large binary reads.
+    const hostIP = getParallelsHostIP()
+    if (!hostIP) {
+      throw new Error("Cannot determine Parallels host IP for installer delivery — no prl*/bridge* interface found")
+    }
+
+    // Validate values that will be interpolated into the PowerShell script.
+    // Both are internally generated (not user input), but guard against unexpected values.
+    if (!/^[\d.]+$/.test(hostIP)) {
+      throw new Error(`Unsafe hostIP: ${hostIP}`)
+    }
+
+    // Compute the installer hash on the Mac side before serving so the Windows side can verify it.
+    const installerBinPath = path.join(dirPath, "TestApp Setup.exe")
+    const expectedSha256 = await sha256File(installerBinPath)
+    if (!/^[0-9a-f]{64}$/i.test(expectedSha256)) {
+      throw new Error(`Unexpected hash value: ${expectedSha256}`)
+    }
+
+    const { server: installerServer, port: installerPort } = await createLocalServer(dirPath, "0.0.0.0")
+    if (!Number.isInteger(installerPort) || installerPort < 1024 || installerPort > 65535) {
+      throw new Error(`Unsafe port: ${installerPort}`)
+    }
+
+    // Write the installer script to Mac home dir; the VM reads it via \\Mac\Home\ (UNC).
+    // Using -File instead of -Command avoids double-quote stripping by prlctl/cmd.exe,
+    // which allows the Add-Type heredoc and DllImport attributes to work correctly.
+    // A small PS script file (<5 KB) reads fine from \\Mac\Home\ (only large binary reads hang).
+    const scriptPath = path.join(homedir(), `.eb-nsis-${randomUUID()}.ps1`)
+    const psScript = [
+      `$tmpDir = $null`,
+      `try {`,
+      // Kill any stale installer from a previous test run — it holds the NSIS APP_GUID mutex
+      `    Stop-Process -Name 'eb-setup' -Force -ErrorAction SilentlyContinue`,
+      `    Start-Sleep -Seconds 1`,
+      `    $tmpDir = Join-Path $env:TEMP ([Guid]::NewGuid().ToString())`,
+      `    New-Item -ItemType Directory -Path $tmpDir | Out-Null`,
+      `    $dest = Join-Path $tmpDir 'eb-setup.exe'`,
+      `    Invoke-WebRequest -Uri 'http://${hostIP}:${installerPort}/TestApp%20Setup.exe' -OutFile $dest -UseBasicParsing`,
+      `    if (-not (Test-Path $dest)) { Write-Error 'Download failed'; exit 1 }`,
+      `    Write-Output ('DOWNLOAD_SIZE:' + (Get-Item $dest).Length)`,
+      // Verify download integrity; hash was computed on the Mac before the HTTP server started
+      `    $actualHash = (Get-FileHash $dest -Algorithm SHA256).Hash.ToLower()`,
+      `    $expectedHash = '${expectedSha256}'`,
+      `    if ($actualHash -ne $expectedHash) { Write-Error ('Hash mismatch: expected ' + $expectedHash + ' got ' + $actualHash); exit 1 }`,
+      `    Write-Output ('HASH_OK:true')`,
+      // Remove Mark-of-the-Web only after integrity is confirmed
+      `    Unblock-File -Path $dest -ErrorAction SilentlyContinue`,
+      `    Write-Output ('DEST_PATH:' + $dest)`,
+      `    $proc = Start-Process -FilePath $dest -ArgumentList '/S' -PassThru`,
+      `    $finished = $proc.WaitForExit(180000)`,
+      `    if (-not $finished) {`,
+      `        $proc.Kill() | Out-Null`,
+      `        Write-Error 'Installer timed out after 180s'; exit 1`,
+      `    }`,
+      `    Write-Output ('INSTALLER_EXIT:' + $proc.ExitCode)`,
+      // NSIS one-click calls quitSuccess (SetErrorLevel 0; Quit) on success → exit 0
+      `    if ($proc.ExitCode -ne 0) { Write-Error ('Installer exited with code ' + $proc.ExitCode); exit 1 }`,
+      `    Start-Sleep -Seconds 3`,
+      `    $lad = [Environment]::GetFolderPath('LocalApplicationData')`,
+      `    $installPath = Join-Path $lad 'Programs\\TestApp\\TestApp.exe'`,
+      `    Write-Output ('APP_EXISTS:' + (Test-Path $installPath))`,
+      `    if (-not (Test-Path $installPath)) { Write-Error 'App not installed at expected path'; exit 1 }`,
+      `} finally {`,
+      // PowerShell guarantees finally runs on all exit paths including exit 1
+      `    if ($tmpDir) { Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue }`,
+      `}`,
+    ].join("\n")
+
+    await outputFile(scriptPath, psScript)
+    const winScriptPath = vm.toVmFile(scriptPath)
+    try {
+      const installResult = await vm.exec("powershell.exe", ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", winScriptPath], { timeout: 300000 })
+      console.log("Installer output:", installResult)
+    } finally {
+      installerServer.close()
+      await remove(scriptPath).catch(() => {})
+    }
+    appPath = `${localAppData}\\Programs\\TestApp\\TestApp.exe`
   } else if (process.platform === "darwin") {
     appPath = path.join(dirPath, `mac${getArchSuffix(arch)}`, `TestApp.app`, "Contents", "MacOS", "TestApp")
   } else {
@@ -443,16 +570,29 @@ async function handleCleanupPerOS({ target }: { target: string }) {
   }
 }
 
-async function runTestWithinServer(doTest: (rootDirectory: string, updateConfigPath: string) => Promise<void>) {
+async function runTestWithinServer(doTest: (rootDirectory: string, updateConfigPath: string) => Promise<void>, vm?: VmManager) {
   const tmpDir = new TmpDir("blackbox-update-test")
   const root = await tmpDir.getTempDir({ prefix: "server-root" })
 
-  const { server, port } = await createLocalServer(root)
+  // When a VM is in use, the update server must be reachable from inside the VM.
+  // Parallels exposes the macOS host via the prl* interface IP — bind to all
+  // interfaces so that IP is accessible, and use it in the config URL.
+  const bindAddress = vm ? "0.0.0.0" : "127.0.0.1"
+  const { server, port } = await createLocalServer(root, bindAddress)
+  const serverHost = vm ? (getParallelsHostIP() ?? "127.0.0.1") : "127.0.0.1"
 
-  const updateConfig = await writeUpdateConfig<GenericServerOptions>({
-    provider: "generic",
-    url: `http://127.0.0.1:${port}`,
-  })
+  const serverConfig: GenericServerOptions = { provider: "generic", url: `http://${serverHost}:${port}` }
+  let updateConfig: string
+  let vmConfigDir: string | undefined
+  if (vm) {
+    // Write config to home dir → \\Mac\Home\... which Parallels always shares.
+    // System temp → \\Mac\Host\private\var\folders\... requires "All Disks" sharing and may be inaccessible.
+    vmConfigDir = path.join(homedir(), `.eb-update-test-${randomUUID()}`)
+    updateConfig = path.join(vmConfigDir, "app-update.yml")
+    await outputFile(updateConfig, serializeToYaml(serverConfig))
+  } else {
+    updateConfig = await writeUpdateConfig<GenericServerOptions>(serverConfig)
+  }
 
   const cleanup = () => {
     try {
@@ -464,6 +604,9 @@ async function runTestWithinServer(doTest: (rootDirectory: string, updateConfigP
       server.close()
     } catch (error) {
       console.error("Failed to close server", error)
+    }
+    if (vmConfigDir) {
+      remove(vmConfigDir).catch(() => {})
     }
   }
 

--- a/test/src/updater/blackboxUpdateTest.ts
+++ b/test/src/updater/blackboxUpdateTest.ts
@@ -1,5 +1,6 @@
 import { ToolsetConfig } from "app-builder-lib"
 import { PM } from "app-builder-lib/out/node-module-collector"
+import { ParallelsVmManager } from "app-builder-lib/out/vm/ParallelsVm"
 import { getWindowsVm, VmManager } from "app-builder-lib/out/vm/vm"
 import { GenericServerOptions, Nullish } from "builder-util-runtime"
 import { archFromString, DebugLogger, getArchSuffix, isEmptyOrSpaces, log, serializeToYaml, spawn, TmpDir } from "builder-util/out/util"
@@ -17,7 +18,11 @@ import { assertPack, EXTENDED_TIMEOUT, modifyPackageJson, PackedContext } from "
 import { ELECTRON_VERSION } from "../helpers/testConfig"
 import { NEW_VERSION_NUMBER, OLD_VERSION_NUMBER, writeUpdateConfig } from "../helpers/updaterTestUtil"
 
-const windowsVmPromise: Promise<VmManager | undefined> = getWindowsVm(new DebugLogger(false)).catch(() => undefined)
+// Resolve only to a ParallelsVmManager — PwshVmManager (used for code-signing on Linux/Mac via Wine)
+// is not capable of installing or running Windows executables and must not be treated as a Windows VM.
+const windowsVmPromise: Promise<ParallelsVmManager | undefined> = getWindowsVm(new DebugLogger(false))
+  .then(vm => (vm instanceof ParallelsVmManager ? vm : undefined))
+  .catch(() => undefined)
 
 async function sha256File(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/test/src/windows/winReseditTest.ts
+++ b/test/src/windows/winReseditTest.ts
@@ -1,4 +1,4 @@
-import { ResourceEditOptions, editWindowsResources } from "app-builder-lib/src/util/resEdit"
+import { ResourceEditOptions, editWindowsResources } from "app-builder-lib/out/util/resEdit"
 import * as fs from "fs/promises"
 import * as os from "os"
 import path from "path"

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -8,7 +8,7 @@ import { SHARD_INDEX, SupportedPlatforms, TEST_FILES_PATTERN } from "./smart-con
 import SmartSequencer from "./vitest-smart-sequencer"
 
 const testRegex = TEST_FILES_PATTERN?.split(",")
-const includeRegex = `(${testRegex.join("|")})`
+const includeRegex = `(${testRegex.join("|")}|${testRegex.map(t => `${t}Test`).join("|")})`
 console.log("TEST_FILES pattern", includeRegex)
 
 async function main() {


### PR DESCRIPTION
Extends the blackbox updater test suite so that NSIS/Windows tests can run directly from a macOS host using an existing Parallels Windows VM, without needing a native Windows runner.

- Searches for an available Parallels Windows VM at module load via `getWindowsVm()` IIFE; if found, Windows build/install/update steps are routed through it
- Writes a temporary update config to `~/` (mapped as `\\Mac\Home\` in the VM — always shared) rather than system temp (`\\Mac\Host\private\var\folders\...` which requires "All Disks" sharing)
- Serves the NSIS installer over HTTP from the macOS host so the VM can download it without relying on slow UNC file reads for large binaries. Includes SHA-256 integrity verification of the downloaded installer before execution