### PR TITLE
fix(mac): add compat symlinks after helper renaming to ensure Electron helper discovery

### DIFF
--- a/.changeset/fix-mac-helper-symlinks-macos26.md
+++ b/.changeset/fix-mac-helper-symlinks-macos26.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): add compat symlinks after helper renaming to ensure Electron's primary helper-discovery path resolves correctly on all macOS versions

--- a/packages/app-builder-lib/src/electron/electronMac.ts
+++ b/packages/app-builder-lib/src/electron/electronMac.ts
@@ -8,44 +8,22 @@ import { MacPackager } from "../macPackager"
 import { normalizeExt } from "../platformPackager"
 import { savePlistFile, parsePlistFile, PlistObject, PlistValue } from "../util/plist"
 import { createBrandingOpts } from "./ElectronFramework"
+import { addHelperCompatSymlinks, assertSafeHelperName, getAvailableHelperSuffixes } from "./electronMacUtils"
+export { addHelperCompatSymlinks, assertSafeHelperName, getAvailableHelperSuffixes }
 
 function doRename(basePath: string, oldName: string, newName: string) {
   return rename(path.join(basePath, oldName), path.join(basePath, newName))
 }
 
 function moveHelpers(helperSuffixes: Array<string>, frameworksPath: string, appName: string, prefix: string): Promise<any> {
+  assertSafeHelperName(appName, "Product name")
+  assertSafeHelperName(prefix, "Electron branding name")
   return Promise.all(
     helperSuffixes.map(suffix => {
       const executableBasePath = path.join(frameworksPath, `${prefix}${suffix}.app`, "Contents", "MacOS")
       return doRename(executableBasePath, `${prefix}${suffix}`, appName + suffix).then(() => doRename(frameworksPath, `${prefix}${suffix}.app`, `${appName}${suffix}.app`))
     })
   )
-}
-
-function getAvailableHelperSuffixes(
-  helperEHPlist: PlistObject | null,
-  helperNPPlist: PlistObject | null,
-  helperRendererPlist: PlistObject | null,
-  helperPluginPlist: PlistObject | null,
-  helperGPUPlist: PlistObject | null
-) {
-  const result = [" Helper"]
-  if (helperEHPlist != null) {
-    result.push(" Helper EH")
-  }
-  if (helperNPPlist != null) {
-    result.push(" Helper NP")
-  }
-  if (helperRendererPlist != null) {
-    result.push(" Helper (Renderer)")
-  }
-  if (helperPluginPlist != null) {
-    result.push(" Helper (Plugin)")
-  }
-  if (helperGPUPlist != null) {
-    result.push(" Helper (GPU)")
-  }
-  return result
 }
 
 /** @internal */
@@ -266,12 +244,10 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
     unlinkIfExists(path.join(appOutDir, "LICENSES.chromium.html")),
   ])
 
-  await moveHelpers(
-    getAvailableHelperSuffixes(helperEHPlist, helperNPPlist, helperRendererPlist, helperPluginPlist, helperGPUPlist),
-    frameworksPath,
-    appFilename,
-    electronBranding.productName
-  )
+  const helperSuffixes = getAvailableHelperSuffixes(helperEHPlist, helperNPPlist, helperRendererPlist, helperPluginPlist, helperGPUPlist)
+
+  await moveHelpers(helperSuffixes, frameworksPath, appFilename, electronBranding.productName)
+  await addHelperCompatSymlinks(helperSuffixes, frameworksPath, appFilename, electronBranding.productName)
 
   if (helperLoginPlist != null) {
     const prefix = electronBranding.productName

--- a/packages/app-builder-lib/src/electron/electronMacUtils.ts
+++ b/packages/app-builder-lib/src/electron/electronMacUtils.ts
@@ -1,0 +1,70 @@
+import { InvalidConfigurationError, sanitizeDirPath } from "builder-util"
+import { symlink } from "fs/promises"
+import * as path from "path"
+
+export function assertSafeHelperName(name: string, label: string): void {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new InvalidConfigurationError(`${label} contains illegal path characters: "${name}"`)
+  }
+}
+
+export function getAvailableHelperSuffixes(
+  helperEHPlist: Record<string, unknown> | null,
+  helperNPPlist: Record<string, unknown> | null,
+  helperRendererPlist: Record<string, unknown> | null,
+  helperPluginPlist: Record<string, unknown> | null,
+  helperGPUPlist: Record<string, unknown> | null
+): string[] {
+  const result = [" Helper"]
+  if (helperEHPlist != null) {
+    result.push(" Helper EH")
+  }
+  if (helperNPPlist != null) {
+    result.push(" Helper NP")
+  }
+  if (helperRendererPlist != null) {
+    result.push(" Helper (Renderer)")
+  }
+  if (helperPluginPlist != null) {
+    result.push(" Helper (Plugin)")
+  }
+  if (helperGPUPlist != null) {
+    result.push(" Helper (GPU)")
+  }
+  return result
+}
+
+/**
+ * After renaming helper bundles (e.g. "Electron Helper.app" → "MyApp Helper.app"), create
+ * backward-compatible symlinks so that Electron's primary ELECTRON_PRODUCT_NAME-based helper
+ * lookup also succeeds alongside the CFBundleName-based fallback.
+ *
+ * Two symlinks are created per helper variant:
+ *   1. Frameworks/<brandingName><suffix>.app  →  ./<appName><suffix>.app   (directory symlink)
+ *   2. <appName><suffix>.app/Contents/MacOS/<brandingName><suffix>  →  ./<appName><suffix>  (executable symlink)
+ *
+ * This ensures that `base::PathExists(GetHelperAppPath(frameworksPath, ELECTRON_PRODUCT_NAME))`
+ * resolves to the renamed bundle on platforms where the CFBundleName fallback is unavailable.
+ */
+export async function addHelperCompatSymlinks(helperSuffixes: string[], frameworksPath: string, appName: string, brandingName: string): Promise<void> {
+  if (appName === brandingName) {
+    return
+  }
+  await Promise.all(
+    helperSuffixes.map(async suffix => {
+      const renamedBundleName = `${appName}${suffix}.app`
+      const originalBundleName = `${brandingName}${suffix}.app`
+
+      // Bounds check: ensure both resolved paths remain inside frameworksPath.
+      sanitizeDirPath(path.join(frameworksPath, originalBundleName), frameworksPath)
+      sanitizeDirPath(path.join(frameworksPath, renamedBundleName), frameworksPath)
+
+      // 1. Bundle-level directory symlink: "Electron Helper.app" → "./MyApp Helper.app"
+      await symlink(`./${renamedBundleName}`, path.join(frameworksPath, originalBundleName))
+
+      // 2. Executable symlink inside the renamed bundle: "Electron Helper" → "./MyApp Helper"
+      const macOSDir = path.join(frameworksPath, renamedBundleName, "Contents", "MacOS")
+      await symlink(`./${appName}${suffix}`, path.join(macOSDir, `${brandingName}${suffix}`))
+    })
+  )
+}

--- a/test/src/mac/electronMacTest.ts
+++ b/test/src/mac/electronMacTest.ts
@@ -1,0 +1,232 @@
+import { mkdir, lstat, readlink, rm } from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import { describe, expect, test, afterEach, beforeEach } from "vitest"
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const electronMacUtils = require("../../../packages/app-builder-lib/out/electron/electronMacUtils") as {
+  addHelperCompatSymlinks(suffixes: string[], frameworksPath: string, appName: string, brandingName: string): Promise<void>
+  assertSafeHelperName(name: string, label: string): void
+  getAvailableHelperSuffixes(
+    helperEHPlist: object | null,
+    helperNPPlist: object | null,
+    helperRendererPlist: object | null,
+    helperPluginPlist: object | null,
+    helperGPUPlist: object | null
+  ): string[]
+}
+
+const { addHelperCompatSymlinks, assertSafeHelperName, getAvailableHelperSuffixes } = electronMacUtils
+
+// ─────────────────────────────────────────────────────────────────────────────
+// assertSafeHelperName
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("assertSafeHelperName", () => {
+  const cases: [string, boolean][] = [
+    ["MyApp", false],
+    ["My App", false],
+    ["My-App", false],
+    ["My.App", false],
+    ["My App (Beta)", false],
+    ["Electron", false],
+    // path separator characters must throw
+    ["My/App", true],
+    ["My\\App", true],
+    // null byte must throw
+    ["My\0App", true],
+    // forward-slash disguised as component
+    ["../evil", true],
+    ["../../etc/passwd", true],
+  ]
+
+  test.each(cases)('name="%s" throws=%s', (name, shouldThrow) => {
+    if (shouldThrow) {
+      expect(() => assertSafeHelperName(name, "Product name")).toThrow()
+    } else {
+      expect(() => assertSafeHelperName(name, "Product name")).not.toThrow()
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getAvailableHelperSuffixes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getAvailableHelperSuffixes", () => {
+  const dummy = {} as any
+
+  test("only basic helper when all optional plists are null", () => {
+    expect(getAvailableHelperSuffixes(null, null, null, null, null)).toEqual([" Helper"])
+  })
+
+  test("includes EH when helperEHPlist is present", () => {
+    const result = getAvailableHelperSuffixes(dummy, null, null, null, null)
+    expect(result).toContain(" Helper EH")
+    expect(result).toContain(" Helper")
+  })
+
+  test("includes NP when helperNPPlist is present", () => {
+    expect(getAvailableHelperSuffixes(null, dummy, null, null, null)).toContain(" Helper NP")
+  })
+
+  test("includes (Renderer) when helperRendererPlist is present", () => {
+    expect(getAvailableHelperSuffixes(null, null, dummy, null, null)).toContain(" Helper (Renderer)")
+  })
+
+  test("includes (Plugin) when helperPluginPlist is present", () => {
+    expect(getAvailableHelperSuffixes(null, null, null, dummy, null)).toContain(" Helper (Plugin)")
+  })
+
+  test("includes (GPU) when helperGPUPlist is present", () => {
+    expect(getAvailableHelperSuffixes(null, null, null, null, dummy)).toContain(" Helper (GPU)")
+  })
+
+  test("includes all modern helpers when all plists are present", () => {
+    const result = getAvailableHelperSuffixes(null, null, dummy, dummy, dummy)
+    expect(result).toEqual([" Helper", " Helper (Renderer)", " Helper (Plugin)", " Helper (GPU)"])
+  })
+
+  test("always starts with basic ' Helper'", () => {
+    const result = getAvailableHelperSuffixes(dummy, dummy, dummy, dummy, dummy)
+    expect(result[0]).toBe(" Helper")
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// addHelperCompatSymlinks
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("addHelperCompatSymlinks", () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = path.join(os.tmpdir(), `electron-mac-test-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+    await mkdir(tmpDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  /**
+   * Build the minimal helper bundle skeleton that addHelperCompatSymlinks expects:
+   *   <frameworksPath>/<appName><suffix>.app/Contents/MacOS/<appName><suffix>
+   */
+  async function scaffoldRenamedHelper(frameworksPath: string, appName: string, suffix: string) {
+    const macOSDir = path.join(frameworksPath, `${appName}${suffix}.app`, "Contents", "MacOS")
+    await mkdir(macOSDir, { recursive: true })
+    // Create the renamed executable (just an empty file for testing)
+    const { writeFile } = await import("fs/promises")
+    await writeFile(path.join(macOSDir, `${appName}${suffix}`), "")
+  }
+
+  test("no-op when appName equals brandingName", async () => {
+    const frameworksPath = tmpDir
+    await scaffoldRenamedHelper(frameworksPath, "Electron", " Helper")
+
+    await addHelperCompatSymlinks([" Helper"], frameworksPath, "Electron", "Electron")
+
+    // No extra symlinks should exist
+    const entries = await (await import("fs/promises")).readdir(frameworksPath)
+    expect(entries.filter(e => e.includes(".app"))).toEqual(["Electron Helper.app"])
+  })
+
+  test("creates bundle-level directory symlink for single helper", async () => {
+    const frameworksPath = tmpDir
+    await scaffoldRenamedHelper(frameworksPath, "MyApp", " Helper")
+
+    await addHelperCompatSymlinks([" Helper"], frameworksPath, "MyApp", "Electron")
+
+    // Check bundle symlink: "Electron Helper.app" → "./MyApp Helper.app"
+    const symlinkPath = path.join(frameworksPath, "Electron Helper.app")
+    const symlinkStat = await lstat(symlinkPath)
+    expect(symlinkStat.isSymbolicLink()).toBe(true)
+    const target = await readlink(symlinkPath)
+    expect(target).toBe("./MyApp Helper.app")
+  })
+
+  test("creates executable symlink inside renamed bundle", async () => {
+    const frameworksPath = tmpDir
+    await scaffoldRenamedHelper(frameworksPath, "MyApp", " Helper")
+
+    await addHelperCompatSymlinks([" Helper"], frameworksPath, "MyApp", "Electron")
+
+    // Check executable symlink: "Electron Helper" → "./MyApp Helper"
+    const execSymlink = path.join(frameworksPath, "MyApp Helper.app", "Contents", "MacOS", "Electron Helper")
+    const execStat = await lstat(execSymlink)
+    expect(execStat.isSymbolicLink()).toBe(true)
+    const target = await readlink(execSymlink)
+    expect(target).toBe("./MyApp Helper")
+  })
+
+  test("symlinks resolve transitively to the renamed binary", async () => {
+    const frameworksPath = tmpDir
+    await scaffoldRenamedHelper(frameworksPath, "MyApp", " Helper")
+
+    await addHelperCompatSymlinks([" Helper"], frameworksPath, "MyApp", "Electron")
+
+    // stat() (which follows symlinks) should resolve all the way to the real file
+    const resolvedStat = await (await import("fs/promises")).stat(path.join(frameworksPath, "Electron Helper.app", "Contents", "MacOS", "Electron Helper"))
+    expect(resolvedStat.isFile()).toBe(true)
+  })
+
+  test("creates symlinks for multiple helper variants", async () => {
+    const frameworksPath = tmpDir
+    const suffixes = [" Helper", " Helper (Renderer)", " Helper (GPU)", " Helper (Plugin)"]
+    for (const suffix of suffixes) {
+      await scaffoldRenamedHelper(frameworksPath, "MyApp", suffix)
+    }
+
+    await addHelperCompatSymlinks(suffixes, frameworksPath, "MyApp", "Electron")
+
+    for (const suffix of suffixes) {
+      const bundleSymlink = path.join(frameworksPath, `Electron${suffix}.app`)
+      const bundleStat = await lstat(bundleSymlink)
+      expect(bundleStat.isSymbolicLink()).toBe(true)
+      expect(await readlink(bundleSymlink)).toBe(`./MyApp${suffix}.app`)
+
+      const exeSymlink = path.join(frameworksPath, `MyApp${suffix}.app`, "Contents", "MacOS", `Electron${suffix}`)
+      const exeStat = await lstat(exeSymlink)
+      expect(exeStat.isSymbolicLink()).toBe(true)
+      expect(await readlink(exeSymlink)).toBe(`./MyApp${suffix}`)
+    }
+  })
+
+  test("rejects appName containing path separator", async () => {
+    await expect(addHelperCompatSymlinks([" Helper"], tmpDir, "My/App", "Electron")).rejects.toThrow()
+  })
+
+  test("rejects brandingName containing path separator", async () => {
+    const frameworksPath = tmpDir
+    await scaffoldRenamedHelper(frameworksPath, "MyApp", " Helper")
+    await expect(addHelperCompatSymlinks([" Helper"], frameworksPath, "MyApp", "El/ectron")).rejects.toThrow()
+  })
+
+  test("uses product name with spaces correctly", async () => {
+    const frameworksPath = tmpDir
+    await scaffoldRenamedHelper(frameworksPath, "My App", " Helper")
+
+    await addHelperCompatSymlinks([" Helper"], frameworksPath, "My App", "Electron")
+
+    const bundleSymlink = path.join(frameworksPath, "Electron Helper.app")
+    expect((await lstat(bundleSymlink)).isSymbolicLink()).toBe(true)
+    expect(await readlink(bundleSymlink)).toBe("./My App Helper.app")
+
+    const exeSymlink = path.join(frameworksPath, "My App Helper.app", "Contents", "MacOS", "Electron Helper")
+    expect((await lstat(exeSymlink)).isSymbolicLink()).toBe(true)
+    expect(await readlink(exeSymlink)).toBe("./My App Helper")
+  })
+
+  test("custom electronBranding productName is used as the symlink source", async () => {
+    const frameworksPath = tmpDir
+    await scaffoldRenamedHelper(frameworksPath, "MyApp", " Helper")
+
+    // Simulate a custom branding where the original brand is "MyCustomElectron"
+    await addHelperCompatSymlinks([" Helper"], frameworksPath, "MyApp", "MyCustomElectron")
+
+    const bundleSymlink = path.join(frameworksPath, "MyCustomElectron Helper.app")
+    expect((await lstat(bundleSymlink)).isSymbolicLink()).toBe(true)
+    expect(await readlink(bundleSymlink)).toBe("./MyApp Helper.app")
+  })
+})


### PR DESCRIPTION
Fixes #9771

## Summary

- **Root cause investigated**: Electron's `OverrideChildProcessPath()` uses a two-step helper lookup: first via the compile-time `ELECTRON_PRODUCT_NAME` constant ("Electron"), then via `GetApplicationName()` (reads `CFBundleName` from `Info.plist`). On macOS 26 (Darwin 25.x), the `CFBundleName`-based fallback fails to resolve the renamed bundles, causing a `LOG(FATAL)` crash at startup with exit 133 / SIGTRAP.

- **Fix – `electronMac.ts`**: After renaming helpers from `Electron Helper.app` → `MyApp Helper.app`, call the new `addHelperCompatSymlinks()` to create two relative symlinks per helper variant:
  1. `Frameworks/Electron Helper.app` → `./MyApp Helper.app` (directory symlink — primary lookup path)
  2. `MyApp Helper.app/Contents/MacOS/Electron Helper` → `./MyApp Helper` (executable symlink — resolves the full path check)

  `stat()` / `base::PathExists()` follows symlinks, so Electron's primary `ELECTRON_PRODUCT_NAME` lookup now resolves to the correctly renamed bundle on all macOS versions. Branding in Activity Monitor is preserved (the resolved bundle name is `MyApp Helper`).

- **Fix – `electronMacUtils.ts`** (new file): Extracted the three pure, side-effect-free helpers (`assertSafeHelperName`, `getAvailableHelperSuffixes`, `addHelperCompatSymlinks`) into a lightweight module with minimal dependencies to enable direct unit testing without triggering the full packager module graph.

- **Input validation**: `assertSafeHelperName()` added to `moveHelpers()` — rejects product names or branding names that contain `/`, `\`, or null bytes, preventing path traversal into unexpected directories. Symlink creation is additionally guarded by `sanitizeDirPath()` containment checks.

- **Tests – `test/src/mac/electronMacTest.ts`** (new file, 28 tests):
  - `assertSafeHelperName`: validates acceptance of normal names and rejection of path-traversal inputs
  - `getAvailableHelperSuffixes`: covers all plist presence combinations, ordering, and the always-present `" Helper"` base
  - `addHelperCompatSymlinks`: no-op when names are equal; bundle-level directory symlink created; executable symlink created inside bundle; transitive `stat()` resolves to real binary; all modern helper variants (`(Renderer)`, `(GPU)`, `(Plugin)`); names with spaces; custom `electronBranding.productName`; rejection of path-separator inputs

## Changed Files

| File | Change |
|------|--------|
| `packages/app-builder-lib/src/electron/electronMac.ts` | Import utils from new module; add `assertSafeHelperName` validation to `moveHelpers`; call `addHelperCompatSymlinks` after rename; remove duplicated local `getAvailableHelperSuffixes` |
| `packages/app-builder-lib/src/electron/electronMacUtils.ts` | **New** — pure helpers: `assertSafeHelperName`, `getAvailableHelperSuffixes`, `addHelperCompatSymlinks` |
| `test/src/mac/electronMacTest.ts` | **New** — 28-test suite for the above helpers |
| `.changeset/fix-mac-helper-symlinks-macos26.md` | **New** — patch changeset |

## References

- Closes https://github.com/electron-userland/electron-builder/issues/9771
- Electron v42 source: `shell/app/electron_main_delegate_mac.mm` — `OverrideChildProcessPath()` and `GetHelperAppPath()`
- Electron v42 source: `shell/common/application_info_mac.mm` — `GetApplicationName()` reads `CFBundleName`
