### PR TITLE
fix(dynamic-import): resolve module paths via CJS resolver for reliable subpath imports

### DIFF
--- a/.changeset/fix-dynamic-import-pnpm-subpath.md
+++ b/.changeset/fix-dynamic-import-pnpm-subpath.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(dynamic-import): use CJS resolver to reliably resolve package subpaths in pnpm projects

--- a/packages/app-builder-lib/helpers/dynamic-import.js
+++ b/packages/app-builder-lib/helpers/dynamic-import.js
@@ -1,13 +1,18 @@
 const url = require("url")
 const fs = require("fs")
+const path = require("path")
 
 // Resolve a module specifier to a file:// URL using CJS resolution, which
 // adds .js extensions automatically and follows pnpm's symlinked node_modules.
-// Falls back to the raw specifier if require.resolve() cannot find the path
-// (e.g. the module isn't installed yet — caller will get the normal error).
+// Returns null for Node built-ins (require.resolve returns a bare string, not
+// an absolute path) and for any specifier that cannot be resolved, so callers
+// fall back to importing the raw specifier and get the normal error.
 function resolveToFileUrl(modulePath) {
   try {
-    return url.pathToFileURL(require.resolve(modulePath)).href
+    const resolved = require.resolve(modulePath)
+    // Built-in modules (e.g. "fs", "path") resolve to their bare name, not a
+    // filesystem path. Passing a bare name to pathToFileURL produces a bogus URL.
+    return path.isAbsolute(resolved) ? url.pathToFileURL(resolved).href : null
   } catch {
     return null
   }

--- a/packages/app-builder-lib/helpers/dynamic-import.js
+++ b/packages/app-builder-lib/helpers/dynamic-import.js
@@ -1,20 +1,32 @@
 const url = require("url")
 const fs = require("fs")
 
-exports.dynamicImport = async function dynamicImport(path) {
+// Resolve a module specifier to a file:// URL using CJS resolution, which
+// adds .js extensions automatically and follows pnpm's symlinked node_modules.
+// Falls back to the raw specifier if require.resolve() cannot find the path
+// (e.g. the module isn't installed yet — caller will get the normal error).
+function resolveToFileUrl(modulePath) {
   try {
-    return await import(fs.existsSync(path) ? url.pathToFileURL(path).href : path)
-  } catch (error) {
-    return Promise.reject(error)
+    return url.pathToFileURL(require.resolve(modulePath)).href
+  } catch {
+    return null
   }
 }
 
-exports.dynamicImportMaybe = async function dynamicImportMaybe(path) {
+exports.dynamicImport = async function dynamicImport(modulePath) {
+  if (fs.existsSync(modulePath)) {
+    return import(url.pathToFileURL(modulePath).href)
+  }
+  const fileUrl = resolveToFileUrl(modulePath)
+  return import(fileUrl !== null ? fileUrl : modulePath)
+}
+
+exports.dynamicImportMaybe = async function dynamicImportMaybe(modulePath) {
   try {
-    return require(path)
+    return require(modulePath)
   } catch (e1) {
     try {
-      return await exports.dynamicImport(path)
+      return await exports.dynamicImport(modulePath)
     } catch (e2) {
       e1.message = "\n1. " + e1.message + "\n2. " + e2.message
       throw e1

--- a/test/src/dynamicImportTest.ts
+++ b/test/src/dynamicImportTest.ts
@@ -33,7 +33,7 @@ describe("dynamicImport", () => {
   test("imports an absolute file path", async () => {
     const tempDir = path.join(WORKSPACE_ROOT, "temp")
     fs.mkdirSync(tempDir, { recursive: true })
-    const tmpFile = path.join(tempDir, `dynamic-import-test-${Date.now()}.js`)
+    const tmpFile = path.join(tempDir, `dynamic-import-test-${Date.now()}-${Math.random().toString(16).slice(2)}.js`)
     fs.writeFileSync(tmpFile, "exports.value = 42")
     try {
       const mod = await helper.dynamicImport(tmpFile)

--- a/test/src/dynamicImportTest.ts
+++ b/test/src/dynamicImportTest.ts
@@ -43,6 +43,12 @@ describe("dynamicImport", () => {
     }
   })
 
+  test("imports a Node built-in module", async () => {
+    // Built-ins must not be routed through pathToFileURL — require.resolve("fs") === "fs"
+    const mod = await helper.dynamicImport("fs")
+    expect(typeof mod.readFileSync).toBe("function")
+  })
+
   test("rejects for a nonexistent module", async () => {
     await expect(helper.dynamicImport("__nonexistent_pkg_that_does_not_exist__")).rejects.toThrow()
   })
@@ -56,6 +62,7 @@ describe("dynamicImportMaybe", () => {
   })
 
   test("rejects with combined error message for a nonexistent module", async () => {
-    await expect(helper.dynamicImportMaybe("__nonexistent_pkg_that_does_not_exist__")).rejects.toThrow(/1\.|2\./)
+    // Require both markers in order: "\n1. <cjs error>\n2. <esm error>"
+    await expect(helper.dynamicImportMaybe("__nonexistent_pkg_that_does_not_exist__")).rejects.toThrow(/1\.[\s\S]*2\./)
   })
 })

--- a/test/src/dynamicImportTest.ts
+++ b/test/src/dynamicImportTest.ts
@@ -1,0 +1,61 @@
+import * as fs from "fs"
+import * as path from "path"
+import { expect } from "vitest"
+
+const WORKSPACE_ROOT = path.resolve(__dirname, "../../")
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const helper = require("../../packages/app-builder-lib/helpers/dynamic-import") as {
+  dynamicImport(modulePath: string): Promise<any>
+  dynamicImportMaybe(modulePath: string): Promise<any>
+}
+
+describe("dynamicImport", () => {
+  test("imports a package root specifier", async () => {
+    const mod = await helper.dynamicImport("@electron/osx-sign")
+    expect(mod).toBeDefined()
+    expect(typeof mod.signAsync).toBe("function")
+  })
+
+  test("imports a package subpath specifier (no .js extension)", async () => {
+    // This is the scenario reported in issue #9816 — pnpm fails without .js
+    const mod = await helper.dynamicImport("@electron/osx-sign/dist/cjs/util-identities")
+    expect(mod).toBeDefined()
+    expect(typeof mod.Identity).toBe("function")
+  })
+
+  test("imports a package subpath specifier (with .js extension)", async () => {
+    const mod = await helper.dynamicImport("@electron/osx-sign/dist/cjs/util-identities.js")
+    expect(mod).toBeDefined()
+    expect(typeof mod.Identity).toBe("function")
+  })
+
+  test("imports an absolute file path", async () => {
+    const tempDir = path.join(WORKSPACE_ROOT, "temp")
+    fs.mkdirSync(tempDir, { recursive: true })
+    const tmpFile = path.join(tempDir, `dynamic-import-test-${Date.now()}.js`)
+    fs.writeFileSync(tmpFile, "exports.value = 42")
+    try {
+      const mod = await helper.dynamicImport(tmpFile)
+      expect(mod.value).toBe(42)
+    } finally {
+      fs.unlinkSync(tmpFile)
+    }
+  })
+
+  test("rejects for a nonexistent module", async () => {
+    await expect(helper.dynamicImport("__nonexistent_pkg_that_does_not_exist__")).rejects.toThrow()
+  })
+})
+
+describe("dynamicImportMaybe", () => {
+  test("loads a CJS-compatible package via require", async () => {
+    const mod = await helper.dynamicImportMaybe("@electron/osx-sign")
+    expect(mod).toBeDefined()
+    expect(typeof mod.signAsync).toBe("function")
+  })
+
+  test("rejects with combined error message for a nonexistent module", async () => {
+    await expect(helper.dynamicImportMaybe("__nonexistent_pkg_that_does_not_exist__")).rejects.toThrow(/1\.|2\./)
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-builder/issues/9816

## Summary

- **Root cause**: `helpers/dynamic-import.js` called `import(specifier)` directly for non-filesystem specifiers, relying on Node.js's ESM loader to resolve bare package names and subpaths. In pnpm environments, the ESM loader resolves packages to `.pnpm`-namespaced locations and requires explicit `.js` file extensions for subpath imports (e.g. `@electron/osx-sign/dist/cjs/util-identities` fails; `@electron/osx-sign/dist/cjs/util-identities.js` succeeds). This caused a crash at build time on pnpm projects.

- **Fix**: Introduce a `resolveToFileUrl` helper inside `dynamic-import.js` that calls `require.resolve(specifier)` before importing. The CJS resolver (`require.resolve`) automatically appends `.js` extensions, follows pnpm's symlinked `node_modules`, and returns the real absolute file path. We then convert that to a `file://` URL for `import()`, which always works regardless of package manager layout. If `require.resolve` fails (e.g. the module is not installed), the function falls back to the raw specifier so the caller receives the normal module-not-found error.

- **Code hygiene**: Removed the redundant `catch (error) { return Promise.reject(error) }` pattern from the old `dynamicImport` — in an `async` function a thrown error is already a rejected Promise; the extra wrapper was a no-op. Renamed the local variable `path` → `modulePath` throughout to avoid shadowing the built-in `path` module name.

- **Tests**: Added `test/src/dynamicImportTest.ts` covering all resolution branches:
  - Package root specifier (`@electron/osx-sign`)
  - Subpath specifier without `.js` extension (the regression case from the issue)
  - Subpath specifier with `.js` extension
  - Absolute file path (existing `fs.existsSync` branch)
  - Nonexistent module (error propagation)
  - `dynamicImportMaybe` CJS-first path
  - `dynamicImportMaybe` combined error message

## Changed Files

| File | Change |
|------|--------|
| [`packages/app-builder-lib/helpers/dynamic-import.js`](packages/app-builder-lib/helpers/dynamic-import.js) | Use `require.resolve()` to obtain the actual file path before `import()`; extract `resolveToFileUrl` helper; clean up redundant error wrapping; rename `path` → `modulePath` |
| [`test/src/dynamicImportTest.ts`](test/src/dynamicImportTest.ts) | New test suite for `dynamicImport` and `dynamicImportMaybe` |

## Design Notes

`require.resolve()` is called inside `dynamic-import.js` itself (a CJS file), so Node.js resolves paths relative to that file's location — i.e. `packages/app-builder-lib/helpers/`. This means the same `@electron/*` packages that `app-builder-lib` depends on are found correctly, regardless of whether the caller is in the same package or a test runner elsewhere in the monorepo.