### PR TITLE
fix(nsis): `nsisEscapeString` incorrectly converting INSTDIR runtime var to double-$$

### DIFF
--- a/.changeset/fuzzy-birds-train.md
+++ b/.changeset/fuzzy-birds-train.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: `nsisEscapeString` incorrectly converting INSTDIR runtime var to double-$$

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -738,7 +738,7 @@ export class NsisTarget extends Target {
             const customIcon = await packager.getResource(getPlatformIconFileName(item.icon, false), `${extensions[0]}.ico`)
             let installedIconPath = "$appExe,0"
             if (customIcon != null) {
-              installedIconPath = `$INSTDIR\\resources\\${path.basename(customIcon)}`
+              installedIconPath = `$INSTDIR\\resources\\${nsisEscapeString(path.basename(customIcon))}`
               registerFileAssociationsScript.file(installedIconPath, customIcon)
             }
 
@@ -786,7 +786,7 @@ async function generateForPreCompressed(preCompressedFileExtensions: Array<strin
   if (preCompressedAssets.length !== 0) {
     const macro = new NsisScriptGenerator()
     for (const file of preCompressedAssets) {
-      macro.file(`$INSTDIR\\${path.relative(dir, file).replace(/\//g, "\\")}`, file)
+      macro.file(`$INSTDIR\\${nsisEscapeString(path.relative(dir, file).replace(/\//g, "\\"))}`, file)
     }
     scriptGenerator.macro(`customFiles_${Arch[arch]}`, macro)
   }

--- a/packages/app-builder-lib/src/targets/nsis/nsisScriptGenerator.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisScriptGenerator.ts
@@ -20,8 +20,7 @@ export class NsisScriptGenerator {
   }
 
   file(outputName: string | null, file: string) {
-    const safeName = outputName == null ? null : nsisEscapeString(outputName)
-    this.lines.push(`File${safeName == null ? "" : ` "/oname=${safeName}"`} "${file}"`)
+    this.lines.push(`File${outputName == null ? "" : ` "/oname=${outputName}"`} "${file}"`)
   }
 
   insertMacro(name: string, parameters: string) {

--- a/test/src/windows/nsisScriptGeneratorTest.ts
+++ b/test/src/windows/nsisScriptGeneratorTest.ts
@@ -1,4 +1,18 @@
-import { nsisEscapeString } from "app-builder-lib/src/targets/nsis/nsisScriptGenerator"
+import { NsisScriptGenerator, nsisEscapeString } from "app-builder-lib/src/targets/nsis/nsisScriptGenerator"
+
+describe("NsisScriptGenerator.file", () => {
+  test("preserves $INSTDIR variable in output name without escaping", ({ expect }) => {
+    const gen = new NsisScriptGenerator()
+    gen.file("$INSTDIR\\resources\\icon.ico", "C:\\build\\icon.ico")
+    expect(gen.build()).toContain(`File "/oname=$INSTDIR\\resources\\icon.ico" "C:\\build\\icon.ico"`)
+  })
+
+  test("omits /oname when outputName is null", ({ expect }) => {
+    const gen = new NsisScriptGenerator()
+    gen.file(null, "C:\\build\\icon.ico")
+    expect(gen.build()).toBe(`File "C:\\build\\icon.ico"\n`)
+  })
+})
 
 describe("nsisEscapeString", () => {
   test("leaves plain strings unchanged", ({ expect }) => {


### PR DESCRIPTION
Root cause: `nsisEscapeString()` was added to the `file()` method in `NsisScriptGenerator` as a template hardening improvement. This converted `$INSTDIR` (an NSIS runtime variable) to `$$INSTDIR` (a literal $), causing Windows to interpret the installer path as a directory literally named `$INSTDIR`.

Fixes: #9772