### PR TITLE
feat: add `disableAsarIntegrity` config option to skip ASAR integrity computation

### DIFF
--- a/.changeset/silent-swans-leave.md
+++ b/.changeset/silent-swans-leave.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: add `disableAsarIntegrity` config option to skip ASAR integrity computation

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -9159,6 +9159,11 @@
       ],
       "description": "Directories for build resources"
     },
+    "disableAsarIntegrity": {
+      "default": false,
+      "description": "Whether to skip ASAR integrity hash computation. Useful for custom electron forks with encrypted ASAR support where the header is not readable by standard tools.",
+      "type": "boolean"
+    },
     "disableDefaultIgnoredFiles": {
       "default": false,
       "description": "Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.",

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -314,6 +314,12 @@ export interface Configuration extends CommonConfiguration, PlatformSpecificBuil
    * @default false
    */
   readonly disableSanityCheckAsar?: boolean
+
+  /**
+   * Whether to skip ASAR integrity hash computation. Useful for custom electron forks with encrypted ASAR support where the header is not readable by standard tools.
+   * @default false
+   */
+  readonly disableAsarIntegrity?: boolean
 }
 
 export type Hook<T, V> = (contextOrPath: T) => Promise<V> | V

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -2,7 +2,21 @@ import { notarize } from "@electron/notarize"
 import { NotarizeOptionsNotaryTool, NotaryToolKeychainCredentials } from "@electron/notarize/lib/types"
 import { PerFileSignOptions, SignOptions } from "@electron/osx-sign/dist/cjs/types"
 import { Identity } from "@electron/osx-sign/dist/cjs/util-identities"
-import { Arch, AsyncTaskManager, copyFile, exec, exists, getArchSuffix, InvalidConfigurationError, log, orIfFileNotExist, sanitizeDirPath, statOrNull, unlinkIfExists, use } from "builder-util"
+import {
+  Arch,
+  AsyncTaskManager,
+  copyFile,
+  exec,
+  exists,
+  getArchSuffix,
+  InvalidConfigurationError,
+  log,
+  orIfFileNotExist,
+  sanitizeDirPath,
+  statOrNull,
+  unlinkIfExists,
+  use,
+} from "builder-util"
 import { deepAssign, MemoLazy, Nullish } from "builder-util-runtime"
 import * as fs from "fs/promises"
 import { mkdir, readdir } from "fs/promises"

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -315,7 +315,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       const resourcesRelativePath = this.platform === Platform.MAC ? "Resources" : isElectronBased(framework) ? "resources" : ""
 
       let asarIntegrity: AsarIntegrity | null = null
-      if (!(asarOptions == null || options?.disableAsarIntegrity)) {
+      if (!(asarOptions == null || options?.disableAsarIntegrity || this.config.disableAsarIntegrity)) {
         asarIntegrity = await computeData({ resourcesPath, resourcesRelativePath, resourcesDestinationPath: this.getResourcesDir(appOutDir), extraResourceMatchers })
       }
 

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -2,6 +2,12 @@
 
 exports[`macPackager > Build macOS on Windows is not supported 1`] = `"ERR_ELECTRON_BUILDER_INVALID_CONFIGURATION"`;
 
+exports[`macPackager > disableAsarIntegrity skips ASAR integrity computation 1`] = `
+{
+  "mac": [],
+}
+`;
+
 exports[`macPackager > extraFiles are placed in product app bundle Contents, not Electron.app 1`] = `
 {
   "mac": [],

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -218,4 +218,23 @@ describe("macPackager", { sequential: true }, () => {
       }
     )
   )
+
+  test.ifMac("disableAsarIntegrity skips ASAR integrity computation", ({ expect }) =>
+    app(
+      expect,
+      {
+        targets: Platform.MAC.createTarget(DIR_TARGET, Arch.x64),
+        config: {
+          mac: { notarize: false },
+          disableAsarIntegrity: true,
+        },
+      },
+      {
+        signed: false,
+        checkMacApp: async (_appDir, info) => {
+          expect(info.ElectronAsarIntegrity).toBeUndefined()
+        },
+      }
+    )
+  )
 })


### PR DESCRIPTION
Closes #9677

## Problem

Users who build custom/patched Electron with encrypted ASAR support hit a hard crash during
`doPack`:

```
RangeError: The value of "offset" is out of range. It must be >= 0 and <= 4. Received -2404272720
    at hashHeader (app-builder-lib/src/asar/integrity.ts:84:22)
    at computeData (app-builder-lib/src/asar/integrity.ts:73:18)
    at MacPackager.doPack (app-builder-lib/src/platformPackager.ts:321:25)
```

`computeData` unconditionally reads every `.asar` header to compute a SHA256 hash. When the
archive is encrypted, `chromium-pickle-js` cannot parse the header bytes and throws
`ERR_OUT_OF_RANGE`. There was no way to skip this step.

These users also disable the `EnableEmbeddedAsarIntegrityValidation` Electron fuse (since
encrypted ASARs cannot pass the runtime integrity check), but many do so outside of
electron-builder via `@electron/fuses` in an `afterPack` hook — so keying the skip off of
`electronFuses.enableEmbeddedAsarIntegrityValidation` alone would not cover their case.

## Solution

Expose `disableAsarIntegrity: true` as a top-level user config option, following the exact
pattern of the existing `disableSanityCheckAsar` flag (which was added for the same class of
use case).

When set, `computeData` is not called and `asarIntegrity` is passed as `null` to
`beforeCopyExtraFiles` — meaning no `ElectronAsarIntegrity` entry is written to the app's
`Info.plist` or embedded in the Windows executable.

## Changes

- **`packages/app-builder-lib/src/configuration.ts`** — add `disableAsarIntegrity?: boolean`
  to `Configuration` with JSDoc
- **`packages/app-builder-lib/src/platformPackager.ts`** — extend the existing guard to also
  check `this.config.disableAsarIntegrity`
- **`packages/app-builder-lib/scheme.json`** — register the new property in the JSON schema so
  config validation accepts it
- **`test/src/mac/macPackagerTest.ts`** — new `test.ifMac` that asserts `ElectronAsarIntegrity`
  is absent from the plist when the flag is set

## Usage

```yaml
# electron-builder.yml
disableAsarIntegrity: true
```

or in `package.json`:

```json
{
  "build": {
    "disableAsarIntegrity": true
  }
}
```

## Test plan

- [x] `pnpm compile` — no type errors
- [x] `TEST_FILES=macPackagerTest pnpm ci:test` — all 7 tests pass, new test confirms
  `ElectronAsarIntegrity` is absent from the plist when `disableAsarIntegrity: true`
