### PR TITLE
fix(nsis): validate makensis stderr and installer file size post-build

### DIFF
--- a/.changeset/nsis-installer-output-validation.md
+++ b/.changeset/nsis-installer-output-validation.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): validate makensis stderr and installer file size after build to catch truncated output caused by low disk space

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -653,7 +653,7 @@ export class NsisTarget extends Target {
       cwd: nsisTemplatesDir,
     })
 
-    checkMakensisOutput(stdout, stderr)
+    checkMakensisOutput(stdout, stderr, "BUILD_UNINSTALLER" in defines)
 
     // Only verify output size for the final, non-web installer.
     // BUILD_UNINSTALLER marks the intermediate uninstaller build (no embedded archives).

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -655,8 +655,11 @@ export class NsisTarget extends Target {
 
     checkMakensisOutput(stdout, stderr)
 
-    // Only verify output size for the final installer, not the intermediate uninstaller
-    if (!("BUILD_UNINSTALLER" in defines)) {
+    // Only verify output size for the final, non-web installer.
+    // BUILD_UNINSTALLER marks the intermediate uninstaller build (no embedded archives).
+    // APP_PACKAGE_STORE_FILE marks nsis-web: archives are downloaded at install-time,
+    // so the EXE is intentionally smaller than the archive(s).
+    if (!("BUILD_UNINSTALLER" in defines) && !("APP_PACKAGE_STORE_FILE" in defines)) {
       const outFile = commands["OutFile"].replace(/^"|"$/g, "")
       await verifyInstallerSize(outFile, defines)
     }
@@ -805,6 +808,10 @@ async function generateForPreCompressed(preCompressedFileExtensions: Array<strin
 async function runMakensis(command: string, args: Array<string>, script: string, options: { env?: NodeJS.ProcessEnv; cwd?: string }): Promise<{ stdout: string; stderr: string }> {
   const childProcess = doSpawn(command, args, { ...options, stdio: ["pipe", "pipe", "pipe"] as any })
   const timeout = setTimeout(() => childProcess.kill(), 4 * 60 * 1000)
+  // Mirror live output to parent process streams when the nsis debug logger is
+  // active (DEBUG=electron-builder:nsis or DEBUG=*), matching the original
+  // inherit-mode behaviour of spawnAndWrite in debug builds.
+  const isDebugEnabled = debug.enabled
 
   return new Promise((resolve, reject) => {
     let stdout = ""
@@ -817,9 +824,15 @@ async function runMakensis(command: string, args: Array<string>, script: string,
 
     childProcess.stdout!.on("data", (chunk: Buffer) => {
       stdout += chunk.toString()
+      if (isDebugEnabled) {
+        process.stdout.write(chunk)
+      }
     })
     childProcess.stderr!.on("data", (chunk: Buffer) => {
       stderr += chunk.toString()
+      if (isDebugEnabled) {
+        process.stderr.write(chunk)
+      }
     })
 
     childProcess.stdin!.end(script)

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -2,7 +2,9 @@ import {
   Arch,
   asArray,
   AsyncTaskManager,
+  doSpawn,
   exec,
+  ExecError,
   exists,
   generateKsuid,
   getArchSuffix,
@@ -10,7 +12,6 @@ import {
   getPlatformIconFileName,
   InvalidConfigurationError,
   log,
-  spawnAndWrite,
   statOrNull,
   use,
   walk,
@@ -39,6 +40,7 @@ import { NsisOptions, PortableOptions } from "./nsisOptions"
 import { NsisScriptGenerator, nsisEscapeString } from "./nsisScriptGenerator"
 import { getMakeNsisPath, getNsisPluginsPath } from "../../toolsets/windows"
 import { AppPackageHelper, nsisTemplatesDir, UninstallerReader } from "./nsisUtil"
+import { checkMakensisOutput, verifyInstallerSize } from "./nsisValidation"
 
 const debug = _debug("electron-builder:nsis")
 
@@ -646,10 +648,18 @@ export class NsisTarget extends Target {
     }
 
     const makensis = await getMakeNsisPath(this.packager.config.toolsets?.nsis, this.options.customNsisBinary)
-    await spawnAndWrite(makensis.path, args, script, {
+    const { stdout, stderr } = await runMakensis(makensis.path, args, script, {
       env: { ...process.env, ...(makensis.env ?? {}) },
       cwd: nsisTemplatesDir,
     })
+
+    checkMakensisOutput(stdout, stderr)
+
+    // Only verify output size for the final installer, not the intermediate uninstaller
+    if (!("BUILD_UNINSTALLER" in defines)) {
+      const outFile = commands["OutFile"].replace(/^"|"$/g, "")
+      await verifyInstallerSize(outFile, defines)
+    }
   }
 
   private async computeCommonInstallerScriptHeader(): Promise<string> {
@@ -790,6 +800,39 @@ async function generateForPreCompressed(preCompressedFileExtensions: Array<strin
     }
     scriptGenerator.macro(`customFiles_${Arch[arch]}`, macro)
   }
+}
+
+async function runMakensis(command: string, args: Array<string>, script: string, options: { env?: NodeJS.ProcessEnv; cwd?: string }): Promise<{ stdout: string; stderr: string }> {
+  const childProcess = doSpawn(command, args, { ...options, stdio: ["pipe", "pipe", "pipe"] as any })
+  const timeout = setTimeout(() => childProcess.kill(), 4 * 60 * 1000)
+
+  return new Promise((resolve, reject) => {
+    let stdout = ""
+    let stderr = ""
+
+    childProcess.on("error", err => {
+      clearTimeout(timeout)
+      reject(err)
+    })
+
+    childProcess.stdout!.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    childProcess.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    childProcess.stdin!.end(script)
+
+    childProcess.once("close", code => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolve({ stdout, stderr })
+      } else {
+        reject(new ExecError(command, code ?? -1, stdout, stderr))
+      }
+    })
+  })
 }
 
 async function ensureNotBusy(outFile: string): Promise<void> {

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -351,14 +351,22 @@ export class NsisTarget extends Target {
 
     this.buildQueueManager.add(async () => {
       const sharedHeader = await this.computeCommonInstallerScriptHeader()
-      const script = isPortable
-        ? await readFile(path.join(nsisTemplatesDir, "portable.nsi"), "utf8")
-        : await this.computeScriptAndSignUninstaller(definesUninstaller, commandsUninstaller, installerPath, sharedHeader, archs)
+      let rawScript: string
+      let isCustomScript = false
+      if (isPortable) {
+        rawScript = await readFile(path.join(nsisTemplatesDir, "portable.nsi"), "utf8")
+      } else {
+        const result = await this.computeScriptAndSignUninstaller(definesUninstaller, commandsUninstaller, installerPath, sharedHeader, archs)
+        rawScript = result.script
+        isCustomScript = result.isCustomScript
+      }
 
       // copy outfile name into main options, as the computeScriptAndSignUninstaller function was kind enough to add important data to temporary defines.
       defines.UNINSTALLER_OUT_FILE = definesUninstaller.UNINSTALLER_OUT_FILE
 
-      await this.executeMakensis(defines, commands, sharedHeader + (await this.computeFinalScript(script, true, archs)))
+      // Skip size verification for portable (NSIS recompresses the archive, installer < archive is normal)
+      // and for custom scripts (may not embed archives).
+      await this.executeMakensis(defines, commands, sharedHeader + (await this.computeFinalScript(rawScript, true, archs)), { skipSizeVerification: isPortable || isCustomScript })
       await Promise.all<any>([packager.signIf(installerPath), defines.UNINSTALLER_OUT_FILE == null ? Promise.resolve() : unlink(defines.UNINSTALLER_OUT_FILE)])
 
       const safeArtifactName = computeSafeArtifactNameIfNeeded(installerFilename, () => this.generateGitHubInstallerName(primaryArch, defaultArch))
@@ -400,14 +408,14 @@ export class NsisTarget extends Target {
     return false
   }
 
-  private async computeScriptAndSignUninstaller(defines: Defines, commands: Commands, installerPath: string, sharedHeader: string, archs: Map<Arch, string>): Promise<string> {
+  private async computeScriptAndSignUninstaller(defines: Defines, commands: Commands, installerPath: string, sharedHeader: string, archs: Map<Arch, string>): Promise<{ script: string; isCustomScript: boolean }> {
     const packager = this.packager
     const customScriptPath = await packager.getResource(this.options.script, "installer.nsi")
     const script = await readFile(customScriptPath || path.join(nsisTemplatesDir, "installer.nsi"), "utf8")
 
     if (customScriptPath != null) {
       log.info({ reason: "custom NSIS script is used" }, "uninstaller is not signed by electron-builder")
-      return script
+      return { script, isCustomScript: true }
     }
 
     // https://github.com/electron-userland/electron-builder/issues/2103
@@ -443,7 +451,7 @@ export class NsisTarget extends Target {
     delete defines.BUILD_UNINSTALLER
     // platform-specific path, not wine
     defines.UNINSTALLER_OUT_FILE = uninstallerPath
-    return script
+    return { script, isCustomScript: false }
   }
 
   private computeVersionKey(short = false) {
@@ -601,7 +609,7 @@ export class NsisTarget extends Target {
     }
   }
 
-  private async executeMakensis(defines: Defines, commands: Commands, script: string): Promise<void> {
+  private async executeMakensis(defines: Defines, commands: Commands, script: string, opts: { skipSizeVerification?: boolean } = {}): Promise<void> {
     const args: Array<string> = this.options.warningsAsErrors === false ? [] : ["-WX"]
     args.push("-INPUTCHARSET", "UTF8")
     for (const name of Object.keys(defines)) {
@@ -652,13 +660,14 @@ export class NsisTarget extends Target {
       cwd: nsisTemplatesDir,
     })
 
-    checkMakensisOutput(stdout, stderr, "BUILD_UNINSTALLER" in defines)
+    checkMakensisOutput(stdout, stderr)
 
     // Only verify output size for the final, non-web installer.
-    // BUILD_UNINSTALLER marks the intermediate uninstaller build (no embedded archives).
-    // APP_PACKAGE_STORE_FILE marks nsis-web: archives are downloaded at install-time,
-    // so the EXE is intentionally smaller than the archive(s).
-    if (!("BUILD_UNINSTALLER" in defines) && !("APP_PACKAGE_STORE_FILE" in defines)) {
+    // BUILD_UNINSTALLER: intermediate uninstaller build — no embedded archives.
+    // APP_PACKAGE_STORE_FILE: nsis-web — archives downloaded at install-time.
+    // skipSizeVerification: portable builds (NSIS recompresses the archive, so
+    //   installer < archive_size is normal) and custom scripts (may not embed archives).
+    if (!("BUILD_UNINSTALLER" in defines) && !("APP_PACKAGE_STORE_FILE" in defines) && !opts.skipSizeVerification) {
       const outFile = commands["OutFile"].replace(/^"|"$/g, "")
       await verifyInstallerSize(outFile, defines)
     }

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -2,9 +2,8 @@ import {
   Arch,
   asArray,
   AsyncTaskManager,
-  doSpawn,
   exec,
-  ExecError,
+  spawnAndWriteWithOutput,
   exists,
   generateKsuid,
   getArchSuffix,
@@ -648,7 +647,7 @@ export class NsisTarget extends Target {
     }
 
     const makensis = await getMakeNsisPath(this.packager.config.toolsets?.nsis, this.options.customNsisBinary)
-    const { stdout, stderr } = await runMakensis(makensis.path, args, script, {
+    const { stdout, stderr } = await spawnAndWriteWithOutput(makensis.path, args, script, {
       env: { ...process.env, ...(makensis.env ?? {}) },
       cwd: nsisTemplatesDir,
     })
@@ -803,49 +802,6 @@ async function generateForPreCompressed(preCompressedFileExtensions: Array<strin
     }
     scriptGenerator.macro(`customFiles_${Arch[arch]}`, macro)
   }
-}
-
-async function runMakensis(command: string, args: Array<string>, script: string, options: { env?: NodeJS.ProcessEnv; cwd?: string }): Promise<{ stdout: string; stderr: string }> {
-  const childProcess = doSpawn(command, args, { ...options, stdio: ["pipe", "pipe", "pipe"] as any })
-  const timeout = setTimeout(() => childProcess.kill(), 4 * 60 * 1000)
-  // Mirror live output to parent process streams when the nsis debug logger is
-  // active (DEBUG=electron-builder:nsis or DEBUG=*), matching the original
-  // inherit-mode behaviour of spawnAndWrite in debug builds.
-  const isDebugEnabled = debug.enabled
-
-  return new Promise((resolve, reject) => {
-    let stdout = ""
-    let stderr = ""
-
-    childProcess.on("error", err => {
-      clearTimeout(timeout)
-      reject(err)
-    })
-
-    childProcess.stdout!.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString()
-      if (isDebugEnabled) {
-        process.stdout.write(chunk)
-      }
-    })
-    childProcess.stderr!.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString()
-      if (isDebugEnabled) {
-        process.stderr.write(chunk)
-      }
-    })
-
-    childProcess.stdin!.end(script)
-
-    childProcess.once("close", code => {
-      clearTimeout(timeout)
-      if (code === 0) {
-        resolve({ stdout, stderr })
-      } else {
-        reject(new ExecError(command, code ?? -1, stdout, stderr))
-      }
-    })
-  })
 }
 
 async function ensureNotBusy(outFile: string): Promise<void> {

--- a/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
@@ -1,0 +1,63 @@
+import { ExecError, statOrNull } from "builder-util"
+import type { Defines } from "./Defines"
+
+/**
+ * Validates makensis stdout/stderr after a zero-exit run.
+ *
+ * NSIS can emit "Error:" lines on stderr and still exit 0 (e.g. disk-full
+ * scenarios where the OS silently drops writes). Also checks the
+ * "Install data: <written> / <expected> bytes" progress line for truncation.
+ */
+export function checkMakensisOutput(stdout: string, stderr: string): void {
+  const errorLines = stderr
+    .split("\n")
+    .map(l => l.trim())
+    .filter(l => /^Error:/i.test(l))
+
+  if (errorLines.length > 0) {
+    throw new ExecError("makensis", 0, stdout, stderr)
+  }
+
+  const match = /^Install data:\s*(\d+)\s*\/\s*(\d+)/im.exec(stdout)
+  if (match != null) {
+    const written = parseInt(match[1], 10)
+    const expected = parseInt(match[2], 10)
+    if (written < expected) {
+      throw new Error(`makensis wrote ${written} of ${expected} install-data bytes — output may be truncated (check available disk space)`)
+    }
+  }
+}
+
+/**
+ * Verifies the generated installer is at least as large as the sum of the
+ * embedded archive(s). An installer smaller than its payload is definitively
+ * truncated regardless of the makensis exit code.
+ *
+ * Only runs when APP_64/APP_32/APP_ARM64 defines are present (i.e. normal,
+ * non-portable installers). Skipped for the intermediate uninstaller build.
+ */
+export async function verifyInstallerSize(outFile: string, defines: Defines): Promise<void> {
+  let archiveSize = 0
+  for (const key of ["APP_64", "APP_32", "APP_ARM64"] as const) {
+    const p = defines[key]
+    if (typeof p === "string") {
+      const s = await statOrNull(p)
+      if (s != null) {
+        archiveSize += s.size
+      }
+    }
+  }
+
+  if (archiveSize === 0) {
+    return
+  }
+
+  const outStat = await statOrNull(outFile)
+  const actualSize = outStat?.size ?? 0
+  if (actualSize < archiveSize) {
+    throw new Error(
+      `Generated installer (${actualSize} bytes) is smaller than the embedded archive(s) (${archiveSize} bytes) — ` +
+        `output may be incomplete. Check available disk space and try again.`
+    )
+  }
+}

--- a/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
@@ -8,7 +8,7 @@ import type { Defines } from "./Defines"
  * scenarios where the OS silently drops writes). Also checks the
  * "Install data: <written> / <expected> bytes" progress line for truncation.
  */
-export function checkMakensisOutput(stdout: string, stderr: string): void {
+export function checkMakensisOutput(stdout: string, stderr: string, skipInstallDataCheck = false): void {
   const errorLines = stderr
     .split("\n")
     .map(l => l.trim())
@@ -18,12 +18,14 @@ export function checkMakensisOutput(stdout: string, stderr: string): void {
     throw new ExecError("makensis", 0, stdout, stderr)
   }
 
-  const match = /^Install data:\s*(\d+)\s*\/\s*(\d+)/im.exec(stdout)
-  if (match != null) {
-    const written = parseInt(match[1], 10)
-    const expected = parseInt(match[2], 10)
-    if (written < expected) {
-      throw new Error(`makensis wrote ${written} of ${expected} install-data bytes — output may be truncated (check available disk space)`)
+  if (!skipInstallDataCheck) {
+    const match = /^Install data:\s*(\d+)\s*\/\s*(\d+)/im.exec(stdout)
+    if (match != null) {
+      const written = parseInt(match[1], 10)
+      const expected = parseInt(match[2], 10)
+      if (written < expected) {
+        throw new Error(`makensis wrote ${written} of ${expected} install-data bytes — output may be truncated (check available disk space)`)
+      }
     }
   }
 }

--- a/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
@@ -8,7 +8,7 @@ import type { Defines } from "./Defines"
  * scenarios where the OS silently drops writes). Also checks the
  * "Install data: <written> / <expected> bytes" progress line for truncation.
  */
-export function checkMakensisOutput(stdout: string, stderr: string, skipInstallDataCheck = false): void {
+export function checkMakensisOutput(stdout: string, stderr: string): void {
   const errorLines = stderr
     .split("\n")
     .map(l => l.trim())
@@ -16,17 +16,6 @@ export function checkMakensisOutput(stdout: string, stderr: string, skipInstallD
 
   if (errorLines.length > 0) {
     throw new ExecError("makensis", 0, stdout, stderr)
-  }
-
-  if (!skipInstallDataCheck) {
-    const match = /^Install data:\s*(\d+)\s*\/\s*(\d+)/im.exec(stdout)
-    if (match != null) {
-      const written = parseInt(match[1], 10)
-      const expected = parseInt(match[2], 10)
-      if (written < expected) {
-        throw new Error(`makensis wrote ${written} of ${expected} install-data bytes — output may be truncated (check available disk space)`)
-      }
-    }
   }
 }
 

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -273,6 +273,47 @@ export function spawnAndWrite(command: string, args: Array<string>, data: string
   })
 }
 
+export function spawnAndWriteWithOutput(command: string, args: Array<string>, data: string, options?: SpawnOptions): Promise<{ stdout: string; stderr: string }> {
+  const childProcess = doSpawn(command, args, { ...options, stdio: ["pipe", "pipe", "pipe"] as any })
+  const timeout = setTimeout(() => childProcess.kill(), 4 * 60 * 1000)
+  const isDebugEnabled = debug.enabled
+
+  return new Promise((resolve, reject) => {
+    let stdout = ""
+    let stderr = ""
+
+    childProcess.on("error", (err: Error) => {
+      clearTimeout(timeout)
+      reject(err)
+    })
+
+    childProcess.stdout!.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString()
+      if (isDebugEnabled) {
+        process.stdout.write(chunk)
+      }
+    })
+
+    childProcess.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString()
+      if (isDebugEnabled) {
+        process.stderr.write(chunk)
+      }
+    })
+
+    childProcess.stdin!.end(data)
+
+    childProcess.once("close", (code: number) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolve({ stdout, stderr })
+      } else {
+        reject(new ExecError(command, code ?? -1, stdout, stderr))
+      }
+    })
+  })
+}
+
 export function spawn(command: string, args?: Array<string> | null, options?: SpawnOptions, extraOptions?: ExtraSpawnOptions): Promise<any> {
   return new Promise<any>((resolve, reject) => {
     handleProcess("close", doSpawn(command, args || [], options, extraOptions), command, resolve, reject)

--- a/test/src/windows/nsisOutputValidationTest.ts
+++ b/test/src/windows/nsisOutputValidationTest.ts
@@ -1,0 +1,171 @@
+import { promises as fsp } from "fs"
+import * as os from "os"
+import * as path from "path"
+import { afterEach, beforeEach } from "vitest"
+import { checkMakensisOutput, verifyInstallerSize } from "app-builder-lib/src/targets/nsis/nsisValidation"
+import type { Defines } from "app-builder-lib/src/targets/nsis/Defines"
+
+// ─── checkMakensisOutput ────────────────────────────────────────────────────
+
+describe("checkMakensisOutput", () => {
+  test("passes when stdout and stderr are empty", ({ expect }) => {
+    expect(() => checkMakensisOutput("", "")).not.toThrow()
+  })
+
+  test("passes when NSIS prints normal progress with no errors", ({ expect }) => {
+    const stdout = "Processing: installer.nsi\nInstall: 1 file (123 KB)\n"
+    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
+  })
+
+  test("throws when stderr contains an Error: line", ({ expect }) => {
+    const stderr = "Error: can't write 67108864 bytes to output\nError - aborting creation process\n"
+    expect(() => checkMakensisOutput("", stderr)).toThrow()
+  })
+
+  test("throws when stderr has mixed output with an Error: line", ({ expect }) => {
+    const stderr = "Processing plugins\nError: out of disk space\n"
+    expect(() => checkMakensisOutput("", stderr)).toThrow()
+  })
+
+  test("does not throw for stderr lines that merely contain the word error", ({ expect }) => {
+    // Only lines *starting* with "Error:" (case-insensitive) are treated as fatal
+    const stderr = "warning: deprecated function used in installer\nno errors found\n"
+    expect(() => checkMakensisOutput("", stderr)).not.toThrow()
+  })
+
+  test("throws when Install data shows written < expected bytes", ({ expect }) => {
+    const stdout = "Install data: 82086281 / 124000000 bytes\n"
+    expect(() => checkMakensisOutput(stdout, "")).toThrow(/truncated/i)
+  })
+
+  test("throws when Install data line has written exactly matching the low number from the issue", ({ expect }) => {
+    // Reproduce the exact numbers from issue #9602
+    const stdout = "Install data: 82086281 / 82371305 bytes\n"
+    expect(() => checkMakensisOutput(stdout, "")).toThrow(/truncated/i)
+  })
+
+  test("passes when Install data shows written == expected bytes", ({ expect }) => {
+    const stdout = "Install data: 124000000 / 124000000 bytes\n"
+    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
+  })
+
+  test("passes when Install data shows written > expected (shouldn't happen, but is safe)", ({ expect }) => {
+    const stdout = "Install data: 124000001 / 124000000 bytes\n"
+    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
+  })
+
+  test("passes when stdout has no Install data line", ({ expect }) => {
+    const stdout = "Processing: installer.nsi\nOutput: installer.exe\n"
+    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
+  })
+
+  test("Install data match is case-insensitive", ({ expect }) => {
+    const stdout = "install data: 100 / 200 bytes\n"
+    expect(() => checkMakensisOutput(stdout, "")).toThrow(/truncated/i)
+  })
+
+  test("Error: matching is case-insensitive on stderr", ({ expect }) => {
+    const stderr = "ERROR: some fatal condition\n"
+    expect(() => checkMakensisOutput("", stderr)).toThrow()
+  })
+})
+
+// ─── verifyInstallerSize ────────────────────────────────────────────────────
+
+describe("verifyInstallerSize", () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "eb-nsis-test-"))
+  })
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  async function writeFile(name: string, size: number): Promise<string> {
+    const p = path.join(tmpDir, name)
+    await fsp.writeFile(p, Buffer.alloc(size))
+    return p
+  }
+
+  function baseDefines(): Defines {
+    return {
+      APP_ID: "test",
+      APP_GUID: "test-guid",
+      UNINSTALL_APP_KEY: "test-key",
+      PRODUCT_NAME: "Test",
+      PRODUCT_FILENAME: "test",
+      APP_FILENAME: "test",
+      APP_DESCRIPTION: "Test",
+      VERSION: "1.0.0",
+      PROJECT_DIR: tmpDir,
+      BUILD_RESOURCES_DIR: tmpDir,
+      APP_PACKAGE_NAME: "test",
+    }
+  }
+
+  test("passes when no archive defines are present", async ({ expect }) => {
+    const outFile = await writeFile("installer.exe", 1024)
+    const defines = baseDefines()
+    await expect(verifyInstallerSize(outFile, defines)).resolves.not.toThrow()
+  })
+
+  test("passes when installer is larger than single archive", async ({ expect }) => {
+    const archive = await writeFile("app.7z", 1000)
+    const outFile = await writeFile("installer.exe", 5000)
+    const defines = { ...baseDefines(), APP_64: archive }
+    await expect(verifyInstallerSize(outFile, defines)).resolves.not.toThrow()
+  })
+
+  test("passes when installer exactly equals archive size", async ({ expect }) => {
+    const archive = await writeFile("app.7z", 1000)
+    const outFile = await writeFile("installer.exe", 1000)
+    const defines = { ...baseDefines(), APP_64: archive }
+    await expect(verifyInstallerSize(outFile, defines)).resolves.not.toThrow()
+  })
+
+  test("throws when installer is smaller than single archive", async ({ expect }) => {
+    const archive = await writeFile("app.7z", 5000)
+    const outFile = await writeFile("installer.exe", 1000)
+    const defines = { ...baseDefines(), APP_64: archive }
+    await expect(verifyInstallerSize(outFile, defines)).rejects.toThrow(/1000.*5000|smaller/i)
+  })
+
+  test("throws when installer is smaller than sum of x64 and x86 archives", async ({ expect }) => {
+    const archive64 = await writeFile("app-x64.7z", 3000)
+    const archive32 = await writeFile("app-x86.7z", 2000)
+    const outFile = await writeFile("installer.exe", 4000) // 4000 < 5000
+    const defines = { ...baseDefines(), APP_64: archive64, APP_32: archive32 }
+    await expect(verifyInstallerSize(outFile, defines)).rejects.toThrow(/smaller/i)
+  })
+
+  test("passes when installer covers sum of x64 and x86 archives", async ({ expect }) => {
+    const archive64 = await writeFile("app-x64.7z", 3000)
+    const archive32 = await writeFile("app-x86.7z", 2000)
+    const outFile = await writeFile("installer.exe", 6000) // 6000 >= 5000
+    const defines = { ...baseDefines(), APP_64: archive64, APP_32: archive32 }
+    await expect(verifyInstallerSize(outFile, defines)).resolves.not.toThrow()
+  })
+
+  test("throws when installer file does not exist", async ({ expect }) => {
+    const archive = await writeFile("app.7z", 5000)
+    const defines = { ...baseDefines(), APP_64: archive }
+    const missingOut = path.join(tmpDir, "missing.exe")
+    await expect(verifyInstallerSize(missingOut, defines)).rejects.toThrow(/smaller/i)
+  })
+
+  test("skips size check when archive path does not exist", async ({ expect }) => {
+    const outFile = await writeFile("installer.exe", 100)
+    const defines = { ...baseDefines(), APP_64: path.join(tmpDir, "nonexistent.7z") }
+    // nonexistent archive → archiveSize stays 0 → no check performed
+    await expect(verifyInstallerSize(outFile, defines)).resolves.not.toThrow()
+  })
+
+  test("includes ARM64 archive in size calculation", async ({ expect }) => {
+    const archiveArm64 = await writeFile("app-arm64.7z", 4000)
+    const outFile = await writeFile("installer.exe", 3000)
+    const defines = { ...baseDefines(), APP_ARM64: archiveArm64 }
+    await expect(verifyInstallerSize(outFile, defines)).rejects.toThrow(/smaller/i)
+  })
+})

--- a/test/src/windows/nsisOutputValidationTest.ts
+++ b/test/src/windows/nsisOutputValidationTest.ts
@@ -68,6 +68,17 @@ describe("checkMakensisOutput", () => {
     const stderr = "ERROR: some fatal condition\n"
     expect(() => checkMakensisOutput("", stderr)).toThrow()
   })
+
+  test("skipInstallDataCheck=true suppresses install-data error (uninstaller build)", ({ expect }) => {
+    // BUILD_UNINSTALLER pass legitimately produces "Install data: 0 / 8" — must not throw
+    const stdout = "Install data: 0 / 8 bytes\n"
+    expect(() => checkMakensisOutput(stdout, "", true)).not.toThrow()
+  })
+
+  test("skipInstallDataCheck=true still throws on stderr Error: lines", ({ expect }) => {
+    const stderr = "Error: out of disk space\n"
+    expect(() => checkMakensisOutput("", stderr, true)).toThrow()
+  })
 })
 
 // ─── verifyInstallerSize ────────────────────────────────────────────────────

--- a/test/src/windows/nsisOutputValidationTest.ts
+++ b/test/src/windows/nsisOutputValidationTest.ts
@@ -33,51 +33,14 @@ describe("checkMakensisOutput", () => {
     expect(() => checkMakensisOutput("", stderr)).not.toThrow()
   })
 
-  test("throws when Install data shows written < expected bytes", ({ expect }) => {
-    const stdout = "Install data: 82086281 / 124000000 bytes\n"
-    expect(() => checkMakensisOutput(stdout, "")).toThrow(/truncated/i)
-  })
-
-  test("throws when Install data line has written exactly matching the low number from the issue", ({ expect }) => {
-    // Reproduce the exact numbers from issue #9602
-    const stdout = "Install data: 82086281 / 82371305 bytes\n"
-    expect(() => checkMakensisOutput(stdout, "")).toThrow(/truncated/i)
-  })
-
-  test("passes when Install data shows written == expected bytes", ({ expect }) => {
-    const stdout = "Install data: 124000000 / 124000000 bytes\n"
-    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
-  })
-
-  test("passes when Install data shows written > expected (shouldn't happen, but is safe)", ({ expect }) => {
-    const stdout = "Install data: 124000001 / 124000000 bytes\n"
-    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
-  })
-
-  test("passes when stdout has no Install data line", ({ expect }) => {
-    const stdout = "Processing: installer.nsi\nOutput: installer.exe\n"
-    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
-  })
-
-  test("Install data match is case-insensitive", ({ expect }) => {
-    const stdout = "install data: 100 / 200 bytes\n"
-    expect(() => checkMakensisOutput(stdout, "")).toThrow(/truncated/i)
-  })
-
   test("Error: matching is case-insensitive on stderr", ({ expect }) => {
     const stderr = "ERROR: some fatal condition\n"
     expect(() => checkMakensisOutput("", stderr)).toThrow()
   })
 
-  test("skipInstallDataCheck=true suppresses install-data error (uninstaller build)", ({ expect }) => {
-    // BUILD_UNINSTALLER pass legitimately produces "Install data: 0 / 8" — must not throw
-    const stdout = "Install data: 0 / 8 bytes\n"
-    expect(() => checkMakensisOutput(stdout, "", true)).not.toThrow()
-  })
-
-  test("skipInstallDataCheck=true still throws on stderr Error: lines", ({ expect }) => {
-    const stderr = "Error: out of disk space\n"
-    expect(() => checkMakensisOutput("", stderr, true)).toThrow()
+  test("passes when stdout has non-matching content", ({ expect }) => {
+    const stdout = "Processing: installer.nsi\nOutput: installer.exe\nInstall data: 100 / 200 bytes\n"
+    expect(() => checkMakensisOutput(stdout, "")).not.toThrow()
   })
 })
 


### PR DESCRIPTION
Fixes #9602

This pull request improves the reliability of NSIS installer builds by adding validation to detect truncated or incomplete output, especially in cases of low disk space or silent failures from makensis. It introduces new checks after building the installer to ensure that errors are caught even when makensis exits with a zero status, and that the generated installer file is not smaller than its embedded payloads. Comprehensive tests are also added to verify these new validation behaviors.

**NSIS build reliability improvements:**

* Added validation after NSIS builds to check makensis stderr for error lines, catching silent failures (e.g., due to low disk space) even when makensis exits 0. (`checkMakensisOutput` in `nsisValidation.ts`, integration in `NsisTarget.ts`) [[1]](diffhunk://#diff-4cd25ad9eff5969985b07ef2df7c19f9084e32c89b10c5d273162f045b857447R1-R5) [[2]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867R42) [[3]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867L649-R673) [[4]](diffhunk://#diff-2698243ff4256db7ec6ca20d916bdc95f88c2a7ad90884319bd682829b3c6a9aR1-R54)
* Implemented a post-build check to verify that the generated installer file size is at least as large as the sum of its embedded archives, preventing distribution of truncated installers. This check is skipped for portable builds and custom scripts. (`verifyInstallerSize` in `nsisValidation.ts`, integration in `NsisTarget.ts`) [[1]](diffhunk://#diff-4cd25ad9eff5969985b07ef2df7c19f9084e32c89b10c5d273162f045b857447R1-R5) [[2]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867L353-R369) [[3]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867L649-R673) [[4]](diffhunk://#diff-2698243ff4256db7ec6ca20d916bdc95f88c2a7ad90884319bd682829b3c6a9aR1-R54)

**Codebase enhancements:**

* Refactored makensis execution to use a new `spawnAndWriteWithOutput` utility, capturing both stdout and stderr for validation purposes. (`spawnAndWriteWithOutput` in `util.ts`, usage in `NsisTarget.ts`) [[1]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867R6-L13) [[2]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867L649-R673) [[3]](diffhunk://#diff-8a4ee97b9f021edfafd70d632abc37fc743a85f92fdbef5b56818e53655b1500R276-R316)
* Refactored `computeScriptAndSignUninstaller` to return both the script and a flag indicating if a custom script is used, enabling conditional validation logic. [[1]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867L402-R418) [[2]](diffhunk://#diff-22c0d94d349d9c673f74434497a2da5bf74ed271ce195b8acf77bf0c756e4867L445-R454)

**Testing improvements:**

* Added comprehensive tests for both `checkMakensisOutput` and `verifyInstallerSize`, covering various edge cases (e.g., error lines, archive size mismatches, missing files). (`nsisOutputValidationTest.ts`)