### PR TITLE
chore(test): fix caching mechanism for vitest-smart-cache test suite durations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -489,6 +489,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -568,18 +570,22 @@ jobs:
         with:
           name: vitest-smart-cache-*
           failOnError: false
+        continue-on-error: true
 
       - name: Upload merged cache artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.2
+        if: always()
         with:
           name: vitest-smart-cache-merged
           path: merged-cache/_vitest-smart-cache.json
           retention-days: 2
 
       - name: Copy merged cache to canonical path
+        if: always()
         run: cp merged-cache/_vitest-smart-cache.json test/vitest-scripts/_vitest-smart-cache.json
 
       - name: Save merged cache for future runs on this branch
+        if: always()
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: test/vitest-scripts/_vitest-smart-cache.json

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -489,8 +489,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
This should do the trick?

We keep getting this on `master` branch where the cache should be present at all times:
```
Cache not found for input keys: vitest-smart-cache-master-7ad9141999f7b12c444b42b087fb1f199e813cd4, vitest-smart-cache-master-, vitest-smart-cache-master-
```