### PR TITLE
fix: add toolset lockfile for operations that leverage system utils that don't support parallelism (e.g. hdiutil, WiX, etc.)

### DIFF
--- a/.changeset/fresh-stars-tie.md
+++ b/.changeset/fresh-stars-tie.md
@@ -1,0 +1,7 @@
+---
+"electron-builder-squirrel-windows": patch
+"app-builder-lib": patch
+"dmg-builder": patch
+---
+
+fix: add toolset lockfile for operations that leverage system utils that don't support parallelism (e.g. hdiutil, WiX, etc.)

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -10,6 +10,7 @@ docker run --rm \
   -e UPDATE_SNAPSHOT="${UPDATE_SNAPSHOT:-false}" \
   -e UPDATE_LOCKFILE_FIXTURES="${UPDATE_LOCKFILE_FIXTURES:-false}" \
   -e TEST_FILES="${TEST_FILES:-}" \
+  -e TEST_SEQUENTIAL_FILES="${TEST_SEQUENTIAL_FILES:-}" \
   -w /project \
   -v "$(pwd):/project" \
   -v "$(pwd)/node-modules-docker:/project/node_modules" \

--- a/packages/app-builder-lib/src/targets/MsiTarget.ts
+++ b/packages/app-builder-lib/src/targets/MsiTarget.ts
@@ -14,6 +14,7 @@ import { getTemplatePath } from "../util/pathManager"
 import { VmManager } from "../vm/vm"
 import { WineVmManager } from "../vm/WineVm"
 import { WinPackager } from "../winPackager"
+import { withToolsetLock } from "../util/toolsetLock"
 import { createStageDir, getWindowsInstallationDirName } from "./targetUtil"
 
 const ELECTRON_BUILDER_UPGRADE_CODE_NS_UUID = UUID.parse("d752fe43-5d44-44d5-9fc9-6dd1bf19d5cc")
@@ -91,11 +92,12 @@ export default class MsiTarget extends Target {
     // noinspection SpellCheckingInspection
     const candleArgs = ["-arch", wixArch === Arch.ia32 ? "x86" : "x64", `-dappDir=${vm.toVmFile(appOutDir)}`].concat(this.getCommonWixArgs())
     candleArgs.push("project.wxs")
-    await vm.exec(vm.toVmFile(path.join(vendorPath, "candle.exe")), candleArgs, {
-      cwd: stageDir.dir,
+    await withToolsetLock(async () => {
+      await vm.exec(vm.toVmFile(path.join(vendorPath, "candle.exe")), candleArgs, {
+        cwd: stageDir.dir,
+      })
+      await this.light(objectFiles, vm, artifactPath, appOutDir, vendorPath, stageDir.dir)
     })
-
-    await this.light(objectFiles, vm, artifactPath, appOutDir, vendorPath, stageDir.dir)
 
     await stageDir.cleanup()
 

--- a/packages/app-builder-lib/src/toolsets/linux.ts
+++ b/packages/app-builder-lib/src/toolsets/linux.ts
@@ -24,31 +24,8 @@ export const appimageChecksums = {
   },
 } as const
 
-export const linuxToolsChecksums = {
-  "0.0.0": {
-    // legacy
-  },
-  "1.0.0": {
-    "linux-tools-darwin-arm64.tar.gz": "2ac82919e2167f050531d67414c0ebca268cb50784dbc8a483482e32f9b3a6cd",
-  },
-} as const
-
-export function getLinuxToolsPath(linuxToolsVersion: ToolsetConfig["linuxTools"]) {
-  if (process.env.CUSTOM_LINUX_TOOLS_PATH != null) {
-    return path.resolve(process.env.CUSTOM_LINUX_TOOLS_PATH)
-  }
-  if (process.platform !== "darwin") {
-    throw new Error("Portable linux tools are only provided for macOS")
-  }
-  if (linuxToolsVersion == null || linuxToolsVersion === "0.0.0") {
-    return getBinFromUrl("linux-tools-mac-10.12.3", "linux-tools-mac-10.12.3.7z", "58ff69a6f5082c78b809b72c929f5f2a82e6c3974c014bd1382fc87d9da1075c")
-  }
-  return downloadBuilderToolset({
-    releaseName: `linux-tools@${linuxToolsVersion}`,
-    filenameWithExt: "linux-tools-darwin-arm64.tar.gz",
-    checksums: linuxToolsChecksums[linuxToolsVersion],
-    githubOrgRepo: "electron-userland/electron-builder-binaries",
-  })
+export function getLinuxToolsPath() {
+  return getBinFromUrl("linux-tools-mac-10.12.3", "linux-tools-mac-10.12.3.7z", "58ff69a6f5082c78b809b72c929f5f2a82e6c3974c014bd1382fc87d9da1075c")
 }
 
 export async function getFpmPath() {

--- a/packages/app-builder-lib/src/toolsets/linux.ts
+++ b/packages/app-builder-lib/src/toolsets/linux.ts
@@ -24,8 +24,31 @@ export const appimageChecksums = {
   },
 } as const
 
-export function getLinuxToolsPath() {
-  return getBinFromUrl("linux-tools-mac-10.12.3", "linux-tools-mac-10.12.3.7z", "58ff69a6f5082c78b809b72c929f5f2a82e6c3974c014bd1382fc87d9da1075c")
+export const linuxToolsChecksums = {
+  "0.0.0": {
+    // legacy
+  },
+  "1.0.0": {
+    "linux-tools-darwin-arm64.tar.gz": "2ac82919e2167f050531d67414c0ebca268cb50784dbc8a483482e32f9b3a6cd",
+  },
+} as const
+
+export function getLinuxToolsPath(linuxToolsVersion: ToolsetConfig["linuxTools"]) {
+  if (process.env.CUSTOM_LINUX_TOOLS_PATH != null) {
+    return path.resolve(process.env.CUSTOM_LINUX_TOOLS_PATH)
+  }
+  if (process.platform !== "darwin") {
+    throw new Error("Portable linux tools are only provided for macOS")
+  }
+  if (linuxToolsVersion == null || linuxToolsVersion === "0.0.0") {
+    return getBinFromUrl("linux-tools-mac-10.12.3", "linux-tools-mac-10.12.3.7z", "58ff69a6f5082c78b809b72c929f5f2a82e6c3974c014bd1382fc87d9da1075c")
+  }
+  return downloadBuilderToolset({
+    releaseName: `linux-tools@${linuxToolsVersion}`,
+    filenameWithExt: "linux-tools-darwin-arm64.tar.gz",
+    checksums: linuxToolsChecksums[linuxToolsVersion],
+    githubOrgRepo: "electron-userland/electron-builder-binaries",
+  })
 }
 
 export async function getFpmPath() {

--- a/packages/app-builder-lib/src/util/toolsetLock.ts
+++ b/packages/app-builder-lib/src/util/toolsetLock.ts
@@ -1,0 +1,20 @@
+import { log } from "builder-util"
+import { writeFile } from "fs/promises"
+import * as lockfile from "proper-lockfile"
+import * as os from "os"
+import * as path from "path"
+
+const LOCK_FILE = path.join(os.tmpdir(), ".electron-builder-toolset.lock")
+
+export async function withToolsetLock<T>(task: () => Promise<T>): Promise<T> {
+  await writeFile(LOCK_FILE, "", { flag: "a" })
+  const release = await lockfile.lock(LOCK_FILE, {
+    retries: { retries: 100, minTimeout: 1000, maxTimeout: 5000 },
+    stale: 120_000,
+  })
+  try {
+    return await task()
+  } finally {
+    await release().catch((err: Error) => log.warn({ err }, "failed to release toolset lock"))
+  }
+}

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -1,5 +1,6 @@
 import { DmgOptions, MacPackager, PlatformPackager } from "app-builder-lib"
 import { downloadBuilderToolset } from "app-builder-lib/out/util/electronGet"
+import { withToolsetLock } from "app-builder-lib/out/util/toolsetLock"
 import { exec, executeFinally, exists, InvalidConfigurationError, isEmptyOrSpaces, log, TmpDir } from "builder-util"
 import { stat } from "fs/promises"
 import { writeFile } from "fs-extra"
@@ -210,12 +211,14 @@ export async function customizeDmg({ appPath, artifactPath, volumeName, specific
   await writeFile(settingsFile, JSON.stringify(settings, null, 2))
 
   const dmgbuild = await getDmgVendorPath()
-  await exec(dmgbuild, ["-s", settingsFile, path.basename(volumePath), artifactPath], {
-    env: {
-      ...process.env,
-      PYTHONIOENCODING: "utf8",
-    },
-  })
+  await withToolsetLock(() =>
+    exec(dmgbuild, ["-s", settingsFile, path.basename(volumePath), artifactPath], {
+      env: {
+        ...process.env,
+        PYTHONIOENCODING: "utf8",
+      },
+    })
+  )
 
   // effectiveOptionComputed, when present, is purely for verifying result during test execution
   return (

--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -3,6 +3,7 @@ import { execWine } from "app-builder-lib/out/wine"
 import { getBinFromUrl } from "app-builder-lib/out/binDownload"
 import { sanitizeFileName } from "builder-util/out/filename"
 import { Arch, getArchSuffix, SquirrelWindowsOptions, Target, WinPackager } from "app-builder-lib"
+import { withToolsetLock } from "app-builder-lib/out/util/toolsetLock"
 import * as path from "path"
 import * as fs from "fs"
 import * as os from "os"
@@ -87,7 +88,7 @@ export default class SquirrelWindowsTarget extends Target {
       })
       const distOptions = await this.computeEffectiveDistOptions(appOutDir, installerOutDir, setupFile)
       await this.generateStubExecutableExe(appOutDir, distOptions.vendorDirectory!)
-      await createWindowsInstaller(distOptions)
+      await withToolsetLock(() => createWindowsInstaller(distOptions))
 
       await packager.signAndEditResources(artifactPath, arch, installerOutDir)
 

--- a/test/src/updater/test-specific-platforms.sh
+++ b/test/src/updater/test-specific-platforms.sh
@@ -17,6 +17,7 @@ DOCKERFILE="${1:-all}"
 TARGET="${2:-all}"
 
 export TEST_FILES="${TEST_FILES:-blackboxUpdateTest,linuxUpdaterTest,blackboxInstallTest}"
+export TEST_SEQUENTIAL_FILES="${TEST_SEQUENTIAL_FILES:-true}"
 export DEBUG="${DEBUG:-electron-updater}"
 
 do_build() {

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -61,7 +61,7 @@ async function main() {
 
     maxWorkers: "50%",
 
-    fileParallelism: false,
+    fileParallelism: process.env.TEST_SEQUENTIAL_FILES !== "true",
     sequence: {
       sequencer: SmartSequencer,
       concurrent: process.env.TEST_SEQUENTIAL === "false",


### PR DESCRIPTION
This pull request introduces a toolset lock mechanism to prevent parallel execution of operations that rely on system utilities lacking parallelism support (such as `hdiutil` on macOS and WiX on Windows). The lock ensures these tools are only accessed by one process at a time, addressing issues with race conditions during builds. Additionally, the test infrastructure is updated to allow sequential test execution for scenarios where parallelism causes failures.

This also re-enables `fileParallelism: true` to be applied to the overall test suite (minus package-manager-related auto-update tests)