### PR TITLE
fix(builder-util): add timeout to `spawnAndWriteWithOutput`

### DIFF
--- a/.changeset/warm-bugs-hide.md
+++ b/.changeset/warm-bugs-hide.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"builder-util": patch
+---
+
+fix(builder-util): add timeout to `spawnAndWriteWithOutput`

--- a/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisValidation.ts
@@ -44,10 +44,12 @@ export async function verifyInstallerSize(outFile: string, defines: Defines): Pr
   }
 
   const outStat = await statOrNull(outFile)
-  const actualSize = outStat?.size ?? 0
-  if (actualSize < archiveSize) {
+  if (outStat == null) {
+    throw new Error(`Generated installer was not created at "${outFile}" — output may be incomplete. Check available disk space and try again.`)
+  }
+  if (outStat.size < archiveSize) {
     throw new Error(
-      `Generated installer (${actualSize} bytes) is smaller than the embedded archive(s) (${archiveSize} bytes) — ` +
+      `Generated installer (${outStat.size} bytes) is smaller than the embedded archive(s) (${archiveSize} bytes) — ` +
         `output may be incomplete. Check available disk space and try again.`
     )
   }

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -275,12 +275,17 @@ export function spawnAndWrite(command: string, args: Array<string>, data: string
 
 export function spawnAndWriteWithOutput(command: string, args: Array<string>, data: string, options?: SpawnOptions): Promise<{ stdout: string; stderr: string }> {
   const childProcess = doSpawn(command, args, { ...options, stdio: ["pipe", "pipe", "pipe"] as any })
-  const timeout = setTimeout(() => childProcess.kill(), 4 * 60 * 1000)
   const isDebugEnabled = debug.enabled
 
   return new Promise((resolve, reject) => {
     let stdout = ""
     let stderr = ""
+    let timedOut = false
+
+    const timeout = setTimeout(() => {
+      timedOut = true
+      childProcess.kill()
+    }, 4 * 60 * 1000)
 
     childProcess.on("error", (err: Error) => {
       clearTimeout(timeout)
@@ -305,7 +310,9 @@ export function spawnAndWriteWithOutput(command: string, args: Array<string>, da
 
     childProcess.once("close", (code: number) => {
       clearTimeout(timeout)
-      if (code === 0) {
+      if (timedOut) {
+        reject(new Error(`${command} timed out after 4 minutes`))
+      } else if (code === 0) {
         resolve({ stdout, stderr })
       } else {
         reject(new ExecError(command, code ?? -1, stdout, stderr))

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -1,4 +1,4 @@
-import { removePassword, filterSensitiveEnv } from "builder-util"
+import { removePassword, filterSensitiveEnv, spawnAndWriteWithOutput, ExecError } from "builder-util"
 import { parseValidEnvVarUrl } from "builder-util/out/envUtil"
 import { afterEach, vi } from "vitest"
 
@@ -260,5 +260,71 @@ describe("removePassword: multiple keys in one string", () => {
     const output = removePassword(input)
 
     expect(output).toMatchSnapshot()
+  })
+})
+
+// ─── spawnAndWriteWithOutput ────────────────────────────────────────────────
+
+describe("spawnAndWriteWithOutput", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("resolves with captured stdout and stderr", async ({ expect }) => {
+    const script = `
+      let buf = ""
+      process.stdin.on("data", d => { buf += d })
+      process.stdin.on("end", () => {
+        process.stdout.write("out:" + buf)
+        process.stderr.write("err:" + buf)
+      })
+    `
+    const { stdout, stderr } = await spawnAndWriteWithOutput(process.execPath, ["-e", script], "hello")
+    expect(stdout).toBe("out:hello")
+    expect(stderr).toBe("err:hello")
+  })
+
+  test("resolves with empty stdout and stderr when process emits nothing", async ({ expect }) => {
+    const { stdout, stderr } = await spawnAndWriteWithOutput(process.execPath, ["-e", ""], "")
+    expect(stdout).toBe("")
+    expect(stderr).toBe("")
+  })
+
+  test("rejects with ExecError on non-zero exit code", async ({ expect }) => {
+    const script = `process.stdout.write("some output"); process.exit(1)`
+    await expect(spawnAndWriteWithOutput(process.execPath, ["-e", script], "")).rejects.toBeInstanceOf(ExecError)
+  })
+
+  test("ExecError includes stdout and stderr from failed process", async ({ expect }) => {
+    const script = `process.stdout.write("stdoutval"); process.stderr.write("stderrval"); process.exit(2)`
+    let caught: unknown
+    try {
+      await spawnAndWriteWithOutput(process.execPath, ["-e", script], "")
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ExecError)
+    const err = caught as ExecError
+    expect(err.exitCode).toBe(2)
+    expect(err.message).toContain("stdoutval")
+    expect(err.message).toContain("stderrval")
+  })
+
+  test("writes data to stdin and reads it back", async ({ expect }) => {
+    const script = `
+      let buf = ""
+      process.stdin.on("data", d => { buf += d })
+      process.stdin.on("end", () => process.stdout.write(buf.toUpperCase()))
+    `
+    const { stdout } = await spawnAndWriteWithOutput(process.execPath, ["-e", script], "hello world")
+    expect(stdout).toBe("HELLO WORLD")
+  })
+
+  test("rejects with a timeout error when process does not finish within 4 minutes", async ({ expect }) => {
+    vi.useFakeTimers()
+    const script = `setInterval(() => {}, 999999)`
+    const promise = spawnAndWriteWithOutput(process.execPath, ["-e", script], "")
+    vi.advanceTimersByTime(4 * 60 * 1000 + 100)
+    await expect(promise).rejects.toThrow(/timed out/i)
   })
 })

--- a/test/src/windows/nsisOutputValidationTest.ts
+++ b/test/src/windows/nsisOutputValidationTest.ts
@@ -122,11 +122,11 @@ describe("verifyInstallerSize", () => {
     await expect(verifyInstallerSize(outFile, defines)).resolves.not.toThrow()
   })
 
-  test("throws when installer file does not exist", async ({ expect }) => {
+  test("throws a descriptive error when installer file does not exist", async ({ expect }) => {
     const archive = await writeFile("app.7z", 5000)
     const defines = { ...baseDefines(), APP_64: archive }
     const missingOut = path.join(tmpDir, "missing.exe")
-    await expect(verifyInstallerSize(missingOut, defines)).rejects.toThrow(/smaller/i)
+    await expect(verifyInstallerSize(missingOut, defines)).rejects.toThrow(/not created/i)
   })
 
   test("skips size check when archive path does not exist", async ({ expect }) => {
@@ -141,5 +141,30 @@ describe("verifyInstallerSize", () => {
     const outFile = await writeFile("installer.exe", 3000)
     const defines = { ...baseDefines(), APP_ARM64: archiveArm64 }
     await expect(verifyInstallerSize(outFile, defines)).rejects.toThrow(/smaller/i)
+  })
+
+  test("passes when installer covers all three arch archives combined", async ({ expect }) => {
+    const a64 = await writeFile("app-x64.7z", 2000)
+    const a32 = await writeFile("app-x86.7z", 1000)
+    const aArm64 = await writeFile("app-arm64.7z", 1500)
+    const outFile = await writeFile("installer.exe", 5000) // 5000 >= 4500
+    const defines = { ...baseDefines(), APP_64: a64, APP_32: a32, APP_ARM64: aArm64 }
+    await expect(verifyInstallerSize(outFile, defines)).resolves.not.toThrow()
+  })
+
+  test("throws when installer is smaller than all three arch archives combined", async ({ expect }) => {
+    const a64 = await writeFile("app-x64.7z", 2000)
+    const a32 = await writeFile("app-x86.7z", 1000)
+    const aArm64 = await writeFile("app-arm64.7z", 1500)
+    const outFile = await writeFile("installer.exe", 4000) // 4000 < 4500
+    const defines = { ...baseDefines(), APP_64: a64, APP_32: a32, APP_ARM64: aArm64 }
+    await expect(verifyInstallerSize(outFile, defines)).rejects.toThrow(/smaller/i)
+  })
+
+  test("error message from missing file contains the outFile path", async ({ expect }) => {
+    const archive = await writeFile("app.7z", 5000)
+    const defines = { ...baseDefines(), APP_64: archive }
+    const missingOut = path.join(tmpDir, "missing.exe")
+    await expect(verifyInstallerSize(missingOut, defines)).rejects.toThrow("missing.exe")
   })
 })

--- a/test/src/windows/nsisScriptGeneratorTest.ts
+++ b/test/src/windows/nsisScriptGeneratorTest.ts
@@ -50,4 +50,24 @@ describe("nsisEscapeString", () => {
   test("escapes bare $ but leaves ${...} references intact", ({ expect }) => {
     expect(nsisEscapeString("${INSTDIR}\\price $9.99")).toBe("${INSTDIR}\\price $$9.99")
   })
+
+  test("escapes multiple consecutive dollar signs", ({ expect }) => {
+    expect(nsisEscapeString("$$")).toBe("$$$$")
+  })
+
+  test("empty string is returned unchanged", ({ expect }) => {
+    expect(nsisEscapeString("")).toBe("")
+  })
+
+  test("string with only newlines becomes spaces", ({ expect }) => {
+    expect(nsisEscapeString("\n\r\n\r")).toBe("   ")
+  })
+
+  test("preserves backslash characters", ({ expect }) => {
+    expect(nsisEscapeString("C:\\Users\\name")).toBe("C:\\Users\\name")
+  })
+
+  test("escapes multiple double quotes", ({ expect }) => {
+    expect(nsisEscapeString('a"b"c')).toBe('a$\\"b$\\"c')
+  })
 })


### PR DESCRIPTION
- **Improve timeout error in `spawnAndWriteWithOutput`** — Previously, when the 4-minute kill-timeout fired, the child process was killed but the resulting rejection carried only a cryptic "exit code -1" message. A `timedOut` flag is now tracked so the `close` handler emits a clear `"<command> timed out after 4 minutes"` error instead. ([`packages/builder-util/src/util.ts`](packages/builder-util/src/util.ts))
- **Improve `verifyInstallerSize` missing-file error** — When makensis produced no output file at all, the old code fell through to a "0 bytes" smaller-than-archive message. The function now explicitly detects a missing output file and throws a dedicated `"was not created at …"` error that includes the expected path, making disk-space failures immediately actionable. ([`packages/app-builder-lib/src/targets/nsis/nsisValidation.ts`](packages/app-builder-lib/src/targets/nsis/nsisValidation.ts))
- **Unit tests for `spawnAndWriteWithOutput`** — 6 new tests covering: stdout/stderr capture, stdin round-trip, empty process, `ExecError` on non-zero exit (with output in the message), and the 4-minute timeout via `vi.useFakeTimers()`. ([`test/src/builder-util/utilTest.ts`](test/src/builder-util/utilTest.ts))
- **Additional edge-case tests for NSIS helpers** — Extended `nsisScriptGeneratorTest.ts` with 6 more `nsisEscapeString` cases (consecutive `$`, empty string, only-newlines, backslashes, multiple quotes). Extended `nsisOutputValidationTest.ts` with 4 more `verifyInstallerSize` cases (all-three-arch pass, all-three-arch fail, missing-file path in error message). Updated existing "file does not exist" assertion to match the new descriptive message. ([`test/src/windows/nsisScriptGeneratorTest.ts`](test/src/windows/nsisScriptGeneratorTest.ts), [`test/src/windows/nsisOutputValidationTest.ts`](test/src/windows/nsisOutputValidationTest.ts))