### PR TITLE
feat(nsis): transition UAC elevation to pure `powershell + Start-Process + RunAs`

### DIFF
--- a/.changeset/sad-ends-vanish.md
+++ b/.changeset/sad-ends-vanish.md
@@ -1,0 +1,6 @@
+---
+"electron-updater": minor
+"app-builder-lib": minor
+---
+
+feat(nsis): transition UAC elevation to pure `powershell + Start-Process + RunAs` with legacy `elevate.exe` as fallback

--- a/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -130,14 +130,21 @@ export class CopyElevateHelper {
       return promise
     }
 
-    promise = NSIS_PATH().then(it => {
+    promise = NSIS_PATH().then(async it => {
+      const sourceFile = path.join(it, "elevate.exe")
       const outFile = path.join(appOutDir, "resources", "elevate.exe")
-      const promise = copyFile(path.join(it, "elevate.exe"), outFile, false)
+      try {
+        await fs.access(sourceFile)
+      } catch {
+        log.debug({ path: sourceFile }, "elevate.exe not included in NSIS directory — skipping (UAC elevation uses PowerShell instead as primary method)")
+        return
+      }
+      const copyPromise = copyFile(sourceFile, outFile, false)
       const { signAndEditExecutable, signExecutable } = target.packager.platformSpecificBuildOptions
       if (signAndEditExecutable !== false && signExecutable !== false) {
-        return promise.then(() => target.packager.signIf(outFile))
+        return copyPromise.then(() => target.packager.signIf(outFile))
       }
-      return promise
+      return copyPromise
     })
     this.copied.set(appOutDir, promise)
     return promise

--- a/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -135,7 +135,10 @@ export class CopyElevateHelper {
       const outFile = path.join(appOutDir, "resources", "elevate.exe")
       try {
         await fs.access(sourceFile)
-      } catch {
+      } catch (e: any) {
+        if (e.code !== "ENOENT") {
+          throw e
+        }
         log.debug({ path: sourceFile }, "elevate.exe not included in NSIS directory — skipping (UAC elevation uses PowerShell instead as primary method)")
         return
       }

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -8,7 +8,7 @@ import { FileWithEmbeddedBlockMapDifferentialDownloader } from "./differentialDo
 import { DOWNLOAD_PROGRESS } from "./types"
 import { VerifyUpdateCodeSignature } from "./main"
 import { findFile, Provider } from "./providers/Provider"
-import { unlink } from "fs-extra"
+import { existsSync, unlink } from "fs-extra"
 import { verifySignature } from "./windowsExecutableCodeSignatureVerifier"
 import { URL } from "url"
 
@@ -159,8 +159,14 @@ export class NsisUpdater extends BaseUpdater {
           this.dispatchError(e)
           return
         }
-        // powershell.exe not found — fall back to legacy elevate.exe
-        this.spawnLog(path.join(process.resourcesPath, "elevate.exe"), [installerPath].concat(args)).catch(err => this.dispatchError(err))
+        const elevateExe = path.join(process.resourcesPath, "elevate.exe")
+        if (existsSync(elevateExe)) {
+          this._logger.info("Falling back to elevate.exe for UAC elevation")
+          this.spawnLog(elevateExe, [installerPath].concat(args)).catch(err => this.dispatchError(err))
+          return
+        }
+        this._logger.error("Cannot elevate installer, elevate.exe not found, and PowerShell failed to run: " + e)
+        this.dispatchError(e)
       })
     }
 

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -151,11 +151,21 @@ export class NsisUpdater extends BaseUpdater {
     }
 
     const callUsingElevation = (): void => {
-      this.spawnLog(path.join(process.resourcesPath, "elevate.exe"), [installerPath].concat(args)).catch(e => this.dispatchError(e))
+      const psInstallArgs = args.map(a => `'${a.replace(/'/g, "''")}'`).join(",")
+      const psScript = `Start-Process -FilePath '${installerPath.replace(/'/g, "''")}' -ArgumentList @(${psInstallArgs}) -Verb RunAs`
+      const encodedCmd = Buffer.from(psScript, "utf16le").toString("base64")
+      this.spawnLog("powershell.exe", ["-NonInteractive", "-EncodedCommand", encodedCmd]).catch(e => {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          this.dispatchError(e)
+          return
+        }
+        // powershell.exe not found — fall back to legacy elevate.exe
+        this.spawnLog(path.join(process.resourcesPath, "elevate.exe"), [installerPath].concat(args)).catch(err => this.dispatchError(err))
+      })
     }
 
     if (options.isAdminRightsRequired) {
-      this._logger.info("isAdminRightsRequired is set to true, run installer using elevate.exe")
+      this._logger.info("isAdminRightsRequired is set to true, running installer with UAC elevation via PowerShell (elevate.exe fallback if PowerShell unavailable)")
       callUsingElevation()
       return true
     }
@@ -165,7 +175,7 @@ export class NsisUpdater extends BaseUpdater {
       // Node 8 sends errors: https://nodejs.org/dist/latest-v8.x/docs/api/errors.html#errors_common_system_errors
       const errorCode = (e as NodeJS.ErrnoException).code
       this._logger.info(
-        `Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using elevate if EACCES, and will try to use electron.shell.openItem if ENOENT`
+        `Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using UAC elevation if EACCES, and will try to use electron.shell.openItem if ENOENT`
       )
       if (errorCode === "UNKNOWN" || errorCode === "EACCES") {
         callUsingElevation()

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -8,7 +8,7 @@ import { FileWithEmbeddedBlockMapDifferentialDownloader } from "./differentialDo
 import { DOWNLOAD_PROGRESS } from "./types"
 import { VerifyUpdateCodeSignature } from "./main"
 import { findFile, Provider } from "./providers/Provider"
-import { existsSync, unlink } from "fs-extra"
+import { unlink } from "fs-extra"
 import { verifySignature } from "./windowsExecutableCodeSignatureVerifier"
 import { URL } from "url"
 
@@ -151,22 +151,17 @@ export class NsisUpdater extends BaseUpdater {
     }
 
     const callUsingElevation = (): void => {
-      const psInstallArgs = args.map(a => `'${a.replace(/'/g, "''")}'`).join(",")
+      // Wrap args containing spaces in Win32 double-quotes so Start-Process preserves them as single tokens
+      const psInstallArgs = args.map(a => (a.includes(" ") ? `'"${a.replace(/"/g, '""')}"'` : `'${a.replace(/'/g, "''")}'`)).join(",")
       const psScript = `Start-Process -FilePath '${installerPath.replace(/'/g, "''")}' -ArgumentList @(${psInstallArgs}) -Verb RunAs`
       const encodedCmd = Buffer.from(psScript, "utf16le").toString("base64")
-      this.spawnLog("powershell.exe", ["-NonInteractive", "-EncodedCommand", encodedCmd]).catch(e => {
+      this.spawnLog("powershell.exe", ["-NonInteractive", "-NoProfile", "-EncodedCommand", encodedCmd]).catch(e => {
         if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
           this.dispatchError(e)
           return
         }
-        const elevateExe = path.join(process.resourcesPath, "elevate.exe")
-        if (existsSync(elevateExe)) {
-          this._logger.info("Falling back to elevate.exe for UAC elevation")
-          this.spawnLog(elevateExe, [installerPath].concat(args)).catch(err => this.dispatchError(err))
-          return
-        }
-        this._logger.error("Cannot elevate installer, elevate.exe not found, and PowerShell failed to run: " + e)
-        this.dispatchError(e)
+        // powershell.exe not found — fall back to legacy elevate.exe
+        this.spawnLog(path.join(process.resourcesPath, "elevate.exe"), [installerPath].concat(args)).catch(err => this.dispatchError(err))
       })
     }
 
@@ -181,7 +176,7 @@ export class NsisUpdater extends BaseUpdater {
       // Node 8 sends errors: https://nodejs.org/dist/latest-v8.x/docs/api/errors.html#errors_common_system_errors
       const errorCode = (e as NodeJS.ErrnoException).code
       this._logger.info(
-        `Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using UAC elevation if EACCES, and will try to use electron.shell.openItem if ENOENT`
+        `Cannot run installer: error code: ${errorCode}, error message: "${e.message}", will be executed again using UAC elevation if EACCES, and will try to use electron.shell.openPath if ENOENT`
       )
       if (errorCode === "UNKNOWN" || errorCode === "EACCES") {
         callUsingElevation()

--- a/test/snapshots/updater/nsisUpdaterInstallTest.js.snap
+++ b/test/snapshots/updater/nsisUpdaterInstallTest.js.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NsisUpdater.doInstall elevation > uses PowerShell with -NoProfile and -EncodedCommand when isAdminRightsRequired 1`] = `
+[
+  "-NonInteractive",
+  "-NoProfile",
+  "-EncodedCommand",
+]
+`;
+
+exports[`NsisUpdater.doInstall elevation > uses PowerShell with -NoProfile and -EncodedCommand when isAdminRightsRequired 2`] = `"Start-Process -FilePath '/fake/installer.exe' -ArgumentList @('--updated','/S') -Verb RunAs"`;

--- a/test/src/updater/nsisUpdaterInstallTest.ts
+++ b/test/src/updater/nsisUpdaterInstallTest.ts
@@ -1,5 +1,5 @@
 import * as path from "path"
-import { vi, describe, beforeEach, afterEach } from "vitest"
+import { vi, beforeEach, afterEach } from "vitest"
 import { createNsisUpdater } from "../helpers/updaterTestUtil"
 
 describe("NsisUpdater.doInstall elevation", () => {
@@ -23,17 +23,10 @@ describe("NsisUpdater.doInstall elevation", () => {
     expect(spawnLogMock).toHaveBeenCalledOnce()
     const [cmd, args] = spawnLogMock.mock.calls[0] as [string, string[]]
     expect(cmd).toBe("powershell.exe")
-    expect(args).toContain("-NoProfile")
-    expect(args).toContain("-NonInteractive")
-
     const encodedIdx = args.indexOf("-EncodedCommand")
-    expect(encodedIdx).toBeGreaterThan(-1)
     const script = Buffer.from(args[encodedIdx + 1], "base64").toString("utf16le")
-    expect(script).toContain("Start-Process")
-    expect(script).toContain("-Verb RunAs")
-    expect(script).toContain("/fake/installer.exe")
-    expect(script).toContain("--updated")
-    expect(script).toContain("/S")
+    expect(args.slice(0, encodedIdx + 1)).toMatchSnapshot()
+    expect(script).toMatchSnapshot()
   })
 
   test("wraps installer args containing spaces in Win32 double-quotes", async ({ expect }) => {
@@ -77,3 +70,44 @@ describe("NsisUpdater.doInstall elevation", () => {
     expect(spawnLogMock.mock.calls[1][0]).toBe(path.join("/fake/resources", "elevate.exe"))
   })
 })
+
+describe.ifWindows("NsisUpdater.doInstall elevation — Windows integration", () => {
+  test("powershell.exe accepts -EncodedCommand on this system", async ({ expect }) => {
+    const { execFile } = await import("child_process")
+    const { promisify } = await import("util")
+    const execFileAsync = promisify(execFile)
+    const script = "Write-Output 'elevation-test-ok'"
+    const encoded = Buffer.from(script, "utf16le").toString("base64")
+    const { stdout } = await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded], { encoding: "utf8" })
+    expect(stdout.trim()).toBe("elevation-test-ok")
+  })
+
+  test("generated Start-Process script is syntactically valid for plain args", async ({ expect }) => {
+    const installerPath = "C:\\fake\\installer.exe"
+    const args = ["--updated", "/S"]
+    const psInstallArgs = args.map(a => `'${a.replace(/'/g, "''")}'`).join(",")
+    const psScript = `Start-Process -FilePath '${installerPath.replace(/'/g, "''")}' -ArgumentList @(${psInstallArgs}) -Verb RunAs`
+    await assertPsScriptParses(psScript)
+    expect(true).toBe(true)
+  })
+
+  test("generated Start-Process script is syntactically valid for args containing spaces", async ({ expect }) => {
+    const installerPath = "C:\\fake\\installer.exe"
+    const args = ["--updated", "/D=C:\\Program Files\\My App"]
+    const psInstallArgs = args.map(a => (a.includes(" ") ? `'"${a.replace(/"/g, '""')}"'` : `'${a.replace(/'/g, "''")}'`)).join(",")
+    const psScript = `Start-Process -FilePath '${installerPath.replace(/'/g, "''")}' -ArgumentList @(${psInstallArgs}) -Verb RunAs`
+    await assertPsScriptParses(psScript)
+    expect(true).toBe(true)
+  })
+})
+
+async function assertPsScriptParses(script: string): Promise<void> {
+  const { execFile } = await import("child_process")
+  const { promisify } = await import("util")
+  const execFileAsync = promisify(execFile)
+  // Count parse errors without executing the script
+  const parseCmd = `$errors = $null; $null = [System.Management.Automation.Language.Parser]::ParseInput(${JSON.stringify(script)}, [ref]$null, [ref]$errors); exit $errors.Count`
+  const encoded = Buffer.from(parseCmd, "utf16le").toString("base64")
+  // Throws on non-zero exit code (= parse errors found)
+  await execFileAsync("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded])
+}

--- a/test/src/updater/nsisUpdaterInstallTest.ts
+++ b/test/src/updater/nsisUpdaterInstallTest.ts
@@ -1,0 +1,79 @@
+import * as path from "path"
+import { vi, describe, beforeEach, afterEach } from "vitest"
+import { createNsisUpdater } from "../helpers/updaterTestUtil"
+
+describe("NsisUpdater.doInstall elevation", () => {
+  beforeEach(() => {
+    // process.resourcesPath is Electron-specific; stub it for the Node test environment
+    Object.defineProperty(process, "resourcesPath", { value: "/fake/resources", writable: true, configurable: true })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(process, "resourcesPath", { value: undefined, writable: true, configurable: true })
+  })
+
+  test("uses PowerShell with -NoProfile and -EncodedCommand when isAdminRightsRequired", async ({ expect }) => {
+    const updater = await createNsisUpdater()
+    const spawnLogMock = vi.spyOn(updater as any, "spawnLog").mockResolvedValue(true)
+    vi.spyOn(updater as any, "installerPath", "get").mockReturnValue("/fake/installer.exe")
+
+    ;(updater as any).doInstall({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: true })
+
+    expect(spawnLogMock).toHaveBeenCalledOnce()
+    const [cmd, args] = spawnLogMock.mock.calls[0] as [string, string[]]
+    expect(cmd).toBe("powershell.exe")
+    expect(args).toContain("-NoProfile")
+    expect(args).toContain("-NonInteractive")
+
+    const encodedIdx = args.indexOf("-EncodedCommand")
+    expect(encodedIdx).toBeGreaterThan(-1)
+    const script = Buffer.from(args[encodedIdx + 1], "base64").toString("utf16le")
+    expect(script).toContain("Start-Process")
+    expect(script).toContain("-Verb RunAs")
+    expect(script).toContain("/fake/installer.exe")
+    expect(script).toContain("--updated")
+    expect(script).toContain("/S")
+  })
+
+  test("wraps installer args containing spaces in Win32 double-quotes", async ({ expect }) => {
+    const updater = await createNsisUpdater()
+    updater.installDirectory = "C:\\Program Files\\My App"
+    const spawnLogMock = vi.spyOn(updater as any, "spawnLog").mockResolvedValue(true)
+    vi.spyOn(updater as any, "installerPath", "get").mockReturnValue("/fake/installer.exe")
+
+    ;(updater as any).doInstall({ isSilent: false, isForceRunAfter: false, isAdminRightsRequired: true })
+
+    const [, args] = spawnLogMock.mock.calls[0] as [string, string[]]
+    const encodedIdx = args.indexOf("-EncodedCommand")
+    const script = Buffer.from(args[encodedIdx + 1], "base64").toString("utf16le")
+    expect(script).toContain('"/D=C:\\Program Files\\My App"')
+  })
+
+  test("dispatches error when powershell.exe fails with non-ENOENT error", async ({ expect }) => {
+    const updater = await createNsisUpdater()
+    const error = Object.assign(new Error("spawn UNKNOWN"), { code: "UNKNOWN" })
+    vi.spyOn(updater as any, "spawnLog").mockRejectedValue(error)
+    vi.spyOn(updater as any, "installerPath", "get").mockReturnValue("/fake/installer.exe")
+    const dispatchErrorMock = vi.spyOn(updater as any, "dispatchError").mockImplementation(() => {})
+
+    ;(updater as any).doInstall({ isSilent: false, isForceRunAfter: false, isAdminRightsRequired: true })
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    expect(dispatchErrorMock).toHaveBeenCalledWith(error)
+  })
+
+  test("falls back to elevate.exe spawn when powershell.exe not found", async ({ expect }) => {
+    const updater = await createNsisUpdater()
+    const psError = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" })
+    const spawnLogMock = vi.spyOn(updater as any, "spawnLog").mockRejectedValueOnce(psError).mockResolvedValueOnce(true)
+    vi.spyOn(updater as any, "installerPath", "get").mockReturnValue("/fake/installer.exe")
+
+    ;(updater as any).doInstall({ isSilent: false, isForceRunAfter: false, isAdminRightsRequired: true })
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    expect(spawnLogMock).toHaveBeenCalledTimes(2)
+    expect(spawnLogMock.mock.calls[0][0]).toBe("powershell.exe")
+    expect(spawnLogMock.mock.calls[1][0]).toBe(path.join("/fake/resources", "elevate.exe"))
+  })
+})


### PR DESCRIPTION
This pull request introduces a new approach for UAC (User Account Control) elevation in the NSIS updater, transitioning from the legacy `elevate.exe` helper to using PowerShell as the primary method. The legacy `elevate.exe` is retained as a fallback for environments where PowerShell is unavailable. Additional changes improve error messages and the handling of the elevation helper.

* The NSIS updater now attempts to elevate privileges using PowerShell (`Start-Process -Verb RunAs`) as the primary method, falling back to `elevate.exe` if encountering `ENOENT`