### PR TITLE
chore(node-module-collector): emit warn-level log for non-installed platform-specific optional packages

### DIFF
--- a/.changeset/little-bees-mate.md
+++ b/.changeset/little-bees-mate.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(node-module-collector): emit warn-level log for missing platform-specific optional packages with actionable suggestion to add them to optionalDependencies

--- a/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
@@ -11,6 +11,7 @@ export enum LogMessageByKey {
   PKG_NOT_ON_DISK = "dependency not found on disk",
   PKG_SELF_REF = "self-referential dependencies",
   PKG_OPTIONAL_NOT_INSTALLED = "missing optional dependencies",
+  PKG_OPTIONAL_PLATFORM_NOT_INSTALLED = "platform-specific optional dependencies not bundled — add them to your project's optionalDependencies if your app requires them (pnpm 10+ does not auto-install transitive platform binaries)",
   PKG_COLLECTOR_OUTPUT = "collector stderr output",
 }
 export const logMessageLevelByKey: Record<LogMessageByKey, LogLevel> = {
@@ -20,6 +21,7 @@ export const logMessageLevelByKey: Record<LogMessageByKey, LogLevel> = {
   [LogMessageByKey.PKG_NOT_ON_DISK]: "warn",
   [LogMessageByKey.PKG_SELF_REF]: "debug",
   [LogMessageByKey.PKG_OPTIONAL_NOT_INSTALLED]: "info",
+  [LogMessageByKey.PKG_OPTIONAL_PLATFORM_NOT_INSTALLED]: "warn",
   [LogMessageByKey.PKG_COLLECTOR_OUTPUT]: "warn",
 }
 

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -304,7 +304,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
       // fix npm list issue
       // https://github.com/npm/cli/issues/8535
       if (!(await this.cache.exists[p])) {
-        this.cache.logSummary[LogMessageByKey.PKG_NOT_ON_DISK].push(key)
+        this.logMissingDependency(key)
         continue
       }
 
@@ -322,7 +322,13 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
     result.sort((a, b) => a.name.localeCompare(b.name))
   }
 
-  async asyncExec(command: string, args: string[], cwd: string = this.rootDir): Promise<{ stdout: string | undefined; stderr: string | undefined }> {
+  protected logMissingDependency(pkgName: string) {
+    const PLATFORM_PACKAGE_RE = /(linux|win32|darwin|freebsd|android)[-_](x64|arm64|ia32|arm|ppc64|s390x|loong64|riscv64|universal)/
+    const diskLogKey = PLATFORM_PACKAGE_RE.test(pkgName) ? LogMessageByKey.PKG_OPTIONAL_PLATFORM_NOT_INSTALLED : LogMessageByKey.PKG_NOT_ON_DISK
+    this.cache.logSummary[diskLogKey].push(pkgName)
+  }
+
+  protected async asyncExec(command: string, args: string[], cwd: string = this.rootDir): Promise<{ stdout: string | undefined; stderr: string | undefined }> {
     const file = await this.tempDirManager.getTempFile({ prefix: "exec-", suffix: ".txt" })
     try {
       await this.streamCollectorCommandToFile(command, args, cwd, file)
@@ -350,7 +356,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
    * @returns Promise that resolves when the command completes successfully or rejects if it fails
    * @throws {Error} If the child process spawn fails or exits with a non-zero code
    */
-  async streamCollectorCommandToFile(command: string, args: string[], cwd: string, tempOutputFile: string) {
+  protected async streamCollectorCommandToFile(command: string, args: string[], cwd: string, tempOutputFile: string) {
     const execName = path.basename(command, path.extname(command))
     const ext = path.extname(command).toLowerCase()
     // Wrap .cmd files in a .bat file for correct cmd.exe execution.

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -89,6 +89,10 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
     return promise
   }
 
+  // pnpm 10+ does not automatically preserve transitive optional platform-specific
+  // packages (e.g. sass-embedded-linux-x64) across lock file regeneration. Users
+  // must list them as direct optionalDependencies. Missing ones are emitted as
+  // PKG_OPTIONAL_PLATFORM_NOT_INSTALLED warnings in the log summary.
   protected async extractProductionDependencyGraph(tree: PnpmDependency, dependencyId: string) {
     if (this.productionGraph[dependencyId]) {
       return
@@ -124,7 +128,7 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
       if (optional[packageName]) {
         const pkg = await this.locateFromDepOrRoot(packageName, tree.path, dependency.version)
         if (!pkg) {
-          this.cache.logSummary[LogMessageByKey.PKG_OPTIONAL_NOT_INSTALLED].push(`${packageName}@${dependency.version}`)
+          this.logMissingDependency(`${packageName}@${dependency.version}`)
           return undefined
         }
       }

--- a/test/src/node-module-collector/streamCollectorTest.ts
+++ b/test/src/node-module-collector/streamCollectorTest.ts
@@ -19,6 +19,10 @@ class TestCollector extends NodeModulesCollector<any, any> {
   }
   protected async extractProductionDependencyGraph() {}
   protected async collectAllDependencies() {}
+  // expose protected method for testing
+  streamCollectorCommandToFile(command: string, args: string[], cwd: string, tempOutputFile: string) {
+    return super.streamCollectorCommandToFile(command, args, cwd, tempOutputFile)
+  }
 }
 
 const BAT_PATH = "C:\\Temp\\pnpm-deadbeef.bat"


### PR DESCRIPTION
This pull request improves how missing platform-specific optional dependencies are detected and reported in the node module collector, especially for users of pnpm 10+. It introduces a new warning log and actionable suggestions for these cases, refactors logging logic for missing dependencies, and clarifies the relevant code paths. These changes help users ensure their applications bundle required platform binaries correctly.
