### PR TITLE
feat: replace legacy `linux-tools-mac` toolset with v1.0.0 (arm64 + x64 bundles) for deb/tar builds on macOS

### DIFF
--- a/.changeset/bitter-crews-reply.md
+++ b/.changeset/bitter-crews-reply.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": minor
+---
+
+feat(linux): replace legacy `linux-tools-mac` toolset with v1.0.0 for macOS deb/tar builds for packaging or extracting Linux archives
+

--- a/packages/app-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/app-builder-lib/src/targets/ArchiveTarget.ts
@@ -44,7 +44,7 @@ export class ArchiveTarget extends Target {
       })
       let updateInfo: any = null
       if (format.startsWith("tar.")) {
-        await tar(packager.compression, format, artifactPath, appOutDir, isMac, packager.info.tempDirManager)
+        await tar({ compression: packager.compression, format, outFile: artifactPath, dirToArchive: appOutDir, isMacApp: isMac, tempDirManager: packager.info.tempDirManager })
       } else {
         let withoutDir = !isMac
         let dirToArchive = appOutDir

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -4,7 +4,7 @@ import * as path from "path"
 import { create } from "tar"
 import { TmpDir } from "temp-file"
 import { CompressionLevel } from "../core"
-import { getLinuxToolsPath } from "../toolsets/linux"
+import { getLinuxToolsMacToolset } from "../toolsets/linux"
 import { TarOptionsWithAliasesAsync } from "tar/dist/commonjs/options"
 
 const ALLOWED_7Z_FILTERS = new Set(["BCJ", "BCJ2", "ARM", "ARMT", "IA64", "PPC", "SPARC", "DELTA"])
@@ -15,8 +15,17 @@ function validateCompressionLevel(level: string): void {
   }
 }
 
+type TarConfig = {
+  compression: CompressionLevel | any
+  format: string
+  outFile: string
+  dirToArchive: string
+  isMacApp: boolean
+  tempDirManager: TmpDir
+}
+
 /** @internal */
-export async function tar(compression: CompressionLevel | any, format: string, outFile: string, dirToArchive: string, isMacApp: boolean, tempDirManager: TmpDir): Promise<void> {
+export async function tar({ compression, format, outFile, dirToArchive, isMacApp, tempDirManager }: TarConfig): Promise<void> {
   const tarFile = await tempDirManager.getTempFile({ suffix: ".tar" })
   const tarArgs: TarOptionsWithAliasesAsync = {
     file: tarFile,
@@ -38,11 +47,7 @@ export async function tar(compression: CompressionLevel | any, format: string, o
   ])
 
   if (format === "tar.lz") {
-    // noinspection SpellCheckingInspection
-    let lzipPath = "lzip"
-    if (process.platform === "darwin") {
-      lzipPath = path.join(await getLinuxToolsPath(), "bin", lzipPath)
-    }
+    const lzipPath = process.platform === "darwin" ? (await getLinuxToolsMacToolset()).lzip : "lzip"
     await exec(lzipPath, [compression === "store" ? "-1" : "-9", "--keep" /* keep (don't delete) input files */, tarFile])
     // bloody lzip creates file in the same dir where input file with postfix `.lz`, option --output doesn't work
     await move(`${tarFile}.lz`, outFile)

--- a/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisUtil.ts
@@ -1,9 +1,10 @@
-import { Arch, copyFile, dirSize, isEmptyOrSpaces, log } from "builder-util"
+import { Arch, copyFile, dirSize, log } from "builder-util"
 import { PackageFileInfo } from "builder-util-runtime"
 import * as fs from "fs/promises"
 import * as path from "path"
 import * as zlib from "zlib"
 import { getBinFromCustomLoc, getBinFromUrl } from "../../binDownload"
+import { resolveEnvToolsetPath } from "../../util/envPath"
 import { getTemplatePath } from "../../util/pathManager"
 import { NsisOptions } from "./nsisOptions"
 import { NsisTarget } from "./NsisTarget"
@@ -19,13 +20,12 @@ export const NsisTargetOptions = (() => {
   }
 })()
 
-export const NSIS_PATH = () => {
-  const custom = process.env.ELECTRON_BUILDER_NSIS_DIR?.trim()
-  if (!isEmptyOrSpaces(custom)) {
-    log.info({ path: custom }, "using local nsis")
-    return Promise.resolve(custom)
+export const NSIS_PATH = async () => {
+  const envPath = resolveEnvToolsetPath("ELECTRON_BUILDER_NSIS_DIR")
+  if (envPath != null) {
+    return envPath
   }
-  return NsisTargetOptions.then((options: NsisOptions) => {
+  return await NsisTargetOptions.then((options: NsisOptions) => {
     if (options.customNsisBinary) {
       const { checksum, url, version } = options.customNsisBinary
       if (checksum && url) {
@@ -38,13 +38,12 @@ export const NSIS_PATH = () => {
   })
 }
 
-export const NSIS_RESOURCES_PATH = () => {
-  const custom = process.env.ELECTRON_BUILDER_NSIS_RESOURCES_DIR?.trim()
-  if (!isEmptyOrSpaces(custom)) {
-    log.info({ path: custom }, "using local nsis-resources")
-    return Promise.resolve(custom)
+export const NSIS_RESOURCES_PATH = async () => {
+  const envPath = resolveEnvToolsetPath("ELECTRON_BUILDER_NSIS_RESOURCES_DIR")
+  if (envPath != null) {
+    return envPath
   }
-  return NsisTargetOptions.then((options: NsisOptions) => {
+  return await NsisTargetOptions.then((options: NsisOptions) => {
     if (options.customNsisResources) {
       const { checksum, url, version } = options.customNsisResources
       return getBinFromCustomLoc("nsis-resources", version, url, checksum)

--- a/packages/app-builder-lib/src/toolsets/linux.ts
+++ b/packages/app-builder-lib/src/toolsets/linux.ts
@@ -1,4 +1,4 @@
-import { Arch } from "builder-util"
+import { Arch, isEmptyOrSpaces } from "builder-util"
 import * as path from "path"
 import { getBinFromUrl } from "../binDownload"
 import { downloadBuilderToolset } from "../util/electronGet"
@@ -24,13 +24,42 @@ export const appimageChecksums = {
   },
 } as const
 
-export function getLinuxToolsPath() {
-  return getBinFromUrl("linux-tools-mac-10.12.3", "linux-tools-mac-10.12.3.7z", "58ff69a6f5082c78b809b72c929f5f2a82e6c3974c014bd1382fc87d9da1075c")
+// no legacy toolset as macos arm64 BSD gtar/ar/lzip are not compatible with linux targets, so we always use newer toolset on macos for linux archives
+const linuxToolsMacChecksums = {
+  "linux-tools-mac-darwin-arm64.tar.gz": "204e76f08364352edb28a6a4be87e8f9bd9340213865d9a0d1c664aa46fcf053",
+  "linux-tools-mac-darwin-x86_64.tar.gz": "7ee26dfbd0d2a4c2c83b55a9416a30cc84876eef01c6497ca49bb016a190c726",
+} as const
+
+export async function getLinuxToolsPath(): Promise<string> {
+  if (!isEmptyOrSpaces(process.env.LINUX_TOOLS_MAC_PATH)) {
+    return path.resolve(process.env.LINUX_TOOLS_MAC_PATH.trim())
+  }
+  const arch = process.arch === "arm64" ? "arm64" : "x86_64"
+  const toolsetVersion = "1.0.0"
+  const filename: keyof typeof linuxToolsMacChecksums = `linux-tools-mac-darwin-${arch}.tar.gz`
+  return await downloadBuilderToolset({
+    releaseName: `linux-tools-mac@${toolsetVersion}`,
+    filenameWithExt: filename,
+    checksums: {
+      [filename]: linuxToolsMacChecksums[filename],
+    },
+    githubOrgRepo: "electron-userland/electron-builder-binaries",
+  })
+}
+
+export async function getLinuxToolsMacToolset() {
+  const linuxToolsPath = await getLinuxToolsPath()
+  const bin = (pkg: string) => path.join(linuxToolsPath, "bin", pkg)
+  return {
+    ar: bin("ar"),
+    lzip: bin("lzip"),
+    gtar: bin("gtar"),
+  }
 }
 
 export async function getFpmPath() {
-  if (process.env.CUSTOM_FPM_PATH != null) {
-    return path.resolve(process.env.CUSTOM_FPM_PATH)
+  if (!isEmptyOrSpaces(process.env.CUSTOM_FPM_PATH)) {
+    return path.resolve(process.env.CUSTOM_FPM_PATH.trim())
   }
   const exec = "fpm"
   if (process.platform === "win32" || process.env.USE_SYSTEM_FPM === "true") {

--- a/packages/app-builder-lib/src/toolsets/linux.ts
+++ b/packages/app-builder-lib/src/toolsets/linux.ts
@@ -1,8 +1,9 @@
-import { Arch, isEmptyOrSpaces } from "builder-util"
+import { Arch } from "builder-util"
 import * as path from "path"
 import { getBinFromUrl } from "../binDownload"
-import { downloadBuilderToolset } from "../util/electronGet"
 import { ToolsetConfig } from "../configuration"
+import { downloadBuilderToolset } from "../util/electronGet"
+import { resolveEnvToolsetPath } from "../util/envPath"
 
 const fpmChecksums = {
   "fpm-1.17.0-ruby-3.4.3-darwin-arm64.7z": "6cc6d4785875bc7d79bdf52ca146080a4c300e1d663376ae79615fb548030ede",
@@ -31,8 +32,9 @@ const linuxToolsMacChecksums = {
 } as const
 
 export async function getLinuxToolsPath(): Promise<string> {
-  if (!isEmptyOrSpaces(process.env.LINUX_TOOLS_MAC_PATH)) {
-    return path.resolve(process.env.LINUX_TOOLS_MAC_PATH.trim())
+  const envPath = resolveEnvToolsetPath("LINUX_TOOLS_MAC_PATH")
+  if (envPath != null) {
+    return envPath
   }
   const arch = process.arch === "arm64" ? "arm64" : "x86_64"
   const toolsetVersion = "1.0.0"
@@ -58,8 +60,9 @@ export async function getLinuxToolsMacToolset() {
 }
 
 export async function getFpmPath() {
-  if (!isEmptyOrSpaces(process.env.CUSTOM_FPM_PATH)) {
-    return path.resolve(process.env.CUSTOM_FPM_PATH.trim())
+  const customFpmPath = resolveEnvToolsetPath("CUSTOM_FPM_PATH")
+  if (customFpmPath != null) {
+    return customFpmPath
   }
   const exec = "fpm"
   if (process.platform === "win32" || process.env.USE_SYSTEM_FPM === "true") {
@@ -94,27 +97,28 @@ export async function getAppImageTools(appimageToolVersion: ToolsetConfig["appim
     )
   }
 
-  const override = process.env.APPIMAGE_TOOLS_PATH?.trim()
-  const filenameWithExt = "appimage-tools-runtime-20251108.tar.gz"
-  let artifactPath =
-    override ||
-    (await downloadBuilderToolset({
-      releaseName: `appimage@${appimageToolVersion}`,
-      filenameWithExt,
-      checksums: {
-        [filenameWithExt]: appimageChecksums[appimageToolVersion][filenameWithExt],
-      },
-      githubOrgRepo: "electron-userland/electron-builder-binaries",
-    }))
-
-  artifactPath = path.resolve(artifactPath)
-
   const runtimeArch = targetArch === Arch.armv7l ? "arm32" : targetArch === Arch.arm64 ? "arm64" : targetArch === Arch.ia32 ? "ia32" : "x64"
 
-  return {
-    mksquashfs: path.join(artifactPath, "mksquashfs"),
-    desktopFileValidate: path.join(artifactPath, "desktop-file-validate"),
-    runtime: path.join(artifactPath, "runtimes", `runtime-${runtimeArch}`),
-    runtimeLibraries: path.join(artifactPath, "lib", runtimeArch),
+  const getPaths = (artifactPath: string) => ({
+    mksquashfs: path.resolve(artifactPath, "mksquashfs"),
+    desktopFileValidate: path.resolve(artifactPath, "desktop-file-validate"),
+    runtime: path.resolve(artifactPath, "runtimes", `runtime-${runtimeArch}`),
+    runtimeLibraries: path.resolve(artifactPath, "lib", runtimeArch),
+  })
+
+  const filenameWithExt = "appimage-tools-runtime-20251108.tar.gz"
+  const envPath = resolveEnvToolsetPath("APPIMAGE_TOOLS_PATH")
+  if (envPath != null) {
+    return getPaths(envPath)
   }
+  const artifact = await downloadBuilderToolset({
+    releaseName: `appimage@${appimageToolVersion}`,
+    filenameWithExt,
+    checksums: {
+      [filenameWithExt]: appimageChecksums[appimageToolVersion][filenameWithExt],
+    },
+    githubOrgRepo: "electron-userland/electron-builder-binaries",
+  })
+
+  return getPaths(artifact)
 }

--- a/packages/app-builder-lib/src/toolsets/windows.ts
+++ b/packages/app-builder-lib/src/toolsets/windows.ts
@@ -1,4 +1,5 @@
-import { Arch, isEmptyOrSpaces, log } from "builder-util"
+import { Arch } from "builder-util"
+import { resolveEnvToolsetPath } from "../util/envPath"
 import { Nullish } from "builder-util-runtime"
 import * as os from "os"
 import * as path from "path"
@@ -53,9 +54,9 @@ export async function getSignToolPath(winCodeSign: ToolsetConfig["winCodeSign"] 
     return { path: "osslsigncode" }
   }
 
-  const result = process.env.SIGNTOOL_PATH?.trim()
-  if (result) {
-    return { path: path.resolve(result) }
+  const signToolPath = resolveEnvToolsetPath("SIGNTOOL_PATH")
+  if (signToolPath != null) {
+    return { path: signToolPath }
   }
 
   if (isWin) {
@@ -69,9 +70,9 @@ export async function getSignToolPath(winCodeSign: ToolsetConfig["winCodeSign"] 
 }
 
 export async function getWindowsKitsBundle({ winCodeSign, arch }: { winCodeSign: CodeSignVersionKey | Nullish; arch: Arch }) {
-  const overridePath = process.env.ELECTRON_BUILDER_WINDOWS_KITS_PATH
-  if (!isEmptyOrSpaces(overridePath)) {
-    return { kit: overridePath, appxAssets: overridePath }
+  const kitPath = resolveEnvToolsetPath("ELECTRON_BUILDER_WINDOWS_KITS_PATH")
+  if (kitPath != null) {
+    return { kit: kitPath, appxAssets: kitPath }
   }
 
   const useLegacy = winCodeSign == null || winCodeSign === "0.0.0"
@@ -104,9 +105,9 @@ async function getWindowsSignToolExe({ winCodeSign, arch }: { winCodeSign: CodeS
 }
 
 async function getOsslSigncodeBundle(winCodeSign: ToolsetConfig["winCodeSign"] | Nullish) {
-  const overridePath = process.env.ELECTRON_BUILDER_OSSL_SIGNCODE_PATH
-  if (!isEmptyOrSpaces(overridePath)) {
-    return { path: overridePath }
+  const osslSigncodePath = resolveEnvToolsetPath("ELECTRON_BUILDER_OSSL_SIGNCODE_PATH")
+  if (osslSigncodePath != null) {
+    return { path: osslSigncodePath }
   }
   if (process.platform === "win32" || process.env.USE_SYSTEM_OSSLSIGNCODE === "true") {
     return { path: "osslsigncode" }
@@ -141,9 +142,9 @@ export async function getRceditBundle(winCodeSign: ToolsetConfig["winCodeSign"] 
   const ia32 = "rcedit-ia32.exe"
   const x86 = "rcedit-x86.exe"
   const x64 = "rcedit-x64.exe"
-  const overridePath = process.env.ELECTRON_BUILDER_RCEDIT_PATH?.trim()
-  if (!isEmptyOrSpaces(overridePath)) {
-    log.debug({ searchFiles: [x86, x64], overridePath }, `Using RCEdit from ELECTRON_BUILDER_RCEDIT_PATH`)
+  const rcedit = resolveEnvToolsetPath("ELECTRON_BUILDER_RCEDIT_PATH")
+  if (rcedit != null) {
+    const overridePath = rcedit
     return { x86: path.join(overridePath, x86), x64: path.join(overridePath, x64) }
   }
   if (winCodeSign === "0.0.0" || winCodeSign == null) {

--- a/packages/app-builder-lib/src/util/envPath.ts
+++ b/packages/app-builder-lib/src/util/envPath.ts
@@ -7,7 +7,9 @@ export function validateEnvValue(envVarName: string): string | null {
     return null
   }
   const trimmed = rawValue.trim()
-  if (/[;&|`$<>"'\\]/.test(trimmed)) {
+  // On Windows, backslash is the native path separator and must not be rejected
+  const shellUnsafeChars = process.platform === "win32" ? /[;&|`$<>"']/ : /[;&|`$<>"'\\]/
+  if (shellUnsafeChars.test(trimmed)) {
     throw new Error(`${envVarName} contains shell-unsafe characters: ${trimmed}`)
   }
   return trimmed

--- a/packages/app-builder-lib/src/util/envPath.ts
+++ b/packages/app-builder-lib/src/util/envPath.ts
@@ -1,0 +1,23 @@
+import { isEmptyOrSpaces, log } from "builder-util"
+import * as path from "path"
+
+export function validateEnvValue(envVarName: string): string | null {
+  const rawValue = process.env[envVarName]
+  if (isEmptyOrSpaces(rawValue)) {
+    return null
+  }
+  const trimmed = rawValue.trim()
+  if (/[;&|`$<>"'\\]/.test(trimmed)) {
+    throw new Error(`${envVarName} contains shell-unsafe characters: ${trimmed}`)
+  }
+  return trimmed
+}
+
+export function resolveEnvToolsetPath(envVarKey: string): string | null {
+  const value = validateEnvValue(envVarKey)
+  if (value == null) {
+    return null
+  }
+  log.info({ envVarKey, value }, `resolved value from environment variable`)
+  return path.resolve(value)
+}

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -1,7 +1,7 @@
 import { PublishManager } from "app-builder-lib"
 import { verifyAsarFileTree as _verifyAsarFileTree } from "./asarVerifier"
 import { computeArchToTargetNamesMap } from "app-builder-lib/out/targets/targetFactory"
-import { getLinuxToolsPath } from "app-builder-lib/out/toolsets/linux"
+import { getLinuxToolsMacToolset } from "app-builder-lib/out/toolsets/linux"
 import { parsePlistFile, PlistObject } from "app-builder-lib/out/util/plist"
 import { AsarIntegrity } from "app-builder-lib/out/asar/integrity"
 import { addValue, copyDir, deepAssign, exec, executeFinally, exists, FileCopier, log, USE_HARD_LINKS, walk } from "builder-util"
@@ -551,7 +551,7 @@ async function checkLinuxResult(expect: ExpectStatic, outDir: string, packager: 
   const { member: controlMember, tarArgs: controlArgs } = await resolveDebMember(packagePath, "control.tar.")
   const control = parseDebControl(
     (
-      await execShell(`ar p '${packagePath}' ${controlMember} | ${await getTarExecutable()} -x ${controlArgs} --to-stdout ./control`, {
+      await execShell(`${await getArExecutable()} p '${packagePath}' ${controlMember} | ${await getTarExecutable()} -x ${controlArgs} --to-stdout ./control`, {
         maxBuffer: 10 * 1024 * 1024,
       })
     ).stdout
@@ -735,11 +735,22 @@ const checkResult = (expect: ExpectStatic, artifacts: Array<ArtifactCreated>, ex
 export const execShell: any = promisify(require("child_process").exec)
 
 export async function getTarExecutable() {
-  return process.platform === "darwin" ? path.join(await getLinuxToolsPath(), "bin", "gtar") : "tar"
+  return process.platform === "darwin" ? (await getLinuxToolsMacToolset()).gtar : "tar"
+}
+
+export async function getArExecutable() {
+  if (process.platform === "darwin") {
+    return (await getLinuxToolsMacToolset()).ar
+  }
+  return "ar"
 }
 
 export async function resolveDebMember(debFile: string, memberPrefix: "data.tar." | "control.tar."): Promise<{ member: string; tarArgs: string }> {
-  const { stdout: memberList } = await execShell(`ar t '${debFile}'`, { maxBuffer: 1024 * 1024 })
+  const arExecutable = await getArExecutable()
+  const { stdout: memberList, stderr } = await execShell(`${arExecutable} t '${debFile}'`, { maxBuffer: 1024 * 1024 })
+  if (stderr.length > 0) {
+    throw new Error(`Failed to list members of ${debFile}: ${stderr}`)
+  }
   const member = memberList
     .trim()
     .split("\n")
@@ -758,7 +769,8 @@ export async function readDebCompression(debFile: string): Promise<string> {
 
 async function getContents(packageFile: string) {
   const { member, tarArgs } = await resolveDebMember(packageFile, "data.tar.")
-  const result = await execShell(`ar p '${packageFile}' ${member} | ${await getTarExecutable()} -t ${tarArgs}`, {
+  const arExecutable = await getArExecutable()
+  const result = await execShell(`${arExecutable} p '${packageFile}' ${member} | ${await getTarExecutable()} -t ${tarArgs}`, {
     maxBuffer: 10 * 1024 * 1024,
     env: {
       ...process.env,

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -551,7 +551,7 @@ async function checkLinuxResult(expect: ExpectStatic, outDir: string, packager: 
   const { member: controlMember, tarArgs: controlArgs } = await resolveDebMember(packagePath, "control.tar.")
   const control = parseDebControl(
     (
-      await execShell(`${await getArExecutable()} p '${packagePath}' ${controlMember} | ${await getTarExecutable()} -x ${controlArgs} --to-stdout ./control`, {
+      await execShell(`'${await getArExecutable()}' p '${packagePath}' ${controlMember} | '${await getTarExecutable()}' -x ${controlArgs} --to-stdout ./control`, {
         maxBuffer: 10 * 1024 * 1024,
       })
     ).stdout
@@ -747,7 +747,7 @@ export async function getArExecutable() {
 
 export async function resolveDebMember(debFile: string, memberPrefix: "data.tar." | "control.tar."): Promise<{ member: string; tarArgs: string }> {
   const arExecutable = await getArExecutable()
-  const { stdout: memberList, stderr } = await execShell(`${arExecutable} t '${debFile}'`, { maxBuffer: 1024 * 1024 })
+  const { stdout: memberList, stderr } = await execShell(`'${arExecutable}' t '${debFile}'`, { maxBuffer: 1024 * 1024 })
   if (stderr.length > 0) {
     throw new Error(`Failed to list members of ${debFile}: ${stderr}`)
   }
@@ -770,7 +770,7 @@ export async function readDebCompression(debFile: string): Promise<string> {
 async function getContents(packageFile: string) {
   const { member, tarArgs } = await resolveDebMember(packageFile, "data.tar.")
   const arExecutable = await getArExecutable()
-  const result = await execShell(`${arExecutable} p '${packageFile}' ${member} | ${await getTarExecutable()} -t ${tarArgs}`, {
+  const result = await execShell(`'${arExecutable}' p '${packageFile}' ${member} | '${await getTarExecutable()}' -t ${tarArgs}`, {
     maxBuffer: 10 * 1024 * 1024,
     env: {
       ...process.env,

--- a/test/src/linux/debTest.ts
+++ b/test/src/linux/debTest.ts
@@ -1,6 +1,6 @@
 import { Arch, Platform } from "electron-builder"
 import * as fs from "fs/promises"
-import { app, execShell, getTarExecutable, resolveDebMember } from "../helpers/packTester"
+import { app, execShell, getArExecutable, getTarExecutable, resolveDebMember } from "../helpers/packTester"
 
 const defaultDebTarget = Platform.LINUX.createTarget("deb", Arch.x64)
 
@@ -77,7 +77,7 @@ describe.heavy.ifNotWindows("deb", () => {
           const debPath = `${context.outDir}/TestApp_1.1.0_amd64.deb`
           const { member: controlMember, tarArgs: controlArgs } = await resolveDebMember(debPath, "control.tar.")
           const postinst = (
-            await execShell(`ar p '${debPath}' ${controlMember} | ${await getTarExecutable()} -x ${controlArgs} --to-stdout ./postinst`, {
+            await execShell(`${await getArExecutable()} p '${debPath}' ${controlMember} | ${await getTarExecutable()} -x ${controlArgs} --to-stdout ./postinst`, {
               maxBuffer: 10 * 1024 * 1024,
             })
           ).stdout
@@ -106,9 +106,12 @@ describe.heavy.ifNotWindows("deb", () => {
           const debPath = `${context.outDir}/TestApp_1.1.0_amd64.deb`
           const { member: dataMember, tarArgs: dataArgs } = await resolveDebMember(debPath, "data.tar.")
           const mime = (
-            await execShell(`ar p '${debPath}' ${dataMember} | ${await getTarExecutable()} -x ${dataArgs} --to-stdout './usr/share/mime/packages/testapp.xml'`, {
-              maxBuffer: 10 * 1024 * 1024,
-            })
+            await execShell(
+              `${await getArExecutable()} p '${debPath}' ${dataMember} | ${await getTarExecutable()} -x ${dataArgs} --to-stdout './usr/share/mime/packages/testapp.xml'`,
+              {
+                maxBuffer: 10 * 1024 * 1024,
+              }
+            )
           ).stdout
           expect(mime.trim()).toMatchSnapshot()
         },

--- a/test/src/linux/debTest.ts
+++ b/test/src/linux/debTest.ts
@@ -77,7 +77,7 @@ describe.heavy.ifNotWindows("deb", () => {
           const debPath = `${context.outDir}/TestApp_1.1.0_amd64.deb`
           const { member: controlMember, tarArgs: controlArgs } = await resolveDebMember(debPath, "control.tar.")
           const postinst = (
-            await execShell(`${await getArExecutable()} p '${debPath}' ${controlMember} | ${await getTarExecutable()} -x ${controlArgs} --to-stdout ./postinst`, {
+            await execShell(`'${await getArExecutable()}' p '${debPath}' ${controlMember} | '${await getTarExecutable()}' -x ${controlArgs} --to-stdout ./postinst`, {
               maxBuffer: 10 * 1024 * 1024,
             })
           ).stdout
@@ -107,7 +107,7 @@ describe.heavy.ifNotWindows("deb", () => {
           const { member: dataMember, tarArgs: dataArgs } = await resolveDebMember(debPath, "data.tar.")
           const mime = (
             await execShell(
-              `${await getArExecutable()} p '${debPath}' ${dataMember} | ${await getTarExecutable()} -x ${dataArgs} --to-stdout './usr/share/mime/packages/testapp.xml'`,
+              `'${await getArExecutable()}' p '${debPath}' ${dataMember} | '${await getTarExecutable()}' -x ${dataArgs} --to-stdout './usr/share/mime/packages/testapp.xml'`,
               {
                 maxBuffer: 10 * 1024 * 1024,
               }


### PR DESCRIPTION
Note: This macos toolset update is required to:
- provides dedicated arm64 binaries for Apple Silicon
- macOS `ar` is BSD and will constantly fail during test runs (tests analyze deb package for compression and contents during `debTest` using `ar`). Legacy toolset does not include GNU `ar` (ref: Root Issue)

## Summary

- Replaces the legacy `linux-tools-mac-10.12.3` toolset with `linux-tools-mac@1.0.0` for all macOS-built Linux archive and `.deb` builds
- Adds `getLinuxToolsMacToolset()` — a unified accessor for the `ar`, `gtar`, and `lzip` binaries from the new toolset
- Adds `getArExecutable()` to test helpers so deb content inspection uses GNU `ar` instead of BSD `ar`

## Root Issue

macOS ships BSD `ar` (`/usr/bin/ar`). When BSD `ar` archives non-Mach-O files (e.g. `debian-binary`, `control.tar.xz`, `data.tar.xz`), it runs `ranlib` implicitly and produces a **96-byte archive containing only `__.SYMDEF SORTED`** — the member content is silently discarded. This is a macOS-specific quirk: BSD `ar` is designed for Mach-O static libraries, not general-purpose archives.

Because the old toolset (`linux-tools-mac-10.12.3`) only shipped `gtar` and `lzip` (no `ar`), fpm fell back to `/usr/bin/ar` when building `.deb` packages on macOS, producing corrupt output that made all downstream deb inspection fail with:

```
Error: No data.tar.* member found in TestApp_1.1.0_amd64.deb
```

## Fix

`linux-tools-mac@1.0.0` ships proper GNU `ar`, `gtar`, and `lzip` binaries compiled for both `darwin-arm64` and `darwin-x86_64`. By routing both the fpm build `PATH` and the test-helper invocations through this toolset, `.deb` packages are created and inspected with GNU tools end-to-end.