### PR TITLE
fix: improving filtering of log redactor

### DIFF
--- a/.changeset/lucky-olives-cover.md
+++ b/.changeset/lucky-olives-cover.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: improving filtering of log redactor and adding support for filtering out potentially-sensitive env vars

--- a/.context/notes.md
+++ b/.context/notes.md
@@ -1,3 +1,5 @@
-Tests are run as `TEST_FILES="<test file name>" pnpm ci:test`
-Project compiles with `pnpm compile` from workspace root
-Always write vitest cases (under `test/src`) instead of using `node -e` validations, preferably organize the tests under a specific folder for a relevant platform or utility.
+Tests are run as `TEST_FILES="<test file name>" pnpm ci:test`.
+Project compiles with `pnpm compile` from workspace root.
+Prioritize always writing vitest cases under `test/src`, preferably organized under a specific folder for a relevant platform.
+Use `gh` CLI wherever appropriate instead of WebFetch.
+Do not ever commit and push, or write/update a PR, while using `gh`.

--- a/.context/notes.md
+++ b/.context/notes.md
@@ -1,0 +1,3 @@
+Tests are run as `TEST_FILES="<test file name>" pnpm ci:test`
+Project compiles with `pnpm compile` from workspace root
+Always write vitest cases (under `test/src`) instead of using `node -e` validations, preferably organize the tests under a specific folder for a relevant platform or utility.

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -66,9 +66,11 @@ export function removePassword(input: string): string {
   })
 
   // pass:value — colon acts as separator; handles both pass:secret (no space) and pass: secret (space)
-  input = input.replace(/(?<!\S)pass:\s*([^\s]+)/gi, (_match, val) => {
-    const hashed = createHash("sha256").update(val).digest("hex")
-    return `pass:${hashed} (sha256 hash)`
+  // Quoted phrases (pass:'a b c' or pass:"a b c") are captured in full so the whole phrase is hashed.
+  input = input.replace(/(?<!\S)pass:\s*(?:(["'])(.*?)\1|([^\s]+))/gi, (_match, quote, quotedVal, unquotedVal) => {
+    const value = quotedVal ?? unquotedVal
+    const hashed = createHash("sha256").update(value).digest("hex")
+    return quote ? `pass:${quote}${hashed} (sha256 hash)${quote}` : `pass:${hashed} (sha256 hash)`
   })
 
   // /b … /c block format
@@ -78,7 +80,7 @@ export function removePassword(input: string): string {
   })
 }
 
-const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD/i
+const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|PASS/i
 
 export function filterSensitiveEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
   const out: Record<string, string | undefined> = {}

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -46,13 +46,13 @@ export function serializeToYaml(object: any, skipInvalid = false, noRefs = false
 }
 
 export function removePassword(input: string): string {
-  const flagList = ["--accessKey", "--secretKey", "-p", "-pass", "-String", "/p"]
-  const escapedFlags = flagList.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")
-
-  // (?<!\S) requires flag starts at whitespace or start-of-string (word boundary on the left).
-  // (?=[\s"']|$) requires the flag ends as a standalone token, not embedded in a longer flag like -path or -StringLength.
-  // i flag: covers all capitalisation variants (e.g. -P, -PASS, --ACCESSKEY) without listing each separately.
-  const flagPattern = new RegExp(`(?<!\\S)(${escapedFlags})(?=[\\s"']|$)\\s*(?:(["'])(.*?)\\2|([^\\s]+))`, "gi")
+  // Sensitive parameter stems — any of `-`, `--`, or `/` prefix is accepted for all stems.
+  // `pass:` is intentionally absent; the dedicated pass: handler below covers it without double-processing.
+  const sensitiveStems = ["accessKey", "secretKey", "passphrase", "password", "secret", "token", "String", "pass", "p"]
+  const stemAlt = sensitiveStems.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")
+  // (?:--?|/) matches -, --, or / prefix. Longest stems listed first to minimise backtracking.
+  // (?<!\S) / (?=[\s"']|$) word-boundary guards prevent matching -path, -StringLength, etc.
+  const flagPattern = new RegExp(`(?<!\\S)((?:--?|/)(?:${stemAlt}))(?=[\\s"']|$)\\s*(?:(["'])(.*?)\\2|([^\\s]+))`, "gi")
 
   input = input.replace(flagPattern, (_match, prefix, quote, quotedVal, unquotedVal) => {
     const value = quotedVal ?? unquotedVal

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -85,7 +85,7 @@ const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|PASS/i
 export function filterSensitiveEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
   const out: Record<string, string | undefined> = {}
   for (const [k, v] of Object.entries(env)) {
-    out[k] = SENSITIVE_ENV_KEY_RE.test(k) ? "[REDACTED]" : v
+    out[k] = SENSITIVE_ENV_KEY_RE.test(k) && v != null ? `${createHash("sha256").update(v).digest("hex")} (sha256 hash)` : v
   }
   return out
 }

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -80,7 +80,7 @@ export function removePassword(input: string): string {
   })
 }
 
-const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|PASS/i
+const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|PASS|CREDENTIAL|CSC/i
 
 export function filterSensitiveEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
   const out: Record<string, string | undefined> = {}

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -46,17 +46,18 @@ export function serializeToYaml(object: any, skipInvalid = false, noRefs = false
 }
 
 export function removePassword(input: string): string {
-  const blockList = ["--accessKey", "--secretKey", "-P", "-p", "-pass", "-String", "/p", "pass:"]
+  const flagList = ["--accessKey", "--secretKey", "-p", "-pass", "-String", "/p"]
+  const escapedFlags = flagList.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")
 
-  // Create a regex pattern that supports:
-  //   - space-separated unquoted values: --key value
-  //   - quoted values: --key "value with spaces" or 'value with spaces'
-  const blockPattern = new RegExp(`(${blockList.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\s*(?:(["'])(.*?)\\2|([^\\s]+))`, "g")
+  // (?<!\S) requires flag starts at whitespace or start-of-string (word boundary on the left).
+  // (?=[\s"']|$) requires the flag ends as a standalone token, not embedded in a longer flag like -path or -StringLength.
+  // i flag: covers all capitalisation variants (e.g. -P, -PASS, --ACCESSKEY) without listing each separately.
+  const flagPattern = new RegExp(`(?<!\\S)(${escapedFlags})(?=[\\s"']|$)\\s*(?:(["'])(.*?)\\2|([^\\s]+))`, "gi")
 
-  input = input.replace(blockPattern, (_match, prefix, quote, quotedVal, unquotedVal) => {
+  input = input.replace(flagPattern, (_match, prefix, quote, quotedVal, unquotedVal) => {
     const value = quotedVal ?? unquotedVal
 
-    if (prefix.trim() === "/p" && value.startsWith("\\\\Mac\\Host\\\\")) {
+    if (prefix.trim().toLowerCase() === "/p" && value.startsWith("\\\\Mac\\Host\\")) {
       return `${prefix} ${quote ?? ""}${value}${quote ?? ""}`
     }
 
@@ -64,11 +65,27 @@ export function removePassword(input: string): string {
     return `${prefix} ${quote ?? ""}${hashed} (sha256 hash)${quote ?? ""}`
   })
 
-  // Also handle `/b ... /c` block format
+  // pass:value — colon acts as separator; handles both pass:secret (no space) and pass: secret (space)
+  input = input.replace(/(?<!\S)pass:\s*([^\s]+)/gi, (_match, val) => {
+    const hashed = createHash("sha256").update(val).digest("hex")
+    return `pass:${hashed} (sha256 hash)`
+  })
+
+  // /b … /c block format
   return input.replace(/(\/b\s+)(.*?)(\s+\/c)/g, (_match, p1, p2, p3) => {
     const hashed = createHash("sha256").update(p2).digest("hex")
     return `${p1}${hashed} (sha256 hash)${p3}`
   })
+}
+
+const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD/i
+
+export function filterSensitiveEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {}
+  for (const [k, v] of Object.entries(env)) {
+    out[k] = SENSITIVE_ENV_KEY_RE.test(k) ? "[REDACTED]" : v
+  }
+  return out
 }
 
 function getProcessEnv(env: Record<string, string | undefined> | Nullish): NodeJS.ProcessEnv | undefined {
@@ -107,7 +124,7 @@ export function exec(file: string, args?: Array<string> | null, options?: ExecFi
             delete diffEnv[name]
           }
         }
-        logFields.env = safeStringifyJson(diffEnv)
+        logFields.env = safeStringifyJson(filterSensitiveEnv(diffEnv))
       }
     }
 

--- a/test/snapshots/builder-util/utilTest.js.snap
+++ b/test/snapshots/builder-util/utilTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`removePassword: /b … /c block > handles /b … /c block (snapshot) 1`] = `"/b f2ef4a8a9ab5b2021260622b256a52005822ddb3de11985e382b6243166d3c60 (sha256 hash) /c"`;
 
-exports[`removePassword: /p > handles Mac host path without hashing (snapshot) 1`] = `"/p 7692bad00279b4b3c87898de51da122d987a060f244ae38340bbf1b587c8d4c3 (sha256 hash)"`;
+exports[`removePassword: /p > handles Mac host path without hashing (snapshot) 1`] = `"/p \\\\Mac\\Host\\Users\\user"`;
 
 exports[`removePassword: /p > handles double-quoted value (snapshot) 1`] = `"/p "643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)""`;
 
@@ -22,12 +22,6 @@ exports[`removePassword: --secretKey > handles single-quoted value (snapshot) 1`
 
 exports[`removePassword: --secretKey > handles unquoted value (snapshot) 1`] = `"--secretKey 916925d896d4e9b97f81aab67a3f7f916b39135db74bf4cbf03d4c4b49a411e4 (sha256 hash)"`;
 
-exports[`removePassword: -P > handles double-quoted value (snapshot) 1`] = `"-P "643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)""`;
-
-exports[`removePassword: -P > handles single-quoted value (snapshot) 1`] = `"-P '643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)'"`;
-
-exports[`removePassword: -P > handles unquoted value (snapshot) 1`] = `"-P 916925d896d4e9b97f81aab67a3f7f916b39135db74bf4cbf03d4c4b49a411e4 (sha256 hash)"`;
-
 exports[`removePassword: -String > handles double-quoted value (snapshot) 1`] = `"-String "643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)""`;
 
 exports[`removePassword: -String > handles single-quoted value (snapshot) 1`] = `"-String '643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)'"`;
@@ -40,20 +34,20 @@ exports[`removePassword: -p > handles single-quoted value (snapshot) 1`] = `"-p 
 
 exports[`removePassword: -p > handles unquoted value (snapshot) 1`] = `"-p 916925d896d4e9b97f81aab67a3f7f916b39135db74bf4cbf03d4c4b49a411e4 (sha256 hash)"`;
 
-exports[`removePassword: -pass > handles double-quoted value (snapshot) 1`] = `"-p 2062f80093066633876b542212c496501a5e79523cc4ea9b28667dff065afd8f (sha256 hash) "secret with spaces""`;
+exports[`removePassword: -pass > handles double-quoted value (snapshot) 1`] = `"-pass "643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)""`;
 
-exports[`removePassword: -pass > handles single-quoted value (snapshot) 1`] = `"-p 2062f80093066633876b542212c496501a5e79523cc4ea9b28667dff065afd8f (sha256 hash) 'secret with spaces'"`;
+exports[`removePassword: -pass > handles single-quoted value (snapshot) 1`] = `"-pass '643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)'"`;
 
-exports[`removePassword: -pass > handles unquoted value (snapshot) 1`] = `"-p 2062f80093066633876b542212c496501a5e79523cc4ea9b28667dff065afd8f (sha256 hash) secretValue"`;
+exports[`removePassword: -pass > handles unquoted value (snapshot) 1`] = `"-pass 916925d896d4e9b97f81aab67a3f7f916b39135db74bf4cbf03d4c4b49a411e4 (sha256 hash)"`;
 
-exports[`removePassword: multiple keys in one string > handles mixed quoted and unquoted keys (snapshot) 1`] = `"-p '9014b632e87590ac0b58afc11dd044f17c7d5e3766e1b76275329450320f3ed6 (sha256 hash)' -p 2062f80093066633876b542212c496501a5e79523cc4ea9b28667dff065afd8f (sha256 hash) unquoted"`;
+exports[`removePassword: multiple keys in one string > handles mixed quoted and unquoted keys (snapshot) 1`] = `"-p '9014b632e87590ac0b58afc11dd044f17c7d5e3766e1b76275329450320f3ed6 (sha256 hash)' -pass 2553887a625308ecc0216a02ae916fe9a69b03b6dc1473c2d0db6d281b28cb23 (sha256 hash)"`;
 
-exports[`removePassword: multiple keys in one string > handles several keys and /b … /c block (snapshot) 1`] = `"pass: cc1d9c865e8380c2d566dc724c66369051acfaa3e9e8f36ad6c67d7d9b8461a5 (sha256 hash) --accessKey "3fafdea1e2907edbaf937e22a71a27217ddb22399f7558c57551bd60a466b1ed (sha256 hash)" /b 61403ebadd9d565f57fea9b275ab739c2f1e60072e6011e92ae82934eba43bda (sha256 hash) /c"`;
+exports[`removePassword: multiple keys in one string > handles several keys and /b … /c block (snapshot) 1`] = `"pass:cc1d9c865e8380c2d566dc724c66369051acfaa3e9e8f36ad6c67d7d9b8461a5 (sha256 hash) --accessKey "3fafdea1e2907edbaf937e22a71a27217ddb22399f7558c57551bd60a466b1ed (sha256 hash)" /b 61403ebadd9d565f57fea9b275ab739c2f1e60072e6011e92ae82934eba43bda (sha256 hash) /c"`;
 
 exports[`removePassword: multiple keys in one string > handles two keys unquoted (snapshot) 1`] = `"--accessKey 8174099687a26621f4e2cdd7cc03b3dacedb3fb962255b1aafd033cabe831530 (sha256 hash) --secretKey b10253764c8b233fb37542e23401c7b450e5a6f9751f3b5a014f6f67e8bc999d (sha256 hash)"`;
 
-exports[`removePassword: pass: > handles double-quoted value (snapshot) 1`] = `"pass: "643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)""`;
+exports[`removePassword: pass: > handles double-quoted value (snapshot) 1`] = `"pass:c232b4779997b8d97d3c4dc863c167007c9139a33db1714b1225c7d60399860f (sha256 hash) with spaces""`;
 
-exports[`removePassword: pass: > handles single-quoted value (snapshot) 1`] = `"pass: '643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)'"`;
+exports[`removePassword: pass: > handles single-quoted value (snapshot) 1`] = `"pass:070f8b633da85e99590f05466f89a5237a659c883cb43abfaed67c6f533a309a (sha256 hash) with spaces'"`;
 
-exports[`removePassword: pass: > handles unquoted value (snapshot) 1`] = `"pass: 916925d896d4e9b97f81aab67a3f7f916b39135db74bf4cbf03d4c4b49a411e4 (sha256 hash)"`;
+exports[`removePassword: pass: > handles unquoted value (snapshot) 1`] = `"pass:916925d896d4e9b97f81aab67a3f7f916b39135db74bf4cbf03d4c4b49a411e4 (sha256 hash)"`;

--- a/test/snapshots/builder-util/utilTest.js.snap
+++ b/test/snapshots/builder-util/utilTest.js.snap
@@ -46,8 +46,8 @@ exports[`removePassword: multiple keys in one string > handles several keys and 
 
 exports[`removePassword: multiple keys in one string > handles two keys unquoted (snapshot) 1`] = `"--accessKey 8174099687a26621f4e2cdd7cc03b3dacedb3fb962255b1aafd033cabe831530 (sha256 hash) --secretKey b10253764c8b233fb37542e23401c7b450e5a6f9751f3b5a014f6f67e8bc999d (sha256 hash)"`;
 
-exports[`removePassword: pass: > handles double-quoted value (snapshot) 1`] = `"pass:c232b4779997b8d97d3c4dc863c167007c9139a33db1714b1225c7d60399860f (sha256 hash) with spaces""`;
+exports[`removePassword: pass: > handles double-quoted value (snapshot) 1`] = `"pass:"643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)""`;
 
-exports[`removePassword: pass: > handles single-quoted value (snapshot) 1`] = `"pass:070f8b633da85e99590f05466f89a5237a659c883cb43abfaed67c6f533a309a (sha256 hash) with spaces'"`;
+exports[`removePassword: pass: > handles single-quoted value (snapshot) 1`] = `"pass:'643dc0c1c3f4f28bd42a534af23ddea45ff9021a53c8d1cd88a01e2611ecf511 (sha256 hash)'"`;
 
 exports[`removePassword: pass: > handles unquoted value (snapshot) 1`] = `"pass:916925d896d4e9b97f81aab67a3f7f916b39135db74bf4cbf03d4c4b49a411e4 (sha256 hash)"`;

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -111,9 +111,9 @@ describe("removePassword: word boundary protection", () => {
     expect(removePassword(input)).toBe(input)
   })
 
-  test("does not redact -passphrase argument", ({ expect }) => {
+  test("redacts -passphrase argument", ({ expect }) => {
     const input = "tool -passphrase secret"
-    expect(removePassword(input)).toBe(input)
+    expect(removePassword(input)).not.toContain("secret")
   })
 
   test("still redacts -p when it is a standalone flag", ({ expect }) => {

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -217,6 +217,27 @@ describe("filterSensitiveEnv", () => {
     expect(result.GITHUB_TOKEN).toMatch(SHA256_HASH_RE)
     expect(result.MY_API_KEY).toMatch(SHA256_HASH_RE)
   })
+
+  test("redacts values for keys containing CSC (code-signing certificate vars)", ({ expect }) => {
+    const result = filterSensitiveEnv({ CSC_LINK: "https://example.com/cert.p12" })
+    expect(result.CSC_LINK).toMatch(SHA256_HASH_RE)
+  })
+
+  test("redacts values for WIN_CSC_LINK", ({ expect }) => {
+    const result = filterSensitiveEnv({ WIN_CSC_LINK: "/path/to/cert.pfx" })
+    expect(result.WIN_CSC_LINK).toMatch(SHA256_HASH_RE)
+  })
+
+  test("redacts values for keys containing CREDENTIAL", ({ expect }) => {
+    const result = filterSensitiveEnv({ DB_CREDENTIAL: "s3cr3t" })
+    expect(result.DB_CREDENTIAL).toMatch(SHA256_HASH_RE)
+  })
+
+  test("does not redact unrelated LINK or CSC-free vars", ({ expect }) => {
+    const result = filterSensitiveEnv({ GITHUB_LINK: "https://github.com", ELECTRON_CACHE: "/tmp" })
+    expect(result.GITHUB_LINK).toBe("https://github.com")
+    expect(result.ELECTRON_CACHE).toBe("/tmp")
+  })
 })
 
 describe("removePassword: multiple keys in one string", () => {

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -1,29 +1,29 @@
-import { removePassword } from "builder-util"
+import { removePassword, filterSensitiveEnv } from "builder-util"
 import { parseValidEnvVarUrl } from "builder-util/out/envUtil"
-import { afterEach, describe, it, vi } from "vitest"
+import { afterEach, vi } from "vitest"
 
 const testValue = "secretValue"
 const testQuoted = "secret with spaces"
 
-const keys = ["--accessKey", "--secretKey", "-P", "-p", "-pass", "-String", "/p", "pass:"]
+const keys = ["--accessKey", "--secretKey", "-p", "-pass", "-String", "/p", "pass:"]
 
 keys.forEach(key => {
   describe(`removePassword: ${key}`, () => {
-    it("handles unquoted value (snapshot)", ({ expect }) => {
+    test("handles unquoted value (snapshot)", ({ expect }) => {
       const input = `${key} ${testValue}`
       const output = removePassword(input)
 
       expect(output).toMatchSnapshot()
     })
 
-    it("handles double-quoted value (snapshot)", ({ expect }) => {
+    test("handles double-quoted value (snapshot)", ({ expect }) => {
       const input = `${key} "${testQuoted}"`
       const output = removePassword(input)
 
       expect(output).toMatchSnapshot()
     })
 
-    it("handles single-quoted value (snapshot)", ({ expect }) => {
+    test("handles single-quoted value (snapshot)", ({ expect }) => {
       const input = `${key} '${testQuoted}'`
       const output = removePassword(input)
 
@@ -31,7 +31,7 @@ keys.forEach(key => {
     })
 
     if (key === "/p") {
-      it("handles Mac host path without hashing (snapshot)", ({ expect }) => {
+      test("handles Mac host path without hashing (snapshot)", ({ expect }) => {
         const macPath = "\\\\Mac\\Host\\Users\\user"
         const input = `${key} ${macPath}`
         const output = removePassword(input)
@@ -43,7 +43,7 @@ keys.forEach(key => {
 })
 
 describe("removePassword: /b … /c block", () => {
-  it("handles /b … /c block (snapshot)", ({ expect }) => {
+  test("handles /b … /c block (snapshot)", ({ expect }) => {
     const secret = "blockSecret"
     const input = `/b ${secret} /c`
     const output = removePassword(input)
@@ -59,53 +59,180 @@ describe("validateEnvVarUrl", () => {
     vi.unstubAllEnvs()
   })
 
-  it("returns null when env var is not set", ({ expect }) => {
+  test("returns null when env var is not set", ({ expect }) => {
     delete process.env[VAR]
     expect(parseValidEnvVarUrl(VAR)).toBeNull()
   })
 
-  it("throws when value is not a valid URL", ({ expect }) => {
+  test("throws when value is not a valid URL", ({ expect }) => {
     vi.stubEnv(VAR, "not-a-url")
     expect(() => parseValidEnvVarUrl(VAR)).toThrow(`${VAR} is not a valid URL`)
   })
 
-  it("throws when protocol is http (non-https)", ({ expect }) => {
+  test("throws when protocol is http (non-https)", ({ expect }) => {
     vi.stubEnv(VAR, "http://example.com/")
     expect(() => parseValidEnvVarUrl(VAR)).toThrow(`${VAR} must use https://`)
   })
 
-  it("throws when protocol is file", ({ expect }) => {
+  test("throws when protocol is file", ({ expect }) => {
     vi.stubEnv(VAR, "file:///etc/passwd")
     expect(() => parseValidEnvVarUrl(VAR)).toThrow(`${VAR} must use https://`)
   })
 
-  it("returns the URL string for a valid https URL", ({ expect }) => {
+  test("returns the URL string for a valid https URL", ({ expect }) => {
     vi.stubEnv(VAR, "https://mirror.example.com/")
     expect(parseValidEnvVarUrl(VAR)).toBe("https://mirror.example.com/")
   })
 
-  it("returns the URL string unchanged when it has a path and query", ({ expect }) => {
+  test("returns the URL string unchanged when it has a path and query", ({ expect }) => {
     vi.stubEnv(VAR, "https://mirror.example.com/path?q=1")
     expect(parseValidEnvVarUrl(VAR)).toBe("https://mirror.example.com/path?q=1")
   })
 })
 
+describe("removePassword: word boundary protection", () => {
+  test("does not redact -path argument", ({ expect }) => {
+    const input = "tool -path /some/dir"
+    expect(removePassword(input)).toBe(input)
+  })
+
+  test("does not redact -pid argument", ({ expect }) => {
+    const input = "tool -pid 1234"
+    expect(removePassword(input)).toBe(input)
+  })
+
+  test("does not redact -StringLength argument", ({ expect }) => {
+    const input = "tool -StringLength 10"
+    expect(removePassword(input)).toBe(input)
+  })
+
+  test("does not redact a bare file path containing /p", ({ expect }) => {
+    const input = "/path/to/file"
+    expect(removePassword(input)).toBe(input)
+  })
+
+  test("does not redact -passphrase argument", ({ expect }) => {
+    const input = "tool -passphrase secret"
+    expect(removePassword(input)).toBe(input)
+  })
+
+  test("still redacts -p when it is a standalone flag", ({ expect }) => {
+    const input = "tool -p secret"
+    expect(removePassword(input)).not.toContain("secret")
+  })
+
+  test("still redacts /p when preceded by whitespace", ({ expect }) => {
+    const input = "tool /p secret"
+    expect(removePassword(input)).not.toContain("secret")
+  })
+})
+
+describe("removePassword: case-insensitive flag matching", () => {
+  const secret = "caseSecret"
+
+  test("redacts -P (uppercase variant of -p)", ({ expect }) => {
+    expect(removePassword(`-P ${secret}`)).not.toContain(secret)
+  })
+
+  test("redacts -PASS (uppercase variant of -pass)", ({ expect }) => {
+    expect(removePassword(`-PASS ${secret}`)).not.toContain(secret)
+  })
+
+  test("redacts -STRING (uppercase variant of -String)", ({ expect }) => {
+    expect(removePassword(`-STRING ${secret}`)).not.toContain(secret)
+  })
+
+  test("redacts --ACCESSKEY (uppercase variant of --accessKey)", ({ expect }) => {
+    expect(removePassword(`--ACCESSKEY ${secret}`)).not.toContain(secret)
+  })
+})
+
+describe("removePassword: pass: colon-separator style", () => {
+  test("redacts pass:value with no space (OpenSSL style)", ({ expect }) => {
+    // -pass is NOT in the input, so the pass: pattern handles it directly
+    const output = removePassword("enc pass:topsecret --other")
+    expect(output).not.toContain("topsecret")
+    expect(output).toContain("pass:")
+    expect(output).toContain("(sha256 hash)")
+  })
+
+  test("redacts pass: value with space", ({ expect }) => {
+    const output = removePassword("pass: spaced")
+    expect(output).not.toContain("spaced")
+    expect(output).toContain("(sha256 hash)")
+  })
+})
+
+describe("filterSensitiveEnv", () => {
+  test("redacts values for keys containing KEY", ({ expect }) => {
+    const result = filterSensitiveEnv({ MY_API_KEY: "abc123" })
+    expect(result.MY_API_KEY).toBe("[REDACTED]")
+  })
+
+  test("redacts values for keys containing TOKEN", ({ expect }) => {
+    const result = filterSensitiveEnv({ GITHUB_TOKEN: "ghp_secret" })
+    expect(result.GITHUB_TOKEN).toBe("[REDACTED]")
+  })
+
+  test("redacts values for keys containing SECRET", ({ expect }) => {
+    const result = filterSensitiveEnv({ AWS_SECRET_ACCESS_KEY: "secret" })
+    expect(result.AWS_SECRET_ACCESS_KEY).toBe("[REDACTED]")
+  })
+
+  test("redacts values for keys containing PASSWORD", ({ expect }) => {
+    const result = filterSensitiveEnv({ DB_PASSWORD: "hunter2" })
+    expect(result.DB_PASSWORD).toBe("[REDACTED]")
+  })
+
+  test("is case-insensitive on the key name", ({ expect }) => {
+    const result = filterSensitiveEnv({ api_key: "secret", Auth_Token: "tok" })
+    expect(result.api_key).toBe("[REDACTED]")
+    expect(result.Auth_Token).toBe("[REDACTED]")
+  })
+
+  test("does not redact values for non-sensitive keys", ({ expect }) => {
+    const result = filterSensitiveEnv({ NODE_ENV: "production", PATH: "/usr/bin" })
+    expect(result.NODE_ENV).toBe("production")
+    expect(result.PATH).toBe("/usr/bin")
+  })
+
+  test("replaces the entire value, not just the sensitive substring within it", ({ expect }) => {
+    // The value itself contains 'password' — only the key triggers redaction.
+    // The entire value must become "[REDACTED]", not "thisismy[REDACTED]".
+    const result = filterSensitiveEnv({ DB_PASSWORD: "thisismypassword" })
+    expect(result.DB_PASSWORD).toBe("[REDACTED]")
+  })
+
+  test("handles a mixed env object, redacting only sensitive keys", ({ expect }) => {
+    const result = filterSensitiveEnv({
+      HOME: "/home/user",
+      GITHUB_TOKEN: "tok",
+      NODE_ENV: "test",
+      MY_API_KEY: "key123",
+    })
+    expect(result.HOME).toBe("/home/user")
+    expect(result.NODE_ENV).toBe("test")
+    expect(result.GITHUB_TOKEN).toBe("[REDACTED]")
+    expect(result.MY_API_KEY).toBe("[REDACTED]")
+  })
+})
+
 describe("removePassword: multiple keys in one string", () => {
-  it("handles two keys unquoted (snapshot)", ({ expect }) => {
+  test("handles two keys unquoted (snapshot)", ({ expect }) => {
     const input = `--accessKey key1 --secretKey key2`
     const output = removePassword(input)
 
     expect(output).toMatchSnapshot()
   })
 
-  it("handles mixed quoted and unquoted keys (snapshot)", ({ expect }) => {
+  test("handles mixed quoted and unquoted keys (snapshot)", ({ expect }) => {
     const input = `-p 'quoted secret' -pass unquoted`
     const output = removePassword(input)
 
     expect(output).toMatchSnapshot()
   })
 
-  it("handles several keys and /b … /c block (snapshot)", ({ expect }) => {
+  test("handles several keys and /b … /c block (snapshot)", ({ expect }) => {
     const input = `pass: val1 --accessKey "val two" /b blockpass /c`
     const output = removePassword(input)
 

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -163,31 +163,33 @@ describe("removePassword: pass: colon-separator style", () => {
   })
 })
 
+const SHA256_HASH_RE = /^[a-f0-9]{64} \(sha256 hash\)$/
+
 describe("filterSensitiveEnv", () => {
   test("redacts values for keys containing KEY", ({ expect }) => {
     const result = filterSensitiveEnv({ MY_API_KEY: "abc123" })
-    expect(result.MY_API_KEY).toBe("[REDACTED]")
+    expect(result.MY_API_KEY).toMatch(SHA256_HASH_RE)
   })
 
   test("redacts values for keys containing TOKEN", ({ expect }) => {
     const result = filterSensitiveEnv({ GITHUB_TOKEN: "ghp_secret" })
-    expect(result.GITHUB_TOKEN).toBe("[REDACTED]")
+    expect(result.GITHUB_TOKEN).toMatch(SHA256_HASH_RE)
   })
 
   test("redacts values for keys containing SECRET", ({ expect }) => {
     const result = filterSensitiveEnv({ AWS_SECRET_ACCESS_KEY: "secret" })
-    expect(result.AWS_SECRET_ACCESS_KEY).toBe("[REDACTED]")
+    expect(result.AWS_SECRET_ACCESS_KEY).toMatch(SHA256_HASH_RE)
   })
 
   test("redacts values for keys containing PASSWORD", ({ expect }) => {
     const result = filterSensitiveEnv({ DB_PASSWORD: "hunter2" })
-    expect(result.DB_PASSWORD).toBe("[REDACTED]")
+    expect(result.DB_PASSWORD).toMatch(SHA256_HASH_RE)
   })
 
   test("is case-insensitive on the key name", ({ expect }) => {
     const result = filterSensitiveEnv({ api_key: "secret", Auth_Token: "tok" })
-    expect(result.api_key).toBe("[REDACTED]")
-    expect(result.Auth_Token).toBe("[REDACTED]")
+    expect(result.api_key).toMatch(SHA256_HASH_RE)
+    expect(result.Auth_Token).toMatch(SHA256_HASH_RE)
   })
 
   test("does not redact values for non-sensitive keys", ({ expect }) => {
@@ -198,9 +200,9 @@ describe("filterSensitiveEnv", () => {
 
   test("replaces the entire value, not just the sensitive substring within it", ({ expect }) => {
     // The value itself contains 'password' — only the key triggers redaction.
-    // The entire value must become "[REDACTED]", not "thisismy[REDACTED]".
+    // The entire value must be replaced with a sha256 hash, not "thisismy<hash>".
     const result = filterSensitiveEnv({ DB_PASSWORD: "thisismypassword" })
-    expect(result.DB_PASSWORD).toBe("[REDACTED]")
+    expect(result.DB_PASSWORD).toMatch(SHA256_HASH_RE)
   })
 
   test("handles a mixed env object, redacting only sensitive keys", ({ expect }) => {
@@ -212,8 +214,8 @@ describe("filterSensitiveEnv", () => {
     })
     expect(result.HOME).toBe("/home/user")
     expect(result.NODE_ENV).toBe("test")
-    expect(result.GITHUB_TOKEN).toBe("[REDACTED]")
-    expect(result.MY_API_KEY).toBe("[REDACTED]")
+    expect(result.GITHUB_TOKEN).toMatch(SHA256_HASH_RE)
+    expect(result.MY_API_KEY).toMatch(SHA256_HASH_RE)
   })
 })
 


### PR DESCRIPTION
The overeager log filter has many false positives, sometimes double hashes, and overall makes debugging nigh impossible sometimes.

This PR:
- Expands removePassword matching for more sensitive flag variants and safer word-boundary handling.
- Adds filterSensitiveEnv and applies it to exec debug env logging.