### PR TITLE
fix: add cache corruption/extraction detection to prevent malformed toolsets

### DIFF
--- a/.changeset/famous-frogs-crash.md
+++ b/.changeset/famous-frogs-crash.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: add cache corruption/extraction detection to prevent malformed 7z extractions

--- a/.context/notes.md
+++ b/.context/notes.md
@@ -1,0 +1,5 @@
+Tests are run as `TEST_FILES="<test file name>" pnpm ci:test`.
+Project compiles with `pnpm compile` from workspace root.
+Prioritize always writing vitest cases under `test/src`, preferably organized under a specific folder for a relevant platform.
+Use `gh` CLI wherever appropriate instead of WebFetch.
+Do not ever commit and push, or write/update a PR, while using `gh`.

--- a/packages/app-builder-lib/src/util/cacheState.ts
+++ b/packages/app-builder-lib/src/util/cacheState.ts
@@ -116,7 +116,7 @@ export async function validateCacheDirectory(extractDir: string, expectedFileCou
       return false
     }
 
-    if (expectedFileCount) {
+    if (expectedFileCount != null && expectedFileCount > 0) {
       const { fileCount: actual } = await computeCacheMetadata(extractDir)
       if (actual !== expectedFileCount) {
         log.warn({ extractDir, expected: expectedFileCount, actual }, "Cache file count mismatch, treating as invalid")
@@ -131,8 +131,8 @@ export async function validateCacheDirectory(extractDir: string, expectedFileCou
   }
 }
 
-export async function cleanupCacheDirectory(extractDir: string): Promise<void> {
-  const filesToClean = [extractDir, `${extractDir}.state`, `${extractDir}.tmp`, `${extractDir}.lock`, `${extractDir}.tmp.lock`]
+export async function cleanupCacheDirectory(extractDir: string, { skipLockFiles = false } = {}): Promise<void> {
+  const filesToClean = [extractDir, `${extractDir}.state`, `${extractDir}.tmp`, ...(!skipLockFiles ? [`${extractDir}.lock`, `${extractDir}.tmp.lock`] : [])]
 
   for (const file of filesToClean) {
     try {

--- a/packages/app-builder-lib/src/util/cacheState.ts
+++ b/packages/app-builder-lib/src/util/cacheState.ts
@@ -26,42 +26,41 @@ function getStateFilePath(extractDir: string): string {
   return `${extractDir}.state`
 }
 
-export async function readCacheState(extractDir: string): Promise<CacheState | null> {
+export async function readCacheStateFile(extractDir: string): Promise<CacheStateFile | null> {
   const stateFile = getStateFilePath(extractDir)
   try {
     if (!(await exists(stateFile))) {
-      // Check for legacy .complete marker for backward compatibility
-      if (await exists(`${extractDir}.complete`)) {
-        return CacheState.complete
-      }
-      return CacheState.pending
+      return null
     }
-
     const content = await fs.readFile(stateFile, "utf-8")
     const data: CacheStateFile = JSON.parse(content)
-    let state = data.state as CacheState
-
-    // Detect stale extracting state (process likely crashed)
-    if (state === CacheState.extracting) {
+    if (data.state === CacheState.extracting) {
       const age = Date.now() - data.timestamp
       if (age > STALE_EXTRACTING_TIMEOUT_MS) {
         log.warn({ stateFile, age }, "Detected stale extracting state, marking as corrupted")
-        return CacheState.corrupted
+        return { ...data, state: CacheState.corrupted }
       }
     }
-
-    return state
+    return data
   } catch (e: any) {
     log.warn({ stateFile, error: e.message }, "Failed to read cache state file")
-    return CacheState.pending
+    return null
   }
 }
 
-export async function writeCacheState(
-  extractDir: string,
-  state: CacheState,
-  metadata?: { fileCount?: number; extractedSize?: number }
-): Promise<void> {
+export async function readCacheState(extractDir: string): Promise<CacheState | null> {
+  const data = await readCacheStateFile(extractDir)
+  if (data !== null) {
+    return data.state
+  }
+  // Check for legacy .complete marker for backward compatibility
+  if (await exists(`${extractDir}.complete`)) {
+    return CacheState.complete
+  }
+  return CacheState.pending
+}
+
+export async function writeCacheState(extractDir: string, state: CacheState, metadata?: { fileCount?: number; extractedSize?: number }): Promise<void> {
   const stateFile = getStateFilePath(extractDir)
   const stateData: CacheStateFile = {
     version: STATE_FILE_VERSION,
@@ -78,7 +77,7 @@ export async function writeCacheState(
   }
 }
 
-export async function validateCacheDirectory(extractDir: string): Promise<boolean> {
+export async function validateCacheDirectory(extractDir: string, expectedFileCount?: number): Promise<boolean> {
   try {
     if (!(await exists(extractDir))) {
       return false
@@ -89,13 +88,8 @@ export async function validateCacheDirectory(extractDir: string): Promise<boolea
       return false
     }
 
-    // For 7z/WiX extractions, verify we have both executables and DLLs
-    const hasExe = files.some(f => f.toLowerCase().endsWith(".exe"))
-    const hasDlls = files.some(f => f.toLowerCase().endsWith(".dll"))
-
-    // If it looks like a 7z extraction (has .exe), it should also have DLLs
-    if (hasExe && !hasDlls) {
-      log.warn({ extractDir, files: files.length }, "Incomplete extraction: exe present but no DLLs")
+    if (expectedFileCount && files.length !== expectedFileCount) {
+      log.warn({ extractDir, expected: expectedFileCount, actual: files.length }, "Cache file count mismatch, treating as invalid")
       return false
     }
 
@@ -107,12 +101,7 @@ export async function validateCacheDirectory(extractDir: string): Promise<boolea
 }
 
 export async function cleanupCacheDirectory(extractDir: string): Promise<void> {
-  const filesToClean = [
-    extractDir,
-    `${extractDir}.state`,
-    `${extractDir}.complete`,
-    `${extractDir}.tmp`,
-  ]
+  const filesToClean = [extractDir, `${extractDir}.state`, `${extractDir}.complete`, `${extractDir}.tmp`]
 
   for (const file of filesToClean) {
     try {

--- a/packages/app-builder-lib/src/util/cacheState.ts
+++ b/packages/app-builder-lib/src/util/cacheState.ts
@@ -48,16 +48,9 @@ export async function readCacheStateFile(extractDir: string): Promise<CacheState
   }
 }
 
-export async function readCacheState(extractDir: string): Promise<CacheState | null> {
+export async function readCacheState(extractDir: string): Promise<CacheState> {
   const data = await readCacheStateFile(extractDir)
-  if (data !== null) {
-    return data.state
-  }
-  // Check for legacy .complete marker for backward compatibility
-  if (await exists(`${extractDir}.complete`)) {
-    return CacheState.complete
-  }
-  return CacheState.pending
+  return data?.state ?? CacheState.pending
 }
 
 export async function writeCacheState(extractDir: string, state: CacheState, metadata?: { fileCount?: number; extractedSize?: number }): Promise<void> {
@@ -101,7 +94,7 @@ export async function validateCacheDirectory(extractDir: string, expectedFileCou
 }
 
 export async function cleanupCacheDirectory(extractDir: string): Promise<void> {
-  const filesToClean = [extractDir, `${extractDir}.state`, `${extractDir}.complete`, `${extractDir}.tmp`]
+  const filesToClean = [extractDir, `${extractDir}.state`, `${extractDir}.tmp`]
 
   for (const file of filesToClean) {
     try {

--- a/packages/app-builder-lib/src/util/cacheState.ts
+++ b/packages/app-builder-lib/src/util/cacheState.ts
@@ -1,0 +1,124 @@
+import { log } from "builder-util"
+import { exists } from "builder-util"
+import * as fs from "fs/promises"
+
+export enum CacheState {
+  pending = "pending",
+  downloaded = "downloaded",
+  extracting = "extracting",
+  extracted = "extracted",
+  complete = "complete",
+  corrupted = "corrupted",
+}
+
+export interface CacheStateFile {
+  version: number
+  state: CacheState
+  timestamp: number
+  fileCount: number
+  extractedSize: number
+}
+
+const STATE_FILE_VERSION = 1
+const STALE_EXTRACTING_TIMEOUT_MS = 120000 // 120 seconds
+
+function getStateFilePath(extractDir: string): string {
+  return `${extractDir}.state`
+}
+
+export async function readCacheState(extractDir: string): Promise<CacheState | null> {
+  const stateFile = getStateFilePath(extractDir)
+  try {
+    if (!(await exists(stateFile))) {
+      // Check for legacy .complete marker for backward compatibility
+      if (await exists(`${extractDir}.complete`)) {
+        return CacheState.complete
+      }
+      return CacheState.pending
+    }
+
+    const content = await fs.readFile(stateFile, "utf-8")
+    const data: CacheStateFile = JSON.parse(content)
+    let state = data.state as CacheState
+
+    // Detect stale extracting state (process likely crashed)
+    if (state === CacheState.extracting) {
+      const age = Date.now() - data.timestamp
+      if (age > STALE_EXTRACTING_TIMEOUT_MS) {
+        log.warn({ stateFile, age }, "Detected stale extracting state, marking as corrupted")
+        return CacheState.corrupted
+      }
+    }
+
+    return state
+  } catch (e: any) {
+    log.warn({ stateFile, error: e.message }, "Failed to read cache state file")
+    return CacheState.pending
+  }
+}
+
+export async function writeCacheState(
+  extractDir: string,
+  state: CacheState,
+  metadata?: { fileCount?: number; extractedSize?: number }
+): Promise<void> {
+  const stateFile = getStateFilePath(extractDir)
+  const stateData: CacheStateFile = {
+    version: STATE_FILE_VERSION,
+    state,
+    timestamp: Date.now(),
+    fileCount: metadata?.fileCount ?? 0,
+    extractedSize: metadata?.extractedSize ?? 0,
+  }
+
+  try {
+    await fs.writeFile(stateFile, JSON.stringify(stateData, null, 2), "utf-8")
+  } catch (e: any) {
+    log.warn({ stateFile, error: e.message }, "Failed to write cache state file")
+  }
+}
+
+export async function validateCacheDirectory(extractDir: string): Promise<boolean> {
+  try {
+    if (!(await exists(extractDir))) {
+      return false
+    }
+
+    const files = await fs.readdir(extractDir)
+    if (files.length === 0) {
+      return false
+    }
+
+    // For 7z/WiX extractions, verify we have both executables and DLLs
+    const hasExe = files.some(f => f.toLowerCase().endsWith(".exe"))
+    const hasDlls = files.some(f => f.toLowerCase().endsWith(".dll"))
+
+    // If it looks like a 7z extraction (has .exe), it should also have DLLs
+    if (hasExe && !hasDlls) {
+      log.warn({ extractDir, files: files.length }, "Incomplete extraction: exe present but no DLLs")
+      return false
+    }
+
+    return true
+  } catch (e: any) {
+    log.warn({ extractDir, error: e.message }, "Failed to validate cache directory")
+    return false
+  }
+}
+
+export async function cleanupCacheDirectory(extractDir: string): Promise<void> {
+  const filesToClean = [
+    extractDir,
+    `${extractDir}.state`,
+    `${extractDir}.complete`,
+    `${extractDir}.tmp`,
+  ]
+
+  for (const file of filesToClean) {
+    try {
+      await fs.rm(file, { recursive: true, force: true })
+    } catch (e: any) {
+      log.warn({ file, error: e.message }, "Failed to clean up cache file")
+    }
+  }
+}

--- a/packages/app-builder-lib/src/util/cacheState.ts
+++ b/packages/app-builder-lib/src/util/cacheState.ts
@@ -1,6 +1,6 @@
 import { log } from "builder-util"
-import { exists } from "builder-util"
 import * as fs from "fs/promises"
+import * as path from "path"
 
 export enum CacheState {
   pending = "pending",
@@ -28,12 +28,21 @@ function getStateFilePath(extractDir: string): string {
 
 export async function readCacheStateFile(extractDir: string): Promise<CacheStateFile | null> {
   const stateFile = getStateFilePath(extractDir)
+  let content: string
   try {
-    if (!(await exists(stateFile))) {
+    content = await fs.readFile(stateFile, "utf-8")
+  } catch (e: any) {
+    if (e.code !== "ENOENT") {
+      log.warn({ stateFile, error: e.message }, "Failed to read cache state file")
+    }
+    return null
+  }
+  try {
+    const data: CacheStateFile = JSON.parse(content)
+    if (data.version !== STATE_FILE_VERSION) {
+      log.warn({ stateFile, version: data.version, expected: STATE_FILE_VERSION }, "Cache state file version mismatch, ignoring")
       return null
     }
-    const content = await fs.readFile(stateFile, "utf-8")
-    const data: CacheStateFile = JSON.parse(content)
     if (data.state === CacheState.extracting) {
       const age = Date.now() - data.timestamp
       if (age > STALE_EXTRACTING_TIMEOUT_MS) {
@@ -43,17 +52,12 @@ export async function readCacheStateFile(extractDir: string): Promise<CacheState
     }
     return data
   } catch (e: any) {
-    log.warn({ stateFile, error: e.message }, "Failed to read cache state file")
+    log.warn({ stateFile, error: e.message }, "Failed to parse cache state file")
     return null
   }
 }
 
-export async function readCacheState(extractDir: string): Promise<CacheState> {
-  const data = await readCacheStateFile(extractDir)
-  return data?.state ?? CacheState.pending
-}
-
-export async function writeCacheState(extractDir: string, state: CacheState, metadata?: { fileCount?: number; extractedSize?: number }): Promise<void> {
+export async function writeCacheState(extractDir: string, state: CacheState, metadata?: { fileCount?: number; extractedSize?: number }, throwOnError = false): Promise<void> {
   const stateFile = getStateFilePath(extractDir)
   const stateData: CacheStateFile = {
     version: STATE_FILE_VERSION,
@@ -67,23 +71,57 @@ export async function writeCacheState(extractDir: string, state: CacheState, met
     await fs.writeFile(stateFile, JSON.stringify(stateData, null, 2), "utf-8")
   } catch (e: any) {
     log.warn({ stateFile, error: e.message }, "Failed to write cache state file")
+    if (throwOnError) {
+      throw e
+    }
   }
+}
+
+export async function computeCacheMetadata(dir: string): Promise<{ fileCount: number; extractedSize: number }> {
+  let fileCount = 0
+  let extractedSize = 0
+  const stack: string[] = [dir]
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    let entries
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(fullPath)
+      } else {
+        fileCount++
+        if (entry.isFile()) {
+          try {
+            const stat = await fs.stat(fullPath)
+            extractedSize += stat.size
+          } catch {
+            // ignore stat errors for individual files
+          }
+        }
+      }
+    }
+  }
+  return { fileCount, extractedSize }
 }
 
 export async function validateCacheDirectory(extractDir: string, expectedFileCount?: number): Promise<boolean> {
   try {
-    if (!(await exists(extractDir))) {
+    const topLevel = await fs.readdir(extractDir)
+    if (topLevel.length === 0) {
       return false
     }
 
-    const files = await fs.readdir(extractDir)
-    if (files.length === 0) {
-      return false
-    }
-
-    if (expectedFileCount && files.length !== expectedFileCount) {
-      log.warn({ extractDir, expected: expectedFileCount, actual: files.length }, "Cache file count mismatch, treating as invalid")
-      return false
+    if (expectedFileCount) {
+      const { fileCount: actual } = await computeCacheMetadata(extractDir)
+      if (actual !== expectedFileCount) {
+        log.warn({ extractDir, expected: expectedFileCount, actual }, "Cache file count mismatch, treating as invalid")
+        return false
+      }
     }
 
     return true
@@ -94,7 +132,7 @@ export async function validateCacheDirectory(extractDir: string, expectedFileCou
 }
 
 export async function cleanupCacheDirectory(extractDir: string): Promise<void> {
-  const filesToClean = [extractDir, `${extractDir}.state`, `${extractDir}.tmp`]
+  const filesToClean = [extractDir, `${extractDir}.state`, `${extractDir}.tmp`, `${extractDir}.lock`, `${extractDir}.tmp.lock`]
 
   for (const file of filesToClean) {
     try {

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -18,6 +18,7 @@ import { pipeline } from "stream/promises"
 import * as tar from "tar"
 import * as unzipper from "unzipper"
 import { ElectronPlatformName } from "../electron/ElectronFramework"
+import { CacheState, cleanupCacheDirectory, readCacheState, validateCacheDirectory, writeCacheState } from "./cacheState"
 
 export type ElectronGetOptions = Omit<
   ElectronPlatformArtifactDetails,
@@ -172,10 +173,13 @@ export async function extractArchive(file: string, dir: string) {
 
   const release = await lockfile.lock(tmpDir, {
     retries: { retries: 5, minTimeout: 1000, maxTimeout: 5000 },
-    stale: 60000,
+    stale: 120000, // Increased from 60s to allow long-running extractions
   })
 
   try {
+    // Write extracting state before extraction starts
+    await writeCacheState(dir, CacheState.extracting)
+
     // rm + mkdir happen AFTER acquiring the lock so no concurrent caller can clear our tmpDir mid-extraction
     await fs.rm(tmpDir, { recursive: true, force: true })
     await fs.mkdir(tmpDir, { recursive: true })
@@ -185,10 +189,48 @@ export async function extractArchive(file: string, dir: string) {
     } else if (file.endsWith(".zip")) {
       await extractZipStreaming(file, tmpDir)
     } else if (file.endsWith(".7z")) {
-      await exec(await getPath7za(), ["x", "-bd", file, `-o${tmpDir}`, "-y"])
+      const cmd7za = await getPath7za()
+      try {
+        await exec(cmd7za, ["x", "-bd", file, `-o${tmpDir}`, "-y"])
+      } catch (e: any) {
+        // Check if extraction actually failed or just had benign warnings
+        const files = await fs.readdir(tmpDir)
+        if (files.length === 0) {
+          log.warn({ file, tmpDir, error: e.message }, "7z extraction produced no output")
+          throw new Error(`7z extraction failed for ${file}: ${e.message}`)
+        }
+        // If files were extracted despite the error, log and continue
+        log.warn({ error: e.message, filesExtracted: files.length }, "7z reported error but extracted files")
+      }
     } else {
       throw new Error(`Unsupported archive format: ${path.basename(file)}`)
     }
+
+    // Verify extraction produced files
+    const extractedFiles = await fs.readdir(tmpDir)
+    if (extractedFiles.length === 0) {
+      throw new Error(`Extraction of ${path.basename(file)} produced no files`)
+    }
+
+    // For 7z extractions, verify critical files exist
+    if (file.endsWith(".7z")) {
+      const hasExe = extractedFiles.some(f => f.toLowerCase().endsWith(".exe"))
+      const hasDlls = extractedFiles.some(f => f.toLowerCase().endsWith(".dll"))
+      if (!hasExe || !hasDlls) {
+        throw new Error(`Incomplete 7z extraction: exe=${hasExe}, dlls=${hasDlls}, files=${extractedFiles.length}`)
+      }
+    }
+
+    // Calculate extracted size for state tracking
+    const stats = await Promise.all(extractedFiles.map(f => fs.stat(path.join(tmpDir, f))))
+    const totalSize = stats.reduce((sum, stat) => sum + stat.size, 0)
+
+    // Write extracted state with metadata
+    await writeCacheState(dir, CacheState.extracted, {
+      fileCount: extractedFiles.length,
+      extractedSize: totalSize,
+    })
+
     await fs.rm(dir, { recursive: true, force: true })
     await fs.rename(tmpDir, dir)
   } finally {
@@ -256,29 +298,77 @@ async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact
 
   await fs.mkdir(extractDir, { recursive: true })
 
-  if (await isCached()) {
-    log.debug({ file: label, path: extractDir }, "using cached artifact - skipping download/extract")
-    return extractDir
+  // Check for corrupted cache BEFORE attempting to use it
+  const currentState = await readCacheState(extractDir)
+  if (currentState === CacheState.corrupted) {
+    log.warn({ extractDir, state: currentState }, "Corrupted cache detected, cleaning up and re-extracting")
+    await cleanupCacheDirectory(extractDir)
+    // Recreate directory so lockfile.lock can acquire a lock on it below
+    await fs.mkdir(extractDir, { recursive: true })
+  } else if (currentState === CacheState.complete) {
+    // Validate the complete state - ensure files still exist and are valid
+    const isValid = await validateCacheDirectory(extractDir)
+    if (isValid) {
+      log.debug({ file: label, path: extractDir }, "using cached artifact - cache valid")
+      return extractDir
+    } else {
+      log.warn({ extractDir }, "Cache marked complete but files invalid, clearing")
+      await cleanupCacheDirectory(extractDir)
+      // Recreate directory so lockfile.lock can acquire a lock on it below
+      await fs.mkdir(extractDir, { recursive: true })
+    }
+  } else if (await isCached()) {
+    // Legacy .complete marker exists, validate it
+    const isValid = await validateCacheDirectory(extractDir)
+    if (isValid) {
+      log.debug({ file: label, path: extractDir }, "using cached artifact - legacy marker valid")
+      return extractDir
+    } else {
+      await cleanupCacheDirectory(extractDir)
+      // Recreate directory so lockfile.lock can acquire a lock on it below
+      await fs.mkdir(extractDir, { recursive: true })
+    }
   }
+
+  // Write pending state
+  await writeCacheState(extractDir, CacheState.pending)
 
   const release = await lockfile.lock(extractDir, {
     retries: { retries: 5, minTimeout: 1000, maxTimeout: 5000 },
-    stale: 60000,
+    stale: 120000,
   })
   let downloadedFile: string | null = null
   try {
     // Re-check after acquiring lock: another worker may have completed while we waited.
-    if (await isCached()) {
-      log.debug({ file: label, path: extractDir }, "using cached artifact - skipping download/extract")
-      return extractDir
+    const stateAfterLock = await readCacheState(extractDir)
+    if (stateAfterLock === CacheState.complete) {
+      const isValid = await validateCacheDirectory(extractDir)
+      if (isValid) {
+        log.debug({ file: label, path: extractDir }, "using cached artifact - skipping download/extract")
+        return extractDir
+      }
     }
 
+    log.debug({ file: label }, "downloading")
     downloadedFile = await downloadArtifactToFile(config, label)
+    if (!downloadedFile) {
+      throw new Error(`Failed to download artifact: ${label}`)
+    }
+
+    // Write downloaded state
+    await writeCacheState(extractDir, CacheState.downloaded)
+
+    // Extract while holding the lock to prevent concurrent interference
+    await extractArchive(downloadedFile, extractDir)
+
+    // Write complete state BEFORE releasing the lock to prevent partial-extraction race
+    await writeCacheState(extractDir, CacheState.complete)
+
+    // Also write legacy .complete marker for backward compatibility
+    await fs.writeFile(completeMarker, "")
   } finally {
     await release().catch(err => log.warn({ err }, "failed to release lockfile"))
   }
-  await extractArchive(downloadedFile, extractDir)
-  await fs.writeFile(completeMarker, "")
   return extractDir
 }
 

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -18,7 +18,7 @@ import { pipeline } from "stream/promises"
 import * as tar from "tar"
 import * as unzipper from "unzipper"
 import { ElectronPlatformName } from "../electron/ElectronFramework"
-import { CacheState, cleanupCacheDirectory, readCacheState, validateCacheDirectory, writeCacheState } from "./cacheState"
+import { CacheState, cleanupCacheDirectory, readCacheStateFile, validateCacheDirectory, writeCacheState } from "./cacheState"
 
 export type ElectronGetOptions = Omit<
   ElectronPlatformArtifactDetails,
@@ -294,44 +294,28 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
  */
 async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact>[0], extractDir: string, label: string): Promise<string> {
   const completeMarker = `${extractDir}.complete`
-  const isCached = async () => exists(completeMarker)
 
   await fs.mkdir(extractDir, { recursive: true })
 
-  // Check for corrupted cache BEFORE attempting to use it
-  const currentState = await readCacheState(extractDir)
+  // Single read — derive both state and metadata without a second file read
+  const stateData = await readCacheStateFile(extractDir)
+  const currentState = stateData?.state ?? ((await exists(completeMarker)) ? CacheState.complete : CacheState.pending)
+
   if (currentState === CacheState.corrupted) {
-    log.warn({ extractDir, state: currentState }, "Corrupted cache detected, cleaning up and re-extracting")
+    log.warn({ extractDir }, "Corrupted cache detected, cleaning up and re-extracting")
     await cleanupCacheDirectory(extractDir)
-    // Recreate directory so lockfile.lock can acquire a lock on it below
     await fs.mkdir(extractDir, { recursive: true })
   } else if (currentState === CacheState.complete) {
-    // Validate the complete state - ensure files still exist and are valid
-    const isValid = await validateCacheDirectory(extractDir)
+    // stateData is null for legacy-marker caches — fileCount undefined skips count check
+    const isValid = await validateCacheDirectory(extractDir, stateData?.fileCount)
     if (isValid) {
       log.debug({ file: label, path: extractDir }, "using cached artifact - cache valid")
       return extractDir
-    } else {
-      log.warn({ extractDir }, "Cache marked complete but files invalid, clearing")
-      await cleanupCacheDirectory(extractDir)
-      // Recreate directory so lockfile.lock can acquire a lock on it below
-      await fs.mkdir(extractDir, { recursive: true })
     }
-  } else if (await isCached()) {
-    // Legacy .complete marker exists, validate it
-    const isValid = await validateCacheDirectory(extractDir)
-    if (isValid) {
-      log.debug({ file: label, path: extractDir }, "using cached artifact - legacy marker valid")
-      return extractDir
-    } else {
-      await cleanupCacheDirectory(extractDir)
-      // Recreate directory so lockfile.lock can acquire a lock on it below
-      await fs.mkdir(extractDir, { recursive: true })
-    }
+    log.warn({ extractDir }, "Cache marked complete but files invalid, clearing")
+    await cleanupCacheDirectory(extractDir)
+    await fs.mkdir(extractDir, { recursive: true })
   }
-
-  // Write pending state
-  await writeCacheState(extractDir, CacheState.pending)
 
   const release = await lockfile.lock(extractDir, {
     retries: { retries: 5, minTimeout: 1000, maxTimeout: 5000 },
@@ -340,9 +324,9 @@ async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact
   let downloadedFile: string | null = null
   try {
     // Re-check after acquiring lock: another worker may have completed while we waited.
-    const stateAfterLock = await readCacheState(extractDir)
-    if (stateAfterLock === CacheState.complete) {
-      const isValid = await validateCacheDirectory(extractDir)
+    const stateDataAfterLock = await readCacheStateFile(extractDir)
+    if (stateDataAfterLock?.state === CacheState.complete) {
+      const isValid = await validateCacheDirectory(extractDir, stateDataAfterLock.fileCount)
       if (isValid) {
         log.debug({ file: label, path: extractDir }, "using cached artifact - skipping download/extract")
         return extractDir

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -212,15 +212,6 @@ export async function extractArchive(file: string, dir: string) {
       throw new Error(`Extraction of ${path.basename(file)} produced no files`)
     }
 
-    // For 7z extractions, verify critical files exist
-    if (file.endsWith(".7z")) {
-      const hasExe = extractedFiles.some(f => f.toLowerCase().endsWith(".exe"))
-      const hasDlls = extractedFiles.some(f => f.toLowerCase().endsWith(".dll"))
-      if (!hasExe || !hasDlls) {
-        throw new Error(`Incomplete 7z extraction: exe=${hasExe}, dlls=${hasDlls}, files=${extractedFiles.length}`)
-      }
-    }
-
     // Calculate extracted size for state tracking
     const stats = await Promise.all(extractedFiles.map(f => fs.stat(path.join(tmpDir, f))))
     const totalSize = stats.reduce((sum, stat) => sum + stat.size, 0)
@@ -240,7 +231,7 @@ export async function extractArchive(file: string, dir: string) {
 
 async function downloadArtifactToFile(config: Parameters<typeof get.downloadArtifact>[0], label: string): Promise<string> {
   const progress = process.stdout.isTTY ? new MultiProgress() : null
-  const progressBar = progress?.createBar(`${" ".repeat(PADDING + 2)}[:bar] :percent | ${label}`, { total: 100 })
+  const progressBar = progress?.createBar(`${" ".repeat(PADDING + 2)}[:bar] :percent | ${label}`, { total: 80 })
   progressBar?.render()
 
   let lastLoggedMilestone = -1
@@ -293,13 +284,11 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
  * Both public download functions delegate here after building their respective configs.
  */
 async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact>[0], extractDir: string, label: string): Promise<string> {
-  const completeMarker = `${extractDir}.complete`
-
   await fs.mkdir(extractDir, { recursive: true })
 
   // Single read — derive both state and metadata without a second file read
   const stateData = await readCacheStateFile(extractDir)
-  const currentState = stateData?.state ?? ((await exists(completeMarker)) ? CacheState.complete : CacheState.pending)
+  const currentState = stateData?.state ?? CacheState.pending
 
   if (currentState === CacheState.corrupted) {
     log.warn({ extractDir }, "Corrupted cache detected, cleaning up and re-extracting")
@@ -347,9 +336,6 @@ async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact
 
     // Write complete state BEFORE releasing the lock to prevent partial-extraction race
     await writeCacheState(extractDir, CacheState.complete)
-
-    // Also write legacy .complete marker for backward compatibility
-    await fs.writeFile(completeMarker, "")
   } finally {
     await release().catch(err => log.warn({ err }, "failed to release lockfile"))
   }

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -18,7 +18,7 @@ import { pipeline } from "stream/promises"
 import * as tar from "tar"
 import * as unzipper from "unzipper"
 import { ElectronPlatformName } from "../electron/ElectronFramework"
-import { CacheState, cleanupCacheDirectory, readCacheStateFile, validateCacheDirectory, writeCacheState } from "./cacheState"
+import { CacheState, cleanupCacheDirectory, computeCacheMetadata, readCacheStateFile, validateCacheDirectory, writeCacheState } from "./cacheState"
 
 export type ElectronGetOptions = Omit<
   ElectronPlatformArtifactDetails,
@@ -177,9 +177,6 @@ export async function extractArchive(file: string, dir: string) {
   })
 
   try {
-    // Write extracting state before extraction starts
-    await writeCacheState(dir, CacheState.extracting)
-
     // rm + mkdir happen AFTER acquiring the lock so no concurrent caller can clear our tmpDir mid-extraction
     await fs.rm(tmpDir, { recursive: true, force: true })
     await fs.mkdir(tmpDir, { recursive: true })
@@ -212,16 +209,6 @@ export async function extractArchive(file: string, dir: string) {
       throw new Error(`Extraction of ${path.basename(file)} produced no files`)
     }
 
-    // Calculate extracted size for state tracking
-    const stats = await Promise.all(extractedFiles.map(f => fs.stat(path.join(tmpDir, f))))
-    const totalSize = stats.reduce((sum, stat) => sum + stat.size, 0)
-
-    // Write extracted state with metadata
-    await writeCacheState(dir, CacheState.extracted, {
-      fileCount: extractedFiles.length,
-      extractedSize: totalSize,
-    })
-
     await fs.rm(dir, { recursive: true, force: true })
     await fs.rename(tmpDir, dir)
   } finally {
@@ -231,7 +218,7 @@ export async function extractArchive(file: string, dir: string) {
 
 async function downloadArtifactToFile(config: Parameters<typeof get.downloadArtifact>[0], label: string): Promise<string> {
   const progress = process.stdout.isTTY ? new MultiProgress() : null
-  const progressBar = progress?.createBar(`${" ".repeat(PADDING + 2)}[:bar] :percent | ${label}`, { total: 80 })
+  const progressBar = progress?.createBar(`${" ".repeat(PADDING + 2)}[:bar] :percent | ${label}`, { total: 100 })
   progressBar?.render()
 
   let lastLoggedMilestone = -1
@@ -286,24 +273,15 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
 async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact>[0], extractDir: string, label: string): Promise<string> {
   await fs.mkdir(extractDir, { recursive: true })
 
-  // Single read — derive both state and metadata without a second file read
+  // Pre-lock fast path: only short-circuit for a definitively complete and valid cache.
+  // Do NOT clean up here — concurrent processes could race to delete under each other.
   const stateData = await readCacheStateFile(extractDir)
-  const currentState = stateData?.state ?? CacheState.pending
-
-  if (currentState === CacheState.corrupted) {
-    log.warn({ extractDir }, "Corrupted cache detected, cleaning up and re-extracting")
-    await cleanupCacheDirectory(extractDir)
-    await fs.mkdir(extractDir, { recursive: true })
-  } else if (currentState === CacheState.complete) {
-    // stateData is null for legacy-marker caches — fileCount undefined skips count check
-    const isValid = await validateCacheDirectory(extractDir, stateData?.fileCount)
+  if (stateData?.state === CacheState.complete) {
+    const isValid = await validateCacheDirectory(extractDir, stateData.fileCount)
     if (isValid) {
       log.debug({ file: label, path: extractDir }, "using cached artifact - cache valid")
       return extractDir
     }
-    log.warn({ extractDir }, "Cache marked complete but files invalid, clearing")
-    await cleanupCacheDirectory(extractDir)
-    await fs.mkdir(extractDir, { recursive: true })
   }
 
   const release = await lockfile.lock(extractDir, {
@@ -320,7 +298,14 @@ async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact
         log.debug({ file: label, path: extractDir }, "using cached artifact - skipping download/extract")
         return extractDir
       }
+      log.warn({ extractDir }, "Cache marked complete but files invalid, clearing")
+    } else if (stateDataAfterLock?.state === CacheState.corrupted) {
+      log.warn({ extractDir }, "Corrupted cache detected, cleaning up and re-extracting")
     }
+
+    // Cleanup inside the lock — skip lock files since we currently hold them
+    await cleanupCacheDirectory(extractDir, { skipLockFiles: true })
+    await fs.mkdir(extractDir, { recursive: true })
 
     log.debug({ file: label }, "downloading")
     downloadedFile = await downloadArtifactToFile(config, label)
@@ -328,14 +313,20 @@ async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact
       throw new Error(`Failed to download artifact: ${label}`)
     }
 
-    // Write downloaded state
     await writeCacheState(extractDir, CacheState.downloaded)
+
+    // Mark extracting so stale-lock detection can recover a crashed mid-extraction process
+    await writeCacheState(extractDir, CacheState.extracting)
 
     // Extract while holding the lock to prevent concurrent interference
     await extractArchive(downloadedFile, extractDir)
 
-    // Write complete state BEFORE releasing the lock to prevent partial-extraction race
-    await writeCacheState(extractDir, CacheState.complete)
+    // Compute metadata with a full recursive walk now that tmpDir has been renamed to extractDir
+    const { fileCount, extractedSize } = await computeCacheMetadata(extractDir)
+
+    // Write complete state with metadata BEFORE releasing the lock; throwOnError=true so a
+    // failed write (disk full, permissions) propagates instead of silently producing a no-op cache
+    await writeCacheState(extractDir, CacheState.complete, { fileCount, extractedSize }, true)
   } finally {
     await release().catch(err => log.warn({ err }, "failed to release lockfile"))
   }

--- a/test/src/electronGetTest.ts
+++ b/test/src/electronGetTest.ts
@@ -11,6 +11,7 @@ import {
   getCacheDirectory,
   getBinariesMirrorUrl,
 } from "app-builder-lib/out/util/electronGet"
+import { CacheState } from "app-builder-lib/out/util/cacheState"
 import { ELECTRON_VERSION } from "./helpers/testConfig"
 
 // ─── getCacheDirectory ────────────────────────────────────────────────────────
@@ -152,7 +153,7 @@ const DOWNLOAD_TIMEOUT = { timeout: 120_000 }
 
 // sequential: tests share the same extractDir (same release + file + mirror → same hash suffix).
 // Running them concurrently causes proper-lockfile contention: the first download holds the lock
-// longer than the retry budget allows. Sequential order ensures test 1 writes the .complete marker
+// longer than the retry budget allows. Sequential order ensures test 1 writes the complete state
 // before tests 2 and 3 run, so they hit the pre-lock cache fast-path instead of waiting on the lock.
 describe("downloadBuilderToolset", { sequential: true }, () => {
   test("downloadArtifact: downloads and extracts appimage@1.0.3 tar.gz with sha256 checksum", DOWNLOAD_TIMEOUT, async ({ expect }) => {
@@ -188,8 +189,9 @@ describe("downloadBuilderToolset", { sequential: true }, () => {
     })
 
     expect(first).toBe(second)
-    // completion marker must exist to prove it was not re-extracted
-    await expect(fs.access(`${first}.complete`)).resolves.toBeUndefined()
+    // state file must record complete to prove it was not re-extracted
+    const stateRaw = await fs.readFile(`${first}.state`, "utf-8")
+    expect(JSON.parse(stateRaw).state).toBe(CacheState.complete)
   })
 
   test("downloadArtifact: respects ELECTRON_BUILDER_BINARIES_MIRROR env var", DOWNLOAD_TIMEOUT, async ({ expect }) => {

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -58,6 +58,7 @@ async function main() {
 
     maxWorkers: "50%",
 
+    fileParallelism: false,
     sequence: {
       sequencer: SmartSequencer,
       concurrent: process.env.TEST_SEQUENTIAL === "false",


### PR DESCRIPTION
Replaces the single .complete marker file with a proper state machine (${extractDir}.state) that tracks the full download/extract lifecycle and surfaces corruption instead of silently reusing a broken cache.
- This issue might only be isolated to unit tests that previously had `fileParallelism: true` and test concurrency, causing multiple extractions to collide due to when the complete marker was written and the lockfile released.

Changes:
- New `CacheState` enum: pending → downloaded → extracting → extracted → complete | corrupted
- Cache hit path does a single state file read and passes fileCount straight to validateCacheDirectory — previously read the file twice and never used the metadata
- Corrupted or count-mismatched cache is cleaned up and re-extracted automatically
- Stale extracting state (timestamp > 120 s) is treated as corruption, recovering from crashed mid-extraction processes
- 7z extraction now tolerates non-zero exit codes when files were actually produced (some versions emit warnings as errors)
- `complete` is written before the lockfile is released, so concurrent waiters see a fully-valid cache the moment the lock drops
- Lock stale timeout raised from 60 s → 120 s to accommodate large tool downloads on slow CI