### PR TITLE
fix(appimage): bundle FUSE2 runtime libraries for x64/ia32, matching Go implementation

### DIFF
--- a/.changeset/yellow-apes-poke.md
+++ b/.changeset/yellow-apes-poke.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(appimage): bundle FUSE2 runtime libraries for x64/ia32, matching Go implementation

--- a/packages/app-builder-lib/src/targets/appimage/appImageUtil.ts
+++ b/packages/app-builder-lib/src/targets/appimage/appImageUtil.ts
@@ -89,8 +89,12 @@ export async function buildLegacyFuse2AppImage(opts: AppImageBuilderOptions): Pr
 
     await writeAppLauncherAndRelatedFiles(opts)
 
-    const { runtime, mksquashfs } = await getAppImageTools("0.0.0", arch)
-    // No runtimeLibraries copy — FUSE2 relies on the host's system libfuse2
+    const { runtime, mksquashfs, runtimeLibraries } = await getAppImageTools("0.0.0", arch)
+    // Mirror the app-builder-lib Go implementation: bundle lib/<arch> into usr/lib for x64 and ia32.
+    // arm targets don't have a dedicated lib dir in the FUSE2 toolset.
+    if (arch === Arch.x64 || arch === Arch.ia32) {
+      await copyDir(runtimeLibraries, path.join(stageDir, "usr", "lib"))
+    }
     await copyDir(appDir, stageDir)
 
     const runtimeData = await fs.readFile(runtime)

--- a/packages/app-builder-lib/src/toolsets/linux.ts
+++ b/packages/app-builder-lib/src/toolsets/linux.ts
@@ -106,8 +106,8 @@ export async function getAppImageTools(appimageToolVersion: ToolsetConfig["appim
     const toolRoot = process.platform === "linux" ? `linux-${hostArch}` : "darwin"
     // Runtime files live at root; armv7l target uses "armv7l" filename, not the internal "arm32" alias
     const runtimeSuffix = targetArch === Arch.armv7l ? "armv7l" : runtimeArch
-    // FUSE2 tree only ships lib/ia32 and lib/x64; arm targets fall back to x64.
-    // buildLegacyFuse2AppImage does not copy runtimeLibraries, so the path is never accessed.
+    // FUSE2 tree only ships lib/ia32 and lib/x64; arm targets fall back to x64 here
+    // but buildLegacyFuse2AppImage only copies runtimeLibraries for x64/ia32.
     const libArch = targetArch === Arch.ia32 ? "ia32" : "x64"
     return {
       mksquashfs: path.resolve(artifactPath, toolRoot, "mksquashfs"),


### PR DESCRIPTION
## Summary

- `buildLegacyFuse2AppImage` now copies `lib/{x64,ia32}` from the FUSE2 toolset into the AppImage's `usr/lib` for x64 and ia32 targets, mirroring the original `app-builder` Go implementation (`appImage.go:94-99`)
- arm/arm64 targets are unaffected — the FUSE2 toolset ships no dedicated lib directory for those architectures, matching the Go code's `if arch == "x64" || arch == "ia32"` guard
- Corrects the prior comment that said "FUSE2 relies on the host's system libfuse2" — the lib directory contains AppImageKit runtime libraries beyond just libfuse2, and omitting them could cause AppImages to fail on hosts missing those system libraries

## What changed

### `targets/appimage/appImageUtil.ts`
- Destructures `runtimeLibraries` from `getAppImageTools("0.0.0", arch)`
- Copies `runtimeLibraries` → `<stageDir>/usr/lib` when `arch` is `x64` or `ia32`

### `toolsets/linux.ts`
- Updated comment in `getFuse2Paths` to accurately describe when `runtimeLibraries` is accessed

## Reference

Go source: https://github.com/develar/app-builder/blob/7004925f95d8f034fc88d7e782c9aa7583debb8e/pkg/package-format/appimage/appImage.go#L94-L99

```go
if arch == "x64" || arch == "ia32" {
    err = fs.CopyUsingHardlink(filepath.Join(appImageToolDir, "lib", arch), filepath.Join(stageDir, "usr", "lib"))
    if err != nil {
        return err
    }
}
```