### PR TITLE
chore(pr-labeler): force run to only pull_request on core repo (ignore forks)

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+- pull_request
 
 permissions:
   contents: read
@@ -15,8 +15,9 @@ jobs:
     - name: Checkout code repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+      continue-on-error: true  # fork PRs have read-only tokens; fail silently
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: ".github/pr-labeler.yml"
-        sync-labels: false
+        sync-labels: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,6 +11,7 @@ jobs:
       contents: read  # for actions/labeler to determine modified files
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
+    if: github.repository == 'electron-userland/electron-builder'
     steps:
     - name: Checkout code repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-semantic.yml
+++ b/.github/workflows/pr-semantic.yml
@@ -1,7 +1,7 @@
 name: "Semantic Versioning enforcer"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
Resolves https://github.com/electron-userland/electron-builder/issues/9819