### PR TITLE
fix(nsis): safely copy UserProgramFiles path

### DIFF
--- a/.changeset/safe-buckets-push.md
+++ b/.changeset/safe-buckets-push.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): safely copy UserProgramFiles path

--- a/packages/app-builder-lib/templates/nsis/multiUser.nsh
+++ b/packages/app-builder-lib/templates/nsis/multiUser.nsh
@@ -1,6 +1,5 @@
 !include FileFunc.nsh
 !include UAC.nsh
-!include WinVer.nsh
 
 !define FOLDERID_UserProgramFiles {5CD7AEE2-2219-4A67-B85D-6C9CE15660CB}
 !define KF_FLAG_CREATE 0x00008000
@@ -30,17 +29,20 @@ Var installMode
     ${else}
       StrCpy $0 "$LocalAppData\Programs"
 
-      ${IfNot} ${AtLeastWin8}
-        System::Store S
-        # Win7 has a per-user programfiles known folder and this can be a non-default location
-        System::Call 'SHELL32::SHGetKnownFolderPath(g "${FOLDERID_UserProgramFiles}", i ${KF_FLAG_CREATE}, p 0, *p .r2)i.r1'
-        ${If} $1 == 0
-          System::Call '*$2(&w${NSIS_MAX_STRLEN} .s)'
-          StrCpy $0 $1
-          System::Call 'OLE32::CoTaskMemFree(p r2)'
-        ${endif}
-        System::Store L
-      ${EndIf}
+      Push $1
+      Push $2
+      # UserProgramFiles is the per-user install root and can be a non-default location
+      StrCpy $2 0
+      System::Call 'SHELL32::SHGetKnownFolderPath(g "${FOLDERID_UserProgramFiles}", i ${KF_FLAG_CREATE}, p 0, *p .r2)i.r1'
+      ${If} $1 == 0
+        System::Call 'KERNEL32::lstrcpynW(w .r0, p r2, i ${NSIS_MAX_STRLEN})p'
+      ${endif}
+      # SHGetKnownFolderPath may return allocated memory even on failure
+      ${If} $2 != 0
+        System::Call 'OLE32::CoTaskMemFree(p r2)'
+      ${endif}
+      Pop $2
+      Pop $1
 
       StrCpy $INSTDIR "$0\${APP_FILENAME}"
     ${endif}


### PR DESCRIPTION
## What

Fix the NSIS per-user install path lookup for `FOLDERID_UserProgramFiles`.

The installer template asks Windows for the current per-user Programs known folder, then uses that path as the default per-user install root. This change keeps that behavior but copies the returned `PWSTR` safely.

## Why

`SHGetKnownFolderPath(FOLDERID_UserProgramFiles)` returns a NUL-terminated `PWSTR` allocated by the Shell. The previous NSIS code read that pointer with `&w${NSIS_MAX_STRLEN}`, which makes `System.dll` copy a fixed number of WCHARs from a buffer that is only sized for the actual path. On some heap layouts this can overread into unmapped memory and crash the setup EXE before extraction.

This replaces the fixed-size read with `lstrcpynW`, bounded by `NSIS_MAX_STRLEN`, and preserves scratch registers with `Push` / `Pop` instead of `System::Store S/L` so the copied path is not restored away.

This also removes the Win8+ guard added in #9564. `FOLDERID_UserProgramFiles` was introduced in Windows 7, but it remains the per-user Programs known folder on later Windows versions and is redirectable. With the unsafe copy fixed, the installer can ask Windows for the actual per-user install root on all supported Windows versions and continue falling back to `$LocalAppData\Programs` if the API call fails.

## Validation

I validated this locally with deterministic NSIS repro harnesses:

- unsafe fixed-size read: exits `-1073741819` / `0xc0000005`
- bounded copy, Unicode NSIS: exits `0`
- bounded copy, ANSI NSIS: exits `0`
- real `SHGetKnownFolderPath(FOLDERID_UserProgramFiles)` path with bounded copy: exits `0`

I will post the PowerShell repro script and sample output in a follow-up comment so the PR description stays focused.

Refs #8536
Refs #9564
