### PR TITLE
fix(traversal): accept transitive dependencies resolved outside their declared range by package manager overrides

### DIFF
--- a/.changeset/red-kings-arrive.md
+++ b/.changeset/red-kings-arrive.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(traversal): accept transitive dependencies resolved outside their declared range by package manager overrides

--- a/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
@@ -13,6 +13,7 @@ export enum LogMessageByKey {
   PKG_OPTIONAL_NOT_INSTALLED = "missing optional dependencies",
   PKG_OPTIONAL_PLATFORM_NOT_INSTALLED = "platform-specific optional dependencies not bundled — add them to your project's optionalDependencies if your app requires them (pnpm 10+ does not auto-install transitive platform binaries)",
   PKG_COLLECTOR_OUTPUT = "collector stderr output",
+  PKG_VERSION_OVERRIDDEN = "dependencies resolved to a version outside the declared range (installed version accepted — likely resolved via package manager overrides)",
 }
 export const logMessageLevelByKey: Record<LogMessageByKey, LogLevel> = {
   [LogMessageByKey.PKG_DUPLICATE_REF]: "info",
@@ -23,6 +24,7 @@ export const logMessageLevelByKey: Record<LogMessageByKey, LogLevel> = {
   [LogMessageByKey.PKG_OPTIONAL_NOT_INSTALLED]: "info",
   [LogMessageByKey.PKG_OPTIONAL_PLATFORM_NOT_INSTALLED]: "warn",
   [LogMessageByKey.PKG_COLLECTOR_OUTPUT]: "warn",
+  [LogMessageByKey.PKG_VERSION_OVERRIDDEN]: "debug",
 }
 
 export type Package = { packageDir: string; packageJson: PackageJson }
@@ -166,6 +168,32 @@ export class ModuleManager {
     if (!parentDir || !pkgName) {
       return null
     }
+
+    const found = await this.searchForPackage(parentDir, pkgName, requiredRange, skipDownwardSearch)
+    if (found) {
+      return found
+    }
+
+    // Second pass: find any installed version of the package when the declared-range search
+    // returns nothing. This handles package manager `overrides` (Bun, npm, pnpm, Yarn) that
+    // resolve a transitive dependency to a version intentionally outside its declared range.
+    // File-system results are already cached, so this pass costs only JS overhead.
+    if (requiredRange) {
+      const overrideResult = await this.searchForPackage(parentDir, pkgName, undefined, skipDownwardSearch)
+      if (overrideResult) {
+        log.debug(
+          { pkg: pkgName, declared: requiredRange, installed: overrideResult.packageJson.version },
+          "accepting installed package version that doesn't satisfy the declared range"
+        )
+        this.logSummary[LogMessageByKey.PKG_VERSION_OVERRIDDEN].push(`${pkgName}@${overrideResult.packageJson.version} (declared ${requiredRange})`)
+        return overrideResult
+      }
+    }
+
+    return null
+  }
+
+  private async searchForPackage(parentDir: string, pkgName: string, requiredRange: string | undefined, skipDownwardSearch: boolean): Promise<Package | null> {
     // 1) check direct parent node_modules/pkgName first
     const direct = path.join(path.resolve(parentDir), "node_modules", pkgName, "package.json")
     if (await this.exists[direct]) {

--- a/test/src/node-module-collector/moduleManagerTest.ts
+++ b/test/src/node-module-collector/moduleManagerTest.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, test } from "vitest"
+import * as fse from "fs-extra"
+import * as os from "os"
+import * as path from "path"
+import { ModuleManager, LogMessageByKey } from "app-builder-lib/src/node-module-collector/moduleManager"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes a minimal package.json tree under a temp root and returns the root
+ * path. The `packages` map is keyed by relative path from the root.
+ */
+async function buildTempTree(packages: Record<string, { name: string; version: string; dependencies?: Record<string, string> }>): Promise<string> {
+  const root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-mm-test-"))
+  for (const [rel, pkg] of Object.entries(packages)) {
+    const absPath = path.join(root, rel)
+    await fse.ensureDir(path.dirname(absPath))
+    await fse.writeJson(absPath, pkg)
+  }
+  return root
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ModuleManager.locatePackageVersion", () => {
+  describe("basic resolution", () => {
+    test("returns null when parentDir is undefined", async ({ expect }) => {
+      const manager = new ModuleManager()
+      const result = await manager.locatePackageVersion({ pkgName: "foo", requiredRange: "^1.0.0" })
+      expect(result).toBeNull()
+    })
+
+    test("returns null when pkgName is undefined", async ({ expect }) => {
+      const manager = new ModuleManager()
+      const result = await manager.locatePackageVersion({ parentDir: "/some/dir", requiredRange: "^1.0.0" })
+      expect(result).toBeNull()
+    })
+
+    test("finds package in direct parent node_modules when version satisfies range", async ({ expect }) => {
+      const root = await buildTempTree({
+        "node_modules/my-pkg/package.json": { name: "my-pkg", version: "1.2.3" },
+      })
+      try {
+        const manager = new ModuleManager()
+        const result = await manager.locatePackageVersion({ parentDir: root, pkgName: "my-pkg", requiredRange: "^1.0.0" })
+        expect(result).not.toBeNull()
+        expect(result!.packageJson.version).toBe("1.2.3")
+        expect(result!.packageDir).toBe(path.join(root, "node_modules", "my-pkg"))
+      } finally {
+        await fse.rm(root, { recursive: true, force: true })
+      }
+    })
+
+    test("returns null when package is absent from the tree", async ({ expect }) => {
+      const root = await buildTempTree({})
+      try {
+        const manager = new ModuleManager()
+        const result = await manager.locatePackageVersion({ parentDir: root, pkgName: "missing-pkg", requiredRange: "^1.0.0" })
+        expect(result).toBeNull()
+      } finally {
+        await fse.rm(root, { recursive: true, force: true })
+      }
+    })
+
+    test("accepts any installed version when no range is given", async ({ expect }) => {
+      const root = await buildTempTree({
+        "node_modules/any-pkg/package.json": { name: "any-pkg", version: "99.0.0" },
+      })
+      try {
+        const manager = new ModuleManager()
+        const result = await manager.locatePackageVersion({ parentDir: root, pkgName: "any-pkg" })
+        expect(result).not.toBeNull()
+        expect(result!.packageJson.version).toBe("99.0.0")
+      } finally {
+        await fse.rm(root, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe("upward (hoisted) resolution", () => {
+    let root = ""
+    afterEach(async () => {
+      if (root) await fse.rm(root, { recursive: true, force: true })
+    })
+
+    test("finds hoisted package that satisfies range", async ({ expect }) => {
+      root = await buildTempTree({
+        // hoisted at root
+        "node_modules/hoisted/package.json": { name: "hoisted", version: "2.0.0" },
+        // nested package that requires hoisted
+        "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      })
+      const manager = new ModuleManager()
+      const result = await manager.locatePackageVersion({
+        parentDir: path.join(root, "node_modules", "consumer"),
+        pkgName: "hoisted",
+        requiredRange: "^2.0.0",
+      })
+      expect(result).not.toBeNull()
+      expect(result!.packageJson.version).toBe("2.0.0")
+    })
+  })
+
+  describe("override fallback (two-pass search)", () => {
+    let root = ""
+    afterEach(async () => {
+      if (root) await fse.rm(root, { recursive: true, force: true })
+    })
+
+    test("accepts package whose installed version is outside the declared range", async ({ expect }) => {
+      // Simulates: keyv-better-sqlite3 declares better-sqlite3@^7.1.1 but bun
+      // resolves it to 12.6.0 via overrides. The installed version is outside the
+      // declared range but should still be accepted.
+      root = await buildTempTree({
+        "node_modules/transitive/package.json": { name: "transitive", version: "12.0.0" },
+        "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      })
+      const manager = new ModuleManager()
+      const result = await manager.locatePackageVersion({
+        parentDir: path.join(root, "node_modules", "consumer"),
+        pkgName: "transitive",
+        requiredRange: "^7.0.0", // declared range, does NOT match installed 12.0.0
+      })
+      expect(result).not.toBeNull()
+      expect(result!.packageJson.version).toBe("12.0.0")
+    })
+
+    test("records overridden dependency in logSummary", async ({ expect }) => {
+      root = await buildTempTree({
+        "node_modules/transitive/package.json": { name: "transitive", version: "12.0.0" },
+        "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      })
+      const manager = new ModuleManager()
+      await manager.locatePackageVersion({
+        parentDir: path.join(root, "node_modules", "consumer"),
+        pkgName: "transitive",
+        requiredRange: "^7.0.0",
+      })
+      const overridden = manager.logSummary[LogMessageByKey.PKG_VERSION_OVERRIDDEN]
+      expect(overridden).toHaveLength(1)
+      expect(overridden[0]).toContain("transitive@12.0.0")
+      expect(overridden[0]).toContain("^7.0.0")
+    })
+
+    test("does NOT add to override log when version satisfies range normally", async ({ expect }) => {
+      root = await buildTempTree({
+        "node_modules/dep/package.json": { name: "dep", version: "7.5.0" },
+        "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      })
+      const manager = new ModuleManager()
+      await manager.locatePackageVersion({
+        parentDir: path.join(root, "node_modules", "consumer"),
+        pkgName: "dep",
+        requiredRange: "^7.0.0", // 7.5.0 satisfies this
+      })
+      const overridden = manager.logSummary[LogMessageByKey.PKG_VERSION_OVERRIDDEN]
+      expect(overridden).toHaveLength(0)
+    })
+
+    test("returns null when package is genuinely absent (not just mismatched version)", async ({ expect }) => {
+      root = await buildTempTree({
+        "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+        // 'transitive' is deliberately absent
+      })
+      const manager = new ModuleManager()
+      const result = await manager.locatePackageVersion({
+        parentDir: path.join(root, "node_modules", "consumer"),
+        pkgName: "transitive",
+        requiredRange: "^7.0.0",
+      })
+      expect(result).toBeNull()
+    })
+
+    test("does not trigger fallback when requiredRange is undefined", async ({ expect }) => {
+      // When no range is given the first-pass already accepts any version;
+      // the fallback should never fire and the logSummary should stay empty.
+      root = await buildTempTree({
+        "node_modules/dep/package.json": { name: "dep", version: "5.0.0" },
+      })
+      const manager = new ModuleManager()
+      await manager.locatePackageVersion({ parentDir: root, pkgName: "dep" })
+      const overridden = manager.logSummary[LogMessageByKey.PKG_VERSION_OVERRIDDEN]
+      expect(overridden).toHaveLength(0)
+    })
+  })
+})
+
+describe("ModuleManager.semverSatisfies (via locatePackageVersion)", () => {
+  let root = ""
+  afterEach(async () => {
+    if (root) await fse.rm(root, { recursive: true, force: true })
+  })
+
+  async function locateWith(version: string, range: string): Promise<{ found: boolean; usedFallback: boolean }> {
+    root = await buildTempTree({
+      "node_modules/pkg/package.json": { name: "pkg", version },
+    })
+    const manager = new ModuleManager()
+    const result = await manager.locatePackageVersion({ parentDir: root, pkgName: "pkg", requiredRange: range })
+    const usedFallback = (manager.logSummary[LogMessageByKey.PKG_VERSION_OVERRIDDEN] ?? []).length > 0
+    await fse.rm(root, { recursive: true, force: true })
+    root = ""
+    return { found: result !== null, usedFallback }
+  }
+
+  test("caret range: matching major", async ({ expect }) => {
+    expect((await locateWith("1.5.0", "^1.0.0")).found).toBe(true)
+  })
+
+  test("tilde range: matching minor", async ({ expect }) => {
+    expect((await locateWith("1.2.3", "~1.2.0")).found).toBe(true)
+  })
+
+  test("exact match", async ({ expect }) => {
+    expect((await locateWith("2.3.4", "2.3.4")).found).toBe(true)
+  })
+
+  test("non-semver range (git URL) is treated as match", async ({ expect }) => {
+    expect((await locateWith("1.0.0", "git+https://github.com/foo/bar.git")).found).toBe(true)
+  })
+
+  test("wildcard range (*) matches any version", async ({ expect }) => {
+    expect((await locateWith("99.0.0", "*")).found).toBe(true)
+  })
+
+  test("major mismatch triggers override fallback and still resolves", async ({ expect }) => {
+    const { found, usedFallback } = await locateWith("12.0.0", "^7.0.0")
+    expect(found).toBe(true)
+    expect(usedFallback).toBe(true)
+  })
+})

--- a/test/src/node-module-collector/traversalCollectorTest.ts
+++ b/test/src/node-module-collector/traversalCollectorTest.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, test, vi } from "vitest"
+import * as fse from "fs-extra"
+import * as os from "os"
+import * as path from "path"
+import { TraversalNodeModulesCollector } from "app-builder-lib/src/node-module-collector/traversalNodeModulesCollector"
+import { LogMessageByKey } from "app-builder-lib/src/node-module-collector/moduleManager"
+import type { TmpDir } from "builder-util"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal TmpDir stub — traversal collector never needs actual temp files. */
+const mockTmpDir = { getTempFile: vi.fn(), getTempDir: vi.fn() } as unknown as TmpDir
+
+/**
+ * Writes a package tree under a fresh temp directory.
+ * Keys are relative paths to package.json files; values are the JSON contents.
+ */
+async function buildPackageTree(packages: Record<string, object>): Promise<string> {
+  const root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-traversal-test-"))
+  for (const [rel, json] of Object.entries(packages)) {
+    const abs = path.join(root, rel)
+    await fse.ensureDir(path.dirname(abs))
+    await fse.writeJson(abs, json)
+  }
+  return root
+}
+
+async function runCollector(rootDir: string, packageName: string) {
+  const collector = new TraversalNodeModulesCollector(rootDir, mockTmpDir)
+  return collector.getNodeModules({ packageName })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TraversalNodeModulesCollector", () => {
+  let root = ""
+  afterEach(async () => {
+    if (root) {
+      await fse.rm(root, { recursive: true, force: true })
+      root = ""
+    }
+  })
+
+  describe("basic dependency collection", () => {
+    test("collects a simple direct dependency", async ({ expect }) => {
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: { "prod-dep": "^1.0.0" },
+        },
+        "node_modules/prod-dep/package.json": {
+          name: "prod-dep",
+          version: "1.5.0",
+        },
+      })
+      const { nodeModules } = await runCollector(root, "my-app")
+      const names = nodeModules.map(m => m.name)
+      expect(names).toContain("prod-dep")
+    })
+
+    test("does not include devDependencies", async ({ expect }) => {
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: { "prod-dep": "^1.0.0" },
+          devDependencies: { "dev-only": "^2.0.0" },
+        },
+        "node_modules/prod-dep/package.json": { name: "prod-dep", version: "1.0.0" },
+        "node_modules/dev-only/package.json": { name: "dev-only", version: "2.0.0" },
+      })
+      const { nodeModules } = await runCollector(root, "my-app")
+      const names = nodeModules.map(m => m.name)
+      expect(names).toContain("prod-dep")
+      expect(names).not.toContain("dev-only")
+    })
+
+    test("skips missing optional dependencies without throwing", async ({ expect }) => {
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: { "prod-dep": "^1.0.0" },
+          optionalDependencies: { "optional-native": "^1.0.0" },
+        },
+        "node_modules/prod-dep/package.json": { name: "prod-dep", version: "1.0.0" },
+        // optional-native is intentionally absent
+      })
+      const { nodeModules } = await runCollector(root, "my-app")
+      const names = nodeModules.map(m => m.name)
+      expect(names).toContain("prod-dep")
+      expect(names).not.toContain("optional-native")
+    })
+
+    test("throws for a genuinely missing production dependency", async ({ expect }) => {
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: { "missing-dep": "^1.0.0" },
+        },
+        // missing-dep is deliberately absent
+      })
+      await expect(runCollector(root, "my-app")).rejects.toThrow(/missing-dep/)
+    })
+  })
+
+  describe("package manager override resolution", () => {
+    test("accepts transitive dep resolved to a version outside its declared range", async ({ expect }) => {
+      // Reproduces the exact scenario from GitHub issue #9641:
+      //   keyv-better-sqlite3 declares better-sqlite3@^7.1.1
+      //   but the user has pinned better-sqlite3@12.6.0 via Bun overrides
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: {
+            "keyv-better-sqlite3": "^1.1.0",
+            "better-sqlite3": "^12.6.0",
+          },
+          overrides: { "better-sqlite3": "^12.6.0" },
+        },
+        "node_modules/keyv-better-sqlite3/package.json": {
+          name: "keyv-better-sqlite3",
+          version: "1.1.0",
+          dependencies: {
+            // declares old range, but the override installs 12.x
+            "better-sqlite3": "^7.1.1",
+          },
+        },
+        "node_modules/better-sqlite3/package.json": {
+          name: "better-sqlite3",
+          version: "12.6.0", // installed via override, outside declared ^7.1.1
+        },
+      })
+
+      // Must not throw; the overridden package must be included.
+      const { nodeModules, logSummary } = await runCollector(root, "my-app")
+      const names = nodeModules.map(m => m.name)
+      expect(names).toContain("keyv-better-sqlite3")
+      expect(names).toContain("better-sqlite3")
+
+      // The override should be noted in the log summary at debug level.
+      const overridden: string[] = logSummary[LogMessageByKey.PKG_VERSION_OVERRIDDEN] ?? []
+      expect(Array.isArray(overridden)).toBe(true)
+      expect(overridden.some(s => s.includes("better-sqlite3"))).toBe(true)
+    })
+
+    test("prefers the exact semver match over the override fallback", async ({ expect }) => {
+      // If a version that DOES satisfy the range is installed alongside the
+      // override candidate, the in-range version should be returned.
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: { consumer: "^1.0.0" },
+        },
+        "node_modules/consumer/package.json": {
+          name: "consumer",
+          version: "1.0.0",
+          dependencies: { dep: "^7.0.0" },
+        },
+        // A local version inside the consumer that satisfies the range
+        "node_modules/consumer/node_modules/dep/package.json": {
+          name: "dep",
+          version: "7.1.0",
+        },
+        // A hoisted version that is outside the range (override candidate)
+        "node_modules/dep/package.json": {
+          name: "dep",
+          version: "12.0.0",
+        },
+      })
+      const { nodeModules, logSummary } = await runCollector(root, "my-app")
+      const names = nodeModules.map(m => m.name)
+      expect(names).toContain("dep")
+
+      // Since 7.1.0 satisfies ^7.0.0, no override fallback should be recorded.
+      const overridden: string[] = logSummary[LogMessageByKey.PKG_VERSION_OVERRIDDEN] ?? []
+      expect(overridden.length).toBe(0)
+    })
+
+    test("handles multiple overridden transitive dependencies in the same tree", async ({ expect }) => {
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: {
+            "pkg-a": "^1.0.0",
+            "pkg-b": "^1.0.0",
+            "shared-dep": "^10.0.0",
+            "other-dep": "^5.0.0",
+          },
+          overrides: {
+            "shared-dep": "^10.0.0",
+            "other-dep": "^5.0.0",
+          },
+        },
+        "node_modules/pkg-a/package.json": {
+          name: "pkg-a",
+          version: "1.0.0",
+          dependencies: { "shared-dep": "^3.0.0" }, // declared old, installed new via override
+        },
+        "node_modules/pkg-b/package.json": {
+          name: "pkg-b",
+          version: "1.0.0",
+          dependencies: { "other-dep": "^2.0.0" }, // declared old, installed new via override
+        },
+        "node_modules/shared-dep/package.json": { name: "shared-dep", version: "10.1.0" },
+        "node_modules/other-dep/package.json": { name: "other-dep", version: "5.2.0" },
+      })
+      const { nodeModules } = await runCollector(root, "my-app")
+      const names = nodeModules.map(m => m.name)
+      expect(names).toContain("pkg-a")
+      expect(names).toContain("pkg-b")
+      expect(names).toContain("shared-dep")
+      expect(names).toContain("other-dep")
+    })
+  })
+
+  describe("circular dependency and self-reference handling", () => {
+    test("handles self-referential dependencies gracefully (does not loop)", async ({ expect }) => {
+      root = await buildPackageTree({
+        "package.json": {
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: { "my-lib": "^1.0.0" },
+        },
+        "node_modules/my-lib/package.json": {
+          name: "my-lib",
+          version: "1.0.0",
+          dependencies: { "my-lib": "^1.0.0" }, // self-ref
+        },
+      })
+      // Should complete without hanging or throwing.
+      const { nodeModules } = await runCollector(root, "my-app")
+      const names = nodeModules.map(m => m.name)
+      expect(names).toContain("my-lib")
+    })
+  })
+})


### PR DESCRIPTION
### Summary

- **Fixes [#9641](https://github.com/electron-userland/electron-builder/issues/9641):** Bun (and any traversal-mode) packaging no longer fails with `Production dependency X not found for package Y` when the installed version of a transitive dependency was resolved outside its declared semver range by a package manager `overrides` field.
- Adds a two-pass search strategy to [`ModuleManager.locatePackageVersion`](packages/app-builder-lib/src/node-module-collector/moduleManager.ts#L142): the first pass enforces the declared semver range (existing behavior); only when that search returns nothing does a second pass accept any installed version of the package — the correct behavior for projects that intentionally pin transitive deps via overrides.
- Extracts the three-tier search logic (direct → upward-hoisted → downward-BFS) into a private `searchForPackage` helper ([`moduleManager.ts:196`](packages/app-builder-lib/src/node-module-collector/moduleManager.ts#L196)), reducing cyclomatic complexity of `locatePackageVersion`.
- Adds a new `PKG_VERSION_OVERRIDDEN` log summary key (debug level) so overridden resolutions are traceable in verbose build output without surfacing as warnings.
- Adds 25 new unit and integration tests across two new test files covering the override scenario, normal resolution paths, semver edge cases, optional-dep handling, self-referential deps, and multi-override trees.

### Changed Files

| File | Change |
|------|--------|
| [`packages/app-builder-lib/src/node-module-collector/moduleManager.ts`](packages/app-builder-lib/src/node-module-collector/moduleManager.ts) | Two-pass override resolution; `searchForPackage` extraction; `PKG_VERSION_OVERRIDDEN` log key |
| [`test/src/node-module-collector/moduleManagerTest.ts`](test/src/node-module-collector/moduleManagerTest.ts) | **New** — 17 unit tests for `ModuleManager.locatePackageVersion` |
| [`test/src/node-module-collector/traversalCollectorTest.ts`](test/src/node-module-collector/traversalCollectorTest.ts) | **New** — 8 integration tests for `TraversalNodeModulesCollector` with override scenarios |

### Design Notes

**Two-pass strategy:** The second pass is only triggered when (a) a `requiredRange` was given and (b) the first pass found nothing. This means:
- Projects with no overrides behave identically to before — the first pass succeeds and the second never runs.
- File-system costs of the second pass are negligible: `ModuleManager`'s caches (`exists`, `json`, `lstat`) are already warm from the first pass, so the second pass is pure JS overhead.
- The fallback correctly handles the override case: the package is physically installed in `node_modules` and resolvable from the dependent's directory — it just carries a version number outside the range declared by the transitive manifest.

**Scope:** The change lives entirely in `ModuleManager`, which is shared by the traversal-mode collector (used for Bun and as a fallback) and the pnpm collector. For pnpm, `requiredRange` is always an exact version from `pnpm list --json` output, so the fallback never fires. For the traversal path (Bun, fallback), `requiredRange` comes from the transitive package's `package.json` — exactly the scenario described in the issue.

### Validations

```
TEST_FILES=moduleManagerTest,traversalCollectorTest,packageManagerResolveTest,streamCollectorTest,HoistTest pnpm ci:test
```
- 73 tests, 5 test files — all pass.

### Test Plan

- [x] `ModuleManager` finds packages with matching semver range (existing behavior unchanged)
- [x] `ModuleManager` fallback accepts package at an overridden version and records it in `PKG_VERSION_OVERRIDDEN` log summary
- [x] `ModuleManager` returns `null` when the package is completely absent — no false positives
- [x] `ModuleManager` does not fire fallback when `requiredRange` is undefined
- [x] `TraversalNodeModulesCollector` reproduces issue #9641 scenario end-to-end without throwing
- [x] Prefers an in-range local version over the override candidate when both are available
- [x] Handles multiple simultaneously overridden transitive dependencies
- [x] Self-referential dependency cycles complete without hanging
- [x] Genuinely absent production dependencies still throw as before
- [x] Optional dependencies that are absent are still skipped gracefully