### PR TITLE
fix(mac): `electronLanguages` config filtering is not correctly applied for MacOS apps

### DIFF
--- a/.changeset/shaky-spoons-change.md
+++ b/.changeset/shaky-spoons-change.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): `electronLanguages` option is not correctly applied for Mac platform

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -617,7 +617,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
   public getMacOsElectronFrameworkResourcesDir(appOutDir: string): string {
     const electronFrameworkName = path.basename(this.info.framework.distMacOsAppName, ".app") + " " + "Framework.framework"
-    return path.join(appOutDir, `${this.appInfo.productFilename}.app`, "Contents", "Frameworks", electronFrameworkName, "Resources")
+    return path.join(appOutDir, `${this.appInfo.productFilename}.app`, "Contents", "Frameworks", electronFrameworkName, "Versions", "A", "Resources")
   }
   public getMacOsResourcesDir(appOutDir: string): string {
     return path.join(appOutDir, `${this.appInfo.productFilename}.app`, "Contents", "Resources")


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/9774