### PR TITLE
fix(docker): reconnect wine to wine64 via symlink and correctly set up wine + mono

### DIFF
--- a/.changeset/angry-memes-hang.md
+++ b/.changeset/angry-memes-hang.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix(docker): reconnect wine to wine64 via symlink and correctly set up wine + mono

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,9 +6,13 @@ NODE_VERSION=$1
 NODE_TAG=$(cut -d '.' -f 1 <<< "$NODE_VERSION")
 DATE=$(date +%m.%y)
 
-docker build -t electronuserland/builder:base -t "electronuserland/builder:base-$DATE" docker/base
+# --provenance=false requires Docker 23.0+ / BuildKit 0.10+. It prevents OCI manifest-list creation
+# (caused by BuildKit provenance attestation) which blocks locally built images from being resolved
+# as bases in subsequent builds when using Docker Desktop's containerd image store.
+docker build --provenance=false -t electronuserland/builder:base -t "electronuserland/builder:base-$DATE" docker/base
 
 docker build \
+  --provenance=false \
   --build-arg NODE_VERSION="$NODE_VERSION" \
   --build-arg IMAGE_VERSION="base-$DATE" \
   -t "electronuserland/builder:$NODE_TAG" \
@@ -16,12 +20,14 @@ docker build \
   docker/node
 
 docker build \
+  --provenance=false \
   --build-arg IMAGE_VERSION="$NODE_TAG-$DATE" \
   -t "electronuserland/builder:$NODE_TAG-wine" \
   -t "electronuserland/builder:$NODE_TAG-wine-$DATE" \
   docker/wine
 
 docker build \
+  --provenance=false \
   --build-arg IMAGE_VERSION="$NODE_TAG-wine-$DATE" \
   -t "electronuserland/builder:$NODE_TAG-wine-chrome" \
   -t "electronuserland/builder:$NODE_TAG-wine-chrome-$DATE" \
@@ -29,6 +35,7 @@ docker build \
 
 # We also use this image for running our unit tests
 docker build \
+  --provenance=false \
   --build-arg IMAGE_VERSION="$NODE_TAG-wine-$DATE" \
   -t "electronuserland/builder:$NODE_TAG-wine-mono" \
   -t "electronuserland/builder:$NODE_TAG-wine-mono-$DATE" \

--- a/docker/wine-mono/Dockerfile
+++ b/docker/wine-mono/Dockerfile
@@ -4,5 +4,13 @@ FROM --platform=linux/x86_64 electronuserland/builder:$IMAGE_VERSION
 # since mono is required only for deprecated target Squirrel.Windows, extracted to separate docker image to reduce size
 
 RUN apt-get -qq update -y && \
-  apt-get -qq install -y --no-install-recommends mono-devel ca-certificates-mono && \
+  # Under QEMU (Apple Silicon cross-builds), the Mono CA cert post-install hook invokes
+  # /usr/bin/mono which crashes with a JIT assertion (x86-codegen.h offset check). Divert
+  # the path so the real binary lands at a temporary name; place /bin/true as a no-op for
+  # the hook; then restore the real binary after installation completes.
+  dpkg-divert --divert /usr/bin/mono.qemu-workaround --rename /usr/bin/mono && \
+  ln -sf /bin/true /usr/bin/mono && \
+  apt-get -qq install -y --no-install-recommends mono-devel && \
+  rm -f /usr/bin/mono && \
+  dpkg-divert --remove --rename /usr/bin/mono && \
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/wine/Dockerfile
+++ b/docker/wine/Dockerfile
@@ -9,6 +9,9 @@ RUN dpkg --add-architecture i386 && \
   wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources && \
   apt-get -qq update && \
   apt-get -qq install -y --install-recommends winehq-stable && \
+  # Wine 9.x+ removed wine64 as a standalone binary; wine on x86_64 is already 64-bit.
+  # Symlink for backward compatibility with tools (e.g. electron-winstaller) that still check for wine64.
+  ln -sf /usr/bin/wine /usr/bin/wine64 && \
   # powershell
   # https://learn.microsoft.com/en-us/powershell/scripting/install/install-ubuntu?view=powershell-7.4
   apt-get install -yq apt-transport-https software-properties-common && \
@@ -24,6 +27,15 @@ RUN dpkg --add-architecture i386 && \
 ENV WINEDEBUG=-all,err+all
 ENV WINEDLLOVERRIDES=winemenubuilder.exe=d
 
-# We expect this to error in the logs due to no screen display, but it seems to be the only way to init a ~/.wine config dir
-# Note: We could run this via xvfb-run, but since `winecfg` is a GUI config tool, the docker build process hangs as the process never exits
-RUN winecfg
+# wineboot --init is the correct headless prefix initialiser (no display needed, exits after init).
+# On Apple Silicon / Linux ARM64 cross-builds, Wine aborts under QEMU due to the host/guest page-size mismatch
+# (host 16KB vs Wine's expected 4KB). We detect this via the assertion text in stderr rather than getconf
+# PAGE_SIZE, because inside the emulated x86_64 container PAGE_SIZE reports 4096 regardless of the host.
+RUN wineboot --init 2>/tmp/wb.log; \
+  if [ $? -ne 0 ]; then \
+    cat /tmp/wb.log >&2; \
+    grep -qE "host_page_mask|anon_mmap|qemu" /tmp/wb.log || \
+      { echo "ERROR: wineboot failed on native x86_64" >&2; exit 1; }; \
+    echo "NOTE: wineboot failed due to QEMU page-size emulation (expected on Apple Silicon/ARM cross-builds)" >&2; \
+  fi; \
+  rm -f /tmp/wb.log


### PR DESCRIPTION
Doesn't seem to be anything production impactful as the previous images still work; only trying to rebuild the images now is the issue appearing.

Resolves this error in the console when rebuilding the docker images:
```
 FAIL  test/src/filesTest.ts > extraResources on Windows
Error: You must install both Mono and Wine on non-Windows
 ❯ node_modules/.pnpm/electron-winstaller@5.4.0/node_modules/electron-winstaller/src/index.ts:66:13
 ❯ step node_modules/.pnpm/electron-winstaller@5.4.0/node_modules/electron-winstaller/lib/index.js:56:23
 ❯ Object.next node_modules/.pnpm/electron-winstaller@5.4.0/node_modules/electron-winstaller/lib/index.js:37:53
 ❯ fulfilled node_modules/.pnpm/electron-winstaller@5.4.0/node_modules/electron-winstaller/lib/index.js:28:58
 ```

TLDR;
Wine 9.x+ removed wine64 as a standalone binary; wine on x86_64 is already 64-bit.
We symlink for backward compatibility with tools (e.g. electron-winstaller) that still check for wine64.
https://github.com/electron/windows-installer/blob/aac1771b4ce33bc592b019ab1c93a98f090ff7ac/src/index.ts#L52-L56

This should fix the blocking/failing docker build issue in https://github.com/electron-userland/electron-builder/pull/9689