### PR TITLE
fix: avoid system path on Windows for cache when user is `system` OR path is `system32`

### DIFF
--- a/.changeset/easy-items-hang.md
+++ b/.changeset/easy-items-hang.md
@@ -1,0 +1,6 @@
+---
+"electron-builder": patch
+"app-builder-lib": patch
+---
+
+fix: avoid system path on windows for cache when user is `system` OR path is `system32`

--- a/packages/app-builder-lib/src/binDownload.ts
+++ b/packages/app-builder-lib/src/binDownload.ts
@@ -14,7 +14,7 @@ export async function download(url: string, output: string, checksum?: string | 
   const downloadedFile = await get.downloadArtifact({
     version: "9.9.9",
     artifactName: filenameWithExt,
-    cacheRoot: path.resolve(getCacheDirectory(), "downloads"),
+    cacheRoot: path.resolve(getCacheDirectory({ allowEnvVarOverride: true }), "downloads"),
     cacheMode: ElectronDownloadCacheMode.ReadWrite,
     ...(checksum != null ? { checksums: { [filenameWithExt]: checksum } } : { unsafelyDisableChecksums: true }),
     mirrorOptions: { resolveAssetURL: async () => Promise.resolve(url) },

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -86,7 +86,8 @@ function hashUrlSafe(input: string, length = 6): string {
   return out.length >= length ? out.slice(0, length) : out.padStart(length, "0")
 }
 
-export function getCacheDirectory({ isAvoidSystemOnWindows = true, allowEnvVarOverride = true }: { isAvoidSystemOnWindows?: boolean; allowEnvVarOverride: boolean }): string {
+export function getCacheDirectory(options: { isAvoidSystemOnWindows?: boolean; allowEnvVarOverride: boolean }): string {
+  const { isAvoidSystemOnWindows = true, allowEnvVarOverride } = options
   const env = process.env.ELECTRON_BUILDER_CACHE?.trim()
   if (allowEnvVarOverride && env && path.parse(env).root) {
     return env

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -86,7 +86,7 @@ function hashUrlSafe(input: string, length = 6): string {
   return out.length >= length ? out.slice(0, length) : out.padStart(length, "0")
 }
 
-export function getCacheDirectory(isAvoidSystemOnWindows = false, allowEnvVarOverride = true): string {
+export function getCacheDirectory({ isAvoidSystemOnWindows = true, allowEnvVarOverride = true }: { isAvoidSystemOnWindows?: boolean; allowEnvVarOverride: boolean }): string {
   const env = process.env.ELECTRON_BUILDER_CACHE?.trim()
   if (allowEnvVarOverride && env && path.parse(env).root) {
     return env
@@ -102,6 +102,7 @@ export function getCacheDirectory(isAvoidSystemOnWindows = false, allowEnvVarOve
   if (platform === "win32") {
     const localAppData = process.env.LOCALAPPDATA?.trim()
     const username = process.env.USERNAME?.trim()?.toLowerCase()
+    // https://github.com/electron-userland/electron-builder/issues/1164
     const isSystemUser = isAvoidSystemOnWindows && (localAppData?.toLowerCase()?.includes("\\windows\\system32\\") || username === "system")
     if (!localAppData || isSystemUser) {
       return path.join(os.tmpdir(), `${appName}-cache`)
@@ -365,7 +366,7 @@ export async function downloadBuilderToolset(options: {
   const fullUrl = overrideUrl ? `${overrideUrl}/${filenameWithExt}` : `${baseUrl}${releaseName}/${filenameWithExt}`
   const suffix = hashUrlSafe(fullUrl, 5)
   const folderName = `${filenameWithExt.replace(/\.(tar\.gz|tgz|zip|7z)$/, "")}-${suffix}`
-  const extractDir = path.join(getCacheDirectory(), releaseName, folderName)
+  const extractDir = path.join(getCacheDirectory({ allowEnvVarOverride: true }), releaseName, folderName)
 
   // Use resolveAssetURL so @electron/get's ELECTRON_MIRROR env var check cannot override
   // the builder-binaries URL we've already resolved (see getArtifactRemoteURL in @electron/get).
@@ -376,7 +377,7 @@ export async function downloadBuilderToolset(options: {
   const config: ElectronDownloadRequest & ElectronDownloadRequestOptions & { isGeneric: true } = {
     version: "9.9.9", // must be >1.3.2 to bypass @electron/get validation shortcut
     artifactName: filenameWithExt,
-    cacheRoot: path.resolve(getCacheDirectory(), "downloads"),
+    cacheRoot: path.resolve(getCacheDirectory({ allowEnvVarOverride: true }), "downloads"),
     cacheMode: resolveCacheMode(),
     ...(checksums != null ? { checksums } : { unsafelyDisableChecksums: true }),
     mirrorOptions,
@@ -447,7 +448,7 @@ export async function downloadElectronArtifact(options: ArtifactDownloadOptions)
 
   const suffix = hashUrlSafe(JSON.stringify(artifactConfig), 5)
   const folderName = `${artifactName}-v${version}-${platform}-${arch}-${suffix}`
-  const extractDir = path.join(getCacheDirectory(), `${artifactName}-v${version}`, folderName)
+  const extractDir = path.join(getCacheDirectory({ allowEnvVarOverride: true }), `${artifactName}-v${version}`, folderName)
 
   return downloadAndExtract(artifactConfig, extractDir, artifactName)
 }

--- a/packages/electron-builder/src/cli/clear-cache.ts
+++ b/packages/electron-builder/src/cli/clear-cache.ts
@@ -5,7 +5,7 @@ import { createInterface } from "readline/promises"
 import * as path from "path"
 
 export async function clearCache(): Promise<void> {
-  const cacheDir = getCacheDirectory(false, false)
+  const cacheDir = getCacheDirectory({ isAvoidSystemOnWindows: false, allowEnvVarOverride: false })
 
   if (cacheDir === path.parse(cacheDir).root) {
     log.error({ cacheDir }, "cache directory resolves to a filesystem root — aborting")

--- a/test/src/cliTest.ts
+++ b/test/src/cliTest.ts
@@ -71,7 +71,7 @@ describe("clearCache", () => {
 
   test("calls getCacheDirectory with isAvoidSystemOnWindows=false, allowEnvVarOverride=false", async () => {
     await clearCache()
-    expect(getCacheDirectory).toHaveBeenCalledWith(false, false)
+    expect(getCacheDirectory).toHaveBeenCalledWith({ isAvoidSystemOnWindows: false, allowEnvVarOverride: false })
   })
 
   test("deletes cache dir when it exists and user confirms", async () => {

--- a/test/src/electronGetTest.ts
+++ b/test/src/electronGetTest.ts
@@ -26,17 +26,17 @@ describe("getCacheDirectory", () => {
 
   test("returns ELECTRON_BUILDER_CACHE when set", ({ expect }) => {
     vi.stubEnv("ELECTRON_BUILDER_CACHE", "/custom/cache")
-    expect(getCacheDirectory()).toBe("/custom/cache")
+    expect(getCacheDirectory({ allowEnvVarOverride: true })).toBe("/custom/cache")
   })
 
   test("trims whitespace from ELECTRON_BUILDER_CACHE", ({ expect }) => {
     vi.stubEnv("ELECTRON_BUILDER_CACHE", "  /padded/path  ")
-    expect(getCacheDirectory()).toBe("/padded/path")
+    expect(getCacheDirectory({ allowEnvVarOverride: true })).toBe("/padded/path")
   })
 
   test("returns platform-appropriate default when env var is absent", ({ expect }) => {
     vi.stubEnv("ELECTRON_BUILDER_CACHE", "")
-    const result = getCacheDirectory()
+    const result = getCacheDirectory({ allowEnvVarOverride: true })
     expect(typeof result).toBe("string")
     expect(result.length).toBeGreaterThan(0)
     if (process.platform === "darwin") {
@@ -55,18 +55,65 @@ describe("getCacheDirectory", () => {
     }
     vi.stubEnv("ELECTRON_BUILDER_CACHE", "")
     vi.stubEnv("XDG_CACHE_HOME", "/xdg/cache")
-    expect(getCacheDirectory()).toBe("/xdg/cache/electron-builder")
+    expect(getCacheDirectory({ allowEnvVarOverride: true })).toBe("/xdg/cache/electron-builder")
   })
 
-  test("isAvoidSystemOnWindows falls back to tmpdir for system users", ({ expect }) => {
+  test("falls back to tmpdir when LOCALAPPDATA is absent on Windows", ({ expect }) => {
     if (process.platform !== "win32") {
       expect(true).toBe(true)
       return
     }
-    vi.stubEnv("ELECTRON_BUILDER_CACHE", "")
     vi.stubEnv("LOCALAPPDATA", "")
-    const result = getCacheDirectory(true)
+    const result = getCacheDirectory({ isAvoidSystemOnWindows: true, allowEnvVarOverride: false })
     expect(result).toContain(os.tmpdir())
+  })
+
+  test("allowEnvVarOverride:false ignores ELECTRON_BUILDER_CACHE even when set", ({ expect }) => {
+    vi.stubEnv("ELECTRON_BUILDER_CACHE", "/custom/cache")
+    const result = getCacheDirectory({ allowEnvVarOverride: false })
+    expect(result).not.toBe("/custom/cache")
+    expect(result).toContain("electron-builder")
+  })
+
+  test("ignores ELECTRON_BUILDER_CACHE when value has no filesystem root (relative path)", ({ expect }) => {
+    vi.stubEnv("ELECTRON_BUILDER_CACHE", "relative/path/no-root")
+    const result = getCacheDirectory({ allowEnvVarOverride: true })
+    expect(result).not.toBe("relative/path/no-root")
+    expect(result).toContain("electron-builder")
+  })
+
+  test("falls back to tmpdir when USERNAME is 'system' (isAvoidSystemOnWindows defaults to true)", ({ expect }) => {
+    if (process.platform !== "win32") {
+      expect(true).toBe(true)
+      return
+    }
+    vi.stubEnv("LOCALAPPDATA", "C:\\Users\\system\\AppData\\Local")
+    vi.stubEnv("USERNAME", "system")
+    const result = getCacheDirectory({ allowEnvVarOverride: false })
+    expect(result).toContain(os.tmpdir())
+  })
+
+  test("falls back to tmpdir when LOCALAPPDATA path contains \\windows\\system32\\", ({ expect }) => {
+    if (process.platform !== "win32") {
+      expect(true).toBe(true)
+      return
+    }
+    vi.stubEnv("LOCALAPPDATA", "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local")
+    vi.stubEnv("USERNAME", "not-system")
+    const result = getCacheDirectory({ allowEnvVarOverride: false })
+    expect(result).toContain(os.tmpdir())
+  })
+
+  test("isAvoidSystemOnWindows:false does not fall back to tmpdir for USERNAME=system", ({ expect }) => {
+    if (process.platform !== "win32") {
+      expect(true).toBe(true)
+      return
+    }
+    vi.stubEnv("LOCALAPPDATA", "C:\\Users\\system\\AppData\\Local")
+    vi.stubEnv("USERNAME", "system")
+    const result = getCacheDirectory({ isAvoidSystemOnWindows: false, allowEnvVarOverride: false })
+    expect(result).not.toContain(os.tmpdir())
+    expect(result).toContain("electron-builder")
   })
 })
 


### PR DESCRIPTION
This pull request addresses issues with cache directory resolution on Windows, particularly to avoid problematic system paths when the user is `system` or the path is within `system32`. The changes improve the reliability and safety of cache handling by updating how the cache directory is determined and used throughout the codebase.