### PR TITLE
fix: wrap any collector path in a .bat on Windows if path has a space in it

### DIFF
--- a/.changeset/eleven-areas-thank.md
+++ b/.changeset/eleven-areas-thank.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: wrap any collector path in a .bat on Windows if path has a space in it

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -357,7 +357,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
     // Also wrap any Windows executable path that contains spaces (e.g. extensionless shims
     // from tools like Volta installed at "C:\Program Files\Volta\") to ensure the path is
     // quoted correctly when passed to `spawn(..., { shell: true })`.
-    const isWindowsScriptFile = process.platform === "win32" && (ext === ".cmd" || (command.includes(" ") && ext !== ".exe"))
+    const isWindowsScriptFile = process.platform === "win32" && (ext === ".cmd" || command.includes(" "))
     if (isWindowsScriptFile) {
       // We need to wrap it in a .bat file to ensure it runs correctly with cmd.exe
       // This is necessary because some files (like .cmd) are not directly executable in the same way as .bat files.
@@ -389,7 +389,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
         stderr += chunk.toString()
       })
       child.on("error", err => {
-        reject(new Error(`Node module collector spawn failed: ${err.message}`))
+        reject(new Error(`Node module collector spawn (${command} ${args.join(" ")}) failed: ${err.message}`))
       })
 
       child.on("close", code => {

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -389,7 +389,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
         stderr += chunk.toString()
       })
       child.on("error", err => {
-        reject(new Error(`Node module collector spawn (${command} ${args.join(" ")}) failed: ${err.message}`))
+        reject(new Error(`Node module collector spawn (${command} ${JSON.stringify(args)}) failed: ${err.message}`))
       })
 
       child.on("close", code => {

--- a/test/src/node-module-collector/packageManagerResolveTest.ts
+++ b/test/src/node-module-collector/packageManagerResolveTest.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, test, vi } from "vitest"
+
+vi.mock("which", () => ({ sync: vi.fn() }))
+
+const originalPlatform = process.platform
+
+function setPlatform(p: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true })
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+})
+
+async function freshImport() {
+  vi.resetModules()
+  const whichMod = await import("which")
+  const { getPackageManagerCommand, PM } = await import("app-builder-lib/src/node-module-collector/packageManager")
+  return { getPackageManagerCommand, PM, whichSync: vi.mocked(whichMod.sync) }
+}
+
+describe.sequential("getPackageManagerCommand", () => {
+  test("non-Windows: returns pm name without calling which", async ({ expect }) => {
+    setPlatform("darwin")
+    const { getPackageManagerCommand, PM, whichSync } = await freshImport()
+    expect(getPackageManagerCommand(PM.PNPM)).toBe("pnpm")
+    expect(whichSync).not.toHaveBeenCalled()
+  })
+
+  test("non-Windows: YARN_BERRY resolves to 'yarn'", async ({ expect }) => {
+    setPlatform("linux")
+    const { getPackageManagerCommand, PM } = await freshImport()
+    expect(getPackageManagerCommand(PM.YARN_BERRY)).toBe("yarn")
+  })
+
+  test("Windows: calls which.sync and returns full path", async ({ expect }) => {
+    setPlatform("win32")
+    const { getPackageManagerCommand, PM, whichSync } = await freshImport()
+    whichSync.mockReturnValue("C:\\nodejs\\npm.cmd")
+    expect(getPackageManagerCommand(PM.NPM)).toBe("C:\\nodejs\\npm.cmd")
+    expect(whichSync).toHaveBeenCalledWith("npm")
+  })
+
+  test("Windows YARN_BERRY: which.sync called with 'yarn'", async ({ expect }) => {
+    setPlatform("win32")
+    const { getPackageManagerCommand, PM, whichSync } = await freshImport()
+    whichSync.mockReturnValue("C:\\tools\\yarn.cmd")
+    getPackageManagerCommand(PM.YARN_BERRY)
+    expect(whichSync).toHaveBeenCalledWith("yarn")
+  })
+
+  test("Windows: falls back to pm name when which.sync throws", async ({ expect }) => {
+    setPlatform("win32")
+    const { getPackageManagerCommand, PM, whichSync } = await freshImport()
+    whichSync.mockImplementation(() => {
+      throw new Error("not found")
+    })
+    expect(getPackageManagerCommand(PM.PNPM)).toBe("pnpm")
+  })
+
+  test("Windows: Volta extensionless shim at path with spaces", async ({ expect }) => {
+    setPlatform("win32")
+    const { getPackageManagerCommand, PM, whichSync } = await freshImport()
+    whichSync.mockReturnValue("C:\\Program Files\\Volta\\pnpm")
+    expect(getPackageManagerCommand(PM.PNPM)).toBe("C:\\Program Files\\Volta\\pnpm")
+  })
+
+  test("Windows: Volta .exe shim at path with spaces", async ({ expect }) => {
+    setPlatform("win32")
+    const { getPackageManagerCommand, PM, whichSync } = await freshImport()
+    whichSync.mockReturnValue("C:\\Program Files\\Volta\\pnpm.exe")
+    expect(getPackageManagerCommand(PM.PNPM)).toBe("C:\\Program Files\\Volta\\pnpm.exe")
+  })
+
+  test("caches result: which.sync called only once per pm", async ({ expect }) => {
+    setPlatform("win32")
+    const { getPackageManagerCommand, PM, whichSync } = await freshImport()
+    whichSync.mockReturnValue("C:\\tools\\npm.cmd")
+    getPackageManagerCommand(PM.NPM)
+    getPackageManagerCommand(PM.NPM)
+    expect(whichSync).toHaveBeenCalledOnce()
+  })
+})

--- a/test/src/node-module-collector/packageManagerResolveTest.ts
+++ b/test/src/node-module-collector/packageManagerResolveTest.ts
@@ -10,6 +10,7 @@ function setPlatform(p: NodeJS.Platform) {
 
 afterEach(() => {
   Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+  vi.clearAllMocks()
 })
 
 async function freshImport() {

--- a/test/src/node-module-collector/streamCollectorTest.ts
+++ b/test/src/node-module-collector/streamCollectorTest.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, test, vi } from "vitest"
+import { NodeModulesCollector } from "app-builder-lib/src/node-module-collector/nodeModulesCollector"
+import { PM } from "app-builder-lib/src/node-module-collector/packageManager"
+import * as childProcess from "child_process"
+import * as fsExtra from "fs-extra"
+import type { TmpDir } from "builder-util"
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }))
+vi.mock("fs-extra", async () => ({
+  ...(await vi.importActual("fs-extra")),
+  createWriteStream: vi.fn(() => ({ close: vi.fn() })),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}))
+
+class TestCollector extends NodeModulesCollector<any, any> {
+  readonly installOptions = { manager: PM.NPM, lockfile: "package-lock.json" }
+  protected getArgs() {
+    return []
+  }
+  protected async extractProductionDependencyGraph() {}
+  protected async collectAllDependencies() {}
+}
+
+const BAT_PATH = "C:\\Temp\\pnpm-deadbeef.bat"
+const OUTPUT_FILE = "/tmp/output.json"
+
+const originalPlatform = process.platform
+
+function setPlatform(p: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true })
+}
+
+let collector: TestCollector
+let closeCb: ((code: number) => void) | undefined
+
+beforeEach(() => {
+  closeCb = undefined
+  const mockChild = {
+    stdout: { pipe: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn((ev: string, cb: (code: number) => void) => {
+      if (ev === "close") closeCb = cb
+    }),
+  }
+  vi.mocked(childProcess.spawn).mockReturnValue(mockChild as any)
+  const mockTmpDir = { getTempFile: vi.fn().mockResolvedValue(BAT_PATH) } as unknown as TmpDir
+  collector = new TestCollector("/rootDir", mockTmpDir)
+})
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+  vi.clearAllMocks()
+})
+
+describe.sequential("streamCollectorCommandToFile", () => {
+  // For bat-wrapped cases: two microtask flushes are needed to drain the
+  // getTempFile and writeFile awaits before the Promise constructor (and thus
+  // the close-callback registration) runs.
+  describe("Windows bat wrapping", () => {
+    test(".cmd file: spawn receives cmd.exe", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile("C:\\nodejs\\npm.cmd", ["list"], "/cwd", OUTPUT_FILE)
+      await Promise.resolve()
+      await Promise.resolve()
+      closeCb!(0)
+      await p
+      const [cmd, args] = vi.mocked(childProcess.spawn).mock.calls[0]
+      expect(cmd).toBe("cmd.exe")
+      expect(args[0]).toBe("/c")
+      expect(args[1]).toBe(`"${BAT_PATH}"`)
+    })
+
+    test(".cmd at path with spaces: wrapped in bat", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile("C:\\Program Files\\nodejs\\npm.cmd", ["list"], "/cwd", OUTPUT_FILE)
+      await Promise.resolve()
+      await Promise.resolve()
+      closeCb!(0)
+      await p
+      expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe("cmd.exe")
+    })
+
+    test("extensionless at path with spaces: wrapped in bat", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile("C:\\Program Files\\Volta\\pnpm", [], "/cwd", OUTPUT_FILE)
+      await Promise.resolve()
+      await Promise.resolve()
+      closeCb!(0)
+      await p
+      expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe("cmd.exe")
+    })
+
+    test(".exe at path with spaces: wrapped in bat (Volta shim fix)", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile("C:\\Program Files\\Volta\\pnpm.exe", [], "/cwd", OUTPUT_FILE)
+      await Promise.resolve()
+      await Promise.resolve()
+      closeCb!(0)
+      await p
+      expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe("cmd.exe")
+    })
+
+    test("bat script quotes command and uses CRLF line endings", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile("C:\\Program Files\\Volta\\pnpm.exe", [], "/cwd", OUTPUT_FILE)
+      await Promise.resolve()
+      await Promise.resolve()
+      closeCb!(0)
+      await p
+      const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as [string, string, unknown]
+      expect(content).toBe('@echo off\r\n"C:\\Program Files\\Volta\\pnpm.exe" %*\r\n')
+    })
+
+    test("bat script escapes double quotes in command path", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile('C:\\some""path\\npm.cmd', [], "/cwd", OUTPUT_FILE)
+      await Promise.resolve()
+      await Promise.resolve()
+      closeCb!(0)
+      await p
+      const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as [string, string, unknown]
+      expect(content).toContain('C:\\some""""path\\npm.cmd')
+    })
+
+    test("original args forwarded after bat path", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile("C:\\Program Files\\npm.cmd", ["list", "--json"], "/cwd", OUTPUT_FILE)
+      await Promise.resolve()
+      await Promise.resolve()
+      closeCb!(0)
+      await p
+      const spawnArgs = vi.mocked(childProcess.spawn).mock.calls[0][1] as string[]
+      expect(spawnArgs.slice(2)).toEqual(["list", "--json"])
+    })
+  })
+
+  describe("no bat wrapping", () => {
+    test(".exe at path without spaces: spawn receives original command", async ({ expect }) => {
+      setPlatform("win32")
+      const cmd = "C:\\tools\\pnpm.exe"
+      const p = collector.streamCollectorCommandToFile(cmd, [], "/cwd", OUTPUT_FILE)
+      closeCb!(0)
+      await p
+      expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe(cmd)
+      expect(vi.mocked(fsExtra.writeFile)).not.toHaveBeenCalled()
+    })
+
+    test("extensionless at path without spaces: spawn receives original command", async ({ expect }) => {
+      setPlatform("win32")
+      const p = collector.streamCollectorCommandToFile("pnpm", [], "/cwd", OUTPUT_FILE)
+      closeCb!(0)
+      await p
+      expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe("pnpm")
+      expect(vi.mocked(fsExtra.writeFile)).not.toHaveBeenCalled()
+    })
+
+    test("non-Windows: never wraps even for spaces-in-path .exe", async ({ expect }) => {
+      setPlatform("darwin")
+      const cmd = "/Applications/Volta/pnpm.exe"
+      const p = collector.streamCollectorCommandToFile(cmd, [], "/cwd", OUTPUT_FILE)
+      closeCb!(0)
+      await p
+      expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe(cmd)
+      expect(vi.mocked(fsExtra.writeFile)).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/src/node-module-collector/streamCollectorTest.ts
+++ b/test/src/node-module-collector/streamCollectorTest.ts
@@ -33,6 +33,15 @@ function setPlatform(p: NodeJS.Platform) {
 let collector: TestCollector
 let closeCb: ((code: number) => void) | undefined
 
+async function waitForCloseCb() {
+  for (let i = 0; i < 50 && closeCb === undefined; i++) {
+    await Promise.resolve()
+  }
+  if (closeCb === undefined) {
+    throw new Error("spawn never registered close callback")
+  }
+}
+
 beforeEach(() => {
   closeCb = undefined
   const mockChild = {
@@ -53,15 +62,11 @@ afterEach(() => {
 })
 
 describe.sequential("streamCollectorCommandToFile", () => {
-  // For bat-wrapped cases: two microtask flushes are needed to drain the
-  // getTempFile and writeFile awaits before the Promise constructor (and thus
-  // the close-callback registration) runs.
   describe("Windows bat wrapping", () => {
     test(".cmd file: spawn receives cmd.exe", async ({ expect }) => {
       setPlatform("win32")
       const p = collector.streamCollectorCommandToFile("C:\\nodejs\\npm.cmd", ["list"], "/cwd", OUTPUT_FILE)
-      await Promise.resolve()
-      await Promise.resolve()
+      await waitForCloseCb()
       closeCb!(0)
       await p
       const [cmd, args] = vi.mocked(childProcess.spawn).mock.calls[0]
@@ -73,8 +78,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
     test(".cmd at path with spaces: wrapped in bat", async ({ expect }) => {
       setPlatform("win32")
       const p = collector.streamCollectorCommandToFile("C:\\Program Files\\nodejs\\npm.cmd", ["list"], "/cwd", OUTPUT_FILE)
-      await Promise.resolve()
-      await Promise.resolve()
+      await waitForCloseCb()
       closeCb!(0)
       await p
       expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe("cmd.exe")
@@ -83,8 +87,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
     test("extensionless at path with spaces: wrapped in bat", async ({ expect }) => {
       setPlatform("win32")
       const p = collector.streamCollectorCommandToFile("C:\\Program Files\\Volta\\pnpm", [], "/cwd", OUTPUT_FILE)
-      await Promise.resolve()
-      await Promise.resolve()
+      await waitForCloseCb()
       closeCb!(0)
       await p
       expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe("cmd.exe")
@@ -93,8 +96,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
     test(".exe at path with spaces: wrapped in bat (Volta shim fix)", async ({ expect }) => {
       setPlatform("win32")
       const p = collector.streamCollectorCommandToFile("C:\\Program Files\\Volta\\pnpm.exe", [], "/cwd", OUTPUT_FILE)
-      await Promise.resolve()
-      await Promise.resolve()
+      await waitForCloseCb()
       closeCb!(0)
       await p
       expect(vi.mocked(childProcess.spawn).mock.calls[0][0]).toBe("cmd.exe")
@@ -103,8 +105,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
     test("bat script quotes command and uses CRLF line endings", async ({ expect }) => {
       setPlatform("win32")
       const p = collector.streamCollectorCommandToFile("C:\\Program Files\\Volta\\pnpm.exe", [], "/cwd", OUTPUT_FILE)
-      await Promise.resolve()
-      await Promise.resolve()
+      await waitForCloseCb()
       closeCb!(0)
       await p
       const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as unknown as [string, string, unknown]
@@ -114,8 +115,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
     test("bat script escapes double quotes in command path", async ({ expect }) => {
       setPlatform("win32")
       const p = collector.streamCollectorCommandToFile('C:\\some""path\\npm.cmd', [], "/cwd", OUTPUT_FILE)
-      await Promise.resolve()
-      await Promise.resolve()
+      await waitForCloseCb()
       closeCb!(0)
       await p
       const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as unknown as [string, string, unknown]
@@ -125,8 +125,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
     test("original args forwarded after bat path", async ({ expect }) => {
       setPlatform("win32")
       const p = collector.streamCollectorCommandToFile("C:\\Program Files\\npm.cmd", ["list", "--json"], "/cwd", OUTPUT_FILE)
-      await Promise.resolve()
-      await Promise.resolve()
+      await waitForCloseCb()
       closeCb!(0)
       await p
       const spawnArgs = vi.mocked(childProcess.spawn).mock.calls[0][1] as string[]

--- a/test/src/node-module-collector/streamCollectorTest.ts
+++ b/test/src/node-module-collector/streamCollectorTest.ts
@@ -107,7 +107,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
       await Promise.resolve()
       closeCb!(0)
       await p
-      const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as [string, string, unknown]
+      const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as unknown as [string, string, unknown]
       expect(content).toBe('@echo off\r\n"C:\\Program Files\\Volta\\pnpm.exe" %*\r\n')
     })
 
@@ -118,7 +118,7 @@ describe.sequential("streamCollectorCommandToFile", () => {
       await Promise.resolve()
       closeCb!(0)
       await p
-      const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as [string, string, unknown]
+      const [, content] = vi.mocked(fsExtra.writeFile).mock.calls[0] as unknown as [string, string, unknown]
       expect(content).toContain('C:\\some""""path\\npm.cmd')
     })
 


### PR DESCRIPTION
This pull request fixes and tests the handling of Windows package manager executable paths—especially those with spaces (such as Volta shims)—in the `NodeModulesCollector`. It ensures correct wrapping of such paths in `.bat` files and improves error messages. The changes also add comprehensive tests to cover these scenarios.

**Bug fixes and improvements:**

* Ensured that any Windows package manager executable path containing spaces is wrapped in a `.bat` file, regardless of its extension, to guarantee correct execution via `cmd.exe` (previously, `.exe` files with spaces were not wrapped).
* Enhanced error messages in the collector to include the actual command and arguments, improving the diagnosability of spawn failures.

**Testing:**

* Added a new test suite (`streamCollectorTest.ts`) to verify that commands are correctly wrapped in `.bat` files for all relevant Windows path scenarios, including `.exe` and extensionless shims with spaces, and that arguments and quoting are handled correctly.
* Added a new test suite (`packageManagerResolveTest.ts`) to ensure that package manager commands are resolved correctly across platforms, that caching works, and that error cases fall back gracefully.
