### PR TITLE
feat(linux): add `syncDesktopName` option to align installed `.desktop` filename with `StartupWMClass`

### DIFF
--- a/.changeset/linux-sync-desktop-name.md
+++ b/.changeset/linux-sync-desktop-name.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat(linux): add `linux.syncDesktopName` opt-in flag to align installed `.desktop` filename with `desktopName` and `StartupWMClass`; will become default in v27

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2331,6 +2331,11 @@
           "$ref": "#/definitions/ReleaseInfo",
           "description": "The release info. Intended for command line usage:\n\n```\n-c.releaseInfo.releaseNotes=\"new features\"\n```"
         },
+        "syncDesktopName": {
+          "default": false,
+          "description": "When `true`, the installed `.desktop` filename is derived from `desktopName` in `package.json`\n(minus the `.desktop` suffix) so that it matches `StartupWMClass` and Electron's `app_id`.\nFalls back to `executableName` when `desktopName` is absent.",
+          "type": "boolean"
+        },
         "synopsis": {
           "description": "The [short description](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Description).",
           "type": [

--- a/packages/app-builder-lib/src/options/linuxOptions.ts
+++ b/packages/app-builder-lib/src/options/linuxOptions.ts
@@ -61,6 +61,17 @@ export interface LinuxConfiguration extends CommonLinuxOptions, PlatformSpecific
    * For user-facing category configuration use the target-specific options (e.g. {@link DebOptions}).
    */
   readonly packageCategory?: string | null
+
+  /**
+   * When `true`, the installed `.desktop` filename is derived from `desktopName` in `package.json`
+   * (minus the `.desktop` suffix) so that it matches `StartupWMClass` and Electron's `app_id`.
+   * Falls back to `executableName` when `desktopName` is absent.
+   *
+   * @default false
+   * @see https://github.com/electron-userland/electron-builder/issues/9103
+   * @remarks Will become the default behavior in v27 and this option will be removed in v27 as well to align with electron upstream and common Linux desktop application practices. If you rely on the current default behavior, set this option to `false` explicitly to silence the warning.
+   */
+  readonly syncDesktopName?: boolean
 }
 
 /**

--- a/packages/app-builder-lib/src/options/linuxOptions.ts
+++ b/packages/app-builder-lib/src/options/linuxOptions.ts
@@ -69,7 +69,7 @@ export interface LinuxConfiguration extends CommonLinuxOptions, PlatformSpecific
    *
    * @default false
    * @see https://github.com/electron-userland/electron-builder/issues/9103
-   * @remarks Will become the default behavior in v27 and this option will be removed in v27 as well to align with electron upstream and common Linux desktop application practices. If you rely on the current default behavior, set this option to `false` explicitly to silence the warning.
+   * @remarks In v27 the default will change to `true`.
    */
   readonly syncDesktopName?: boolean
 }

--- a/packages/app-builder-lib/src/targets/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/FpmTarget.ts
@@ -272,7 +272,7 @@ export default class FpmTarget extends Target {
     }
 
     const desktopFilePath = await this.helper.writeDesktopEntry(this.options)
-    args.push(`${desktopFilePath}=/usr/share/applications/${packager.executableName}.desktop`)
+    args.push(`${desktopFilePath}=/usr/share/applications/${this.helper.getDesktopFileName()}.desktop`)
 
     if (packager.packagerOptions.effectiveOptionComputed != null && (await packager.packagerOptions.effectiveOptionComputed([args, desktopFilePath]))) {
       return

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -242,7 +242,16 @@ export class LinuxTargetHelper {
       return fallback
     }
     const trimmedDesktopName = this.packager.info.metadata.desktopName?.trim()
-    return !isEmptyOrSpaces(trimmedDesktopName) ? trimmedDesktopName.replace(/\.desktop$/, "") : fallback
+    if (isEmptyOrSpaces(trimmedDesktopName)) {
+      return fallback
+    }
+    const basename = trimmedDesktopName.replace(/\.desktop$/, "")
+    // Guard against path traversal: desktopName flows into filesystem paths
+    // (snap/gui/<name>.desktop, /usr/share/applications/<name>.desktop, etc.).
+    if (/[/\\]/.test(basename) || [...basename].some(c => c.charCodeAt(0) === 0)) {
+      throw new InvalidConfigurationError(`desktopName "${trimmedDesktopName}" produces an invalid .desktop filename — remove any path separators or NUL characters`)
+    }
+    return basename
   }
 
   computeDesktopEntry(targetSpecificOptions: CommonLinuxOptions, exec?: string, extra?: Record<string, string>): Promise<string> {
@@ -280,6 +289,15 @@ export class LinuxTargetHelper {
     // Electron derives app_id from desktopName in package.json; StartupWMClass must match.
     // https://github.com/electron/electron/blob/9a7b73b5334f1d72c08e2d5e94106706ed751186/lib/browser/init.ts#L128-L133
     const trimmedDesktopName = packager.info.metadata.desktopName?.trim()
+    if (isEmptyOrSpaces(trimmedDesktopName)) {
+      log.warn(
+        {
+          reason: "desktopName is not set in package.json",
+          docs: "https://www.electron.build/linux",
+        },
+        "Electron uses desktopName as app_id / WM_CLASS for window association. Without it desktop environments may not link running windows to this .desktop entry. Set desktopName in package.json and linux.syncDesktopName: true to fix."
+      )
+    }
     const wmClass = !isEmptyOrSpaces(trimmedDesktopName) ? trimmedDesktopName.replace(/\.desktop$/, "") : appInfo.productName
 
     const desktopMeta = deepAssign<any>(

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -293,9 +293,9 @@ export class LinuxTargetHelper {
       log.warn(
         {
           reason: "desktopName is not set in package.json",
-          docs: "https://www.electron.build/linux",
+          docs: "https://www.electron.build/linux#window-association-desktopname--syncdesktopname",
         },
-        "Electron uses desktopName as app_id / WM_CLASS for window association. Without it desktop environments may not link running windows to this .desktop entry. Set desktopName in package.json and linux.syncDesktopName: true to fix."
+        "electron uses desktopName as app_id / WM_CLASS for window association. Without it desktop environments may not link running windows to this .desktop entry. Set desktopName in package.json and linux.syncDesktopName: true to fix."
       )
     }
     const wmClass = !isEmptyOrSpaces(trimmedDesktopName) ? trimmedDesktopName.replace(/\.desktop$/, "") : appInfo.productName

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -237,6 +237,14 @@ export class LinuxTargetHelper {
     return file
   }
 
+  getDesktopFileName(fallback: string = this.packager.executableName): string {
+    if (!this.packager.platformSpecificBuildOptions.syncDesktopName) {
+      return fallback
+    }
+    const trimmedDesktopName = this.packager.info.metadata.desktopName?.trim()
+    return !isEmptyOrSpaces(trimmedDesktopName) ? trimmedDesktopName.replace(/\.desktop$/, "") : fallback
+  }
+
   computeDesktopEntry(targetSpecificOptions: CommonLinuxOptions, exec?: string, extra?: Record<string, string>): Promise<string> {
     if (exec != null && exec.length === 0) {
       throw new Error("Specified exec is empty")

--- a/packages/app-builder-lib/src/targets/appimage/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/appimage/AppImageTarget.ts
@@ -68,7 +68,10 @@ export default class AppImageTarget extends Target {
       await outputFile(path.join(packager.getResourcesDir(appOutDir), "app-update.yml"), serializeToYaml(publishConfig))
     }
 
-    if (this.packager.packagerOptions.effectiveOptionComputed != null && (await this.packager.packagerOptions.effectiveOptionComputed({ desktop: desktopEntry }))) {
+    if (
+      this.packager.packagerOptions.effectiveOptionComputed != null &&
+      (await this.packager.packagerOptions.effectiveOptionComputed({ desktop: desktopEntry, desktopFileName: `${this.helper.getDesktopFileName()}.desktop` }))
+    ) {
       await stageDir.cleanup()
       return
     }
@@ -90,6 +93,8 @@ export default class AppImageTarget extends Target {
             desktopEntry,
             icons,
             fileAssociations: packager.fileAssociations,
+            desktopName: packager.info.metadata.desktopName?.trim(),
+            syncDesktopName: packager.platformSpecificBuildOptions.syncDesktopName,
             compression: (() => {
               const c = options.compression
               if (c === "xz" || c === "gzip") {
@@ -116,6 +121,8 @@ export default class AppImageTarget extends Target {
             desktopEntry,
             icons,
             fileAssociations: packager.fileAssociations,
+            desktopName: packager.info.metadata.desktopName?.trim(),
+            syncDesktopName: packager.platformSpecificBuildOptions.syncDesktopName,
             compression: (() => {
               const c = options.compression
               if (c === "gzip" || c === "zstd") {

--- a/packages/app-builder-lib/src/targets/appimage/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/appimage/AppImageTarget.ts
@@ -68,9 +68,12 @@ export default class AppImageTarget extends Target {
       await outputFile(path.join(packager.getResourcesDir(appOutDir), "app-update.yml"), serializeToYaml(publishConfig))
     }
 
+    // Validated once here; throws InvalidConfigurationError for path traversal / NUL.
+    const desktopBaseName = this.helper.getDesktopFileName()
+
     if (
       this.packager.packagerOptions.effectiveOptionComputed != null &&
-      (await this.packager.packagerOptions.effectiveOptionComputed({ desktop: desktopEntry, desktopFileName: `${this.helper.getDesktopFileName()}.desktop` }))
+      (await this.packager.packagerOptions.effectiveOptionComputed({ desktop: desktopEntry, desktopFileName: `${desktopBaseName}.desktop` }))
     ) {
       await stageDir.cleanup()
       return
@@ -93,8 +96,7 @@ export default class AppImageTarget extends Target {
             desktopEntry,
             icons,
             fileAssociations: packager.fileAssociations,
-            desktopName: packager.info.metadata.desktopName?.trim(),
-            syncDesktopName: packager.platformSpecificBuildOptions.syncDesktopName,
+            desktopBaseName,
             compression: (() => {
               const c = options.compression
               if (c === "xz" || c === "gzip") {
@@ -121,8 +123,7 @@ export default class AppImageTarget extends Target {
             desktopEntry,
             icons,
             fileAssociations: packager.fileAssociations,
-            desktopName: packager.info.metadata.desktopName?.trim(),
-            syncDesktopName: packager.platformSpecificBuildOptions.syncDesktopName,
+            desktopBaseName,
             compression: (() => {
               const c = options.compression
               if (c === "gzip" || c === "zstd") {

--- a/packages/app-builder-lib/src/targets/appimage/appImageUtil.ts
+++ b/packages/app-builder-lib/src/targets/appimage/appImageUtil.ts
@@ -1,4 +1,4 @@
-import { Arch, copyDir, copyFile, exec, exists, InvalidConfigurationError, log } from "builder-util"
+import { Arch, copyDir, copyFile, exec, exists, InvalidConfigurationError, isEmptyOrSpaces, log } from "builder-util"
 import * as fs from "fs-extra"
 import * as path from "path"
 import { FileAssociation } from "../../options/FileAssociation"
@@ -28,6 +28,8 @@ interface Options {
    *
    */
   compression?: "gzip" | "zstd" | "xz"
+  desktopName?: string
+  syncDesktopName?: boolean
 }
 
 export interface AppImageBuilderOptions {
@@ -162,7 +164,7 @@ export function validateCriticalPathString(str: string, fieldName: string): void
 async function writeAppLauncherAndRelatedFiles(opts: AppImageBuilderOptions): Promise<void> {
   const {
     stageDir,
-    options: { license, executableName, productFilename, productName, desktopEntry },
+    options: { license, executableName, productFilename, productName, desktopEntry, desktopName, syncDesktopName },
   } = opts
 
   // executableName and productFilename are embedded directly into double-quoted bash strings
@@ -172,7 +174,7 @@ async function writeAppLauncherAndRelatedFiles(opts: AppImageBuilderOptions): Pr
   validateCriticalPathString(productFilename, "productFilename")
 
   // Write desktop file
-  const desktopFileName = `${executableName}.desktop`
+  const desktopFileName = `${syncDesktopName && !isEmptyOrSpaces(desktopName) ? desktopName!.replace(/\.desktop$/, "") : executableName}.desktop`
   await fs.writeFile(path.join(stageDir, desktopFileName), desktopEntry, { mode: 0o644 })
   await copyIcons(opts)
 

--- a/packages/app-builder-lib/src/targets/appimage/appImageUtil.ts
+++ b/packages/app-builder-lib/src/targets/appimage/appImageUtil.ts
@@ -1,4 +1,4 @@
-import { Arch, copyDir, copyFile, exec, exists, InvalidConfigurationError, isEmptyOrSpaces, log } from "builder-util"
+import { Arch, copyDir, copyFile, exec, exists, InvalidConfigurationError, log } from "builder-util"
 import * as fs from "fs-extra"
 import * as path from "path"
 import { FileAssociation } from "../../options/FileAssociation"
@@ -28,8 +28,8 @@ interface Options {
    *
    */
   compression?: "gzip" | "zstd" | "xz"
-  desktopName?: string
-  syncDesktopName?: boolean
+  /** Pre-computed desktop basename (already validated). When absent, falls back to `executableName`. */
+  desktopBaseName?: string
 }
 
 export interface AppImageBuilderOptions {
@@ -164,7 +164,7 @@ export function validateCriticalPathString(str: string, fieldName: string): void
 async function writeAppLauncherAndRelatedFiles(opts: AppImageBuilderOptions): Promise<void> {
   const {
     stageDir,
-    options: { license, executableName, productFilename, productName, desktopEntry, desktopName, syncDesktopName },
+    options: { license, executableName, productFilename, productName, desktopEntry, desktopBaseName },
   } = opts
 
   // executableName and productFilename are embedded directly into double-quoted bash strings
@@ -174,7 +174,7 @@ async function writeAppLauncherAndRelatedFiles(opts: AppImageBuilderOptions): Pr
   validateCriticalPathString(productFilename, "productFilename")
 
   // Write desktop file
-  const desktopFileName = `${syncDesktopName && !isEmptyOrSpaces(desktopName) ? desktopName!.replace(/\.desktop$/, "") : executableName}.desktop`
+  const desktopFileName = `${desktopBaseName ?? executableName}.desktop`
   await fs.writeFile(path.join(stageDir, desktopFileName), desktopEntry, { mode: 0o644 })
   await copyIcons(opts)
 

--- a/packages/app-builder-lib/src/targets/snap/core24.ts
+++ b/packages/app-builder-lib/src/targets/snap/core24.ts
@@ -57,7 +57,7 @@ export class SnapCore24 extends SnapCore<SnapOptions24> {
 
     // Create desktop file in snap/gui/ directory
     // Snapcraft will automatically copy this to meta/gui/ in the final snap
-    const desktopFilePath = path.join(guiOutput, `${snap.name}.desktop`)
+    const desktopFilePath = path.join(guiOutput, `${this.helper.getDesktopFileName(snap.name)}.desktop`)
     await this.helper.writeDesktopEntry(this.options, this.packager.executableName + " %U", desktopFilePath, desktopExtraProps)
 
     // Copy app files to the project root `app` directory so `source: app`
@@ -243,13 +243,14 @@ export class SnapCore24 extends SnapCore<SnapOptions24> {
     const commandSuffix = extraArgs.length > 0 ? ` ${extraArgs.join(" ")}` : ""
 
     // Create the app configuration
+    const desktopBaseName = this.helper.getDesktopFileName(appName)
     const app: App = {
       command: `app/${this.packager.executableName}${commandSuffix}`,
       "command-chain": undefined, // explicitly undefined so removeNullish strips it; extensions supply their own command-chain
       plugs: appPlugs,
       slots: appSlots,
-      autostart: options.autoStart ? `${appName}.desktop` : undefined,
-      desktop: `meta/gui/${appName}.desktop`,
+      autostart: options.autoStart ? `${desktopBaseName}.desktop` : undefined,
+      desktop: `meta/gui/${desktopBaseName}.desktop`,
       extensions: resolvedExtensions,
     }
 

--- a/packages/app-builder-lib/src/targets/snap/coreLegacy.ts
+++ b/packages/app-builder-lib/src/targets/snap/coreLegacy.ts
@@ -15,8 +15,16 @@ import { load } from "js-yaml"
 
 // Snap template release info from electron-userland/electron-builder-binaries
 const SNAP_TEMPLATES = {
-  amd64: { releaseName: "snap-template-4.0-2", filenameWithExt: "snap-template-electron-4.0-2-amd64.tar.7z" , checksums: { "snap-template-electron-4.0-2-amd64.tar.7z": "5e3ab4e09364ac06f0072b1c2dab9138318c933f6b2c7374f893b5ec44d19e6f" } },
-  armhf: { releaseName: "snap-template-4.0-1", filenameWithExt: "snap-template-electron-4.0-1-armhf.tar.7z" , checksums: { "snap-template-electron-4.0-1-armhf.tar.7z": "6f7553e904f4e043bc3019f0899d05e01a283b00b61fec22e932296490e3be6b" } },
+  amd64: {
+    releaseName: "snap-template-4.0-2",
+    filenameWithExt: "snap-template-electron-4.0-2-amd64.tar.7z",
+    checksums: { "snap-template-electron-4.0-2-amd64.tar.7z": "5e3ab4e09364ac06f0072b1c2dab9138318c933f6b2c7374f893b5ec44d19e6f" },
+  },
+  armhf: {
+    releaseName: "snap-template-4.0-1",
+    filenameWithExt: "snap-template-electron-4.0-1-armhf.tar.7z",
+    checksums: { "snap-template-electron-4.0-1-armhf.tar.7z": "6f7553e904f4e043bc3019f0899d05e01a283b00b61fec22e932296490e3be6b" },
+  },
 } as const
 
 // Handles core18/core20/core22 snaps via mksquashfs (template) or snapcraft CLI (no-template).
@@ -118,7 +126,7 @@ export class SnapCoreLegacy extends SnapCore<SnapOptions> {
     })
 
     if (options.autoStart) {
-      appDescriptor.autostart = `${snap.name}.desktop`
+      appDescriptor.autostart = `${this.helper.getDesktopFileName(snap.name)}.desktop`
     }
 
     if (options.confinement === "classic") {
@@ -203,7 +211,7 @@ export class SnapCoreLegacy extends SnapCore<SnapOptions> {
     }
 
     const snapMetaDir = path.join(stageDir, this.isUseTemplateApp ? "meta" : "snap")
-    const desktopFile = path.join(snapMetaDir, "gui", `${snap.name}.desktop`)
+    const desktopFile = path.join(snapMetaDir, "gui", `${this.helper.getDesktopFileName(snap.name)}.desktop`)
     await this.helper.writeDesktopEntry(this.options, this.packager.executableName + " %U", desktopFile, {
       Icon: "${SNAP}/meta/gui/icon.png",
     })

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
@@ -227,6 +227,54 @@ exports[`LinuxPackager > AppImage - store compression maps to gzip 1`] = `
 }
 `;
 
+exports[`LinuxPackager > AppImage - syncDesktopName true without desktopName falls back to executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - syncDesktopName uses desktopName for installed filename 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - syncDesktopName without flag keeps executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage 1`] = `
 {
   "linux": [

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
@@ -227,6 +227,54 @@ exports[`LinuxPackager > AppImage - store compression maps to gzip 1`] = `
 }
 `;
 
+exports[`LinuxPackager > AppImage - syncDesktopName true without desktopName falls back to executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - syncDesktopName uses desktopName for installed filename 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - syncDesktopName without flag keeps executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage 1`] = `
 {
   "linux": [

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
@@ -227,6 +227,38 @@ exports[`LinuxPackager > AppImage - store compression maps to gzip 1`] = `
 }
 `;
 
+exports[`LinuxPackager > AppImage - syncDesktopName true without desktopName falls back to executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - syncDesktopName uses desktopName for installed filename 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - syncDesktopName without flag keeps executableName 1`] = `
 {
   "linux": [

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
@@ -227,6 +227,22 @@ exports[`LinuxPackager > AppImage - store compression maps to gzip 1`] = `
 }
 `;
 
+exports[`LinuxPackager > AppImage - syncDesktopName without flag keeps executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage 1`] = `
 {
   "linux": [

--- a/test/src/linux/linuxPackagerTestSuite.ts
+++ b/test/src/linux/linuxPackagerTestSuite.ts
@@ -493,6 +493,69 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       {}
     ))
 
+  test("AppImage - syncDesktopName uses desktopName for installed filename", ({ expect }) =>
+    app(
+      expect,
+      {
+        targets: appImageTarget,
+        config: {
+          toolsets,
+          productName: "Signal",
+          linux: { syncDesktopName: true },
+        },
+        effectiveOptionComputed: async it => {
+          expect(it.desktopFileName).toBe("signal.desktop")
+          return Promise.resolve(false)
+        },
+      },
+      {
+        projectDirCreated: projectDir =>
+          modifyPackageJson(projectDir, data => {
+            data.desktopName = "signal.desktop"
+          }),
+      }
+    ))
+
+  test("AppImage - syncDesktopName without flag keeps executableName", ({ expect }) =>
+    app(
+      expect,
+      {
+        targets: appImageTarget,
+        config: {
+          toolsets,
+          productName: "Signal",
+        },
+        effectiveOptionComputed: async it => {
+          expect(it.desktopFileName).toBe("testapp.desktop")
+          return Promise.resolve(false)
+        },
+      },
+      {
+        projectDirCreated: projectDir =>
+          modifyPackageJson(projectDir, data => {
+            data.desktopName = "com.example.Signal.desktop"
+          }),
+      }
+    ))
+
+  test("AppImage - syncDesktopName true without desktopName falls back to executableName", ({ expect }) =>
+    app(
+      expect,
+      {
+        targets: appImageTarget,
+        config: {
+          toolsets,
+          productName: "Signal",
+          linux: { syncDesktopName: true },
+        },
+        effectiveOptionComputed: async it => {
+          expect(it.desktopFileName).toBe("testapp.desktop")
+          return Promise.resolve(false)
+        },
+      },
+      {}
+    ))
+
   test("forbid desktop.Exec", ({ expect }) =>
     appThrows(expect, {
       targets: appImageTarget,

--- a/test/src/linux/linuxPackagerTestSuite.ts
+++ b/test/src/linux/linuxPackagerTestSuite.ts
@@ -570,4 +570,61 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
         },
       },
     }))
+
+  test("AppImage - syncDesktopName rejects path traversal in desktopName", ({ expect }) =>
+    appThrows(
+      expect,
+      {
+        targets: appImageTarget,
+        config: {
+          toolsets,
+          linux: { syncDesktopName: true },
+        },
+      },
+      {
+        projectDirCreated: projectDir =>
+          modifyPackageJson(projectDir, data => {
+            data.desktopName = "../evil.desktop"
+          }),
+      },
+      err => expect(err.message).toContain("produces an invalid .desktop filename")
+    ))
+
+  test("AppImage - syncDesktopName rejects absolute path in desktopName", ({ expect }) =>
+    appThrows(
+      expect,
+      {
+        targets: appImageTarget,
+        config: {
+          toolsets,
+          linux: { syncDesktopName: true },
+        },
+      },
+      {
+        projectDirCreated: projectDir =>
+          modifyPackageJson(projectDir, data => {
+            data.desktopName = "/etc/passwd.desktop"
+          }),
+      },
+      err => expect(err.message).toContain("produces an invalid .desktop filename")
+    ))
+
+  test("AppImage - syncDesktopName rejects backslash in desktopName", ({ expect }) =>
+    appThrows(
+      expect,
+      {
+        targets: appImageTarget,
+        config: {
+          toolsets,
+          linux: { syncDesktopName: true },
+        },
+      },
+      {
+        projectDirCreated: projectDir =>
+          modifyPackageJson(projectDir, data => {
+            data.desktopName = "evil\\path.desktop"
+          }),
+      },
+      err => expect(err.message).toContain("produces an invalid .desktop filename")
+    ))
 }

--- a/website/docs/linux.md
+++ b/website/docs/linux.md
@@ -71,6 +71,35 @@ linux:
 
 Standard freedesktop.org category values include: `AudioVideo`, `Audio`, `Video`, `Development`, `Education`, `Game`, `Graphics`, `Network`, `Office`, `Science`, `Settings`, `System`, `Utility`.
 
+## Window Association (`desktopName` + `syncDesktopName`)
+
+Electron derives its [`app_id`](https://github.com/electron/electron/blob/main/lib/browser/init.ts) — which becomes the window's `WM_CLASS` — from the `desktopName` field in your root `package.json`. Desktop environments (GNOME, KDE, etc.) use `WM_CLASS` to match a running window to its `.desktop` entry for taskbar grouping, dock badges, and launcher highlighting.
+
+**Without `desktopName` set, this association can break**: the fallback `WM_CLASS` may not match the installed `.desktop` filename, so the DE treats the running app as an unknown window.
+
+To fix this, set `desktopName` in `package.json` and enable `linux.syncDesktopName`:
+
+```json title="package.json"
+{
+  "desktopName": "com.example.MyApp.desktop",
+  "build": {
+    "linux": {
+      "syncDesktopName": true
+    }
+  }
+}
+```
+
+With `syncDesktopName: true`, electron-builder installs the `.desktop` file as `com.example.MyApp.desktop` and sets `StartupWMClass=com.example.MyApp` — both matching Electron's `app_id`. Without the flag the filename continues to use `executableName` (the current default, preserved for backwards compatibility).
+
+:::note[v27]
+`syncDesktopName` will default to `true` in v27. If you rely on the current behaviour, set it explicitly to `false`.
+:::
+
+:::warning[`desktopName` is required for reliable window association]
+If `desktopName` is absent, electron-builder will log a warning at build time. Without it, desktop environments on GNOME, KDE, and others may not correctly link the running application window to its launcher entry.
+:::
+
 See the [freedesktop.org specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/example.html) for all valid keys.
 
 ## Icon Configuration


### PR DESCRIPTION
Follow-up on https://github.com/electron-userland/electron-builder/issues/9103

## Summary

- Adds `linux.syncDesktopName?: boolean` to `LinuxConfiguration` — when `true`, the installed `.desktop` filename is derived from `desktopName` in `package.json` (minus the `.desktop` suffix), matching `StartupWMClass` and Electron's `app_id` so desktop environments can correctly associate running windows with the launcher entry
- Adds `LinuxTargetHelper.getDesktopFileName(fallback?)` as a shared helper used by all Linux targets to compute and **validate** the canonical desktop basename
- Applies the new logic across AppImage, FPM (deb/rpm), Snap coreLegacy, and Snap core24 targets
- No change to Flatpak (it uses `appId`, which is correct for Flatpak's package database)
- **Security**: validates the derived basename and throws `InvalidConfigurationError` if it contains path separators (`/`, `\`) or NUL bytes, preventing path traversal in staging directories
- **DX**: emits a `log.warn` when `desktopName` is absent, guiding developers to set it for correct window association
- **Non-breaking**: the flag defaults to `false`; existing behavior is unchanged unless opted in
- Will become the default in v27

### Why

Desktop environments match a running Electron window to its `.desktop` entry using two things: the `StartupWMClass` field inside the file, and the file's basename. Electron derives its `app_id` (WM_CLASS) from `desktopName` in `package.json`. `StartupWMClass` already correctly reflected `desktopName` (since #9103), but the installed filename always used `executableName`. When `desktopName` is set, the two values diverged and DEs could not reliably associate windows with their launcher entries.

## Changed Files

| File | Change |
|------|--------|
| `packages/app-builder-lib/src/options/linuxOptions.ts` | Add `syncDesktopName?: boolean` to `LinuxConfiguration` |
| `packages/app-builder-lib/src/targets/LinuxTargetHelper.ts` | Add `getDesktopFileName(fallback?)` with path-traversal validation; add `log.warn` when `desktopName` is absent |
| `packages/app-builder-lib/src/targets/FpmTarget.ts` | Use `getDesktopFileName()` for install path |
| `packages/app-builder-lib/src/targets/appimage/appImageUtil.ts` | Replace `desktopName`/`syncDesktopName` fields with pre-validated `desktopBaseName`; remove duplicate derivation logic |
| `packages/app-builder-lib/src/targets/appimage/AppImageTarget.ts` | Compute `desktopBaseName` once via `getDesktopFileName()`; pass through to both build branches |
| `packages/app-builder-lib/src/targets/snap/coreLegacy.ts` | Use `getDesktopFileName()` for desktop path and autostart |
| `packages/app-builder-lib/src/targets/snap/core24.ts` | Use `getDesktopFileName()` for desktop path, autostart, and snap YAML `desktop` key |
| `test/src/linux/linuxPackagerTestSuite.ts` | Add tests for `syncDesktopName` behavior + three security rejection tests |

## Usage

```json
// package.json
{
  "desktopName": "com.example.MyApp.desktop",
  "build": {
    "linux": {
      "syncDesktopName": true
    }
  }
}
```

`desktopName` is a root-level `package.json` field (read from metadata). With this config, the installed file will be `com.example.MyApp.desktop` and `StartupWMClass=com.example.MyApp` — both matching Electron's `app_id`.

## Security

`desktopName` flows into filesystem paths (e.g. `snap/gui/<name>.desktop`, `/usr/share/applications/<name>.desktop`). The validated `getDesktopFileName()` helper now rejects:
- Path separators: `../evil.desktop` → `InvalidConfigurationError`
- Absolute paths: `/etc/passwd.desktop` → `InvalidConfigurationError`
- Windows-style paths: `evil\\path.desktop` → `InvalidConfigurationError`
