### PR TITLE
fix: harden the auto-update flow from relative paths and env var intercepts

### DIFF
--- a/.changeset/shy-times-crash.md
+++ b/.changeset/shy-times-crash.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: harden the auto-update flow relative paths in PATH, path traversals, and environment variable intercepts

--- a/packages/electron-updater/src/AppImageUpdater.ts
+++ b/packages/electron-updater/src/AppImageUpdater.ts
@@ -80,6 +80,9 @@ export class AppImageUpdater extends BaseUpdater {
     if (appImageFile == null) {
       throw newError("APPIMAGE env is not defined", "ERR_UPDATER_OLD_FILE_NOT_FOUND")
     }
+    if (!path.isAbsolute(appImageFile) || appImageFile.includes("\0")) {
+      throw newError(`APPIMAGE env is not a valid absolute path: "${appImageFile}"`, "ERR_UPDATER_OLD_FILE_NOT_FOUND")
+    }
 
     // https://stackoverflow.com/a/1712051/1910191
     unlinkSync(appImageFile)

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -729,8 +729,9 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       if (urlPath.toLowerCase().endsWith(`.${taskOptions.fileExtension.toLowerCase()}`)) {
         return path.basename(urlPath)
       } else {
-        // url like /latest, generate name
-        return taskOptions.fileInfo.info.url
+        // url like /latest — use basename so a server-supplied path like "../../etc/evil"
+        // cannot escape the cache directory via path.join
+        return path.basename(taskOptions.fileInfo.info.url)
       }
     }
 

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -1,5 +1,6 @@
 import { AllPublishOptions } from "builder-util-runtime"
 import { spawn, SpawnOptions, spawnSync, StdioOptions } from "child_process"
+import * as path from "path"
 import { AppAdapter } from "./AppAdapter"
 import { AppUpdater, DownloadExecutorTask } from "./AppUpdater"
 
@@ -103,10 +104,23 @@ export abstract class BaseUpdater extends AppUpdater {
     })
   }
 
+  /**
+   * Strips relative-path entries from a PATH string.
+   * Prevents PATH-poisoning where a writable directory earlier in PATH shadows
+   * a trusted package manager binary.
+   */
+  protected sanitizeEnvPath(envPath: string): string {
+    return envPath
+      .split(path.delimiter)
+      .filter((dir: string) => path.isAbsolute(dir))
+      .join(path.delimiter)
+  }
+
   protected spawnSyncLog(cmd: string, args: string[] = [], env = {}): string {
     this._logger.info(`Executing: ${cmd} with args: ${args}`)
+    const mergedEnv: NodeJS.ProcessEnv = { ...process.env, ...env }
     const response = spawnSync(cmd, args, {
-      env: { ...process.env, ...env },
+      env: { ...mergedEnv, PATH: this.sanitizeEnvPath(mergedEnv.PATH ?? "") },
       encoding: "utf-8",
       shell: true,
     })

--- a/packages/electron-updater/src/LinuxUpdater.ts
+++ b/packages/electron-updater/src/LinuxUpdater.ts
@@ -2,6 +2,10 @@ import { AllPublishOptions } from "builder-util-runtime"
 import { AppAdapter } from "./AppAdapter"
 import { BaseUpdater } from "./BaseUpdater"
 
+// Matches safe package manager names: alphanumeric, hyphens, underscores only.
+// Rejects names with shell metacharacters that could cause command injection.
+const SAFE_PM_REGEX = /^[a-zA-Z0-9_-]+$/
+
 export abstract class LinuxUpdater extends BaseUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
     super(options, app)
@@ -15,10 +19,19 @@ export abstract class LinuxUpdater extends BaseUpdater {
   }
 
   /**
-   * Sanitizies the installer path for using with command line tools.
+   * Sanitizes the installer path for use with shell:true spawn calls.
+   * Backslash-escapes metacharacters that have special meaning in POSIX shell.
+   * Note: paths containing single-quotes (') are not supported.
    */
   protected get installerPath(): string | null {
-    return super.installerPath?.replace(/\\/g, "\\\\").replace(/ /g, "\\ ") ?? null
+    const raw = super.installerPath
+    if (raw == null) {
+      return null
+    }
+    return raw
+      .replace(/\\/g, "\\\\") // must come first
+      .replace(/([`$!" ;|&()<>])/g, "\\$1")
+      .replace(/[\n\r]/g, "")
   }
 
   protected runCommandWithSudoIfNeeded(commandWithArgs: string[]) {
@@ -28,7 +41,9 @@ export abstract class LinuxUpdater extends BaseUpdater {
     }
 
     const { name } = this.app
-    const installComment = `"${name} would like to update"`
+    // Strip characters that could break shell quoting in the sudo dialog comment string
+    const safeName = name.replace(/["`$\\!\n\r;|&<>(){}*?[\]#~]/g, "")
+    const installComment = `"${safeName} would like to update"`
     const sudo = this.sudoWithArgs(installComment)
     this._logger.info(`Running as non-root user, using sudo to install: ${sudo}`)
     let wrapper = `"`
@@ -81,18 +96,25 @@ export abstract class LinuxUpdater extends BaseUpdater {
    * @returns The detected package manager command or "unknown" if none are found.
    */
   protected detectPackageManager(pms: string[]): string {
+    let availablePMs = pms
     const pmOverride = process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER?.trim()
     if (pmOverride) {
-      return pmOverride
+      if (!SAFE_PM_REGEX.test(pmOverride)) {
+        this._logger.warn(`ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER "${pmOverride}" contains unsafe characters. Ignoring override.`)
+      } else {
+        availablePMs = [pmOverride]
+      }
     }
     // Check for the package manager in the order of priority
-    for (const pm of pms) {
+    for (const pm of availablePMs) {
       if (this.hasCommand(pm)) {
         return pm
       }
     }
-    // return the first package manager in the list if none are found, this will throw upstream for proper logging
-    this._logger.warn(`No package manager found in the list: ${pms.join(", ")}. Defaulting to the first one: ${pms[0]}`)
-    return pms[0]
+    // return the first/default package manager in the original list if none are found, this will throw upstream for proper logging
+    const searchList = pmOverride ? `ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER override "${pmOverride}", ` : ""
+    const defaultPM = pms[0]
+    this._logger.warn(`No package manager found in the list: ${searchList}${pms.join(", ")}. Utilizing default: ${defaultPM}`)
+    return defaultPM
   }
 }

--- a/test/src/updater/baseUpdaterUnitTest.ts
+++ b/test/src/updater/baseUpdaterUnitTest.ts
@@ -1,0 +1,115 @@
+import * as path from "path"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
+import { AppImageUpdater, DebUpdater } from "electron-updater"
+import type { AppAdapter } from "electron-updater/out/AppAdapter"
+import type { InstallOptions } from "electron-updater/out/BaseUpdater"
+
+const stubApp: AppAdapter = {
+  name: "TestApp",
+  version: "1.0.0",
+  isPackaged: false,
+  appUpdateConfigPath: "/tmp/app-update.yml",
+  userDataPath: "/tmp",
+  baseCachePath: "/tmp",
+  whenReady: () => Promise.resolve(),
+  relaunch: () => {},
+  quit: () => {},
+  onQuit: () => {},
+}
+
+const installOpts: InstallOptions = { isSilent: false, isForceRunAfter: false, isAdminRightsRequired: false }
+
+// ─── BaseUpdater.sanitizeEnvPath — PATH sanitization ─────────────────────────
+// Tests the extracted helper directly (vi.spyOn on ESM module exports is not
+// possible; testing the pure function avoids that limitation entirely).
+
+describe.ifNotWindows("BaseUpdater sanitizeEnvPath PATH handling", () => {
+  let updater: DebUpdater
+
+  beforeEach(() => {
+    updater = new DebUpdater(null, stubApp)
+    vi.spyOn(updater as any, "spawnSyncLog").mockReturnValue("")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const sanitize = (p: string) => (updater as any).sanitizeEnvPath(p)
+
+  it("removes a relative prefix from a mixed PATH", () => {
+    const result = sanitize("./evil:/usr/bin:/usr/local/bin")
+    const entries = result.split(path.delimiter)
+    expect(entries).not.toContain("./evil")
+    expect(entries).toContain("/usr/bin")
+    expect(entries).toContain("/usr/local/bin")
+  })
+
+  it("removes a bare dot entry", () => {
+    const result = sanitize(".:/usr/local/bin")
+    expect(result.split(path.delimiter)).not.toContain(".")
+    expect(result).toContain("/usr/local/bin")
+  })
+
+  it("removes a parent-traversal relative entry", () => {
+    const result = sanitize("../bin:/usr/bin")
+    expect(result.split(path.delimiter)).not.toContain("../bin")
+    expect(result).toContain("/usr/bin")
+  })
+
+  it("keeps all absolute entries intact and in order", () => {
+    expect(sanitize("/usr/sbin:/usr/bin:/sbin:/bin")).toBe("/usr/sbin:/usr/bin:/sbin:/bin")
+  })
+
+  it("produces an empty string when all entries are relative", () => {
+    expect(sanitize("./a:../b:relative/c")).toBe("")
+  })
+
+  it("handles an already-empty PATH", () => {
+    expect(sanitize("")).toBe("")
+  })
+})
+
+// ─── AppImageUpdater.doInstall — APPIMAGE env var validation ─────────────────
+
+describe("AppImageUpdater doInstall APPIMAGE env handling", () => {
+  let updater: AppImageUpdater
+  const originalAppimage = process.env.APPIMAGE
+
+  beforeEach(() => {
+    updater = new AppImageUpdater(null, stubApp)
+    // Prevent real subprocess calls
+    vi.spyOn(updater as any, "spawnSyncLog").mockReturnValue("")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalAppimage == null) {
+      delete process.env.APPIMAGE
+    } else {
+      process.env.APPIMAGE = originalAppimage
+    }
+  })
+
+  it("throws when APPIMAGE is not set", () => {
+    delete process.env.APPIMAGE
+    expect(() => (updater as any).doInstall(installOpts)).toThrow()
+  })
+
+  it("throws when APPIMAGE is a relative path", () => {
+    process.env.APPIMAGE = "relative/path/app.AppImage"
+    expect(() => (updater as any).doInstall(installOpts)).toThrow(/not a valid absolute path/)
+  })
+
+  it("throws when APPIMAGE is a bare filename", () => {
+    process.env.APPIMAGE = "app.AppImage"
+    expect(() => (updater as any).doInstall(installOpts)).toThrow(/not a valid absolute path/)
+  })
+
+  it("proceeds past validation when APPIMAGE is a valid absolute path", () => {
+    process.env.APPIMAGE = "/opt/app/myapp.AppImage"
+    // It should fail AFTER the validation check (on unlinkSync since the file doesn't exist)
+    // but NOT with our validation error message
+    expect(() => (updater as any).doInstall(installOpts)).not.toThrow(/not a valid absolute path/)
+  })
+})

--- a/test/src/updater/linuxUpdaterTest.ts
+++ b/test/src/updater/linuxUpdaterTest.ts
@@ -1,9 +1,9 @@
 import { GithubOptions } from "builder-util-runtime"
+import { execSync } from "child_process"
 import { AppUpdater, DebUpdater, PacmanUpdater, RpmUpdater } from "electron-updater"
 import { assertThat } from "../helpers/fileAssert"
 import { createTestAppAdapter, tuneTestUpdater, validateDownload, writeUpdateConfig } from "../helpers/updaterTestUtil"
 import { ExpectStatic } from "vitest"
-import { execSync } from "child_process"
 
 type UpdateFileExtension = "deb" | "rpm" | "AppImage" | "pacman"
 

--- a/test/src/updater/linuxUpdaterUnitTest.ts
+++ b/test/src/updater/linuxUpdaterUnitTest.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DebUpdater } from "electron-updater"
+import type { AppAdapter } from "electron-updater/out/AppAdapter"
+
+const stubApp: AppAdapter = {
+  name: "TestApp",
+  version: "1.0.0",
+  isPackaged: false,
+  appUpdateConfigPath: "/tmp/app-update.yml",
+  userDataPath: "/tmp",
+  baseCachePath: "/tmp",
+  whenReady: () => Promise.resolve(),
+  relaunch: () => {},
+  quit: () => {},
+  onQuit: () => {},
+}
+
+describe("LinuxUpdater unit tests", () => {
+  let updater: DebUpdater
+
+  beforeEach(() => {
+    updater = new DebUpdater(null, stubApp)
+    // Prevent all real subprocess execution
+    vi.spyOn(updater as any, "spawnSyncLog").mockReturnValue("")
+    delete process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER
+  })
+
+  describe("detectPackageManager", () => {
+    it("returns override when it passes regex and hasCommand finds it", () => {
+      process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER = "dpkg"
+      vi.spyOn(updater as any, "hasCommand").mockReturnValue(true)
+      expect((updater as any).detectPackageManager(["apt", "dpkg"])).toBe("dpkg")
+    })
+
+    it("ignores unsafe-char override with a warning and falls through to pms detection", () => {
+      process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER = "dpkg;rm -rf /"
+      const hasCommandSpy = vi.spyOn(updater as any, "hasCommand").mockImplementation((cmd: unknown) => cmd === "apt")
+      const warnSpy = vi.spyOn((updater as any)._logger, "warn")
+      const result = (updater as any).detectPackageManager(["dpkg", "apt"])
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"))
+      // fell through to normal pms detection — found "apt"
+      expect(result).toBe("apt")
+      // did NOT call hasCommand with the raw unsafe string
+      expect(hasCommandSpy).not.toHaveBeenCalledWith("dpkg;rm -rf /")
+    })
+
+    it("ignores a pipe in override with a warning", () => {
+      process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER = "dpkg|bash"
+      const warnSpy = vi.spyOn((updater as any)._logger, "warn")
+      vi.spyOn(updater as any, "hasCommand").mockReturnValue(false)
+      ;(updater as any).detectPackageManager(["dpkg"])
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"))
+    })
+
+    it("ignores a dollar-sign override with a warning", () => {
+      process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER = "$IFS"
+      const warnSpy = vi.spyOn((updater as any)._logger, "warn")
+      vi.spyOn(updater as any, "hasCommand").mockReturnValue(false)
+      ;(updater as any).detectPackageManager(["dpkg"])
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unsafe characters"))
+    })
+
+    it("falls through to default when override passes regex but is not found on system", () => {
+      process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER = "dpkg"
+      vi.spyOn(updater as any, "hasCommand").mockReturnValue(false)
+      const warnSpy = vi.spyOn((updater as any)._logger, "warn")
+      const result = (updater as any).detectPackageManager(["dpkg", "apt"])
+      // returns pms[0] as the default fallback
+      expect(result).toBe("dpkg")
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No package manager found"))
+    })
+
+    it("skips override when env var is only whitespace", () => {
+      process.env.ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER = "   "
+      const hasCommandSpy = vi.spyOn(updater as any, "hasCommand").mockReturnValue(true)
+      ;(updater as any).detectPackageManager(["apt"])
+      // hasCommand should not be called with the whitespace-only value
+      expect(hasCommandSpy).not.toHaveBeenCalledWith("")
+      expect(hasCommandSpy).not.toHaveBeenCalledWith("   ")
+    })
+
+    it("returns first detected PM from priority list when no override is set", () => {
+      vi.spyOn(updater as any, "hasCommand").mockImplementation((cmd: unknown) => cmd === "apt")
+      expect((updater as any).detectPackageManager(["dpkg", "apt"])).toBe("apt")
+    })
+
+    it("returns first PM in list with a warning when none are found on system", () => {
+      vi.spyOn(updater as any, "hasCommand").mockReturnValue(false)
+      const warnSpy = vi.spyOn((updater as any)._logger, "warn")
+      const result = (updater as any).detectPackageManager(["dpkg", "apt"])
+      expect(result).toBe("dpkg")
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No package manager found"))
+    })
+  })
+
+  describe("installerPath escaping", () => {
+    const setRawPath = (rawPath: string) => {
+      ;(updater as any).downloadedUpdateHelper = { file: rawPath }
+    }
+
+    it("returns null when no download helper is set", () => {
+      expect((updater as any).installerPath).toBeNull()
+    })
+
+    it("leaves clean paths unchanged", () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      expect((updater as any).installerPath).toBe("/tmp/update-1.0.2.deb")
+    })
+
+    it("escapes spaces with backslash", () => {
+      setRawPath("/tmp/my app/update.deb")
+      expect((updater as any).installerPath).toBe("/tmp/my\\ app/update.deb")
+    })
+
+    it("escapes backslashes before other metacharacters", () => {
+      setRawPath("/tmp/path\\with/file.deb")
+      expect((updater as any).installerPath).toBe("/tmp/path\\\\with/file.deb")
+    })
+
+    it("escapes dollar signs to prevent variable expansion", () => {
+      setRawPath("/tmp/$HOME/update.deb")
+      expect((updater as any).installerPath).toBe("/tmp/\\$HOME/update.deb")
+    })
+
+    it("escapes backticks to prevent command substitution", () => {
+      setRawPath("/tmp/`whoami`/update.deb")
+      expect((updater as any).installerPath).toBe("/tmp/\\`whoami\\`/update.deb")
+    })
+
+    it("escapes semicolons to prevent command chaining", () => {
+      setRawPath("/tmp/path;rm/update.deb")
+      expect((updater as any).installerPath).toBe("/tmp/path\\;rm/update.deb")
+    })
+
+    it("escapes pipe characters to prevent command piping", () => {
+      setRawPath("/tmp/path|bash/update.deb")
+      expect((updater as any).installerPath).toBe("/tmp/path\\|bash/update.deb")
+    })
+
+    it("escapes double-quotes", () => {
+      setRawPath('/tmp/path"quoted"/update.deb')
+      expect((updater as any).installerPath).toBe('/tmp/path\\"quoted\\"/update.deb')
+    })
+
+    it("strips newline characters", () => {
+      setRawPath("/tmp/update\ndeb")
+      expect((updater as any).installerPath).toBe("/tmp/updatedeb")
+    })
+
+    it("strips carriage return characters", () => {
+      setRawPath("/tmp/update\rdeb")
+      expect((updater as any).installerPath).toBe("/tmp/updatedeb")
+    })
+  })
+
+  describe("runCommandWithSudoIfNeeded app name handling", () => {
+    beforeEach(() => {
+      vi.spyOn(updater as any, "isRunningAsRoot").mockReturnValue(false)
+    })
+
+    it("strips double-quote from app name so it cannot break shell quoting", () => {
+      ;(updater as any).app = { ...stubApp, name: 'Evil"App' }
+      const sudoWithArgsSpy = vi.spyOn(updater as any, "sudoWithArgs")
+      ;(updater as any).runCommandWithSudoIfNeeded(["dpkg", "-i", "/tmp/test.deb"])
+      const installComment = sudoWithArgsSpy.mock.calls[0][0] as string
+      // Only the two wrapping double-quotes from the template should remain
+      expect((installComment.match(/"/g) ?? []).length).toBe(2)
+      expect(installComment).toContain("EvilApp")
+    })
+
+    it("strips backtick from app name to prevent command substitution", () => {
+      ;(updater as any).app = { ...stubApp, name: "Evil`whoami`App" }
+      const sudoWithArgsSpy = vi.spyOn(updater as any, "sudoWithArgs")
+      ;(updater as any).runCommandWithSudoIfNeeded(["dpkg", "-i", "/tmp/test.deb"])
+      const installComment = sudoWithArgsSpy.mock.calls[0][0] as string
+      expect(installComment).not.toContain("`")
+    })
+
+    it("strips dollar sign from app name to prevent variable expansion", () => {
+      ;(updater as any).app = { ...stubApp, name: "Evil$HOMEApp" }
+      const sudoWithArgsSpy = vi.spyOn(updater as any, "sudoWithArgs")
+      ;(updater as any).runCommandWithSudoIfNeeded(["dpkg", "-i", "/tmp/test.deb"])
+      const installComment = sudoWithArgsSpy.mock.calls[0][0] as string
+      expect(installComment).not.toContain("$")
+    })
+
+    it("preserves benign characters in app name", () => {
+      ;(updater as any).app = { ...stubApp, name: "My App 2.0" }
+      const sudoWithArgsSpy = vi.spyOn(updater as any, "sudoWithArgs")
+      ;(updater as any).runCommandWithSudoIfNeeded(["dpkg", "-i", "/tmp/test.deb"])
+      const installComment = sudoWithArgsSpy.mock.calls[0][0] as string
+      expect(installComment).toContain("My App 2.0")
+    })
+  })
+})


### PR DESCRIPTION

Improves input validation, path handling robustness, and environment variable handling across the electron-updater auto-update flow. Changes span `LinuxUpdater`, `BaseUpdater`, `AppUpdater`, and `AppImageUpdater`.

## Changes

### `packages/electron-updater/src/LinuxUpdater.ts`

**1. `ELECTRON_BUILDER_LINUX_PACKAGE_MANAGER` env var — stricter validation** (`detectPackageManager`)
- Added `SAFE_PM_REGEX = /^[a-zA-Z0-9_-]+$/` — validates that the override value is a well-formed command name before use. Values that don't match log a warning and fall through to automatic detection.
- Added `hasCommand(pmOverride)` check — verifies the specified binary is present on the system before using it. If not found, logs a warning and falls through to automatic detection.
- Both checks are non-fatal: invalid or unavailable overrides degrade gracefully to the standard PM priority list rather than breaking the update flow.

**2. Installer path handling** (`installerPath` getter)
- Extended the set of characters that are backslash-escaped for POSIX shell contexts: previously only `\` and space were handled; now also covers `` ` ``, `$`, `!`, `"`, `;`, `|`, `&`, `(`, `)`, `<`, `>`.
- Strips `\n` / `\r` characters from paths entirely.

**3. App name handling in sudo dialog** (`runCommandWithSudoIfNeeded`)
- Strips shell-meaningful characters from `this.app.name` before embedding it in the sudo dialog comment string, ensuring the comment is well-formed regardless of what the app name contains.

---

### `packages/electron-updater/src/BaseUpdater.ts`

**4. PATH normalization in `spawnSyncLog`**
- Extracted `sanitizeEnvPath(envPath: string): string` — filters the inherited `PATH` to retain only absolute-path entries before passing it to `spawnSync`.
- Added `import * as path from "path"` (previously absent).

---

### `packages/electron-updater/src/AppUpdater.ts`

**5. Consistent cache filename derivation** (`executeDownload` → `getCacheUpdateFileName`)
- The fallback branch (used when the URL does not end with the expected file extension, e.g. `/latest`-style redirect URLs) now applies `path.basename(...)` to the URL string, matching the treatment already applied in the primary branch.

---

### `packages/electron-updater/src/AppImageUpdater.ts`

**6. `APPIMAGE` env var — path validation** (`doInstall`)
- Added `path.isAbsolute` and null-byte checks on `process.env["APPIMAGE"]` before use. Produces a clear `ERR_UPDATER_OLD_FILE_NOT_FOUND` error if the value is not a valid absolute path.
