### PR TITLE
chore: downgrade docker test CI to use node 22 image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 env:
-  TEST_IMAGE_NODE_MAJOR_VERSION: 24
+  TEST_IMAGE_NODE_MAJOR_VERSION: 22
 
 jobs:
   check-if-docker-build:


### PR DESCRIPTION
The node 24 electron-builder docker image hasn't been published yet since a release hasn't been deployed. Downgrading CI back to node 22 image until release goes out