### PR TITLE
chore: add engines field to package.json

### DIFF
--- a/.changeset/red-mangos-float.md
+++ b/.changeset/red-mangos-float.md
@@ -1,0 +1,12 @@
+---
+"dmg-builder": patch
+"electron-builder-squirrel-windows": patch
+"electron-forge-maker-appimage": patch
+"electron-forge-maker-nsis-web": patch
+"electron-forge-maker-nsis": patch
+"electron-forge-maker-snap": patch
+"electron-publish": patch
+"electron-updater": patch
+---
+
+Adds `"engines"` field to `package.json`

--- a/packages/dmg-builder/package.json
+++ b/packages/dmg-builder/package.json
@@ -9,6 +9,9 @@
 		"url": "git+https://github.com/electron-userland/electron-builder.git",
 		"directory": "packages/dmg-builder"
 	},
+  "engines": {
+    "node": ">=14.0.0"
+  },
 	"bugs": "https://github.com/electron-userland/electron-builder/issues",
 	"homepage": "https://github.com/electron-userland/electron-builder",
 	"files": [

--- a/packages/dmg-builder/package.json
+++ b/packages/dmg-builder/package.json
@@ -1,37 +1,37 @@
 {
-	"name": "dmg-builder",
-	"version": "26.11.1",
-	"main": "out/dmgUtil.js",
-	"author": "Vladimir Krivosheev",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/electron-userland/electron-builder.git",
-		"directory": "packages/dmg-builder"
-	},
+  "name": "dmg-builder",
+  "version": "26.11.1",
+  "main": "out/dmgUtil.js",
+  "author": "Vladimir Krivosheev",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/electron-userland/electron-builder.git",
+    "directory": "packages/dmg-builder"
+  },
   "engines": {
     "node": ">=14.0.0"
   },
-	"bugs": "https://github.com/electron-userland/electron-builder/issues",
-	"homepage": "https://github.com/electron-userland/electron-builder",
-	"files": [
-		"out",
-		"templates"
-	],
-	"dependencies": {
-		"app-builder-lib": "workspace:*",
-		"builder-util": "workspace:*",
-		"fs-extra": "^10.1.0",
-		"iconv-lite": "^0.6.2",
-		"js-yaml": "^4.1.0"
-	},
-	"optionalDependencies": {
-		"dmg-license": "^1.0.11"
-	},
-	"devDependencies": {
-		"@types/fs-extra": "9.0.13",
-		"@types/js-yaml": "4.0.3",
-		"temp-file": "3.4.0"
-	},
-	"typings": "./out/dmg.d.ts"
+  "bugs": "https://github.com/electron-userland/electron-builder/issues",
+  "homepage": "https://github.com/electron-userland/electron-builder",
+  "files": [
+    "out",
+    "templates"
+  ],
+  "dependencies": {
+    "app-builder-lib": "workspace:*",
+    "builder-util": "workspace:*",
+    "fs-extra": "^10.1.0",
+    "iconv-lite": "^0.6.2",
+    "js-yaml": "^4.1.0"
+  },
+  "optionalDependencies": {
+    "dmg-license": "^1.0.11"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "9.0.13",
+    "@types/js-yaml": "4.0.3",
+    "temp-file": "3.4.0"
+  },
+  "typings": "./out/dmg.d.ts"
 }

--- a/packages/electron-builder-squirrel-windows/package.json
+++ b/packages/electron-builder-squirrel-windows/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/electron-userland/electron-builder.git",
     "directory": "packages/electron-builder-squirrel-windows"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-forge-maker-appimage/package.json
+++ b/packages/electron-forge-maker-appimage/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/electron-userland/electron-builder.git",
     "directory": "packages/electron-forge-maker-appimage"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-forge-maker-nsis-web/package.json
+++ b/packages/electron-forge-maker-nsis-web/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/electron-userland/electron-builder.git",
     "directory": "packages/electron-forge-maker-nsis-web"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-forge-maker-nsis/package.json
+++ b/packages/electron-forge-maker-nsis/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/electron-userland/electron-builder.git",
     "directory": "packages/electron-forge-maker-nsis"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-forge-maker-snap/package.json
+++ b/packages/electron-forge-maker-snap/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/electron-userland/electron-builder.git",
     "directory": "packages/electron-forge-maker-snap"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-publish/package.json
+++ b/packages/electron-publish/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/electron-userland/electron-builder.git",
     "directory": "packages/electron-publish"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [

--- a/packages/electron-updater/package.json
+++ b/packages/electron-updater/package.json
@@ -10,6 +10,9 @@
     "url": "git+https://github.com/electron-userland/electron-builder.git",
     "directory": "packages/electron-updater"
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "bugs": "https://github.com/electron-userland/electron-builder/issues",
   "homepage": "https://github.com/electron-userland/electron-builder",
   "files": [


### PR DESCRIPTION
Follow-up on #9671

Adds `"engines"` where it is missing
