### PR TITLE
feat: add the CLI command to clear electron-builder's default cache directory

### DIFF
--- a/.changeset/hungry-phones-leave.md
+++ b/.changeset/hungry-phones-leave.md
@@ -3,4 +3,4 @@
 "electron-builder": minor
 ---
 
-feat: add CLI action to enable quick-clearing of non-overriden electron-builder cache
+feat: add CLI action to clear the electron-builder default cache directory (env var override intentionally ignored for security)

--- a/.changeset/hungry-phones-leave.md
+++ b/.changeset/hungry-phones-leave.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": minor
+"electron-builder": minor
+---
+
+feat: add CLI action to enable quick-clearing of non-overriden electron-builder cache

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -84,9 +84,9 @@ function hashUrlSafe(input: string, length = 6): string {
   return out.length >= length ? out.slice(0, length) : out.padStart(length, "0")
 }
 
-export function getCacheDirectory(isAvoidSystemOnWindows = false): string {
+export function getCacheDirectory(allowEnvVarOverride = true, isAvoidSystemOnWindows = false): string {
   const env = process.env.ELECTRON_BUILDER_CACHE?.trim()
-  if (env && path.parse(env).root) {
+  if (allowEnvVarOverride && env && path.parse(env).root) {
     return env
   }
 

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -84,7 +84,7 @@ function hashUrlSafe(input: string, length = 6): string {
   return out.length >= length ? out.slice(0, length) : out.padStart(length, "0")
 }
 
-export function getCacheDirectory(allowEnvVarOverride = true, isAvoidSystemOnWindows = false): string {
+export function getCacheDirectory(isAvoidSystemOnWindows = false, allowEnvVarOverride = true): string {
   const env = process.env.ELECTRON_BUILDER_CACHE?.trim()
   if (allowEnvVarOverride && env && path.parse(env).root) {
     return env

--- a/packages/electron-builder/src/cli/clear-cache.ts
+++ b/packages/electron-builder/src/cli/clear-cache.ts
@@ -5,7 +5,7 @@ import { createInterface } from "readline/promises"
 import * as path from "path"
 
 export async function clearCache(): Promise<void> {
-  const cacheDir = getCacheDirectory(false)
+  const cacheDir = getCacheDirectory(false, false)
 
   if (cacheDir === path.parse(cacheDir).root) {
     log.error({ cacheDir }, "cache directory resolves to a filesystem root — aborting")
@@ -14,15 +14,25 @@ export async function clearCache(): Promise<void> {
 
   try {
     await access(cacheDir, constants.F_OK | constants.W_OK)
-  } catch {
-    log.info({ cacheDir }, "cache directory does not exist, nothing to clear")
+  } catch (err: any) {
+    if (err.code === "ENOENT") {
+      log.info({ cacheDir }, "cache directory does not exist, nothing to clear")
+    } else if (err.code === "EACCES" || err.code === "EPERM") {
+      log.error({ cacheDir }, "cache directory is not writable")
+    } else {
+      throw err
+    }
     return
   }
 
   const rl = createInterface({ input: process.stdin, output: process.stdout })
-  const answer = await rl.question(`Clear cache at ${cacheDir}? [y/N] `)
-  rl.close()
-  if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
+  let answer: string
+  try {
+    answer = await rl.question(`Clear cache at ${cacheDir}? [y/N] `)
+  } finally {
+    rl.close()
+  }
+  if (answer!.trim().toLowerCase() !== "y" && answer!.trim().toLowerCase() !== "yes") {
     log.info(null, "aborted")
     return
   }

--- a/packages/electron-builder/src/cli/clear-cache.ts
+++ b/packages/electron-builder/src/cli/clear-cache.ts
@@ -1,0 +1,33 @@
+import { getCacheDirectory } from "app-builder-lib/out/util/electronGet"
+import { log } from "builder-util"
+import { access, constants, rm } from "fs/promises"
+import { createInterface } from "readline/promises"
+import * as path from "path"
+
+export async function clearCache(): Promise<void> {
+  const cacheDir = getCacheDirectory(false)
+
+  if (cacheDir === path.parse(cacheDir).root) {
+    log.error({ cacheDir }, "cache directory resolves to a filesystem root — aborting")
+    return
+  }
+
+  try {
+    await access(cacheDir, constants.F_OK | constants.W_OK)
+  } catch {
+    log.info({ cacheDir }, "cache directory does not exist, nothing to clear")
+    return
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  const answer = await rl.question(`Clear cache at ${cacheDir}? [y/N] `)
+  rl.close()
+  if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
+    log.info(null, "aborted")
+    return
+  }
+
+  log.info({ cacheDir }, "clearing cache")
+  await rm(cacheDir, { recursive: true })
+  log.info({ cacheDir }, "cache cleared")
+}

--- a/packages/electron-builder/src/cli/cli-util.ts
+++ b/packages/electron-builder/src/cli/cli-util.ts
@@ -1,0 +1,35 @@
+import { loadEnv } from "app-builder-lib/out/util/config/load"
+import { ExecError, InvalidConfigurationError, log } from "builder-util"
+import { isCI } from "ci-info"
+import { readJson } from "fs-extra"
+import * as path from "path"
+
+export async function checkIsOutdated(): Promise<void> {
+  if (isCI || process.env.NO_UPDATE_NOTIFIER != null) {
+    return
+  }
+  const pkg = await readJson(path.join(__dirname, "..", "..", "package.json"))
+  if (pkg.version === "0.0.0-semantic-release") {
+    return
+  }
+  const UpdateNotifier = require("simple-update-notifier")
+  await UpdateNotifier({ pkg })
+}
+
+export function wrap(task: (args: any) => Promise<any>) {
+  return (args: any) => {
+    checkIsOutdated().catch((e: any) => log.warn({ error: e }, "cannot check updates"))
+    return loadEnv(path.join(process.cwd(), "electron-builder.env"))
+      .then(() => task(args))
+      .catch(error => {
+        process.exitCode = 1
+        // https://github.com/electron-userland/electron-builder/issues/2940
+        process.on("exit", () => (process.exitCode = 1))
+        if (error instanceof InvalidConfigurationError) {
+          log.error(null, error.message)
+        } else if (!(error instanceof ExecError) || !error.alreadyLogged) {
+          log.error({ failedTask: task.name, stackTrace: error.stack }, error.message)
+        }
+      })
+  }
+}

--- a/packages/electron-builder/src/cli/cli.ts
+++ b/packages/electron-builder/src/cli/cli.ts
@@ -39,7 +39,7 @@ void createYargs()
   )
   .command(
     "clear-cache",
-    "Clear the electron-builder cache directory (respects ELECTRON_BUILDER_CACHE if set to an absolute path)",
+    "Clear the electron-builder default cache directory",
     yargs => yargs,
     wrap(() => clearCache())
   )

--- a/packages/electron-builder/src/cli/cli.ts
+++ b/packages/electron-builder/src/cli/cli.ts
@@ -1,15 +1,12 @@
 #! /usr/bin/env node
 
 import { getElectronVersion } from "app-builder-lib/out/electron/electronVersion"
-import { loadEnv } from "app-builder-lib/out/util/config/load"
 import { nodeGypRebuild } from "app-builder-lib/out/util/yarn"
-import { ExecError, InvalidConfigurationError, log } from "builder-util"
 import * as chalk from "chalk"
-import { readJson } from "fs-extra"
-import { isCI } from "ci-info"
-import * as path from "path"
 import { build, configureBuildCommand, createYargs } from "../builder"
 import { configurePublishCommand, publish } from "../publish"
+import { clearCache } from "./clear-cache"
+import { wrap } from "./cli-util"
 import { createSelfSignedCert } from "./create-self-signed-cert"
 import { configureInstallAppDepsCommand, installAppDeps } from "./install-app-deps"
 import { start } from "./start"
@@ -40,41 +37,16 @@ void createYargs()
     yargs => yargs,
     wrap(() => start())
   )
+  .command(
+    "clear-cache",
+    "Clear the electron-builder cache directory (respects ELECTRON_BUILDER_CACHE if set to an absolute path)",
+    yargs => yargs,
+    wrap(() => clearCache())
+  )
   .help()
   .epilog(`See ${chalk.underline("https://electron.build")} for more documentation.`)
   .strict()
   .recommendCommands().argv
-
-function wrap(task: (args: any) => Promise<any>) {
-  return (args: any) => {
-    checkIsOutdated().catch((e: any) => log.warn({ error: e }, "cannot check updates"))
-    loadEnv(path.join(process.cwd(), "electron-builder.env"))
-      .then(() => task(args))
-      .catch(error => {
-        process.exitCode = 1
-        // https://github.com/electron-userland/electron-builder/issues/2940
-        process.on("exit", () => (process.exitCode = 1))
-        if (error instanceof InvalidConfigurationError) {
-          log.error(null, error.message)
-        } else if (!(error instanceof ExecError) || !error.alreadyLogged) {
-          log.error({ failedTask: task.name, stackTrace: error.stack }, error.message)
-        }
-      })
-  }
-}
-
-async function checkIsOutdated() {
-  if (isCI || process.env.NO_UPDATE_NOTIFIER != null) {
-    return
-  }
-
-  const pkg = await readJson(path.join(__dirname, "..", "..", "package.json"))
-  if (pkg.version === "0.0.0-semantic-release") {
-    return
-  }
-  const UpdateNotifier = require("simple-update-notifier")
-  await UpdateNotifier({ pkg })
-}
 
 async function rebuildAppNativeCode(args: any) {
   const projectDir = process.cwd()

--- a/packages/electron-builder/src/cli/create-self-signed-cert.ts
+++ b/packages/electron-builder/src/cli/create-self-signed-cert.ts
@@ -33,7 +33,7 @@ export async function createSelfSignedCert(publisher: string) {
   }
 }
 
-function quoteString(s: string): string {
+export function quoteString(s: string): string {
   if (!s.includes(",") && !s.includes('"')) {
     return s
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: 0.64.0
       vitest:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4)(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1)
+        version: 3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4(vitest@3.2.4))(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1)
 
   packages/app-builder-lib:
     dependencies:
@@ -626,6 +626,9 @@ importers:
       '@types/which':
         specifier: ^3.0.4
         version: 3.0.4
+      '@types/yargs':
+        specifier: ^17.0.33
+        version: 17.0.33
       adm-zip:
         specifier: 0.5.16
         version: 0.5.16
@@ -700,7 +703,7 @@ importers:
         version: 0.12.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4)(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1)
+        version: 3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4(vitest@3.2.4))(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1)
       vitest-mock-commonjs:
         specifier: ^1.0.2
         version: 1.0.2
@@ -7406,7 +7409,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4)(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1)
+      vitest: 3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4(vitest@3.2.4))(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1)
 
   '@vitest/utils@3.0.4':
     dependencies:
@@ -10086,7 +10089,7 @@ snapshots:
 
   vitest-mock-commonjs@1.0.2: {}
 
-  vitest@3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4)(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1):
+  vitest@3.2.4(@types/node@22.13.17)(@vitest/ui@3.0.4(vitest@3.2.4))(jiti@2.4.2)(sass@1.86.1)(yaml@2.7.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4

--- a/test/package.json
+++ b/test/package.json
@@ -16,6 +16,7 @@
     "@types/semver": "7.7.1",
     "@types/unzipper": "^0.10.11",
     "@types/which": "^3.0.4",
+    "@types/yargs": "^17.0.33",
     "adm-zip": "0.5.16",
     "app-builder-lib": "workspace:*",
     "builder-util": "workspace:*",

--- a/test/src/cliTest.ts
+++ b/test/src/cliTest.ts
@@ -7,11 +7,14 @@ vi.mock("app-builder-lib/out/util/electronGet", () => ({
   getCacheDirectory: vi.fn().mockReturnValue("/home/user/.cache/electron-builder"),
 }))
 
-vi.mock("fs/promises", () => ({
-  access: vi.fn().mockResolvedValue(undefined),
-  rm: vi.fn().mockResolvedValue(undefined),
-  constants: { F_OK: 0, W_OK: 2 },
-}))
+vi.mock("fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("fs/promises")>("fs/promises")
+  return {
+    ...actual,
+    access: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+  }
+})
 
 vi.mock("readline/promises", () => ({
   createInterface: vi.fn(() => ({
@@ -54,8 +57,8 @@ import { configurePublishCommand } from "../../packages/electron-builder/src/pub
 describe("clearCache", () => {
   beforeEach(() => {
     vi.mocked(getCacheDirectory).mockReturnValue("/home/user/.cache/electron-builder")
-    vi.mocked(access).mockResolvedValue(undefined)
-    vi.mocked(rm).mockResolvedValue(undefined)
+    vi.mocked(access).mockResolvedValue(undefined as any)
+    vi.mocked(rm).mockResolvedValue(undefined as any)
     vi.mocked(createInterface).mockReturnValue({
       question: vi.fn().mockResolvedValue("y"),
       close: vi.fn(),
@@ -66,9 +69,9 @@ describe("clearCache", () => {
     vi.clearAllMocks()
   })
 
-  test("calls getCacheDirectory with isAvoidSystemOnWindows=false", async () => {
+  test("calls getCacheDirectory with isAvoidSystemOnWindows=false, allowEnvVarOverride=false", async () => {
     await clearCache()
-    expect(getCacheDirectory).toHaveBeenCalledWith(false)
+    expect(getCacheDirectory).toHaveBeenCalledWith(false, false)
   })
 
   test("deletes cache dir when it exists and user confirms", async () => {
@@ -92,10 +95,11 @@ describe("clearCache", () => {
     )
   })
 
-  test("does not delete when cache dir is not writable", async () => {
+  test("does not delete when cache dir is not writable and logs error", async () => {
     vi.mocked(access).mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }))
     await clearCache()
     expect(rm).not.toHaveBeenCalled()
+    expect(log.error).toHaveBeenCalledWith(expect.objectContaining({ cacheDir: expect.any(String) }), "cache directory is not writable")
   })
 
   test("propagates error thrown by rm", async () => {
@@ -111,13 +115,6 @@ describe("clearCache", () => {
       expect.objectContaining({ cacheDir: "/" }),
       expect.stringContaining("filesystem root")
     )
-  })
-
-  test("respects ELECTRON_BUILDER_CACHE env var path", async () => {
-    vi.mocked(getCacheDirectory).mockReturnValue("/custom/cache/path")
-    await clearCache()
-    expect(access).toHaveBeenCalledWith("/custom/cache/path", expect.any(Number))
-    expect(rm).toHaveBeenCalledWith("/custom/cache/path", { recursive: true })
   })
 
   test("closes readline interface even when user aborts", async () => {

--- a/test/src/cliTest.ts
+++ b/test/src/cliTest.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import yargs from "yargs"
+
+// ─── Module mocks (hoisted by vitest above all imports) ───────────────────────
+
+vi.mock("app-builder-lib/out/util/electronGet", () => ({
+  getCacheDirectory: vi.fn().mockReturnValue("/home/user/.cache/electron-builder"),
+}))
+
+vi.mock("fs/promises", () => ({
+  access: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
+  constants: { F_OK: 0, W_OK: 2 },
+}))
+
+vi.mock("readline/promises", () => ({
+  createInterface: vi.fn(() => ({
+    question: vi.fn().mockResolvedValue("y"),
+    close: vi.fn(),
+  })),
+}))
+
+// Keep real InvalidConfigurationError and ExecError for instanceof checks in wrap()
+vi.mock("builder-util", async () => {
+  const actual = await vi.importActual<typeof import("builder-util")>("builder-util")
+  return {
+    ...actual,
+    log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  }
+})
+
+vi.mock("app-builder-lib/out/util/config/load", () => ({
+  loadEnv: vi.fn().mockResolvedValue(undefined),
+}))
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import { access, rm } from "fs/promises"
+import { createInterface } from "readline/promises"
+import { getCacheDirectory } from "app-builder-lib/out/util/electronGet"
+import { ExecError, InvalidConfigurationError, log } from "builder-util"
+// Relative imports bypass project-reference declaration files, which strip @internal exports
+import { clearCache } from "../../packages/electron-builder/src/cli/clear-cache"
+import { wrap } from "../../packages/electron-builder/src/cli/cli-util"
+import { quoteString } from "../../packages/electron-builder/src/cli/create-self-signed-cert"
+import { configureBuildCommand } from "../../packages/electron-builder/src/builder"
+// @ts-ignore — configureInstallAppDepsCommand is @internal; CLI tsc strips it from declarations
+import { configureInstallAppDepsCommand } from "../../packages/electron-builder/src/cli/install-app-deps"
+// @ts-ignore — configurePublishCommand is @internal; CLI tsc strips it from declarations
+import { configurePublishCommand } from "../../packages/electron-builder/src/publish"
+
+// ─── clearCache ───────────────────────────────────────────────────────────────
+
+describe("clearCache", () => {
+  beforeEach(() => {
+    vi.mocked(getCacheDirectory).mockReturnValue("/home/user/.cache/electron-builder")
+    vi.mocked(access).mockResolvedValue(undefined)
+    vi.mocked(rm).mockResolvedValue(undefined)
+    vi.mocked(createInterface).mockReturnValue({
+      question: vi.fn().mockResolvedValue("y"),
+      close: vi.fn(),
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("calls getCacheDirectory with isAvoidSystemOnWindows=false", async () => {
+    await clearCache()
+    expect(getCacheDirectory).toHaveBeenCalledWith(false)
+  })
+
+  test("deletes cache dir when it exists and user confirms", async () => {
+    await clearCache()
+    expect(rm).toHaveBeenCalledWith("/home/user/.cache/electron-builder", { recursive: true })
+    expect(log.info).toHaveBeenCalledWith(expect.objectContaining({ cacheDir: expect.any(String) }), "cache cleared")
+  })
+
+  test("checks both existence and write permission before prompting", async () => {
+    await clearCache()
+    expect(access).toHaveBeenCalledWith("/home/user/.cache/electron-builder", expect.any(Number))
+  })
+
+  test("does not delete and logs when cache dir does not exist", async () => {
+    vi.mocked(access).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+    await clearCache()
+    expect(rm).not.toHaveBeenCalled()
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheDir: expect.any(String) }),
+      "cache directory does not exist, nothing to clear"
+    )
+  })
+
+  test("does not delete when cache dir is not writable", async () => {
+    vi.mocked(access).mockRejectedValue(Object.assign(new Error("EACCES"), { code: "EACCES" }))
+    await clearCache()
+    expect(rm).not.toHaveBeenCalled()
+  })
+
+  test("propagates error thrown by rm", async () => {
+    vi.mocked(rm).mockRejectedValue(new Error("rm failed"))
+    await expect(clearCache()).rejects.toThrow("rm failed")
+  })
+
+  test("aborts and logs error when cache dir resolves to filesystem root", async () => {
+    vi.mocked(getCacheDirectory).mockReturnValue("/")
+    await clearCache()
+    expect(rm).not.toHaveBeenCalled()
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheDir: "/" }),
+      expect.stringContaining("filesystem root")
+    )
+  })
+
+  test("respects ELECTRON_BUILDER_CACHE env var path", async () => {
+    vi.mocked(getCacheDirectory).mockReturnValue("/custom/cache/path")
+    await clearCache()
+    expect(access).toHaveBeenCalledWith("/custom/cache/path", expect.any(Number))
+    expect(rm).toHaveBeenCalledWith("/custom/cache/path", { recursive: true })
+  })
+
+  test("closes readline interface even when user aborts", async () => {
+    const closeSpy = vi.fn()
+    vi.mocked(createInterface).mockReturnValue({
+      question: vi.fn().mockResolvedValue("n"),
+      close: closeSpy,
+    } as any)
+    await clearCache()
+    expect(closeSpy).toHaveBeenCalled()
+  })
+
+  for (const answer of ["y", "Y", "yes", "Yes", "YES", "  y  "]) {
+    test(`proceeds when user answers "${answer}"`, async () => {
+      vi.mocked(createInterface).mockReturnValue({
+        question: vi.fn().mockResolvedValue(answer),
+        close: vi.fn(),
+      } as any)
+      await clearCache()
+      expect(rm).toHaveBeenCalled()
+    })
+  }
+
+  for (const answer of ["n", "N", "no", "", "   ", "maybe"]) {
+    test(`aborts when user answers "${answer}"`, async () => {
+      vi.mocked(createInterface).mockReturnValue({
+        question: vi.fn().mockResolvedValue(answer),
+        close: vi.fn(),
+      } as any)
+      await clearCache()
+      expect(rm).not.toHaveBeenCalled()
+      expect(log.info).toHaveBeenCalledWith(null, "aborted")
+    })
+  }
+})
+
+// ─── wrap ─────────────────────────────────────────────────────────────────────
+
+describe("wrap", () => {
+  const savedExitCode = process.exitCode
+
+  beforeEach(() => {
+    process.env.NO_UPDATE_NOTIFIER = "1"
+    process.exitCode = undefined as any
+  })
+
+  afterEach(() => {
+    delete process.env.NO_UPDATE_NOTIFIER
+    process.exitCode = savedExitCode as any
+    vi.clearAllMocks()
+  })
+
+  test("invokes task with the provided args", async () => {
+    const task = vi.fn().mockResolvedValue("result")
+    await wrap(task)({ foo: "bar" })
+    expect(task).toHaveBeenCalledWith({ foo: "bar" })
+    expect(process.exitCode).toBeUndefined()
+  })
+
+  test("sets exitCode=1 and logs message only for InvalidConfigurationError", async () => {
+    const task = vi.fn().mockRejectedValue(new InvalidConfigurationError("bad config"))
+    await wrap(task)({})
+    expect(process.exitCode).toBe(1)
+    expect(log.error).toHaveBeenCalledWith(null, "bad config")
+  })
+
+  test("sets exitCode=1 but does not re-log ExecError when alreadyLogged=true", async () => {
+    const err = new ExecError("cmd", 1, "", "")
+    err.alreadyLogged = true
+    const task = vi.fn().mockRejectedValue(err)
+    await wrap(task)({})
+    expect(process.exitCode).toBe(1)
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  test("logs ExecError with stack trace when alreadyLogged=false", async () => {
+    const err = new ExecError("cmd", 1, "out", "err output")
+    const task = vi.fn().mockRejectedValue(err)
+    await wrap(task)({})
+    expect(process.exitCode).toBe(1)
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ stackTrace: expect.any(String) }),
+      expect.any(String)
+    )
+  })
+
+  test("logs stack trace for generic errors", async () => {
+    const err = new Error("something went wrong")
+    const task = vi.fn().mockRejectedValue(err)
+    await wrap(task)({})
+    expect(process.exitCode).toBe(1)
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ stackTrace: expect.any(String) }),
+      "something went wrong"
+    )
+  })
+})
+
+// ─── quoteString ─────────────────────────────────────────────────────────────
+
+describe("quoteString", () => {
+  test("returns string unchanged when no special characters", () => {
+    expect(quoteString("Acme Corp")).toBe("Acme Corp")
+  })
+
+  test("wraps in double quotes when string contains a comma", () => {
+    expect(quoteString("Acme, Corp")).toBe('"Acme, Corp"')
+  })
+
+  test("escapes double quotes and wraps", () => {
+    expect(quoteString('Acme "Corp"')).toBe('"Acme \\"Corp\\""')
+  })
+
+  test("handles both comma and double quote", () => {
+    expect(quoteString('Acme, "Corp"')).toBe('"Acme, \\"Corp\\""')
+  })
+
+  test("returns empty string unchanged", () => {
+    expect(quoteString("")).toBe("")
+  })
+})
+
+// ─── Command configuration ───────────────────────────────────────────────────
+
+function makeYargs() {
+  return yargs([] as string[])
+    .exitProcess(false)
+    .fail((msg: string, err: Error) => {
+      throw err ?? new Error(msg)
+    })
+}
+
+describe("configureBuildCommand", () => {
+  test("registers --x64 and --arm64 as boolean arch flags", () => {
+    const instance = makeYargs()
+    configureBuildCommand(instance)
+    const parsed = instance.parseSync(["--x64", "--arm64"])
+    expect(parsed.x64).toBe(true)
+    expect(parsed.arm64).toBe(true)
+  })
+
+  test("registers --mac as an array platform flag", () => {
+    const instance = makeYargs()
+    configureBuildCommand(instance)
+    const parsed = instance.parseSync(["--mac", "dmg", "--mac", "zip"])
+    expect(parsed.mac).toEqual(["dmg", "zip"])
+  })
+
+  test("registers --linux and --win as array platform flags", () => {
+    const instance = makeYargs()
+    configureBuildCommand(instance)
+    const parsed = instance.parseSync(["--linux", "deb"])
+    expect(parsed.linux).toEqual(["deb"])
+  })
+
+  test("registers --dir as boolean flag", () => {
+    const instance = makeYargs()
+    configureBuildCommand(instance)
+    const parsed = instance.parseSync(["--dir"])
+    expect(parsed.dir).toBe(true)
+  })
+
+  test("registers --config / -c option", () => {
+    const instance = makeYargs()
+    configureBuildCommand(instance)
+    const parsed = instance.parseSync(["-c", "my.config.js"])
+    expect(parsed.config).toBe("my.config.js")
+  })
+})
+
+describe("configureInstallAppDepsCommand", () => {
+  test("registers --platform with linux/darwin/win32 choices", () => {
+    const instance = makeYargs()
+    configureInstallAppDepsCommand(instance)
+    expect(() => instance.parseSync(["--platform", "invalid"])).toThrow()
+  })
+
+  test("accepts valid --platform values", () => {
+    for (const platform of ["linux", "darwin", "win32"]) {
+      const instance = makeYargs()
+      configureInstallAppDepsCommand(instance)
+      const parsed = instance.parseSync(["--platform", platform])
+      expect(parsed.platform).toBe(platform)
+    }
+  })
+
+  test("registers --arch option", () => {
+    const instance = makeYargs()
+    configureInstallAppDepsCommand(instance)
+    const parsed = instance.parseSync(["--arch", "x64"])
+    expect(parsed.arch).toBe("x64")
+  })
+})
+
+describe("configurePublishCommand", () => {
+  test("throws when --files is not provided", () => {
+    const instance = makeYargs()
+    configurePublishCommand(instance)
+    expect(() => instance.parseSync([])).toThrow()
+  })
+
+  test("accepts --files with multiple paths", () => {
+    const instance = makeYargs()
+    configurePublishCommand(instance)
+    const parsed = instance.parseSync(["--files", "app.dmg", "--files", "app.exe"])
+    expect(parsed.files).toEqual(["app.dmg", "app.exe"])
+  })
+
+  test("registers --policy with valid choices", () => {
+    const instance = makeYargs()
+    configurePublishCommand(instance)
+    expect(() => instance.parseSync(["--files", "app.dmg", "--policy", "invalid"])).toThrow()
+  })
+
+  test("accepts valid --policy values", () => {
+    for (const policy of ["onTag", "onTagOrDraft", "always", "never"]) {
+      const instance = makeYargs()
+      configurePublishCommand(instance)
+      const parsed = instance.parseSync(["--files", "app.dmg", "--policy", policy])
+      expect(parsed.policy).toBe(policy)
+    }
+  })
+})


### PR DESCRIPTION
Purpose: Allow user intervention as a "nuke" option in case toolsets get corrupted during download (or more specifically - extraction)
Compliments this PR https://github.com/electron-userland/electron-builder/pull/9735

- Adds a new electron-builder clear-cache CLI command that deletes the default platform cache directory with an interactive y/N confirmation prompt.
- Always **only** clears the default cache path — `ELECTRON_BUILDER_CACHE` is intentionally ignored to prevent a compromised env var from abusing the delete against a system path.
- Safety guards: aborts if the path resolves to a filesystem root; distinguishes `ENOENT` (nothing to clear) from `EACCES`/`EPERM` (not writable) in error reporting
- Requires TTY after directory path is logged to receive explicit user-confirmation.