### PR TITLE
perf(pnpm): memoize package resolution and skip downward search in flat virtual store

### DIFF
--- a/.changeset/tough-flies-yawn.md
+++ b/.changeset/tough-flies-yawn.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+perf(pnpm): memoize package resolution and skip downward search in flat virtual store.

--- a/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
@@ -135,7 +135,22 @@ export class ModuleManager {
     return { ...result, packageDir: await this.realPath[result.packageDir] }
   }
 
-  public async locatePackageVersion({ parentDir, pkgName, requiredRange }: { parentDir: string; pkgName: string; requiredRange?: string }): Promise<Package | null> {
+  public async locatePackageVersion({
+    parentDir,
+    pkgName,
+    requiredRange,
+    skipDownwardSearch = false,
+  }: {
+    parentDir: string
+    pkgName: string
+    requiredRange?: string
+    /**
+     * When true, skip the BFS-based `downwardSearch`. Use for layouts that are guaranteed flat
+     * (e.g. pnpm's `.pnpm` virtual store), where the downward walk burns thousands of `readdir`
+     * / `lstat` calls and finds nothing.
+     */
+    skipDownwardSearch?: boolean
+  }): Promise<Package | null> {
     // 1) check direct parent node_modules/pkgName first
     const direct = path.join(path.resolve(parentDir), "node_modules", pkgName, "package.json")
     if (await this.exists[direct]) {
@@ -146,7 +161,14 @@ export class ModuleManager {
     }
 
     // 2) upward hoisted search, then 3) downward non-hoisted search
-    return (await this.upwardSearch(parentDir, pkgName, requiredRange)) || (await this.downwardSearch(parentDir, pkgName, requiredRange)) || null
+    const upward = await this.upwardSearch(parentDir, pkgName, requiredRange)
+    if (upward) {
+      return upward
+    }
+    if (skipDownwardSearch) {
+      return null
+    }
+    return (await this.downwardSearch(parentDir, pkgName, requiredRange)) || null
   }
 
   private semverSatisfies(found: string, range?: string): boolean {

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -1,5 +1,5 @@
 import { Lazy } from "lazy-val"
-import { LogMessageByKey } from "./moduleManager"
+import { LogMessageByKey, type Package } from "./moduleManager"
 import { NodeModulesCollector } from "./nodeModulesCollector"
 import { getPackageManagerCommand, PM } from "./packageManager"
 import { PnpmDependency } from "./types"
@@ -20,6 +20,21 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
     const major = parseInt((result.stdout ?? "0").split(".")[0], 10)
     return isNaN(major) ? 0 : major
   })
+
+  /**
+   * Memo for `locateFromDepOrRoot`, keyed by `name@version`. pnpm's content-addressed virtual
+   * store guarantees that any given `name@version` resolves to a single location on disk, so
+   * once we've resolved a package we can short-circuit every subsequent lookup. This is the
+   * dominant speedup for large workspaces where the `pnpm list --json` tree contains the same
+   * `name@version` thousands of times (one entry per dependent).
+   */
+  private readonly locateMemo: Map<string, Promise<Package | null>> = new Map()
+
+  /**
+   * Visited set for `collectDepsRecursively`, keyed by `name@version`. Without this we re-walk
+   * every shared subtree of the pnpm list output, exploding work in deep workspaces.
+   */
+  private readonly collectedDeps: Set<string> = new Set()
 
   /**
    * Returns the workspace packages to iterate over, gated by detected pnpm version:
@@ -44,10 +59,34 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
    * versions of a dep exist in the workspace.
    */
   private async locateFromDepOrRoot(pkgName: string, parentPath: string | undefined, requiredRange?: string) {
-    return (
-      (parentPath ? await this.cache.locatePackageVersion({ pkgName, parentDir: parentPath, requiredRange }) : null) ||
-      (await this.cache.locatePackageVersion({ pkgName, parentDir: this.rootDir, requiredRange }))
-    )
+    // pnpm's virtual store is content-addressed: every `name@version` lookup is deterministic,
+    // so memoize on the exact version. `requiredRange` is normally an exact version coming from
+    // the pnpm list output (e.g. `value.version`), which makes this cache hit on duplicates.
+    // Only memoize when we have a concrete version — semver ranges could resolve differently
+    // depending on what's installed at `parentPath` vs root, so skip the cache for those.
+    const memoKey = requiredRange && /^\d/.test(requiredRange) ? `${pkgName}@${requiredRange}` : null
+    if (memoKey != null) {
+      const cached = this.locateMemo.get(memoKey)
+      if (cached != null) {
+        return cached
+      }
+    }
+
+    // pnpm's `.pnpm` virtual store is flat — no nested `node_modules/<a>/node_modules/<b>`
+    // structure exists. `downwardSearch` would burn thousands of `readdir`/`lstat` calls
+    // finding nothing, so skip it.
+    const promise = (async (): Promise<Package | null> => {
+      const fromDep = parentPath ? await this.cache.locatePackageVersion({ pkgName, parentDir: parentPath, requiredRange, skipDownwardSearch: true }) : null
+      if (fromDep) {
+        return fromDep
+      }
+      return this.cache.locatePackageVersion({ pkgName, parentDir: this.rootDir, requiredRange, skipDownwardSearch: true })
+    })()
+
+    if (memoKey != null) {
+      this.locateMemo.set(memoKey, promise)
+    }
+    return promise
   }
 
   protected async extractProductionDependencyGraph(tree: PnpmDependency, dependencyId: string) {
@@ -111,22 +150,27 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
   }
 
   private async collectDepsRecursively(tree: PnpmDependency): Promise<void> {
-    for (const [key, value] of Object.entries(tree.dependencies || {})) {
+    const visit = async (key: string, value: PnpmDependency) => {
       if ((value?.dedupedDependenciesCount ?? 0) > 0) {
-        continue
+        return
       }
+      const id = `${key}@${value.version}`
+      // The pnpm list output can include the same `name@version` thousands of times across a
+      // deep workspace; without this guard we re-resolve and re-recurse each occurrence.
+      if (this.collectedDeps.has(id)) {
+        return
+      }
+      this.collectedDeps.add(id)
       const pkg = await this.locateFromDepOrRoot(key, value.path, value.version)
-      this.allDependencies.set(`${key}@${value.version}`, { ...value, path: pkg?.packageDir ?? value.path })
+      this.allDependencies.set(id, { ...value, path: pkg?.packageDir ?? value.path })
       await this.collectDepsRecursively(value)
     }
 
+    for (const [key, value] of Object.entries(tree.dependencies || {})) {
+      await visit(key, value)
+    }
     for (const [key, value] of Object.entries(tree.optionalDependencies || {})) {
-      if ((value?.dedupedDependenciesCount ?? 0) > 0) {
-        continue
-      }
-      const pkg = await this.locateFromDepOrRoot(key, value.path, value.version)
-      this.allDependencies.set(`${key}@${value.version}`, { ...value, path: pkg?.packageDir ?? value.path })
-      await this.collectDepsRecursively(value)
+      await visit(key, value)
     }
   }
 


### PR DESCRIPTION
This patch was generated by AI but tested in https://github.com/Infrawrench/Infrawrench/actions/workflows/desktop-build.yml to save 3 hours on the build!

Memoize `locateFromDepOrRoot` by `name@version` and add a visited set to `collectDepsRecursively` to avoid re-walking shared subtrees in the pnpm list output. Add a `skipDownwardSearch` opt-out to `locatePackageVersion` since pnpm's `.pnpm` virtual store is flat, so the BFS would burn thousands of `readdir`/`lstat` calls finding nothing.