### PR TITLE
fix: update dmgbuilder toolset to 1.2.2 and add mac_alias test case

### DIFF
--- a/.changeset/thick-camels-doubt.md
+++ b/.changeset/thick-camels-doubt.md
@@ -1,0 +1,5 @@
+---
+"dmg-builder": patch
+---
+
+fix: update dmgbuild to 1.2.2 and add mac_alias test case

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -35,15 +35,15 @@ async function getDmgVendorPath(): Promise<string> {
     return resolvedPath
   }
 
-  // https://github.com/electron-userland/electron-builder-binaries/releases/tag/dmg-builder%401.2.1
+  // https://github.com/electron-userland/electron-builder-binaries/releases/tag/dmg-builder%401.2.2
   const config = {
-    "dmgbuild-bundle-arm64-75c8a6c.tar.gz": "e572e513996d7568a640a9c88380a9c1a32f66539f58b0900fa2719afe7a0abe",
-    "dmgbuild-bundle-x86_64-75c8a6c.tar.gz": "e90634f4a85bf042cbefd68677b555160771b3a85f646b0047c6941baf61e0cc",
+    "dmgbuild-bundle-arm64-75c8a6c.tar.gz": "28be390d4cfade51d872c42016bc56712bb240525c9f21ebbfa0b413ade1fe0f",
+    "dmgbuild-bundle-x86_64-75c8a6c.tar.gz": "97d4ac0d2137383d37d02df3338bf653b6e6095d033508458ef195d567d25071",
   }
   const arch = process.arch === "arm64" ? "arm64" : "x86_64"
   const filename: keyof typeof config = `dmgbuild-bundle-${arch}-75c8a6c.tar.gz`
   const file = await downloadBuilderToolset({
-    releaseName: "dmg-builder@1.2.1",
+    releaseName: "dmg-builder@1.2.2",
     filenameWithExt: filename,
     checksums: config,
     githubOrgRepo: "electron-userland/electron-builder-binaries",

--- a/test/snapshots/mac/dmgTest.js.snap
+++ b/test/snapshots/mac/dmgTest.js.snap
@@ -142,6 +142,76 @@ exports[`disable dmg icon (light), bundleVersion 2`] = `
 }
 `;
 
+exports[`dmg > app is copyable from mounted dmg and bundle structure is intact 1`] = `
+{
+  "mac": [
+    {
+      "arch": "x64",
+      "file": "DmgCopyTest-1.1.0.dmg",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    {
+      "file": "DmgCopyTest-1.1.0.dmg.blockmap",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`dmg > app is copyable from mounted dmg and bundle structure is intact 2`] = `
+{
+  "CFBundleDisplayName": "DmgCopyTest",
+  "CFBundleExecutable": "DmgCopyTest",
+  "CFBundleIconFile": "icon.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "DmgCopyTest",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.1.0",
+  "ElectronAsarIntegrity": {
+    "Resources/app.asar": {
+      "algorithm": "SHA256",
+      "hash": "hash",
+    },
+  },
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSEnvironment": {
+    "MallocNanoZone": "0",
+  },
+  "NSAppTransportSecurity": {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": {
+      "127.0.0.1": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSBluetoothAlwaysUsageDescription": "This app needs access to Bluetooth",
+  "NSBluetoothPeripheralUsageDescription": "This app needs access to Bluetooth",
+  "NSHighResolutionCapable": true,
+  "NSPrefersDisplaySafeAreaCompatibilityMode": false,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
 exports[`dmg > background color 1`] = `
 {
   "backgroundColor": "orange",

--- a/test/src/mac/dmgTest.ts
+++ b/test/src/mac/dmgTest.ts
@@ -53,6 +53,8 @@ describe.heavy.ifMac("dmg", { sequential: true }, () => {
           const volumePath = it.volumePath
           await assertThat(expect, path.join(volumePath, ".background.tiff")).isFile()
           await assertThat(expect, path.join(volumePath, "Applications")).isSymbolicLink()
+          const entries = await fs.readdir(volumePath)
+          expect(entries.find(e => e.endsWith(".app"))).toBeTruthy()
           expect(
             it.specification.contents.map((c: any) => ({
               ...c,
@@ -87,6 +89,8 @@ describe.heavy.ifMac("dmg", { sequential: true }, () => {
         }
         delete it.specification.icon
         expect(it.specification).toMatchSnapshot()
+        const entries = await fs.readdir(it.volumePath)
+        expect(entries.find(e => e.endsWith(".app"))).toBeTruthy()
         return Promise.resolve(false)
       },
     }))
@@ -116,6 +120,8 @@ describe.heavy.ifMac("dmg", { sequential: true }, () => {
           }
           expect(it.specification.size).toEqual("500m")
           expect(it.specification.shrink).toEqual(false)
+          const entries = await fs.readdir(it.volumePath)
+          expect(entries.find(e => e.endsWith(".app"))).toBeTruthy()
           return Promise.resolve(false)
         },
       },
@@ -169,6 +175,8 @@ describe.heavy.ifMac("dmg", { sequential: true }, () => {
             return false
           }
           await assertThat(expect, path.join(it.volumePath, ".VolumeIcon.icns")).isFile()
+          const entries = await fs.readdir(it.volumePath)
+          expect(entries.find(e => e.endsWith(".app"))).toBeTruthy()
           return Promise.resolve(true)
         },
       },
@@ -313,6 +321,53 @@ describe.heavy.ifMac("dmg", { sequential: true }, () => {
           return attachAndExecute(path.join(context.outDir, "No-Background-1.1.0.dmg"), false, true, () => {
             return assertThat(expect, path.join("/Volumes/No-Background 1.1.0/.background.tiff")).doesNotExist()
           })
+        },
+      }
+    ))
+
+  // Verifies the full dmgbuild + mac_alias pipeline end-to-end: builds a DMG with a background
+  // image (which exercises alias.to_bytes() / uuid in mac_alias), then simulates what a user
+  // does — mounts, copies the .app out, verifies the bundle is intact — and immediately removes
+  // the copy to keep disk usage minimal.
+  test("app is copyable from mounted dmg and bundle structure is intact", ({ expect }) =>
+    app(
+      expect,
+      {
+        targets: dmgTarget,
+        config: {
+          productName: "DmgCopyTest",
+          publish: null,
+          dmg: {
+            title: "DmgCopyTest",
+          },
+        },
+      },
+      {
+        packed: async context => {
+          const dmgPath = path.join(context.outDir, "DmgCopyTest-1.1.0.dmg")
+          const tmpCopy = await context.tmpDir.createTempDir({ prefix: "dmg-copy-" })
+          try {
+            await attachAndExecute(dmgPath, false, true, async volumePath => {
+              const entries = await fs.readdir(volumePath)
+              const appName = entries.find(e => e.endsWith(".app"))
+              expect(appName).toBeTruthy()
+              // cp -Rf mirrors what Finder does when a user drags the app out of the DMG
+              await exec("cp", ["-Rf", path.join(volumePath, appName!), tmpCopy])
+            })
+
+            const copiedApp = path.join(tmpCopy, "DmgCopyTest.app")
+            await assertThat(expect, copiedApp).isDirectory()
+            await assertThat(expect, path.join(copiedApp, "Contents", "MacOS")).isDirectory()
+            await assertThat(expect, path.join(copiedApp, "Contents", "Info.plist")).isFile()
+
+            // Main executable must exist and have its execute bit set
+            const macosEntries = await fs.readdir(path.join(copiedApp, "Contents", "MacOS"))
+            expect(macosEntries.length).toBeGreaterThan(0)
+            const exeStat = await fs.stat(path.join(copiedApp, "Contents", "MacOS", macosEntries[0]))
+            expect(exeStat.mode & 0o111).toBeGreaterThan(0)
+          } finally {
+            await fs.rm(tmpCopy, { recursive: true, force: true })
+          }
         },
       }
     ))


### PR DESCRIPTION
- Updates dmgbuilder to latest electron-builder-binaries toolset release
- New test: mounts the built DMG, copies the `.app` to a temp dir, verifies `Contents/MacOS` and `Info.plist` are intact, then immediately removes the copy (disk-conscious end-to-end coverage of the `mac_alias` code path)
- Existing mount tests now assert the `.app` bundle is present in the volume