### PR TITLE
fix(mac): skip signing when no certificate found; warn on ad-hoc + hardenedRuntime

### DIFF
--- a/.changeset/cyan-garlics-stare.md
+++ b/.changeset/cyan-garlics-stare.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): skip signing when no certificate found; warn on ad-hoc + hardenedRuntime

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2949,7 +2949,7 @@
         },
         "hardenedRuntime": {
           "default": true,
-          "description": "Whether your app has to be signed with hardened runtime.",
+          "description": "Whether your app has to be signed with hardened runtime.\n\nWhen using ad-hoc signing (`identity: \"-\"`), hardened runtime enforces library validation which\nwill reject pre-signed Electron frameworks that carry a different Team ID. To resolve this either\nset `hardenedRuntime: false` or add the\n[`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation)\nentitlement to your entitlements file.",
           "type": "boolean"
         },
         "helperBundleId": {
@@ -3009,7 +3009,7 @@
           ]
         },
         "identity": {
-          "description": "The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](https://www.electron.build/code-signing) instead of specifying this option.\nMAS installer identity is specified in the [mas](https://www.electron.build/mas).\n\nSet to `-` to use an ad-hoc identity for signing. Set to `null` to skip signing entirely.",
+          "description": "The signing identity (certificate name) to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](https://www.electron.build/code-signing) instead of specifying this option.\nMAS installer identity is specified in the [mas](https://www.electron.build/mas).\n\n- **Not set** (default): electron-builder searches the keychain for a valid signing certificate. If none is found, signing is skipped for all architectures — there is no automatic ad-hoc fallback.\n- **`null`**: skip signing entirely.\n- **`\"-\"`**: opt in to ad-hoc signing explicitly. Note that `hardenedRuntime: true` (the default) combined with ad-hoc signing requires\n  the [`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation)\n  entitlement to prevent app launch failures; otherwise set `hardenedRuntime: false`.",
           "type": [
             "null",
             "string"
@@ -3587,7 +3587,7 @@
         },
         "hardenedRuntime": {
           "default": true,
-          "description": "Whether your app has to be signed with hardened runtime.",
+          "description": "Whether your app has to be signed with hardened runtime.\n\nWhen using ad-hoc signing (`identity: \"-\"`), hardened runtime enforces library validation which\nwill reject pre-signed Electron frameworks that carry a different Team ID. To resolve this either\nset `hardenedRuntime: false` or add the\n[`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation)\nentitlement to your entitlements file.",
           "type": "boolean"
         },
         "helperBundleId": {
@@ -3647,7 +3647,7 @@
           ]
         },
         "identity": {
-          "description": "The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](https://www.electron.build/code-signing) instead of specifying this option.\nMAS installer identity is specified in the [mas](https://www.electron.build/mas).\n\nSet to `-` to use an ad-hoc identity for signing. Set to `null` to skip signing entirely.",
+          "description": "The signing identity (certificate name) to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](https://www.electron.build/code-signing) instead of specifying this option.\nMAS installer identity is specified in the [mas](https://www.electron.build/mas).\n\n- **Not set** (default): electron-builder searches the keychain for a valid signing certificate. If none is found, signing is skipped for all architectures — there is no automatic ad-hoc fallback.\n- **`null`**: skip signing entirely.\n- **`\"-\"`**: opt in to ad-hoc signing explicitly. Note that `hardenedRuntime: true` (the default) combined with ad-hoc signing requires\n  the [`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation)\n  entitlement to prevent app launch failures; otherwise set `hardenedRuntime: false`.",
           "type": [
             "null",
             "string"

--- a/packages/app-builder-lib/src/mac/MacTargetHelper.ts
+++ b/packages/app-builder-lib/src/mac/MacTargetHelper.ts
@@ -15,14 +15,11 @@ export type PlatformType = "mas" | "mas-dev" | "mac"
 export class MacTargetHelper {
   constructor(private packager: MacPackager) {}
 
-  handleNullIdentity(fallBackToAdhoc: boolean): boolean {
+  handleNullIdentity(): boolean {
     if (this.packager.forceCodeSigning) {
       throw new InvalidConfigurationError("identity explicitly is set to null, but forceCodeSigning is set to true")
     }
     log.info({ reason: "identity explicitly is set to null" }, "skipped macOS code signing")
-    if (fallBackToAdhoc) {
-      log.warn("arm64 requires signing, but identity is set to null and signing is being skipped")
-    }
     return false
   }
 
@@ -31,8 +28,7 @@ export class MacTargetHelper {
     isDevelopment: boolean,
     qualifier: string | undefined,
     keychainFile: string | Nullish,
-    config: MacConfiguration | MasConfiguration,
-    fallBackToAdhoc: boolean
+    config: MacConfiguration | MasConfiguration
   ): Promise<Identity | null> {
     const certificateTypes = MacTargetHelper.getCertificateTypes(isMas, isDevelopment)
 
@@ -54,10 +50,13 @@ export class MacTargetHelper {
 
       const noIdentity = !config.sign && identity == null
       if (qualifier === "-") {
-        const { Identity: IdentityClass } = await dynamicImport<{ Identity: new (name: string, hash?: string) => Identity }>("@electron/osx-sign/dist/cjs/util-identities")
-        identity = new IdentityClass("-", undefined)
-      } else if (noIdentity && fallBackToAdhoc) {
-        log.warn(null, "falling back to ad-hoc signature for macOS application code signing")
+        if (MacTargetHelper.isHardenedRuntimeEnabledForSigning(isMas, config)) {
+          log.warn(
+            null,
+            "ad-hoc signing with hardenedRuntime enabled requires the com.apple.security.cs.disable-library-validation entitlement " +
+              "to prevent app launch failures due to library validation. See https://electron.build/code-signing for details."
+          )
+        }
         const { Identity: IdentityClass } = await dynamicImport<{ Identity: new (name: string, hash?: string) => Identity }>("@electron/osx-sign/dist/cjs/util-identities")
         identity = new IdentityClass("-", undefined)
       } else if (noIdentity) {
@@ -253,6 +252,14 @@ export class MacTargetHelper {
     if (targetName === "mas") return "mas"
     if (targetName === "mas-dev") return "mas-dev"
     return "mac"
+  }
+
+  /**
+   * Returns true when hardened runtime will be active for signing.
+   * For non-MAS builds it defaults to on; for MAS it defaults to off.
+   */
+  static isHardenedRuntimeEnabledForSigning(isMas: boolean, config: Pick<MacConfiguration | MasConfiguration, "hardenedRuntime">): boolean {
+    return isMas ? config.hardenedRuntime === true : config.hardenedRuntime !== false
   }
 
   static assertSafePathForCommandUsage(pathValue: string, description: string): void {

--- a/packages/app-builder-lib/src/macPackager.ts
+++ b/packages/app-builder-lib/src/macPackager.ts
@@ -371,10 +371,9 @@ export class MacPackager extends PlatformPackager<MacConfiguration | MasConfigur
 
     const config = options ?? this.platformSpecificBuildOptions
     const qualifier = config.identity
-    const fallBackToAdhoc = (arch === Arch.arm64 || arch === Arch.universal) && !this.forceCodeSigning
 
     if (qualifier === null) {
-      return this.helper.handleNullIdentity(fallBackToAdhoc)
+      return this.helper.handleNullIdentity()
     }
 
     const keychainFile = (await this.codeSigningInfo.value).keychainFile
@@ -382,7 +381,7 @@ export class MacPackager extends PlatformPackager<MacConfiguration | MasConfigur
     const type = explicitType || "distribution"
     const isDevelopment = type === "development"
 
-    const identity = await this.helper.findSigningIdentity(isMas, isDevelopment, qualifier, keychainFile, config, fallBackToAdhoc)
+    const identity = await this.helper.findSigningIdentity(isMas, isDevelopment, qualifier, keychainFile, config)
 
     if (!identity) {
       return false

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -21,10 +21,14 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
   readonly target?: Array<MacOsTargetName | TargetConfiguration> | MacOsTargetName | TargetConfiguration | null
 
   /**
-   * The name of certificate to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](https://www.electron.build/code-signing) instead of specifying this option.
+   * The signing identity (certificate name) to use when signing. Consider using environment variables [CSC_LINK or CSC_NAME](https://www.electron.build/code-signing) instead of specifying this option.
    * MAS installer identity is specified in the [mas](https://www.electron.build/mas).
    *
-   * Set to `-` to use an ad-hoc identity for signing. Set to `null` to skip signing entirely.
+   * - **Not set** (default): electron-builder searches the keychain for a valid signing certificate. If none is found, signing is skipped for all architectures — there is no automatic ad-hoc fallback.
+   * - **`null`**: skip signing entirely.
+   * - **`"-"`**: opt in to ad-hoc signing explicitly. Note that `hardenedRuntime: true` (the default) combined with ad-hoc signing requires
+   *   the [`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation)
+   *   entitlement to prevent app launch failures; otherwise set `hardenedRuntime: false`.
    */
   readonly identity?: string | null
 
@@ -155,6 +159,12 @@ export interface MacConfiguration extends PlatformSpecificBuildOptions {
 
   /**
    * Whether your app has to be signed with hardened runtime.
+   *
+   * When using ad-hoc signing (`identity: "-"`), hardened runtime enforces library validation which
+   * will reject pre-signed Electron frameworks that carry a different Team ID. To resolve this either
+   * set `hardenedRuntime: false` or add the
+   * [`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation)
+   * entitlement to your entitlements file.
    * @default true
    */
   readonly hardenedRuntime?: boolean

--- a/test/src/mac/MacTargetHelperTest.ts
+++ b/test/src/mac/MacTargetHelperTest.ts
@@ -80,15 +80,28 @@ describe("MacTargetHelper", () => {
     }
 
     test("throws when forceCodeSigning is true", () => {
-      expect(() => makeHelper(true).handleNullIdentity(false)).toThrow("identity explicitly is set to null")
+      expect(() => makeHelper(true).handleNullIdentity()).toThrow("identity explicitly is set to null")
     })
 
     test("returns false when forceCodeSigning is false", () => {
-      expect(makeHelper(false).handleNullIdentity(false)).toBe(false)
+      expect(makeHelper(false).handleNullIdentity()).toBe(false)
     })
+  })
 
-    test("returns false with fallBackToAdhoc=true", () => {
-      expect(makeHelper(false).handleNullIdentity(true)).toBe(false)
+  describe("isHardenedRuntimeEnabledForSigning", () => {
+    const cases: [boolean, boolean | undefined, boolean][] = [
+      // non-MAS: defaults to true
+      [false, undefined, true],
+      [false, true, true],
+      [false, false, false],
+      // MAS: defaults to false
+      [true, undefined, false],
+      [true, false, false],
+      [true, true, true],
+    ]
+
+    test.each(cases)("isMas=%s hardenedRuntime=%s => %s", (isMas, hardenedRuntime, expected) => {
+      expect(MacTargetHelper.isHardenedRuntimeEnabledForSigning(isMas, { hardenedRuntime })).toBe(expected)
     })
   })
 

--- a/website/docs/features/code-signing/code-signing-mac.md
+++ b/website/docs/features/code-signing/code-signing-mac.md
@@ -2,7 +2,7 @@
 
 macOS code signing is supported. If the configuration values are provided correctly in your package.json, then signing should be automatically executed.
 
-On a macOS development machine, a valid and appropriate identity from your keychain will be automatically used. If no such identity exists, the default behavior depends on the target architecture. On ARM or universal builds, an ad-hoc signature will be applied by default. On Intel-only builds, the default behavior is to not sign at all.
+On a macOS development machine, a valid and appropriate identity from your keychain will be automatically used. If no valid certificate is found, signing is skipped for all architectures — electron-builder does **not** apply an ad-hoc signature automatically. To opt in to ad-hoc signing explicitly, set `mac.identity` to `"-"` (see [Signing options](#signing-options) below).
 
 :::tip
 See article [Notarizing your Electron application](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/).
@@ -23,19 +23,45 @@ Which certificate to export depends on your electron-builder target:
 
 You can export multiple certificates into one `.p12` file. All selected certificates are imported into the temporary keychain on CI.
 
-## How to Disable Code Signing During the Build Process on macOS
+## Signing Options
 
-To disable Code Signing when building for macOS leave all the above vars unset except for `CSC_IDENTITY_AUTO_DISCOVERY` which needs to be set to `false`. This can be done by running `export CSC_IDENTITY_AUTO_DISCOVERY=false`.
+The `mac.identity` configuration controls how (or whether) the app is signed:
 
-Another way — set `mac.identity` to `null`. You can pass additional configuration using CLI as well: `-c.mac.identity=null`. If you are building for ARM, you likely actually want to use ad-hoc signing, in which case you should set `mac.identity` to `-`.
+| Value | Behavior |
+|---|---|
+| Not set (default) | electron-builder searches the keychain for a valid certificate; signing is skipped if none is found |
+| `null` | Signing is skipped entirely |
+| `"-"` | Ad-hoc signing — see caveats below |
+| Certificate name | Uses that specific certificate from the keychain |
 
-:::warning[Disabling code signing disables hardened runtime]
-Unlike ad-hoc signing (`mac.identity=-`), a complete lack of signing (`mac.identity=null`) will disable hardened runtime in the final output even if its associated configuration setting is enabled. If your goal in setting `mac.identity=null` is to work around one of these issues, consider trying these suggested solutions instead:
+To skip signing, leave all `CSC_*` environment variables unset and set `CSC_IDENTITY_AUTO_DISCOVERY=false`, or set `mac.identity` to `null` in your config (CLI: `-c.mac.identity=null`).
 
-* An error saying "[App] cannot be opened because of a problem" and/or a crash report for your app in Console.app containing the text `[framework] not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs)`: make sure the [`com.apple.security.cs.disable-library-validation` entitlement](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation) is being applied, which is required when using hardened runtime in an app with ad-hoc signing that loads a framework.
-* A crash in Electron Framework: make sure the [`com.apple.security.cs.allow-jit` entitlement](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.allow-jit) is being applied, which Electron requires.
-* Issues when accessing sensors like the camera or microphone or sensitive data on disk such as the Photos library: make sure the [appropriate entitlement](https://developer.apple.com/documentation/Security/hardened-runtime#Resource-Access) is being applied.
+## Ad-hoc Signing (`mac.identity: "-"`)
+
+Ad-hoc signing applies a self-generated signature with no Apple Team ID. It is useful for local development when you do not have a Developer ID certificate. Because Electron's pre-built frameworks carry Apple's Team ID, ad-hoc signing requires one of the following to prevent an app launch failure:
+
+* Add the [`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation) entitlement to your entitlements file — **preferred**, keeps hardened runtime active.
+* Set `mac.hardenedRuntime: false` — disables hardened runtime entirely, which weakens security protections.
+
+:::warning[Ad-hoc signing caveats]
+The following issues can occur when using ad-hoc signing (`mac.identity: "-"`) with the default `hardenedRuntime: true`:
+
+* **App launch failure** — crash report contains `[framework] not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs`: add the [`com.apple.security.cs.disable-library-validation`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.disable-library-validation) entitlement.
+* **Electron Framework crash**: add the [`com.apple.security.cs.allow-jit`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.cs.allow-jit) entitlement, which Electron requires.
+* **Sensor or sensitive-data access failures**: add the [appropriate entitlement](https://developer.apple.com/documentation/Security/hardened-runtime#Resource-Access) for the resource you need.
 :::
+
+:::tip[Local development without a certificate]
+Setting `mac.identity` to `null` (or leaving signing unconfigured with no certificate in the keychain) skips signing entirely. On Apple Silicon, unsigned apps can still be run locally by approving them in **System Settings → Privacy & Security**.
+:::
+
+## Local Development vs. CI/Production
+
+| Scenario | Recommended approach |
+|---|---|
+| Local dev, no certificate | Leave identity unconfigured or set `mac.identity: null` |
+| Local dev, want a runnable ad-hoc build | `mac.identity: "-"` + `com.apple.security.cs.disable-library-validation` entitlement |
+| CI/production distribution | Configure a Developer ID certificate via `CSC_LINK` / keychain |
 
 ## Code Signing and Notarization Tutorial
 Thank you to a community member for putting this together.


### PR DESCRIPTION
Fixes #9396

## Summary

- **Removed automatic ad-hoc fallback**: electron-builder previously signed arm64/universal macOS apps with an ad-hoc identity (`-`) when no signing certificate was found. This automatic fallback, combined with the default `hardenedRuntime: true`, caused macOS to reject the app at launch due to a Team ID mismatch between the ad-hoc-signed main binary and the pre-signed Electron frameworks bundled inside the app.

  Behavior now aligns with electron-forge: when no valid certificate is found, signing is skipped for all architectures. Ad-hoc signing is still supported but must be opted into explicitly by setting `mac.identity: "-"`.

- **Added `isHardenedRuntimeEnabledForSigning` static helper**: extracted the `hardenedRuntime` defaults logic (on by default for non-MAS, off by default for MAS) into a directly-testable static method on `MacTargetHelper`.

- **Added advisory warning for explicit ad-hoc + hardenedRuntime**: when a user explicitly sets `identity: "-"` and `hardenedRuntime` is enabled (the default), a build-time warning is emitted pointing to the `com.apple.security.cs.disable-library-validation` entitlement as the required fix.

- **Improved TSDoc** on `MacConfiguration.identity` and `MacConfiguration.hardenedRuntime` to clearly document the three identity states (`undefined`, `null`, `"-"`) and their interaction with hardened runtime.

- **Updated website docs** (`code-signing-mac.md`): corrected the stated default behavior, restructured guidance around ad-hoc signing into a dedicated section, and added a local-dev vs. CI/production signing reference table.