### PR TITLE
fix(win): log actionable hint when `signAndEditExecutable: false` that icon and metadata are not applied

### DIFF
--- a/.changeset/moody-plants-fall.md
+++ b/.changeset/moody-plants-fall.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(win): log actionable hint when signAndEditExecutable is false so users know to use signExecutable: false to preserve icon and metadata

--- a/packages/app-builder-lib/src/util/resEdit.ts
+++ b/packages/app-builder-lib/src/util/resEdit.ts
@@ -43,21 +43,25 @@ export async function editWindowsResources(opts: ResourceEditOptions): Promise<v
   }
 
   if (opts.requestedExecutionLevel && opts.requestedExecutionLevel !== "asInvoker") {
-    const manifestEntry = res.entries.find(e => e.type === 24 && e.id === 1)
-    if (!manifestEntry) {
-      log.warn({ file: opts.file }, "no RT_MANIFEST resource found; requestedExecutionLevel will not be applied")
-    } else {
-      const originalXml = Buffer.from(manifestEntry.bin).toString("utf-8")
-      const updatedXml = originalXml.replace(/(<requestedExecutionLevel[^>]*\blevel=")[^"]*(")/i, `$1${opts.requestedExecutionLevel}$2`)
-      if (updatedXml === originalXml) {
-        log.warn({ file: opts.file, requestedExecutionLevel: opts.requestedExecutionLevel }, "requestedExecutionLevel node not found in manifest; execution level not updated")
-      } else {
-        const newBuf = Buffer.from(updatedXml, "utf-8")
-        manifestEntry.bin = newBuf.buffer.slice(newBuf.byteOffset, newBuf.byteOffset + newBuf.byteLength)
-      }
-    }
+    patchManifestExecutionLevel(res, opts.requestedExecutionLevel, opts.file)
   }
 
   res.outputResource(executable)
   await writeFile(opts.file, Buffer.from(executable.generate()))
+}
+
+function patchManifestExecutionLevel(res: NtExecutableResource, level: string, file: string): void {
+  const manifestEntry = res.entries.find(e => e.type === 24 && e.id === 1)
+  if (!manifestEntry) {
+    log.warn({ file }, "no RT_MANIFEST resource found; requestedExecutionLevel will not be applied")
+    return
+  }
+  const originalXml = Buffer.from(manifestEntry.bin).toString("utf-8")
+  const updatedXml = originalXml.replace(/(<requestedExecutionLevel[^>]*\blevel=")[^"]*(")/i, `$1${level}$2`)
+  if (updatedXml === originalXml) {
+    log.warn({ file, requestedExecutionLevel: level }, "requestedExecutionLevel node not found in manifest; execution level not updated")
+    return
+  }
+  const newBuf = Buffer.from(updatedXml, "utf-8")
+  manifestEntry.bin = newBuf.buffer.slice(newBuf.byteOffset, newBuf.byteOffset + newBuf.byteLength)
 }

--- a/packages/app-builder-lib/src/winPackager.ts
+++ b/packages/app-builder-lib/src/winPackager.ts
@@ -236,10 +236,10 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
   }
 
   private shouldSignFile(file: string, fallbackValue = false): boolean {
-    const backwardCompatibility = file.endsWith(".exe")
+    const isExe = file.endsWith(".exe")
     const signExts = this.platformSpecificBuildOptions.signExts
     if (!signExts?.length) {
-      return backwardCompatibility || fallbackValue
+      return isExe || fallbackValue
     }
     // process patterns ( !exe => exclude .exe, .dll => include .dll )
     // we process first to allow literal negatives in case a filename matches "help!.txt" or similar
@@ -250,8 +250,7 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
     if (signExts.some(ext => ext.startsWith("!") && file.endsWith(ext.substring(1)))) {
       return false
     }
-    // if no explicit patterns matched, fall back to backward compatibility
-    return backwardCompatibility || fallbackValue
+    return isExe || fallbackValue
   }
 
   protected createTransformerForExtraFiles(packContext: AfterPackContext): FileTransformer | null {
@@ -279,6 +278,10 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       )
     }
     if (this.platformSpecificBuildOptions.signAndEditExecutable === false) {
+      log.info(
+        { exe: log.filePath(path.join(packContext.appOutDir, exeFileName)) },
+        "executable resource editing and code signing skipped — signAndEditExecutable is false. To skip only code signing while keeping icon and metadata applied, use signExecutable: false instead."
+      )
       return false
     }
 
@@ -301,15 +304,18 @@ export class WinPackager extends PlatformPackager<WindowsConfiguration> {
       return true
     }
 
-    const filesPromise = (filepath: string[]) => {
-      const outDir = path.join(packContext.appOutDir, ...filepath)
-      return walk(outDir, (file, stat) => stat.isDirectory() || this.shouldSignFile(file))
-    }
-    const filesToSign = await Promise.all([filesPromise(["resources", "app.asar.unpacked"]), filesPromise(["swiftshader"])])
+    const filesToSign = await Promise.all([
+      this.walkSignableFiles(packContext.appOutDir, "resources", "app.asar.unpacked"),
+      this.walkSignableFiles(packContext.appOutDir, "swiftshader"),
+    ])
     for (const file of filesToSign.flat(1)) {
       await this.signIf(file)
     }
 
     return true
+  }
+
+  private walkSignableFiles(baseDir: string, ...subpath: string[]): Promise<string[]> {
+    return walk(path.join(baseDir, ...subpath), (file, stat) => stat.isDirectory() || this.shouldSignFile(file))
   }
 }

--- a/test/src/windows/winReseditTest.ts
+++ b/test/src/windows/winReseditTest.ts
@@ -138,15 +138,18 @@ describe("editWindowsResources", () => {
     const file = await writePe(makePeBuffer())
     await editWindowsResources({ ...baseOpts, file })
     const res = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file)))
+    expect(res.entries.some(e => e.type === 3)).toBe(false)
     expect(res.entries.some(e => e.type === 14)).toBe(false)
   })
 
   test("replaces existing icon when iconPath is provided", async ({ expect }) => {
     const file = await writePe(makePeBuffer())
     await editWindowsResources({ ...baseOpts, file, iconPath: FIXTURE_ICO })
-    const entriesAfterFirst = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file))).entries.filter(e => e.type === 14).length
+    const resAfterFirst = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file)))
+    const groupCountAfterFirst = resAfterFirst.entries.filter(e => e.type === 14).length
+    expect(groupCountAfterFirst).toBeGreaterThan(0)
     await editWindowsResources({ ...baseOpts, file, iconPath: FIXTURE_ICO })
-    const entriesAfterSecond = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file))).entries.filter(e => e.type === 14).length
-    expect(entriesAfterSecond).toBe(entriesAfterFirst)
+    const groupCountAfterSecond = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file))).entries.filter(e => e.type === 14).length
+    expect(groupCountAfterSecond).toBe(groupCountAfterFirst)
   })
 })

--- a/test/src/windows/winReseditTest.ts
+++ b/test/src/windows/winReseditTest.ts
@@ -5,6 +5,8 @@ import path from "path"
 import { NtExecutable, NtExecutableResource, Resource } from "resedit"
 import { afterEach, beforeEach } from "vitest"
 
+const FIXTURE_ICO = path.join(__dirname, "../../fixtures/test-app/build/icon.ico")
+
 interface PeSnapshot {
   versionStrings: Array<{ lang: number; codepage: number; strings: Record<string, string> }>
   manifestXml: string | null
@@ -122,5 +124,29 @@ describe("editWindowsResources", () => {
     const file = await writePe(makePeBuffer({ withManifest: true }))
     await editWindowsResources({ ...baseOpts, file })
     expect(readPeSnapshot(await fs.readFile(file))).toMatchSnapshot()
+  })
+
+  test("adds icon resources when iconPath is provided", async ({ expect }) => {
+    const file = await writePe(makePeBuffer())
+    await editWindowsResources({ ...baseOpts, file, iconPath: FIXTURE_ICO })
+    const res = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file)))
+    expect(res.entries.some(e => e.type === 3)).toBe(true)
+    expect(res.entries.some(e => e.type === 14)).toBe(true)
+  })
+
+  test("does not add icon resources when iconPath is omitted", async ({ expect }) => {
+    const file = await writePe(makePeBuffer())
+    await editWindowsResources({ ...baseOpts, file })
+    const res = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file)))
+    expect(res.entries.some(e => e.type === 14)).toBe(false)
+  })
+
+  test("replaces existing icon when iconPath is provided", async ({ expect }) => {
+    const file = await writePe(makePeBuffer())
+    await editWindowsResources({ ...baseOpts, file, iconPath: FIXTURE_ICO })
+    const entriesAfterFirst = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file))).entries.filter(e => e.type === 14).length
+    await editWindowsResources({ ...baseOpts, file, iconPath: FIXTURE_ICO })
+    const entriesAfterSecond = NtExecutableResource.from(NtExecutable.from(await fs.readFile(file))).entries.filter(e => e.type === 14).length
+    expect(entriesAfterSecond).toBe(entriesAfterFirst)
   })
 })


### PR DESCRIPTION
## Summary

- **Added an informational log** in [`signApp`](packages/app-builder-lib/src/winPackager.ts#L281) when `signAndEditExecutable: false` is detected, telling users that both resource editing (icon, metadata) **and** code signing are being skipped, and pointing them to `signExecutable: false` as the correct option when they only want to skip signing ([fixes #9385](https://github.com/electron-userland/electron-builder/issues/9385)).

  Before this change, setting `signAndEditExecutable: false` produced no output and left users wondering why their custom icon and metadata were not appearing in the packaged `.exe`. The new log line:

  ```
  • executable resource editing and code signing skipped — signAndEditExecutable is false.
    To skip only code signing while keeping icon and metadata applied, use signExecutable: false instead.
      exe=<path/to/app.exe>
  ```

- **Extracted `walkSignableFiles` private method** in `WinPackager`, replacing an inline closure in `signApp` that walked `app.asar.unpacked` and `swiftshader`. The extracted method has a clean `(baseDir, ...subpath)` signature and is easier to follow at the call site.

- **Renamed `backwardCompatibility` → `isExe`** in `shouldSignFile` — the previous name described the origin of the behaviour, not the thing being checked; `isExe` makes the intent immediately clear.

- **Extracted `patchManifestExecutionLevel` helper** from `editWindowsResources` in [`resEdit.ts`](packages/app-builder-lib/src/util/resEdit.ts), reducing its cyclomatic complexity and making the manifest-patching path independently readable and testable.

- **Added three new unit tests** in [`winReseditTest.ts`](test/src/windows/winReseditTest.ts) covering icon resource handling in `editWindowsResources`:
  - icon resources (RT_ICON type 3, RT_GROUP_ICON type 14) are added when `iconPath` is provided
  - no icon resources are added when `iconPath` is omitted
  - a second call with the same `iconPath` does not duplicate RT_GROUP_ICON entries

## Changed Files

| File | Change |
|------|--------|
| [`packages/app-builder-lib/src/winPackager.ts`](packages/app-builder-lib/src/winPackager.ts) | Informational log when `signAndEditExecutable` is false; `walkSignableFiles` extraction; `isExe` rename |
| [`packages/app-builder-lib/src/util/resEdit.ts`](packages/app-builder-lib/src/util/resEdit.ts) | Extracted `patchManifestExecutionLevel` helper |
| [`test/src/windows/winReseditTest.ts`](test/src/windows/winReseditTest.ts) | Three new icon-related unit tests |
