### PR TITLE
fix: allow mac entitlement files to be linked from outside the workspace

### DIFF
--- a/.changeset/shiny-impalas-march.md
+++ b/.changeset/shiny-impalas-march.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: allow mac entitlement files to be linked from outside the workspace

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -466,19 +466,6 @@ export class MacPackager extends PlatformPackager<MacConfiguration> {
       }
     }
 
-    const projectDir = await this.info.getWorkspaceRoot()
-    const blockExternalLoadPath = (p: string | null | undefined, label: string) => {
-      if (p && path.isAbsolute(p)) {
-        if (!p.startsWith(projectDir + path.sep) && p !== projectDir) {
-          log.error({ path: p, label }, "entitlements path is outside the workspace directory")
-          throw new InvalidConfigurationError(`Entitlements ${label} must be located inside the workspace directory`)
-        }
-      }
-    }
-    blockExternalLoadPath(customSignOptions.entitlements, "entitlements")
-    blockExternalLoadPath(customSignOptions.entitlementsInherit, "entitlementsInherit")
-    blockExternalLoadPath(customSignOptions.entitlementsLoginHelper, "entitlementsLoginHelper")
-
     const requirements = isMas || this.platformSpecificBuildOptions.requirements == null ? undefined : await this.getResource(this.platformSpecificBuildOptions.requirements)
 
     // harden by default for mac builds. Only harden mas builds if explicitly true (backward compatibility)


### PR DESCRIPTION
Addresses https://github.com/electron-userland/electron-builder/pull/9724#issuecomment-4501658497