### PR TITLE
chore: serialize concurrent downloads of the same artifact across vitest workers

### DIFF
--- a/.changeset/whole-otters-lick.md
+++ b/.changeset/whole-otters-lick.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+---
+
+chore: Serialize concurrent downloads of the same artifact across vitest workers to prevent `@electron/get`'s non-atomic `putFileInCache` (remove + move) from racing with a concurrent reader.
+

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+# On macOS the default electron cache lives under Library/Caches; on Linux it follows XDG (~/.cache).
+if [[ "$(uname -s)" = "Darwin" ]]; then
+  _ELECTRON_CACHE_DEFAULT="$HOME/Library/Caches/electron"
+  _ELECTRON_BUILDER_CACHE_DEFAULT="$HOME/Library/Caches/electron-builder"
+else
+  _ELECTRON_CACHE_DEFAULT="$HOME/.cache/electron"
+  _ELECTRON_BUILDER_CACHE_DEFAULT="$HOME/.cache/electron-builder"
+fi
+
 docker run --rm \
   -e CI="${CI:-false}" \
   -e DEBUG="${DEBUG:-}" \
@@ -14,8 +23,8 @@ docker run --rm \
   -w /project \
   -v "$(pwd):/project" \
   -v "$(pwd)/node-modules-docker:/project/node_modules" \
-  -v "${ELECTRON_CACHE_PATH:-$HOME/Library/Caches/electron}:/root/.cache/electron" \
-  -v "${ELECTRON_BUILDER_CACHE_PATH:-$HOME/Library/Caches/electron-builder}:/root/.cache/electron-builder" \
+  -v "${ELECTRON_CACHE_PATH:-$_ELECTRON_CACHE_DEFAULT}:/root/.cache/electron" \
+  -v "${ELECTRON_BUILDER_CACHE_PATH:-$_ELECTRON_BUILDER_CACHE_DEFAULT}:/root/.cache/electron-builder" \
   ${ADDITIONAL_DOCKER_ARGS} \
   "${TEST_RUNNER_IMAGE_TAG:-electronuserland/builder:22-wine-mono}" \
   /bin/bash -c "bash ./docker/test-in-docker.sh"

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -11,6 +11,7 @@ import { buildGotProxyAgent, exec, exists, getPath7za, log, PADDING, parseValidE
 import { MultiProgress } from "electron-publish/out/multiProgress"
 import { createReadStream, createWriteStream } from "fs"
 import * as fs from "fs/promises"
+import * as crypto from "crypto"
 import * as os from "os"
 import * as path from "path"
 import * as lockfile from "proper-lockfile"
@@ -187,6 +188,16 @@ export async function extractArchive(file: string, dir: string) {
     await fs.rm(tmpDir, { recursive: true, force: true })
     await fs.mkdir(tmpDir, { recursive: true })
 
+    // Guard against the transient window in @electron/get's non-atomic putFileInCache (remove → move).
+    // A concurrent worker may have deleted and not yet replaced the source archive; wait briefly for it.
+    for (let i = 0; !(await exists(file)); i++) {
+      if (i >= 4) {
+        throw Object.assign(new Error(`Source archive not found after retries: ${file}`), { code: "ENOENT", path: file })
+      }
+      log.warn({ file, attempt: i + 1 }, "source archive transiently missing, retrying")
+      await new Promise(r => setTimeout(r, 300 * (i + 1)))
+    }
+
     if (file.endsWith(".tar.gz") || file.endsWith(".tgz")) {
       await tar.extract({ file, cwd: tmpDir, strip: 1 })
     } else if (file.endsWith(".zip")) {
@@ -223,6 +234,19 @@ export async function extractArchive(file: string, dir: string) {
 }
 
 async function downloadArtifactToFile(config: Parameters<typeof get.downloadArtifact>[0], label: string): Promise<string> {
+  // Serialize concurrent downloads of the same artifact across vitest workers to prevent @electron/get's
+  // non-atomic putFileInCache (remove + move) from racing with a concurrent reader.
+  const artifactLockKey = crypto
+    .createHash("sha256")
+    .update(JSON.stringify({ v: config.version, p: (config as any).platform, a: (config as any).arch, n: (config as any).artifactName }))
+    .digest("hex")
+    .slice(0, 20)
+  const artifactLockPath = path.join(os.tmpdir(), `eb-dl-${artifactLockKey}.lock`)
+  const releaseArtifactLock = await lockfile.lock(artifactLockPath, {
+    retries: { retries: 30, minTimeout: 500, maxTimeout: 5000 },
+    stale: 600_000,
+    realpath: false,
+  })
   let lastLoggedMilestone = -1
   const state: { bar: ProgressBar | undefined } = { bar: undefined }
 
@@ -266,9 +290,7 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
         interval: 2000,
         backoff: 2000,
         shouldRetry: (e: any) =>
-          e instanceof HttpError
-            ? e.isServerError()
-            : typeof e?.code === "string" && ["ENOTFOUND", "ETIMEDOUT", "ECONNRESET", "EPIPE"].includes(e.code),
+          e instanceof HttpError ? e.isServerError() : typeof e?.code === "string" && ["ENOTFOUND", "ETIMEDOUT", "ECONNRESET", "EPIPE", "ENOENT"].includes(e.code),
       })
     } catch (err) {
       if (typeof (err as any)?.message === "string" && (err as any).message.includes("dest already exists")) {
@@ -288,6 +310,7 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
   } finally {
     state.bar?.update(100)
     state.bar?.terminate()
+    await releaseArtifactLock().catch(err => log.warn({ err }, "failed to release artifact download lock"))
   }
 }
 

--- a/test/src/s3PublishTest.ts
+++ b/test/src/s3PublishTest.ts
@@ -326,7 +326,9 @@ describe("BaseS3Publisher.upload — key construction and S3 request", () => {
     vi.mocked(https.request).mockImplementationOnce((_opts: unknown, _cb: unknown) => {
       const req = new EventEmitter() as ReturnType<typeof https.request>
       ;(req as any).end = vi.fn()
-      ;(req as any).destroy = vi.fn(() => { destroyCalled = true })
+      ;(req as any).destroy = vi.fn(() => {
+        destroyCalled = true
+      })
       ;(req as any).write = vi.fn()
       // Never call the response callback — upload hangs until cancel
       return req

--- a/test/src/updater/blackboxUpdateHelpers.ts
+++ b/test/src/updater/blackboxUpdateHelpers.ts
@@ -38,7 +38,7 @@ export async function doBuild(
   arch: Arch,
   tmpDir: TmpDir,
   isWindows: boolean,
-  extraConfiguration?: Configuration | null,
+  extraConfiguration?: Configuration | null
 ) {
   const currentPlatform = isWindows ? Platform.WINDOWS : Platform.current()
   async function buildApp({
@@ -273,7 +273,14 @@ export async function runTestWithinServer(doTest: (rootDirectory: string, update
   )
 }
 
-export async function runTest(context: TestContext, target: string, packageManager: string, arch: Arch = Arch.x64, toolsets: ToolsetConfig = {}, extraConfig?: Partial<Configuration>) {
+export async function runTest(
+  context: TestContext,
+  target: string,
+  packageManager: string,
+  arch: Arch = Arch.x64,
+  toolsets: ToolsetConfig = {},
+  extraConfig?: Partial<Configuration>
+) {
   const { expect } = context
   const vm = await windowsVmPromise
   if (vm && target === "nsis") {

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -60,7 +60,8 @@ async function main() {
     runner: __dirname + "/vitest-network-retry-runner.ts",
     reporters: ["default", __dirname + "/vitest-smart-reporter.ts"],
 
-    maxWorkers: 3, // limit to 3 workers to avoid overwhelming the system with disk I/O
+    // 2 on Windows (heavy MSI/Squirrel builds saturate the vitest main-thread RPC at 3); 3 elsewhere
+    maxWorkers: process.platform === "win32" ? 2 : 3,
 
     fileParallelism: process.env.TEST_SEQUENTIAL_FILES !== "true",
     sequence: {

--- a/test/vitest-scripts/vitest-heavy-mutex.ts
+++ b/test/vitest-scripts/vitest-heavy-mutex.ts
@@ -155,12 +155,9 @@ beforeEach(
   Infinity
 )
 
-afterEach(
-  ctx => {
-    if (heavyContexts.has(ctx)) {
-      heavyContexts.delete(ctx)
-      heavyMutex.release()
-    }
-  },
-  Infinity
-)
+afterEach(ctx => {
+  if (heavyContexts.has(ctx)) {
+    heavyContexts.delete(ctx)
+    heavyMutex.release()
+  }
+}, Infinity)


### PR DESCRIPTION
## Problem

Two recurring CI failures on commit [`59efef1a8`](https://github.com/electron-userland/electron-builder/actions/runs/26694867379):

- **[Test Linux (Shard 3)](https://github.com/electron-userland/electron-builder/actions/runs/26694867379/jobs/78677577559)** — `ENOENT: no such file or directory, open '/root/.cache/electron/.../electron-v39.8.5-linux-x64.zip'` in `debTest.ts`
- **[Test Windows (Shard 4)](https://github.com/electron-userland/electron-builder/actions/runs/26694867379/jobs/78677577557)** — `[vitest-worker]: Timeout calling "onTaskUpdate"` after all tests passed

---

## Fix 1 — ENOENT electron zip (Linux)

Two bugs compound to produce this failure.

**Bug A: `@electron/get` non-atomic cache write**

`@electron/get@2.0.3`'s `putFileInCache` deletes then moves:

```js
if (await fs.pathExists(cachePath)) await fs.remove(cachePath)
await fs.move(currentPath, cachePath)
```

With `maxWorkers: 3`, the `deb`, `custom depends`, and `top-level exec name` tests all download `electron-v39.8.5-linux-x64.zip` concurrently. Worker B's `remove()` deletes the file while Worker C is mid-extraction → `unzipper.Open.file(cachePath)` throws ENOENT.

**Bug B: wrong Docker volume mount on Linux CI**

`docker/run-tests.sh` defaulted to a macOS cache path:

```bash
# before — resolves to /home/runner/Library/Caches/electron on Linux (doesn't exist)
-v "${ELECTRON_CACHE_PATH:-$HOME/Library/Caches/electron}:/root/.cache/electron"
```

Docker creates an empty directory for a nonexistent host path, so the CI-cached electron zip is never visible inside the container. Every run re-downloads from scratch, maximising concurrent-download overlap.

**Changes:**

`docker/run-tests.sh` — detect OS, use correct XDG path on Linux:
```bash
if [[ "$(uname -s)" = "Darwin" ]]; then
  _ELECTRON_CACHE_DEFAULT="$HOME/Library/Caches/electron"
else
  _ELECTRON_CACHE_DEFAULT="$HOME/.cache/electron"   # correct for Linux CI
fi
-v "${ELECTRON_CACHE_PATH:-$_ELECTRON_CACHE_DEFAULT}:/root/.cache/electron"
```

`electronGet.ts` — per-artifact lock in `downloadArtifactToFile` serializes concurrent downloads of the same artifact so `putFileInCache` never races with a concurrent reader:
```ts
const artifactLockKey = crypto.createHash("sha256")
  .update(JSON.stringify({ v: config.version, p: ..., a: ..., n: ... }))
  .digest("hex").slice(0, 20)
await lockfile.lock(path.join(os.tmpdir(), `eb-dl-${artifactLockKey}.lock`), {
  retries: { retries: 30, minTimeout: 500, maxTimeout: 5000 },
  stale: 600_000, realpath: false,
})
```

`electronGet.ts` — defense-in-depth retry in `extractArchive` before opening the source archive, handling any residual window:
```ts
for (let i = 0; !(await exists(file)); i++) {
  if (i >= 4) throw Object.assign(new Error(`Source archive not found: ${file}`), { code: "ENOENT", path: file })
  await new Promise(r => setTimeout(r, 300 * (i + 1)))
}
```

`electronGet.ts` — `ENOENT` added to `shouldRetry` so a corrupted-cache state also triggers a retry rather than an immediate failure:
```ts
// before
["ENOTFOUND", "ETIMEDOUT", "ECONNRESET", "EPIPE"]
// after
["ENOTFOUND", "ETIMEDOUT", "ECONNRESET", "EPIPE", "ENOENT"]
```

---

## Fix 2 — vitest `onTaskUpdate` timeout (Windows)

Windows Shard 4's squirrel-windows and msiWrapped tests each take 130–200 s. With 3 workers all completing simultaneously, the vitest main thread falls behind processing `onTaskUpdate` RPCs and hits birpc's 60 s timeout — even though every test passed.

`run-vitest.ts` — drop to 2 workers on Windows:
```ts
// before
maxWorkers: 3,

// after
// 2 on Windows (heavy MSI/Squirrel builds saturate vitest main-thread RPC at 3); 3 elsewhere
maxWorkers: process.platform === "win32" ? 2 : 3,
```
