### PR TITLE
chore: better logging when electron in `devDependencies` or `electronVersion` property is not pinned

### DIFF
--- a/.changeset/wild-roses-carry.md
+++ b/.changeset/wild-roses-carry.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: provide better error messaging when electron version in devDependencies or electronVersion property are not pinned

--- a/packages/app-builder-lib/src/electron/electronVersion.ts
+++ b/packages/app-builder-lib/src/electron/electronVersion.ts
@@ -100,14 +100,25 @@ export async function computeElectronVersion(projectDir: string): Promise<string
     throw new InvalidConfigurationError(`Cannot find electron dependency to get electron version in the '${path.join(projectDir, "package.json")}'`)
   }
   const version = dependency?.version
-  if (version == null || !/^\d/.test(version)) {
-    const versionMessage = version == null ? "" : ` and version ("${version}") is not fixed in project`
+  if (version == null) {
     throw new InvalidConfigurationError(
-      `Cannot compute electron version from installed node modules - none of the possible electron modules are installed${versionMessage}.\nSee https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246`
+      `Cannot compute electron version from installed node modules - none of the possible electron modules are installed.\nSee https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246`
     )
   }
 
-  return semver.coerce(version)!.format()
+  const pinnedVersion = semver.valid(version)
+  if (pinnedVersion === null) {
+    log.error(
+      { version },
+      `Electron version "${version}" is a range, not a fixed version. electron-builder requires an exact version because it downloads platform-specific binaries for a specific release — a range cannot be resolved without electron installed in node_modules. ` +
+        `Pin the version in package.json (e.g. "15.3.0" instead of "^15.3.0") or set "electronVersion" explicitly in your electron-builder config.`
+    )
+    throw new InvalidConfigurationError(
+      `Cannot compute electron version from installed node modules - version ("${version}") is not fixed in project.\nSee https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246`
+    )
+  }
+
+  return pinnedVersion
 }
 
 interface NameAndVersion {

--- a/test/src/electronVersionTest.ts
+++ b/test/src/electronVersionTest.ts
@@ -1,0 +1,92 @@
+import * as nodeFs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach, describe, test, vi } from "vitest"
+import { log } from "builder-util"
+
+// getElectronVersion is the public entry point; passing an explicit config with no
+// electronVersion bypasses getConfig and falls through to computeElectronVersion.
+import { getElectronVersion } from "app-builder-lib/out/electron/electronVersion"
+
+function rangeLogMessage(version: string): string {
+  return (
+    `Electron version "${version}" is a range, not a fixed version. electron-builder requires an exact version because it downloads platform-specific binaries for a specific release — a range cannot be resolved without electron installed in node_modules. ` +
+    `Pin the version in package.json (e.g. "15.3.0" instead of "^15.3.0") or set "electronVersion" explicitly in your electron-builder config.`
+  )
+}
+
+function rangeErrorMessage(version: string): string {
+  return `Cannot compute electron version from installed node modules - version ("${version}") is not fixed in project.\nSee https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246`
+}
+
+describe("getElectronVersion (version resolution from package.json)", () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await nodeFs.mkdtemp(path.join(os.tmpdir(), "electron-version-test-"))
+    // Spy on the shared log singleton so the same instance used by electronVersion.ts is intercepted.
+    vi.spyOn(log, "error").mockImplementation(() => {})
+    vi.spyOn(log, "info").mockImplementation(() => {})
+    vi.spyOn(log, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    await nodeFs.rm(tmpDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  async function writePackageJson(content: object) {
+    await nodeFs.writeFile(path.join(tmpDir, "package.json"), JSON.stringify(content))
+  }
+
+  // Pass {} as config so getElectronVersion skips getConfig() and calls computeElectronVersion directly.
+  function resolveVersion() {
+    return getElectronVersion(tmpDir, {})
+  }
+
+  test("returns exact version from devDependencies when electron is not installed", async ({ expect }) => {
+    await writePackageJson({ devDependencies: { electron: "15.3.0" } })
+    await expect(resolveVersion()).resolves.toBe("15.3.0")
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  test("returns exact version from dependencies when electron is not installed", async ({ expect }) => {
+    await writePackageJson({ dependencies: { electron: "20.1.0" } })
+    await expect(resolveVersion()).resolves.toBe("20.1.0")
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  test("calls log.error and throws when version is a caret range", async ({ expect }) => {
+    const version = "^15.3.0"
+    await writePackageJson({ devDependencies: { electron: version } })
+    await expect(resolveVersion()).rejects.toMatchObject({ message: rangeErrorMessage(version) })
+    expect(log.error).toHaveBeenCalledOnce()
+    expect(log.error).toHaveBeenCalledWith({ version }, rangeLogMessage(version))
+  })
+
+  test("calls log.error and throws when version is a tilde range", async ({ expect }) => {
+    const version = "~15.3.0"
+    await writePackageJson({ devDependencies: { electron: version } })
+    await expect(resolveVersion()).rejects.toMatchObject({ message: rangeErrorMessage(version) })
+    expect(log.error).toHaveBeenCalledOnce()
+    expect(log.error).toHaveBeenCalledWith({ version }, rangeLogMessage(version))
+  })
+
+  test("error message tells user to pin or set electronVersion in config", async ({ expect }) => {
+    const version = "^15.3.0"
+    await writePackageJson({ devDependencies: { electron: version } })
+    await expect(resolveVersion()).rejects.toMatchObject({ message: rangeErrorMessage(version) })
+    expect(log.error).toHaveBeenCalledWith({ version }, rangeLogMessage(version))
+  })
+
+  test("throws without log.error when no electron dependency is found", async ({ expect }) => {
+    await writePackageJson({ devDependencies: { react: "18.0.0" } })
+    await expect(resolveVersion()).rejects.toThrow(/none of the possible electron modules are installed/)
+    expect(log.error).not.toHaveBeenCalled()
+  })
+
+  test("throws without log.error when package.json does not exist", async ({ expect }) => {
+    await expect(resolveVersion()).rejects.toThrow(/none of the possible electron modules are installed/)
+    expect(log.error).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Addresses: https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-547115107