### PR TITLE
chore: adding additional validations to downloads and child processes

### DIFF
--- a/.changeset/mean-doors-care.md
+++ b/.changeset/mean-doors-care.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+---
+
+chore: adding additional validations to downloads and child processes

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/pnpm
 
       - name: Generate GitHub App token
-        uses: electron/github-app-auth-action@e25ab7f5aa15b949aee0f00d7e48972f1f3e0f5a
+        uses: electron/github-app-auth-action@e25ab7f5aa15b949aee0f00d7e48972f1f3e0f5a # v1.0.0
         id: generate-token
         with:
           export-git-user: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -174,7 +174,7 @@ jobs:
           TEST_RUNNER_IMAGE_TAG: electronuserland/builder:${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}-wine-mono
 
       - name: Upload smart cache artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
         if: always()
         with:
           name: vitest-smart-cache-${{ matrix.platform }}-${{ matrix.shard }}
@@ -223,7 +223,7 @@ jobs:
           VITEST_SMART_CACHE_FILE: ${{ github.workspace }}\test\vitest-scripts\_vitest-smart-cache.json
 
       - name: Upload smart cache artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
         if: always()
         with:
           name: vitest-smart-cache-${{ matrix.platform }}-${{ matrix.shard }}
@@ -268,7 +268,7 @@ jobs:
           # CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
 
       - name: Upload smart cache artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
         if: always()
         with:
           name: vitest-smart-cache-${{ matrix.platform }}-${{ matrix.shard }}
@@ -344,7 +344,7 @@ jobs:
           ADDITIONAL_DOCKER_ARGS: "--env-file ${{ runner.temp }}/docker-secrets.env -e VITEST_SMART_CACHE_FILE=./test/vitest-scripts/_vitest-smart-cache.json -e RESET_VITEST_SHARD_CACHE=${{ inputs.reset-vitest-smart-cache }}"
 
       - name: Upload smart cache artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
         if: always()
         with:
           name: vitest-smart-cache-updater
@@ -384,7 +384,7 @@ jobs:
           RESET_VITEST_SHARD_CACHE: ${{ inputs.reset-vitest-smart-cache }}
 
       - name: Upload smart cache artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
         if: always()
         with:
           name: vitest-smart-cache-linux-native
@@ -448,7 +448,7 @@ jobs:
             -e RESET_VITEST_SHARD_CACHE=${{ inputs.reset-vitest-smart-cache }}
 
       - name: Upload smart cache artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
         if: always()
         with:
           name: vitest-smart-cache-e2e-${{ matrix.test_config.env.PACKAGE_MANAGER_TO_TEST }}
@@ -546,7 +546,7 @@ jobs:
           failOnError: false
 
       - name: Upload merged cache artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
         with:
           name: vitest-smart-cache-merged
           path: merged-cache/_vitest-smart-cache.json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,13 +158,19 @@ jobs:
           docker image load --input ${{ runner.temp }}/electron-builder-all-${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}.tar
           docker image ls -a
 
+      - name: Write Docker secrets env file
+        run: |
+          printf 'CSC_KEY_PASSWORD=%s\n' "$CSC_KEY_PASSWORD_SECRET" > "${{ runner.temp }}/docker-secrets.env"
+          chmod 600 "${{ runner.temp }}/docker-secrets.env"
+        env:
+          CSC_KEY_PASSWORD_SECRET: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+
       - name: Run shard in docker
         run: |
           echo $TEST_RUNNER_IMAGE_TAG
           pnpm test-linux
         env:
-          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-          ADDITIONAL_DOCKER_ARGS: "-e CSC_KEY_PASSWORD=${{ secrets.WIN_CSC_KEY_PASSWORD }} -e VITEST_SHARD_INDEX=${{ matrix.shard }} -e VITEST_SMART_CACHE_FILE=./test/vitest-scripts/_vitest-smart-cache.json -e RESET_VITEST_SHARD_CACHE=${{ inputs.reset-vitest-smart-cache }}"
+          ADDITIONAL_DOCKER_ARGS: "--env-file ${{ runner.temp }}/docker-secrets.env -e VITEST_SHARD_INDEX=${{ matrix.shard }} -e VITEST_SMART_CACHE_FILE=./test/vitest-scripts/_vitest-smart-cache.json -e RESET_VITEST_SHARD_CACHE=${{ inputs.reset-vitest-smart-cache }}"
           TEST_RUNNER_IMAGE_TAG: electronuserland/builder:${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}-wine-mono
 
       - name: Upload smart cache artifact
@@ -316,6 +322,18 @@ jobs:
           docker image load --input ${{ runner.temp }}/electron-builder-all-${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}.tar
           docker image ls -a
 
+      - name: Write Docker secrets env file
+        run: |
+          printf 'KEYGEN_TOKEN=%s\nBITBUCKET_TOKEN=%s\nGH_TOKEN=%s\nGITLAB_TOKEN=%s\n' \
+            "$KEYGEN_TOKEN_SECRET" "$BITBUCKET_TOKEN_SECRET" "$GH_TOKEN_SECRET" "$GITLAB_TOKEN_SECRET" \
+            > "${{ runner.temp }}/docker-secrets.env"
+          chmod 600 "${{ runner.temp }}/docker-secrets.env"
+        env:
+          KEYGEN_TOKEN_SECRET: ${{ secrets.KEYGEN_TOKEN }}
+          BITBUCKET_TOKEN_SECRET: ${{ secrets.BITBUCKET_TOKEN }}
+          GH_TOKEN_SECRET: ${{ secrets.GH_TOKEN }}
+          GITLAB_TOKEN_SECRET: ${{ secrets.GITLAB_TOKEN }}
+
       - name: Test
         run: |
           echo $TEST_RUNNER_IMAGE_TAG
@@ -323,7 +341,7 @@ jobs:
         env:
           TEST_FILES: nsisUpdaterTest,PublishManagerTest,differentialUpdateTest,GitlabPublisherTest,GitlabPublisher.integration.test
           TEST_RUNNER_IMAGE_TAG: electronuserland/builder:${{ env.TEST_IMAGE_NODE_MAJOR_VERSION }}-wine-mono
-          ADDITIONAL_DOCKER_ARGS: "-e KEYGEN_TOKEN=${{ secrets.KEYGEN_TOKEN }} -e BITBUCKET_TOKEN=${{ secrets.BITBUCKET_TOKEN }} -e GH_TOKEN=${{ secrets.GH_TOKEN }} -e GITLAB_TOKEN=${{ secrets.GITLAB_TOKEN }} -e VITEST_SMART_CACHE_FILE=./test/vitest-scripts/_vitest-smart-cache.json -e RESET_VITEST_SHARD_CACHE=${{ inputs.reset-vitest-smart-cache }}"
+          ADDITIONAL_DOCKER_ARGS: "--env-file ${{ runner.temp }}/docker-secrets.env -e VITEST_SMART_CACHE_FILE=./test/vitest-scripts/_vitest-smart-cache.json -e RESET_VITEST_SHARD_CACHE=${{ inputs.reset-vitest-smart-cache }}"
 
       - name: Upload smart cache artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+.DS_Store
 /.vscode/
+
 node-modules*
+**/node_modules
 *.log
 
 /.idea/compiler.xml
@@ -9,30 +12,20 @@ node-modules*
 /.idea/deployment.xml
 /.idea/shelf/
 
-.DS_Store
+tsconfig.tsbuildinfo
 
 out/
-/test/test-report.xml
-
-/packages/dmg-builder/vendor/
-
-/scripts/jsdoc/out/
-/scripts/renderer/out/
 
 site/
 
-electron-builder-*.d.ts
-
-tsconfig.tsbuildinfo
-
 .pnpm-store/
-**/node_modules
+
 coverage
+test/src/generated/
+/test/test-report.xml
+_vitest-smart-cache.json
 
 /.yalc/
 yalc.lock
-_vitest-smart-cache.json
-.claude
-node-modules-docker
 
-test/src/generated/
+.claude

--- a/packages/app-builder-lib/src/binDownload.ts
+++ b/packages/app-builder-lib/src/binDownload.ts
@@ -29,6 +29,9 @@ export function getBinFromCustomLoc(name: string, version: string, binariesLocUr
 }
 
 export function getBinFromUrl(releaseName: string, filenameWithExt: string, checksum: string, githubOrgRepo = "electron-userland/electron-builder-binaries"): Promise<string> {
+  if (/[/\\]|^\.\./.test(filenameWithExt) || filenameWithExt.includes("..")) {
+    throw new Error(`getBinFromUrl: unsafe filenameWithExt "${filenameWithExt}" — must be a plain filename with no path separators or traversal sequences`)
+  }
   let url: string
   const overrideUrl = parseValidEnvVarUrl("ELECTRON_BUILDER_BINARIES_DOWNLOAD_OVERRIDE_URL")
   if (overrideUrl != null) {

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -374,6 +374,16 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
       args = ["/c", `"${tempBatFile}"`, ...args]
     }
 
+    // shell: true is required on Windows — see https://github.com/electron-userland/electron-builder/issues/9488
+    // Guard: reject any argument that contains characters with special meaning to cmd.exe
+    // or a POSIX shell, to prevent injection if a malicious package.json were to influence args.
+    const SHELL_INJECTION_RE = /[;&|`$(){}[\]<>!]/
+    for (const arg of args) {
+      if (SHELL_INJECTION_RE.test(arg)) {
+        throw new Error(`Refusing to spawn "${command}": argument "${arg}" contains shell metacharacters. Possible injection attempt.`)
+      }
+    }
+
     await new Promise<void>((resolve, reject) => {
       const outStream = createWriteStream(tempOutputFile)
 

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -1,4 +1,4 @@
-import { exists, log, retry, TmpDir } from "builder-util"
+import { exists, log, retry, stripSensitiveEnvVars, TmpDir } from "builder-util"
 import * as childProcess from "child_process"
 import { randomBytes } from "crypto"
 import * as fs from "fs-extra"
@@ -374,13 +374,19 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
       args = ["/c", `"${tempBatFile}"`, ...args]
     }
 
+    const isWindows = process.platform === "win32"
+
     // shell: true is required on Windows — see https://github.com/electron-userland/electron-builder/issues/9488
-    // Guard: reject any argument that contains characters with special meaning to cmd.exe
-    // or a POSIX shell, to prevent injection if a malicious package.json were to influence args.
-    const SHELL_INJECTION_RE = /[;&|`$(){}[\]<>!]/
-    for (const arg of args) {
-      if (SHELL_INJECTION_RE.test(arg)) {
-        throw new Error(`Refusing to spawn "${command}": argument "${arg}" contains shell metacharacters. Possible injection attempt.`)
+    // On non-Windows, shell:false means args are passed directly to the process with no shell
+    // interpretation, so the metacharacter guard is only necessary on Windows.
+    if (isWindows) {
+      // Guard against cmd.exe metacharacters. Parentheses are intentionally excluded because they
+      // appear in legitimate Windows paths (e.g. "C:\Program Files (x86)").
+      const SHELL_INJECTION_RE = /[;&|`${}[\]<>!%^]/
+      for (const arg of args) {
+        if (SHELL_INJECTION_RE.test(arg)) {
+          throw new Error(`Refusing to spawn "${command}": argument "${arg}" contains shell metacharacters. Possible injection attempt.`)
+        }
       }
     }
 
@@ -389,8 +395,9 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
 
       const child = childProcess.spawn(command, args, {
         cwd,
-        env: { COREPACK_ENABLE_STRICT: "0", ...process.env }, // allow `process.env` overrides
-        shell: true, // `true`` is required: https://github.com/electron-userland/electron-builder/issues/9488
+        // Package manager invocations do not need signing/publishing credentials.
+        env: { COREPACK_ENABLE_STRICT: "0", ...stripSensitiveEnvVars(process.env) },
+        shell: isWindows, // shell: true is required on Windows — see https://github.com/electron-userland/electron-builder/issues/9488
       })
 
       let stderr = ""

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -13,6 +13,7 @@ import { debug, log } from "./log"
 import { exists } from "./fs"
 import { mkdir } from "fs-extra"
 import { isEmptyOrSpaces } from "./stringUtil"
+import { isValidKey } from "./mapper"
 
 if (process.env.JEST_WORKER_ID == null) {
   installSourceMap()
@@ -92,7 +93,7 @@ const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|PASS|CREDENTIAL|CSC/i
 export function stripSensitiveEnvVars(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const out: NodeJS.ProcessEnv = {}
   for (const [k, v] of Object.entries(env)) {
-    if (!SENSITIVE_ENV_KEY_RE.test(k)) {
+    if (isValidKey(k) && !SENSITIVE_ENV_KEY_RE.test(k)) {
       out[k] = v
     }
   }

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -114,7 +114,7 @@ function getProcessEnv(env: Record<string, string | undefined> | Nullish): NodeJ
   }
 
   const finalEnv = {
-    ...(env == null ? stripSensitiveEnvVars(process.env) : env),
+    ...(env == null ? process.env : env),
   }
 
   // without LC_CTYPE dpkg can returns encoded unicode symbols
@@ -434,7 +434,7 @@ export async function executeAppBuilder(
 ): Promise<string> {
   const command = appBuilderPath
   const env: any = {
-    ...stripSensitiveEnvVars(process.env),
+    ...process.env,
     SZA_PATH: await getPath7za(),
     FORCE_COLOR: chalk.level === 0 ? "0" : "1",
   }

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -84,6 +84,21 @@ export function removePassword(input: string): string {
 
 const SENSITIVE_ENV_KEY_RE = /KEY|TOKEN|SECRET|PASSWORD|PASS|CREDENTIAL|CSC/i
 
+/**
+ * Returns a copy of the environment with sensitive keys removed.
+ * Use this when building the environment for child processes that do not
+ * need signing credentials, tokens, or passwords (e.g. package managers).
+ */
+export function stripSensitiveEnvVars(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {}
+  for (const [k, v] of Object.entries(env)) {
+    if (!SENSITIVE_ENV_KEY_RE.test(k)) {
+      out[k] = v
+    }
+  }
+  return out
+}
+
 export function filterSensitiveEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
   const out: Record<string, string | undefined> = {}
   for (const [k, v] of Object.entries(env)) {
@@ -98,7 +113,7 @@ function getProcessEnv(env: Record<string, string | undefined> | Nullish): NodeJ
   }
 
   const finalEnv = {
-    ...(env || process.env),
+    ...(env == null ? stripSensitiveEnvVars(process.env) : env),
   }
 
   // without LC_CTYPE dpkg can returns encoded unicode symbols
@@ -418,7 +433,7 @@ export async function executeAppBuilder(
 ): Promise<string> {
   const command = appBuilderPath
   const env: any = {
-    ...process.env,
+    ...stripSensitiveEnvVars(process.env),
     SZA_PATH: await getPath7za(),
     FORCE_COLOR: chalk.level === 0 ? "0" : "1",
   }

--- a/test/src/binDownloadTest.ts
+++ b/test/src/binDownloadTest.ts
@@ -1,6 +1,6 @@
 import * as os from "os"
 import * as path from "path"
-import { afterEach, beforeEach, describe, test, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 import { getBin, getBinFromCustomLoc, getBinFromUrl } from "app-builder-lib/src/binDownload"
 import { downloadBuilderToolset } from "app-builder-lib/src/util/electronGet"
 
@@ -84,6 +84,18 @@ describe.sequential("binDownload", () => {
       expect(downloadBuilderToolset).toHaveBeenCalledOnce()
       const call = vi.mocked(downloadBuilderToolset).mock.calls[0][0]
       expect(call.overrideUrl).toBe("https://override.example.com/custom-path")
+    })
+
+    describe("rejects unsafe filenameWithExt", () => {
+      test.each([
+        ["Unix traversal", "../x"],
+        ["Windows traversal", "..\\x"],
+        ["Unix path separator", "a/b"],
+        ["Windows path separator", "a\\b"],
+        ["embedded traversal", "foo/../bar"],
+      ])("%s — %s", (_label, filename) => {
+        expect(() => getBinFromUrl("some-release", filename, "fakechecksum")).toThrow(/unsafe filenameWithExt/)
+      })
     })
 
     test("deduplicates concurrent calls for the same artifact", async ({ expect }) => {


### PR DESCRIPTION
This pull request introduces several validator improvements and best practices to the build and test infrastructure, focusing on safer handling of environment variables and command arguments. It also updates some workflow actions to include explicit version tags for better traceability.

* Added validation in `getBinFromUrl` (in `binDownload.ts`) to reject any filename with path separators or traversal sequences, preventing unsafe file access.
* In `NodeModulesCollector` (in `nodeModulesCollector.ts`), added a guard to reject command arguments containing shell metacharacters.
* Introduced a new `stripSensitiveEnvVars` utility in `util.ts` to remove sensitive keys from environments passed to child processes that don't require them, and updated related code to use this function.
* In `.github/workflows/test.yaml`, switched Docker secrets handling to use `--env-file` with securely written environment files instead of passing sensitive variables directly, reducing exposure of secrets in logs or process listings.
* Updated GitHub Actions steps to include explicit action version tags for better clarity and reproducibility. 
