### PR TITLE
chore: add custom vitest runner for non-test-failure retries

### DIFF
--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -57,6 +57,7 @@ async function main() {
     include: [`test/src/**/${includeRegex}.ts`],
 
     printConsoleTrace: true,
+    runner: __dirname + "/vitest-network-retry-runner.ts",
     reporters: ["default", __dirname + "/vitest-smart-reporter.ts"],
 
     maxWorkers: 3, // limit to 3 workers to avoid overwhelming the system with disk I/O

--- a/test/vitest-scripts/vitest-network-retry-runner.ts
+++ b/test/vitest-scripts/vitest-network-retry-runner.ts
@@ -1,0 +1,39 @@
+import { getFn, setFn } from "vitest/suite"
+import { VitestTestRunner } from "vitest/runners"
+
+const NETWORK_PATTERNS = [/ENOTFOUND/, /ETIMEDOUT/, /ECONNRESET/, /fetch failed/, /getaddrinfo/]
+
+const MAX_NETWORK_RETRIES = 2
+const RETRY_BASE_DELAY_MS = 2000
+
+function isNetworkError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return NETWORK_PATTERNS.some(p => p.test(message))
+}
+
+export default class NetworkRetryRunner extends VitestTestRunner {
+  override async onBeforeRunTask(test: any): Promise<void> {
+    await super.onBeforeRunTask(test)
+
+    const originalFn = getFn(test)
+    if (!originalFn) {
+      return
+    }
+
+    setFn(test, async () => {
+      for (let attempt = 0; attempt <= MAX_NETWORK_RETRIES; attempt++) {
+        try {
+          await originalFn()
+          return
+        } catch (e) {
+          if (!isNetworkError(e) || attempt === MAX_NETWORK_RETRIES) {
+            throw e
+          }
+          const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt)
+          process.stdout.write(`\n[network-retry] Transient network error in "${test.name}", retrying in ${delay / 1000}s (attempt ${attempt + 1}/${MAX_NETWORK_RETRIES})...\n`)
+          await new Promise(r => setTimeout(r, delay))
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
This is specifically to help with retrying individual test cases where it's not the test failing, but some network or I/O failure (usually related to test fixture setup phase, like during `corepack enable`)

Ex: https://github.com/electron-userland/electron-builder/actions/runs/26673007153/job/78619743231
```
 FAIL  test/src/linux/snapcraftTest.ts > snapcraft > core20: per-core description overrides linux.description
Error: npm process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
Exit code:
1
Error output:
! Corepack is about to download https://registry.npmjs.org/npm/-/npm-9.8.1.tgz
/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22089
    throw new Error(
          ^

Error: Error when performing the request to https://registry.npmjs.org/npm/-/npm-9.8.1.tgz; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting
    at fetch (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22089:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async fetchUrlStream (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22119:20)
    ... 4 lines matching cause stack trace ...
    at async Object.runMain (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:23710:7) {
  [cause]: TypeError: fetch failed
      at node:internal/deps/undici/undici:14976:13
      at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
      at async fetch (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22083:16)
      at async fetchUrlStream (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22119:20)
      at async download (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22290:18)
      at async installVersion (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22386:55)
      at async Engine.ensurePackageManager (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:22899:32)
      at async Engine.executePackageManagerRequest (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:23010:25)
      at async Object.runMain (/Users/runner/hostedtoolcache/node/22.22.3/arm64/lib/node_modules/corepack/dist/lib/corepack.cjs:23710:7) {
    [cause]: Error: getaddrinfo ENOTFOUND registry.npmjs.org
        at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26) {
      errno: -3008,
      code: 'ENOTFOUND',
      syscall: 'getaddrinfo',
      hostname: 'registry.npmjs.org'
    }
  }
}
```