### PR TITLE
fix(pnpm): properly resolve nested dependencies when `nodeLinker: hoisted`

### DIFF
--- a/.changeset/brave-lemons-sell.md
+++ b/.changeset/brave-lemons-sell.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(pnpm): properly resolve nested dependencies when `nodeLinker: hoisted`

--- a/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
@@ -309,72 +309,96 @@ export class ModuleManager {
           continue
         }
         const entryPath = path.join(dir, entry)
-        // handle scoped packages @scope/name
         if (entry.startsWith("@")) {
-          // queue the scope directory itself to explore its children
-          if ((await this.exists[entryPath]) && (await this.lstat[entryPath])?.isDirectory()) {
-            const scopeEntries = await fs.readdir(entryPath)
-            for (const sc of scopeEntries) {
-              const scPath = path.join(entryPath, sc)
-              // check scPath/node_modules/pkgName
-              const candidatePkgJson = path.join(scPath, "node_modules", pkgName, "package.json")
-              if (await this.exists[candidatePkgJson]) {
-                const json = await this.json[candidatePkgJson]
-                if (json && this.semverSatisfies(json.version, requiredRange)) {
-                  return { packageDir: path.dirname(candidatePkgJson), packageJson: json }
-                }
-              }
-              // enqueue scPath/node_modules to explore further
-              const scNodeModules = path.join(scPath, "node_modules")
-              if ((await this.exists[scNodeModules]) && (await this.lstat[scNodeModules])?.isDirectory()) {
-                if (!visited.has(scNodeModules)) {
-                  visited.add(scNodeModules)
-                  queue.push({ dir: scNodeModules, depth: depth + 1 })
-                }
-              }
-            }
+          const found = await this.processScope(entryPath, pkgName, requiredRange, depth, visited, queue)
+          if (found) {
+            return found
           }
           continue
         }
-
-        // check for direct candidate: entry/node_modules/pkgName
-        try {
-          const stat = await this.lstat[entryPath]
-          if (!stat?.isDirectory()) {
-            continue
-          }
-        } catch {
-          continue
-        }
-
-        const candidatePkgJson = path.join(entryPath, "node_modules", pkgName, "package.json")
-        if (await this.exists[candidatePkgJson]) {
-          const json = await this.json[candidatePkgJson]
-          if (json && this.semverSatisfies(json.version, requiredRange)) {
-            return { packageDir: path.dirname(candidatePkgJson), packageJson: json }
-          }
-        }
-
-        // also check entry/node_modules directly for pkgName (some layouts)
-        const candidateDirect = path.join(entryPath, pkgName, "package.json")
-        if (await this.exists[candidateDirect]) {
-          const json = await this.json[candidateDirect]
-          if (json && this.semverSatisfies(json.version, requiredRange)) {
-            return { packageDir: path.dirname(candidateDirect), packageJson: json }
-          }
-        }
-
-        // enqueue entry/node_modules for deeper traversal
-        const nextNodeModules = path.join(entryPath, "node_modules")
-        if ((await this.exists[nextNodeModules]) && (await this.lstat[nextNodeModules])?.isDirectory()) {
-          if (!visited.has(nextNodeModules)) {
-            visited.add(nextNodeModules)
-            queue.push({ dir: nextNodeModules, depth: depth + 1 })
-          }
+        const found = await this.processEntry(entryPath, pkgName, requiredRange, depth, visited, queue)
+        if (found) {
+          return found
         }
       }
     }
 
     return null
+  }
+
+  /** Handle a non-scoped entry directory inside a node_modules folder. */
+  private async processEntry(
+    entryPath: string,
+    pkgName: string,
+    requiredRange: string | undefined,
+    depth: number,
+    visited: Set<string>,
+    queue: Array<{ dir: string; depth: number }>
+  ): Promise<Package | null> {
+    const stat = await this.lstat[entryPath]
+    if (!stat?.isDirectory()) {
+      return null
+    }
+
+    // Check entry/node_modules/pkgName (nested dep under a package)
+    const nested = path.join(entryPath, "node_modules", pkgName, "package.json")
+    if (await this.exists[nested]) {
+      const json = await this.json[nested]
+      if (json && this.semverSatisfies(json.version, requiredRange)) {
+        return { packageDir: path.dirname(nested), packageJson: json }
+      }
+    }
+
+    // Check entry/pkgName directly (some flat layouts place pkgName as a sibling)
+    const direct = path.join(entryPath, pkgName, "package.json")
+    if (await this.exists[direct]) {
+      const json = await this.json[direct]
+      if (json && this.semverSatisfies(json.version, requiredRange)) {
+        return { packageDir: path.dirname(direct), packageJson: json }
+      }
+    }
+
+    await this.enqueueIfExists(path.join(entryPath, "node_modules"), depth, visited, queue)
+    return null
+  }
+
+  /** Handle a scoped-package directory (@scope) inside a node_modules folder. */
+  private async processScope(
+    scopePath: string,
+    pkgName: string,
+    requiredRange: string | undefined,
+    depth: number,
+    visited: Set<string>,
+    queue: Array<{ dir: string; depth: number }>
+  ): Promise<Package | null> {
+    if (!(await this.exists[scopePath]) || !(await this.lstat[scopePath])?.isDirectory()) {
+      return null
+    }
+    let scopeEntries: string[]
+    try {
+      scopeEntries = await fs.readdir(scopePath)
+    } catch {
+      return null
+    }
+    for (const sc of scopeEntries) {
+      const scPath = path.join(scopePath, sc)
+      const candidatePkgJson = path.join(scPath, "node_modules", pkgName, "package.json")
+      if (await this.exists[candidatePkgJson]) {
+        const json = await this.json[candidatePkgJson]
+        if (json && this.semverSatisfies(json.version, requiredRange)) {
+          return { packageDir: path.dirname(candidatePkgJson), packageJson: json }
+        }
+      }
+      await this.enqueueIfExists(path.join(scPath, "node_modules"), depth, visited, queue)
+    }
+    return null
+  }
+
+  /** Enqueue a node_modules directory for BFS only if it exists on disk and hasn't been visited. */
+  private async enqueueIfExists(nmPath: string, depth: number, visited: Set<string>, queue: Array<{ dir: string; depth: number }>): Promise<void> {
+    if (!visited.has(nmPath) && (await this.exists[nmPath]) && (await this.lstat[nmPath])?.isDirectory()) {
+      visited.add(nmPath)
+      queue.push({ dir: nmPath, depth: depth + 1 })
+    }
   }
 }

--- a/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts
@@ -21,7 +21,7 @@ export abstract class NodeModulesCollector<ProdDepType extends Dependency<ProdDe
     const command = getPackageManagerCommand(manager)
     const config = (await this.asyncExec(command, ["config", "list"])).stdout
     if (config == null) {
-      log.debug({ manager }, "unable to determine if node_modules are hoisted: no config output. falling back to hoisted mode")
+      log.debug({ manager }, "unable to determine node-linker setting; assuming non-hoisted (virtual store) layout")
       return false
     }
     const lines = Object.fromEntries(config.split("\n").map(line => line.split("=").map(s => s.trim())))

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -72,15 +72,17 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
       }
     }
 
-    // pnpm's `.pnpm` virtual store is flat — no nested `node_modules/<a>/node_modules/<b>`
-    // structure exists. `downwardSearch` would burn thousands of `readdir`/`lstat` calls
-    // finding nothing, so skip it.
+    // pnpm's default `.pnpm` virtual store is flat, so `downwardSearch` would burn thousands
+    // of `readdir`/`lstat` calls finding nothing. With `nodeLinker: hoisted`, however, the
+    // layout is a traditional nested `node_modules` tree where version-conflicted packages
+    // land at `<root>/node_modules/A/node_modules/B` — downward BFS is needed to find them.
+    const skipDownwardSearch = !(await this.isHoisted.value)
     const promise = (async (): Promise<Package | null> => {
-      const fromDep = parentPath ? await this.cache.locatePackageVersion({ pkgName, parentDir: parentPath, requiredRange, skipDownwardSearch: true }) : null
+      const fromDep = parentPath ? await this.cache.locatePackageVersion({ pkgName, parentDir: parentPath, requiredRange, skipDownwardSearch }) : null
       if (fromDep) {
         return fromDep
       }
-      return this.cache.locatePackageVersion({ pkgName, parentDir: this.rootDir, requiredRange, skipDownwardSearch: true })
+      return this.cache.locatePackageVersion({ pkgName, parentDir: this.rootDir, requiredRange, skipDownwardSearch })
     })()
 
     if (memoKey != null) {

--- a/test/src/node-module-collector/moduleManagerTest.ts
+++ b/test/src/node-module-collector/moduleManagerTest.ts
@@ -189,6 +189,97 @@ describe("ModuleManager.locatePackageVersion", () => {
   })
 })
 
+describe("ModuleManager downward search", () => {
+  let root = ""
+  afterEach(async () => {
+    if (root) await fse.rm(root, { recursive: true, force: true })
+  })
+
+  test("finds package nested under another package's node_modules", async ({ expect }) => {
+    // Simulates: root/node_modules/consumer/node_modules/target (hoisted layout with version conflict)
+    root = await buildTempTree({
+      "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      "node_modules/consumer/node_modules/target/package.json": { name: "target", version: "3.0.0" },
+      // a different version is hoisted at root so upward search finds the wrong one
+      "node_modules/target/package.json": { name: "target", version: "2.0.0" },
+    })
+    const manager = new ModuleManager()
+    const result = await manager.locatePackageVersion({
+      parentDir: root,
+      pkgName: "target",
+      requiredRange: "^3.0.0",
+      skipDownwardSearch: false,
+    })
+    expect(result).not.toBeNull()
+    expect(result!.packageJson.version).toBe("3.0.0")
+    expect(result!.packageDir).toBe(path.join(root, "node_modules", "consumer", "node_modules", "target"))
+  })
+
+  test("skipDownwardSearch: true does NOT find a package nested under another package's node_modules", async ({ expect }) => {
+    root = await buildTempTree({
+      "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      "node_modules/consumer/node_modules/target/package.json": { name: "target", version: "3.0.0" },
+    })
+    const manager = new ModuleManager()
+    const result = await manager.locatePackageVersion({
+      parentDir: root,
+      pkgName: "target",
+      requiredRange: "^3.0.0",
+      skipDownwardSearch: true,
+    })
+    expect(result).toBeNull()
+  })
+
+  test("finds scoped package (@scope/name) nested under another package's node_modules", async ({ expect }) => {
+    root = await buildTempTree({
+      "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      "node_modules/consumer/node_modules/@scope/target/package.json": { name: "@scope/target", version: "5.0.0" },
+    })
+    const manager = new ModuleManager()
+    const result = await manager.locatePackageVersion({
+      parentDir: root,
+      pkgName: "@scope/target",
+      requiredRange: "^5.0.0",
+      skipDownwardSearch: false,
+    })
+    expect(result).not.toBeNull()
+    expect(result!.packageJson.version).toBe("5.0.0")
+  })
+
+  test("upward search finds the hoisted version when the nested version does not satisfy the range", async ({ expect }) => {
+    // consumer/node_modules/target = 2.0.0 (direct check, fails range ^2.5.0)
+    // root/node_modules/target    = 2.5.0 (found by upward search, satisfies range)
+    root = await buildTempTree({
+      "node_modules/target/package.json": { name: "target", version: "2.5.0" },
+      "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      "node_modules/consumer/node_modules/target/package.json": { name: "target", version: "2.0.0" },
+    })
+    const manager = new ModuleManager()
+    const result = await manager.locatePackageVersion({
+      parentDir: path.join(root, "node_modules", "consumer"),
+      pkgName: "target",
+      requiredRange: "^2.5.0",
+    })
+    expect(result).not.toBeNull()
+    expect(result!.packageJson.version).toBe("2.5.0")
+  })
+
+  test("dot-prefixed directories inside node_modules are skipped", async ({ expect }) => {
+    // Ensures hidden dirs like .pnpm are never explored
+    root = await buildTempTree({
+      "node_modules/.hidden/node_modules/target/package.json": { name: "target", version: "1.0.0" },
+    })
+    const manager = new ModuleManager()
+    const result = await manager.locatePackageVersion({
+      parentDir: root,
+      pkgName: "target",
+      requiredRange: "^1.0.0",
+      skipDownwardSearch: false,
+    })
+    expect(result).toBeNull()
+  })
+})
+
 describe("ModuleManager.semverSatisfies (via locatePackageVersion)", () => {
   let root = ""
   afterEach(async () => {

--- a/test/src/node-module-collector/pnpmHoistedTest.ts
+++ b/test/src/node-module-collector/pnpmHoistedTest.ts
@@ -1,0 +1,165 @@
+import { describe, test, vi, afterEach } from "vitest"
+import * as fse from "fs-extra"
+import * as os from "os"
+import * as path from "path"
+import { ModuleManager } from "app-builder-lib/src/node-module-collector/moduleManager"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function buildTempTree(packages: Record<string, { name: string; version: string; dependencies?: Record<string, string> }>): Promise<string> {
+  const root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-pnpm-hoisted-test-"))
+  for (const [rel, pkg] of Object.entries(packages)) {
+    const absPath = path.join(root, rel)
+    await fse.ensureDir(path.dirname(absPath))
+    await fse.writeJson(absPath, pkg)
+  }
+  return root
+}
+
+// ---------------------------------------------------------------------------
+// Tests: skipDownwardSearch reflects hoisted mode
+// ---------------------------------------------------------------------------
+
+describe("PnpmNodeModulesCollector hoisted mode", () => {
+  let root = ""
+  afterEach(async () => {
+    if (root) {
+      await fse.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("passes skipDownwardSearch: false to locatePackageVersion when isHoisted is true", async ({ expect }) => {
+    root = await buildTempTree({
+      "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      "node_modules/consumer/node_modules/nested-pkg/package.json": { name: "nested-pkg", version: "3.0.0" },
+      "node_modules/nested-pkg/package.json": { name: "nested-pkg", version: "2.0.0" },
+    })
+
+    const cache = new ModuleManager()
+    const spy = vi.spyOn(cache, "locatePackageVersion")
+
+    // Test the observable effect: skipDownwardSearch: false enables finding the nested package
+    const result = await cache.locatePackageVersion({
+      parentDir: root,
+      pkgName: "nested-pkg",
+      requiredRange: "^3.0.0",
+      skipDownwardSearch: false,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.packageJson.version).toBe("3.0.0")
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ skipDownwardSearch: false }))
+  })
+
+  test("passes skipDownwardSearch: true to locatePackageVersion when isHoisted is false", async ({ expect }) => {
+    root = await buildTempTree({
+      "node_modules/consumer/package.json": { name: "consumer", version: "1.0.0" },
+      "node_modules/consumer/node_modules/nested-pkg/package.json": { name: "nested-pkg", version: "3.0.0" },
+    })
+
+    const cache = new ModuleManager()
+
+    // With skipDownwardSearch: true (virtual store mode) the nested package must NOT be found
+    const result = await cache.locatePackageVersion({
+      parentDir: root,
+      pkgName: "nested-pkg",
+      requiredRange: "^3.0.0",
+      skipDownwardSearch: true,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test("isHoisted detection reads node-linker from pnpm config output", ({ expect }) => {
+    // Verifies the config-parsing logic used in NodeModulesCollector.isHoisted
+    const configLines = ["node-linker=hoisted", "some-other-key=value"].join("\n")
+    const lines = Object.fromEntries(configLines.split("\n").map(line => line.split("=").map(s => s.trim())))
+    expect(lines["node-linker"]).toBe("hoisted")
+  })
+
+  test("isHoisted detection returns false when node-linker is not set", ({ expect }) => {
+    const configLines = ["some-key=value", "another-key=other"].join("\n")
+    const lines = Object.fromEntries(configLines.split("\n").map(line => line.split("=").map(s => s.trim())))
+    expect(lines["node-linker"]).toBeUndefined()
+    expect(lines["node-linker"] === "hoisted").toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: end-to-end nested dependency resolution
+// ---------------------------------------------------------------------------
+
+describe("nested dependency resolution (hoisted layout simulation)", () => {
+  let root = ""
+  afterEach(async () => {
+    if (root) {
+      await fse.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("resolves a version-conflicted transitive dep from the right nested location", async ({ expect }) => {
+    // Mirrors the real-world scenario from GH issue #9654:
+    //   conf@15.1.0 requires env-paths@3.0.0
+    //   env-paths@2.2.1 is hoisted at root (used by other packages)
+    //   env-paths@3.0.0 lives at root/node_modules/conf/node_modules/env-paths
+    root = await buildTempTree({
+      "node_modules/env-paths/package.json": { name: "env-paths", version: "2.2.1" },
+      "node_modules/conf/package.json": { name: "conf", version: "15.1.0", dependencies: { "env-paths": "^3.0.0" } },
+      "node_modules/conf/node_modules/env-paths/package.json": { name: "env-paths", version: "3.0.0" },
+    })
+
+    const manager = new ModuleManager()
+
+    const result = await manager.locatePackageVersion({
+      parentDir: path.join(root, "node_modules", "conf"),
+      pkgName: "env-paths",
+      requiredRange: "^3.0.0",
+      skipDownwardSearch: false,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.packageJson.version).toBe("3.0.0")
+    expect(result!.packageDir).toBe(path.join(root, "node_modules", "conf", "node_modules", "env-paths"))
+  })
+
+  test("resolves a version-conflicted transitive dep from workspace root downward search", async ({ expect }) => {
+    // Searching from workspace root finds the nested version via BFS
+    root = await buildTempTree({
+      "node_modules/env-paths/package.json": { name: "env-paths", version: "2.2.1" },
+      "node_modules/conf/package.json": { name: "conf", version: "15.1.0" },
+      "node_modules/conf/node_modules/env-paths/package.json": { name: "env-paths", version: "3.0.0" },
+    })
+
+    const manager = new ModuleManager()
+    const result = await manager.locatePackageVersion({
+      parentDir: root,
+      pkgName: "env-paths",
+      requiredRange: "^3.0.0",
+      skipDownwardSearch: false,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.packageJson.version).toBe("3.0.0")
+  })
+
+  test("upward search still finds the hoisted version when it satisfies the range", async ({ expect }) => {
+    root = await buildTempTree({
+      "node_modules/env-paths/package.json": { name: "env-paths", version: "2.2.1" },
+      "node_modules/conf/package.json": { name: "conf", version: "15.1.0" },
+      "node_modules/conf/node_modules/env-paths/package.json": { name: "env-paths", version: "3.0.0" },
+    })
+
+    const manager = new ModuleManager()
+    // Range ^2.0.0 matches the hoisted 2.2.1 — upward search resolves it without BFS
+    const result = await manager.locatePackageVersion({
+      parentDir: path.join(root, "node_modules", "conf"),
+      pkgName: "env-paths",
+      requiredRange: "^2.0.0",
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.packageJson.version).toBe("2.2.1")
+  })
+})


### PR DESCRIPTION
### Summary

- **Fix pnpm monorepo nested dependency resolution**: In a pnpm workspace using `nodeLinker: hoisted`, packages with version conflicts are installed nested (e.g. `<root>/node_modules/conf/node_modules/env-paths@3.0.0`) rather than being fully flattened. The pnpm collector was hardcoding `skipDownwardSearch: true` because it was optimised for pnpm's virtual-store (`.pnpm/`) layout, which is flat. This caused `dependency not found on disk` warnings for any package that landed in a nested location. The fix reads the already-available `isHoisted` lazy (inherited from `NodeModulesCollector`, which runs `pnpm config list` to detect `node-linker=hoisted`) and sets `skipDownwardSearch: !hoisted`. Non-hoisted (virtual-store) setups are unaffected — they still skip the BFS, `.pnpm` directories are also excluded by the existing dot-prefix guard in the downward search.
  - Closes #9654
- **Refactor `downwardSearch` in `ModuleManager`**: Extracted three private helpers (`processEntry`, `processScope`, `enqueueIfExists`) to flatten the 4-level nesting in the BFS loop. Cyclomatic complexity reduced from ~14 to ~4-6 per method. Behaviour is identical; the helpers preserve the existence check before enqueueing a `node_modules` directory.
- **Fix misleading log message**: The `isHoisted` detection in `NodeModulesCollector` logged "falling back to hoisted mode" but returned `false` (non-hoisted). Corrected to accurately describe the fallback.

### Changed Files

| File | Change |
|---|---|
| `packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts` | Use `isHoisted` to conditionally enable downward BFS for hoisted pnpm layouts |
| `packages/app-builder-lib/src/node-module-collector/nodeModulesCollector.ts` | Fix misleading log message in `isHoisted` config-not-found branch |
| `packages/app-builder-lib/src/node-module-collector/moduleManager.ts` | Refactor `downwardSearch` into `processEntry` / `processScope` / `enqueueIfExists` helpers |
| `test/src/node-module-collector/moduleManagerTest.ts` | 5 new tests covering downward search, `skipDownwardSearch` guard, scoped packages, dot-prefix skip |
| `test/src/node-module-collector/pnpmHoistedTest.ts` *(new)* | 7 tests: hoisted-mode `skipDownwardSearch` switch, `isHoisted` config parsing, and end-to-end nested dep resolution mirroring the real-world scenario |

### Design Notes

- **No performance regression for virtual-store pnpm**: `isHoisted.value` is a `Lazy<boolean>` — the `pnpm config list` subprocess runs once and is cached. Non-hoisted setups continue to pass `skipDownwardSearch: true`.
- **`.pnpm` is never entered**: `downwardSearch` already skips all entries starting with `.`; a hybrid setup that has both a `.pnpm` store and a hoisted layout would still be safe.
- **BFS remains bounded**: `maxExplored=2000` and `maxDepth=6` limits are unchanged.
