### PR TITLE
fix: correct `update-alternatives --remove` path and unload AppArmor profile on removal

### DIFF
--- a/.changeset/famous-cloths-do.md
+++ b/.changeset/famous-cloths-do.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: correct `update-alternatives --remove` path and unload AppArmor profile on removal

--- a/packages/app-builder-lib/templates/linux/after-remove.tpl
+++ b/packages/app-builder-lib/templates/linux/after-remove.tpl
@@ -1,15 +1,27 @@
 #!/bin/bash
 
 # Delete the link to the binary
+# update-alternatives --remove <name> <path>: 'path' must be the registered alternative binary,
+# not the generic symlink — see https://man7.org/linux/man-pages/man1/update-alternatives.1.html
 if type update-alternatives >/dev/null 2>&1; then
-    update-alternatives --remove '${executable}' '/usr/bin/${executable}'
+    update-alternatives --remove '${executable}' '/opt/${sanitizedProductName}/${executable}'
 else
     rm -f '/usr/bin/${executable}'
 fi
 
 APPARMOR_PROFILE_DEST='/etc/apparmor.d/${executable}'
 
-# Remove apparmor profile.
+# Remove and unload apparmor profile.
 if [ -f "$APPARMOR_PROFILE_DEST" ]; then
+  # Unload the profile from the running kernel before deleting the file so the
+  # policy is not left enforced until the next reboot.  Mirror the chroot guard
+  # used in the after-install script — live AppArmor operations are not
+  # meaningful inside a chroot.
+  # https://wiki.debian.org/AppArmor/HowToUse
+  if apparmor_status --enabled > /dev/null 2>&1; then
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      apparmor_parser --remove "$APPARMOR_PROFILE_DEST" || true
+    fi
+  fi
   rm -f "$APPARMOR_PROFILE_DEST"
 fi

--- a/test/snapshots/linux/debTest.js.snap
+++ b/test/snapshots/linux/debTest.js.snap
@@ -583,6 +583,122 @@ if apparmor_status --enabled > /dev/null 2>&1; then
 fi"
 `;
 
+exports[`deb > executable path in postrm script 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "TestApp_1.1.0_amd64.deb",
+    },
+  ],
+}
+`;
+
+exports[`deb > executable path in postrm script 2`] = `
+[
+  "/",
+  "/opt/",
+  "/usr/",
+  "/opt/foo/",
+  "/opt/foo/Boo",
+  "/opt/foo/chrome-sandbox",
+  "/opt/foo/chrome_100_percent.pak",
+  "/opt/foo/chrome_200_percent.pak",
+  "/opt/foo/chrome_crashpad_handler",
+  "/opt/foo/icudtl.dat",
+  "/opt/foo/libEGL.so",
+  "/opt/foo/libffmpeg.so",
+  "/opt/foo/libGLESv2.so",
+  "/opt/foo/libvk_swiftshader.so",
+  "/opt/foo/libvulkan.so.1",
+  "/opt/foo/LICENSE.electron.txt",
+  "/opt/foo/LICENSES.chromium.html",
+  "/opt/foo/resources.pak",
+  "/opt/foo/snapshot_blob.bin",
+  "/opt/foo/v8_context_snapshot.bin",
+  "/opt/foo/vk_swiftshader_icd.json",
+  "/usr/share/",
+  "/opt/foo/resources/",
+  "/opt/foo/resources/app.asar",
+  "/opt/foo/resources/apparmor-profile",
+  "/usr/share/applications/",
+  "/usr/share/applications/Boo.desktop",
+  "/usr/share/doc/",
+  "/usr/share/icons/",
+  "/usr/share/doc/testapp/",
+  "/usr/share/doc/testapp/changelog.gz",
+  "/usr/share/icons/hicolor/",
+  "/usr/share/icons/hicolor/128x128/",
+  "/usr/share/icons/hicolor/16x16/",
+  "/usr/share/icons/hicolor/256x256/",
+  "/usr/share/icons/hicolor/32x32/",
+  "/usr/share/icons/hicolor/48x48/",
+  "/usr/share/icons/hicolor/512x512/",
+  "/usr/share/icons/hicolor/64x64/",
+  "/usr/share/icons/hicolor/128x128/apps/",
+  "/usr/share/icons/hicolor/128x128/apps/Boo.png",
+  "/usr/share/icons/hicolor/16x16/apps/",
+  "/usr/share/icons/hicolor/16x16/apps/Boo.png",
+  "/usr/share/icons/hicolor/256x256/apps/",
+  "/usr/share/icons/hicolor/256x256/apps/Boo.png",
+  "/usr/share/icons/hicolor/32x32/apps/",
+  "/usr/share/icons/hicolor/32x32/apps/Boo.png",
+  "/usr/share/icons/hicolor/48x48/apps/",
+  "/usr/share/icons/hicolor/48x48/apps/Boo.png",
+  "/usr/share/icons/hicolor/512x512/apps/",
+  "/usr/share/icons/hicolor/512x512/apps/Boo.png",
+  "/usr/share/icons/hicolor/64x64/apps/",
+  "/usr/share/icons/hicolor/64x64/apps/Boo.png",
+]
+`;
+
+exports[`deb > executable path in postrm script 3`] = `
+{
+  "Architecture": "amd64",
+  "Depends": "libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libuuid1, libsecret-1-0",
+  "Homepage": "http://foo.example.com",
+  "License": "MIT",
+  "Maintainer": "Foo Bar <foo@example.com>",
+  "Package": "testapp",
+  "Priority": "optional",
+  "Recommends": "libappindicator3-1",
+  "Section": "devel",
+  "Vendor": "Foo Bar <foo@example.com>",
+}
+`;
+
+exports[`deb > executable path in postrm script 4`] = `"Test Application (test quite “ #378)"`;
+
+exports[`deb > executable path in postrm script 5`] = `
+"#!/bin/bash
+
+# Delete the link to the binary
+# update-alternatives --remove <name> <path>: 'path' must be the registered alternative binary,
+# not the generic symlink — see https://man7.org/linux/man-pages/man1/update-alternatives.1.html
+if type update-alternatives >/dev/null 2>&1; then
+    update-alternatives --remove 'Boo' '/opt/foo/Boo'
+else
+    rm -f '/usr/bin/Boo'
+fi
+
+APPARMOR_PROFILE_DEST='/etc/apparmor.d/Boo'
+
+# Remove and unload apparmor profile.
+if [ -f "$APPARMOR_PROFILE_DEST" ]; then
+  # Unload the profile from the running kernel before deleting the file so the
+  # policy is not left enforced until the next reboot.  Mirror the chroot guard
+  # used in the after-install script — live AppArmor operations are not
+  # meaningful inside a chroot.
+  # https://wiki.debian.org/AppArmor/HowToUse
+  if apparmor_status --enabled > /dev/null 2>&1; then
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      apparmor_parser --remove "$APPARMOR_PROFILE_DEST" || true
+    fi
+  fi
+  rm -f "$APPARMOR_PROFILE_DEST"
+fi"
+`;
+
 exports[`deb > no quotes for safe exec name 1`] = `
 "[Desktop Entry]
 Name=foo

--- a/test/src/linux/debTest.ts
+++ b/test/src/linux/debTest.ts
@@ -86,6 +86,38 @@ describe.heavy.ifNotWindows("deb", () => {
       }
     ))
 
+  // Regression test for https://github.com/electron-userland/electron-builder/issues/9746:
+  // update-alternatives --remove must receive the registered binary path, not the symlink.
+  test("executable path in postrm script", ({ expect }) =>
+    app(
+      expect,
+      {
+        targets: defaultDebTarget,
+        config: {
+          productName: "foo",
+          linux: {
+            executableName: "Boo",
+          },
+        },
+      },
+      {
+        packed: async context => {
+          const debPath = `${context.outDir}/TestApp_1.1.0_amd64.deb`
+          const { member: controlMember, tarArgs: controlArgs } = await resolveDebMember(debPath, "control.tar.")
+          const postrm = (
+            await execShell(`'${await getArExecutable()}' p '${debPath}' ${controlMember} | '${await getTarExecutable()}' -x ${controlArgs} --to-stdout ./postrm`, {
+              maxBuffer: 10 * 1024 * 1024,
+            })
+          ).stdout
+          expect(postrm.trim()).toMatchSnapshot()
+          // The path passed to --remove must be the registered alternative binary (/opt/…),
+          // not the generic symlink (/usr/bin/…).
+          expect(postrm).toContain("update-alternatives --remove 'Boo' '/opt/foo/Boo'")
+          expect(postrm).not.toContain("update-alternatives --remove 'Boo' '/usr/bin/Boo'")
+        },
+      }
+    ))
+
   test("deb file associations", ({ expect }) =>
     app(
       expect,


### PR DESCRIPTION
**Fixes:** [#9746 — postrm (update-alternatives) script bug](https://github.com/electron-userland/electron-builder/issues/9746)

---

## Root Cause Analysis

### Bug 1 — Wrong `path` argument to `update-alternatives --remove` (issue #9746)

Introduced in commit `e83dc8147` (PR #7501, Apr 2023), the `after-remove.tpl` called:

```bash
# BEFORE (broken)
update-alternatives --remove '${executable}' '/usr/bin/${executable}'
```

Per the [`update-alternatives(1)` man page](https://man7.org/linux/man-pages/man1/update-alternatives.1.html), the signature is:

```
update-alternatives --remove <name> <path>
```

where `<path>` is the **registered alternative binary** — the same path used in `--install`, not the generic symlink. The `--install` call in `after-install.tpl` registers `/opt/${sanitizedProductName}/${executable}`:

```bash
update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100
```

Passing `/usr/bin/${executable}` (the symlink) as `<path>` to `--remove` means the alternatives entry is never removed, leaving a dangling record in `/var/lib/dpkg/alternatives/` after uninstall.

### Bug 2 — AppArmor profile left loaded in kernel after removal

When uninstalling, `after-remove.tpl` deleted the profile file from `/etc/apparmor.d/` but never called `apparmor_parser --remove` to unload it from the running kernel. The old policy remained enforced until the next reboot, inconsistent with `after-install.tpl` which correctly loads the profile on install.

---

## Changes

### [`packages/app-builder-lib/templates/linux/after-remove.tpl`](packages/app-builder-lib/templates/linux/after-remove.tpl)

```diff
-    update-alternatives --remove '${executable}' '/usr/bin/${executable}'
+    # update-alternatives --remove <name> <path>: 'path' must be the registered alternative binary,
+    # not the generic symlink — see https://man7.org/linux/man-pages/man1/update-alternatives.1.html
+    update-alternatives --remove '${executable}' '/opt/${sanitizedProductName}/${executable}'
```

AppArmor removal block updated to unload the policy from the kernel before deleting the file, mirroring the chroot guard used in `after-install.tpl`:

```bash
# Unload the profile from the running kernel before deleting the file so the
# policy is not left enforced until the next reboot.
# https://wiki.debian.org/AppArmor/HowToUse
if apparmor_status --enabled > /dev/null 2>&1; then
  if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
    apparmor_parser --remove "$APPARMOR_PROFILE_DEST" || true
  fi
fi
rm -f "$APPARMOR_PROFILE_DEST"
```

### [`test/src/linux/debTest.ts`](test/src/linux/debTest.ts)

Added a regression test `"executable path in postrm script"` that:
- Extracts the generated `postrm` script from the built `.deb` package
- Snapshots the full content for future regression detection
- Asserts `update-alternatives --remove 'Boo' '/opt/foo/Boo'` is present
- Asserts `update-alternatives --remove 'Boo' '/usr/bin/Boo'` is **not** present

### [`test/snapshots/linux/debTest.js.snap`](test/snapshots/linux/debTest.js.snap)

5 new snapshot entries for the `"executable path in postrm script"` test case.

---

## Changed Files

| File | Change |
|---|---|
| `packages/app-builder-lib/templates/linux/after-remove.tpl` | Fix `--remove` path; add AppArmor kernel unload |
| `test/src/linux/debTest.ts` | Add `postrm` regression test |
| `test/snapshots/linux/debTest.js.snap` | New snapshots for `postrm` content |

---

## Validations

- Bug #9746 confirmed **not intentional** — introduced in `e83dc8147`, no subsequent commit corrected it
- `after-install.tpl` has **no related bugs** — its `--install` path is correct
- The AppArmor `--remove` omission was present since `88cc0b06d` (PR #8636)
