### PR TITLE
fix(smart-cache): deep-merge shard caches so linux timing data survives across runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -506,69 +506,9 @@ jobs:
 
       - name: Merge cache files
         run: |
-          mkdir -p merged-cache
-
-          # Create merge script
-          cat > merge-caches.js << 'EOF'
-          const fs = require('fs');
-          const path = require('path');
-
-          const artifactsDir = 'smart-cache-artifacts';
-          const outputFile = 'merged-cache/_vitest-smart-cache.json';
-          const repoCommittedCache = 'test/vitest-scripts/_vitest-smart-cache.json';
-
-          let mergedCache = {};
-          let filesProcessed = 0;
-
-          // Start with repo-committed cache as base (if it exists)
-          if (fs.existsSync(repoCommittedCache)) {
-            console.log('Loading base cache from repo-committed file');
-            try {
-              mergedCache = JSON.parse(fs.readFileSync(repoCommittedCache, 'utf8'));
-              console.log(`Base cache has ${Object.keys(mergedCache).length} entries`);
-            } catch (err) {
-              console.error('Error reading repo-committed cache:', err.message);
-            }
-          }
-
-          // Check if artifacts directory exists
-          if (!fs.existsSync(artifactsDir)) {
-            console.log('No smart cache artifacts found to merge, using base cache only');
-            fs.writeFileSync(outputFile, JSON.stringify(mergedCache, null, 2));
-            process.exit(0);
-          }
-
-          // Read all cache files from test runs
-          const platforms = fs.readdirSync(artifactsDir);
-
-          platforms.forEach(platform => {
-            const cacheFile = path.join(artifactsDir, platform, '_vitest-smart-cache.json');
-            if (fs.existsSync(cacheFile)) {
-              console.log(`Reading cache from ${platform}`);
-              try {
-                const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
-                filesProcessed++;
-
-                // Deep-merge top-level objects so all shards' new timing data is preserved
-                Object.keys(cache).forEach(key => {
-                  if (mergedCache[key] && typeof mergedCache[key] === 'object' && !Array.isArray(mergedCache[key])) {
-                    mergedCache[key] = { ...mergedCache[key], ...cache[key] };
-                  } else {
-                    mergedCache[key] = cache[key];
-                  }
-                });
-              } catch (err) {
-                console.error(`Error reading cache from ${platform}:`, err.message);
-              }
-            }
-          });
-
-          console.log(`Processed ${filesProcessed} cache files from test runs`);
-          console.log(`Final merged cache has ${Object.keys(mergedCache).length} entries`);
-          fs.writeFileSync(outputFile, JSON.stringify(mergedCache, null, 2));
-          EOF
-
-          node merge-caches.js
+          pnpm ci:test:merge-cache \
+            --artifacts-dir smart-cache-artifacts \
+            --output merged-cache/_vitest-smart-cache.json
 
       - name: Delete individual cache artifacts
         uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "ci:test": "ts-node test/vitest-scripts/run-vitest.ts",
     "ci:test:generate": "ts-node test/vitest-scripts/generate-tests.ts",
     "ci:test:count": "ts-node test/vitest-scripts/smart-shard-count.ts",
+    "ci:test:fetch-cache": "ts-node test/vitest-scripts/fetch-smart-cache.ts",
+    "ci:test:merge-cache": "ts-node test/vitest-scripts/merge-smart-cache.ts",
     "ci:validate": "pnpm compile && pnpm pretest && pnpm generate:all",
     "ci:version": "pnpm i && changeset version && node scripts/update-package-version-export.js && pnpm changelog && pnpm compile && pnpm generate:all && git add .",
     "ci:publish": "pnpm i && pnpm compile && pnpm publish -r --tag ${NPM_DIST_TAG:-next} && changeset tag",

--- a/test/vitest-scripts/cache.ts
+++ b/test/vitest-scripts/cache.ts
@@ -87,7 +87,7 @@ export function saveCache(cache: SmartCache) {
 }
 
 export function getFileStats(cache: SmartCache, f: TestSpecification) {
-  const file = path.relative(TEST_SRC_ROOT, f.moduleId)
+  const file = path.relative(TEST_SRC_ROOT, f.moduleId).split(path.sep).join("/")
   const stat = cache.files[file]
   return { stat, file }
 }

--- a/test/vitest-scripts/fetch-smart-cache.ts
+++ b/test/vitest-scripts/fetch-smart-cache.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env ts-node
+/**
+ * Fetches the latest vitest smart cache artifact from GitHub Actions so you can
+ * inspect timing data locally without pushing to CI.
+ *
+ * Usage:
+ *   ts-node test/vitest-scripts/fetch-smart-cache.ts          # auto-detect branch/PR
+ *   ts-node test/vitest-scripts/fetch-smart-cache.ts --pr 123
+ *   ts-node test/vitest-scripts/fetch-smart-cache.ts --ref master
+ *
+ * After fetching, run:
+ *   pnpm ci:test:count
+ */
+
+import { execSync, spawnSync } from "child_process"
+import * as fs from "fs"
+import * as path from "path"
+import { CACHE_FILE } from "./smart-config"
+
+const REPO = "electron-userland/electron-builder"
+
+function run(cmd: string): string {
+  return execSync(cmd, { encoding: "utf8" }).trim()
+}
+
+function ghJson(endpoint: string): any {
+  const result = spawnSync("gh", ["api", endpoint], { encoding: "utf8" })
+  if (result.status !== 0) return null
+  try {
+    return JSON.parse(result.stdout)
+  } catch {
+    return null
+  }
+}
+
+function detectRef(): string {
+  // Check for open PR for the current branch
+  try {
+    const branch = run("git rev-parse --abbrev-ref HEAD")
+    const pr = run(`gh pr view --json number -q .number 2>/dev/null || echo ""`)
+    if (pr) return `PR-${pr}`
+    return branch
+  } catch {
+    return "master"
+  }
+}
+
+function downloadArtifact(runId: number, artifactName: string, dest: string): boolean {
+  const tmpDir = path.join(path.dirname(dest), ".cache-download-tmp")
+  fs.mkdirSync(tmpDir, { recursive: true })
+  try {
+    const result = spawnSync(
+      "gh",
+      ["run", "download", String(runId), "--repo", REPO, "--name", artifactName, "--dir", tmpDir],
+      { encoding: "utf8" }
+    )
+    if (result.status !== 0) return false
+    const downloaded = fs.readdirSync(tmpDir).find(f => f === "_vitest-smart-cache.json")
+    if (!downloaded) return false
+    fs.copyFileSync(path.join(tmpDir, downloaded), dest)
+    return true
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+}
+
+function findLatestArtifactRunId(artifactName: string): number | null {
+  const data = ghJson(`repos/${REPO}/actions/artifacts?name=${artifactName}&per_page=30`)
+  if (!data?.artifacts?.length) return null
+  const live = (data.artifacts as any[]).filter((a: any) => !a.expired)
+  if (!live.length) return null
+  live.sort((a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+  return live[0].workflow_run.id ?? null
+}
+
+function summarize(dest: string) {
+  const cache = JSON.parse(fs.readFileSync(dest, "utf8"))
+  const files: Record<string, any> = cache.files ?? {}
+  const platforms = ["linux", "win32", "darwin"] as const
+  console.log(`\nCache summary (${Object.keys(files).length} files):`)
+  for (const p of platforms) {
+    const withData = Object.values(files).filter((f: any) => (f.platformRuns?.[p]?.avgMs ?? 0) > 0)
+    console.log(`  ${p}: ${withData.length} files with timing data`)
+  }
+  console.log()
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  let ref: string | null = null
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--pr" && args[i + 1]) ref = `PR-${args[++i]}`
+    else if (args[i] === "--ref" && args[i + 1]) ref = args[++i]
+  }
+  if (!ref) ref = detectRef()
+
+  const cacheName = `vitest-smart-cache-${ref}`
+  const fallbackName = "vitest-smart-cache-master"
+  const dest = CACHE_FILE
+
+  for (const name of [cacheName, fallbackName]) {
+    console.log(`Looking for artifact: ${name}`)
+    const runId = findLatestArtifactRunId(name)
+    if (!runId) {
+      console.log(`  Not found.`)
+      continue
+    }
+    console.log(`  Found in run ${runId}. Downloading...`)
+    if (downloadArtifact(runId, name, dest)) {
+      console.log(`✓ Restored ${name} → ${dest}`)
+      summarize(dest)
+      console.log(`Run 'pnpm ci:test:count' to preview the shard plan with timing data.`)
+      return
+    }
+    console.log(`  Download failed.`)
+  }
+
+  console.log("No smart cache artifact found. Run 'pnpm ci:test:count' to see the default plan.")
+}
+
+main()

--- a/test/vitest-scripts/merge-smart-cache.ts
+++ b/test/vitest-scripts/merge-smart-cache.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env ts-node
+/**
+ * Merges per-shard vitest smart cache artifacts into a single unified cache file.
+ *
+ * Each shard starts from the same base cache and updates only its own assigned files.
+ * A naïve shallow merge would cause later shards to overwrite earlier shards' timing
+ * data with stale zeros from the base. This script avoids that by merging per-file,
+ * per-platform and keeping the record with the higher `runs` count — which is always
+ * the shard that actually ran that file in this cycle.
+ *
+ * Windows reporters write cache keys with `\` separators. All keys are normalized to
+ * `/` so every platform shares a single key namespace.
+ *
+ * Usage (CI — called from merge-smart-cache workflow step):
+ *   ts-node test/vitest-scripts/merge-smart-cache.ts \
+ *     --artifacts-dir smart-cache-artifacts \
+ *     --output merged-cache/_vitest-smart-cache.json
+ *
+ * Usage (local — inspect what a merge would produce from downloaded artifacts):
+ *   pnpm ci:test:merge-cache --artifacts-dir /tmp/my-artifacts --output /tmp/merged.json
+ */
+
+import * as fs from "fs"
+import * as path from "path"
+
+interface PlatformRun {
+  runs: number
+  fails: number
+  avgMs: number
+}
+
+interface FileStats {
+  unstable?: boolean
+  hasHeavyTests?: boolean
+  platformRuns?: Record<string, PlatformRun>
+}
+
+interface SmartCache {
+  tests: Record<string, FileStats>
+  files: Record<string, FileStats>
+}
+
+function normalizeKey(k: string): string {
+  return k.replace(/\\/g, "/")
+}
+
+function mergePlatformRuns(
+  existing: Record<string, PlatformRun> = {},
+  incoming: Record<string, PlatformRun> = {}
+): Record<string, PlatformRun> {
+  const merged = { ...existing }
+  for (const [platform, inPR] of Object.entries(incoming)) {
+    const exPR = merged[platform]
+    if (!exPR || inPR.runs > exPR.runs) {
+      merged[platform] = inPR
+    }
+  }
+  return merged
+}
+
+function mergeEntryMap(target: Record<string, FileStats>, source: Record<string, FileStats>): void {
+  for (const [rawKey, incoming] of Object.entries(source)) {
+    const key = normalizeKey(rawKey)
+    const existing = target[key]
+    if (!existing) {
+      target[key] = incoming
+    } else {
+      target[key] = {
+        ...existing,
+        ...incoming,
+        platformRuns: mergePlatformRuns(existing.platformRuns, incoming.platformRuns),
+        hasHeavyTests: !!(existing.hasHeavyTests || incoming.hasHeavyTests),
+      }
+    }
+  }
+}
+
+function parseArgs(): { artifactsDir: string; output: string } {
+  const args = process.argv.slice(2)
+  let artifactsDir = "smart-cache-artifacts"
+  let output = "merged-cache/_vitest-smart-cache.json"
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--artifacts-dir" && args[i + 1]) artifactsDir = args[++i]
+    else if (args[i] === "--output" && args[i + 1]) output = args[++i]
+  }
+  return { artifactsDir, output }
+}
+
+function main() {
+  const { artifactsDir, output } = parseArgs()
+
+  const mergedFiles: Record<string, FileStats> = {}
+  const mergedTests: Record<string, FileStats> = {}
+  let artifactsProcessed = 0
+
+  if (!fs.existsSync(artifactsDir)) {
+    console.log(`No artifacts directory found at '${artifactsDir}' — writing empty cache`)
+    fs.mkdirSync(path.dirname(output), { recursive: true })
+    fs.writeFileSync(output, JSON.stringify({ tests: {}, files: {} }, null, 2))
+    return
+  }
+
+  for (const artifact of fs.readdirSync(artifactsDir)) {
+    const cacheFile = path.join(artifactsDir, artifact, "_vitest-smart-cache.json")
+    if (!fs.existsSync(cacheFile)) continue
+    console.log(`  Reading ${artifact}`)
+    try {
+      const cache: SmartCache = JSON.parse(fs.readFileSync(cacheFile, "utf8"))
+      mergeEntryMap(mergedFiles, cache.files ?? {})
+      mergeEntryMap(mergedTests, cache.tests ?? {})
+      artifactsProcessed++
+    } catch (err: any) {
+      console.error(`  Error reading ${artifact}: ${err.message}`)
+    }
+  }
+
+  const mergedCache = { tests: mergedTests, files: mergedFiles }
+  const fileCount = Object.keys(mergedFiles).length
+  const testCount = Object.keys(mergedTests).length
+  console.log(`Processed ${artifactsProcessed} artifacts — Files: ${fileCount}, Tests: ${testCount}`)
+
+  fs.mkdirSync(path.dirname(output), { recursive: true })
+  fs.writeFileSync(output, JSON.stringify(mergedCache, null, 2))
+  console.log(`✓ Merged cache written to ${output}`)
+}
+
+main()

--- a/test/vitest-scripts/vitest-smart-reporter.ts
+++ b/test/vitest-scripts/vitest-smart-reporter.ts
@@ -40,13 +40,13 @@ export default class SmarterReporter implements Reporter {
   }
 
   onTestCaseReady(test: TestCase) {
-    const id = `${path.relative(TEST_SRC_ROOT, test.module.moduleId)}::${test.fullName}`
+    const id = `${path.relative(TEST_SRC_ROOT, test.module.moduleId).split(path.sep).join("/")}::${test.fullName}`
     this.inProgressTests.set(id, Date.now())
     process.stdout.write(`\n[test ready] 🏃 ${test.fullName}\n`)
   }
 
   onTestCaseResult(test: TestCase) {
-    const id = `${path.relative(TEST_SRC_ROOT, test.module.moduleId)}::${test.fullName}`
+    const id = `${path.relative(TEST_SRC_ROOT, test.module.moduleId).split(path.sep).join("/")}::${test.fullName}`
     this.inProgressTests.delete(id)
     const dur = test.diagnostic()?.duration ?? 0
     const testResult = test.result().state
@@ -64,7 +64,6 @@ export default class SmarterReporter implements Reporter {
     })()
     process.stdout.write(`\n${status} ${id} (${Math.round(dur / 1000)}s)\n`)
 
-    // Access meta through the test task
     const meta = (test as any).meta || {}
 
     const prev: TestStats = this.cache.tests[id] ?? { ...defaultStat }
@@ -94,7 +93,7 @@ export default class SmarterReporter implements Reporter {
       heavy: isHeavy,
     }
 
-    const file = path.relative(TEST_SRC_ROOT, test.module.moduleId)
+    const file = path.relative(TEST_SRC_ROOT, test.module.moduleId).split(path.sep).join("/")
     this.fileDurations.set(file, (this.fileDurations.get(file) ?? 0) + dur)
     if (testResult === "failed") {
       this.fileFails.set(file, (this.fileFails.get(file) ?? 0) + 1)
@@ -105,7 +104,7 @@ export default class SmarterReporter implements Reporter {
   }
 
   onTestModuleEnd(mod: TestModule) {
-    const file = path.relative(TEST_SRC_ROOT, mod.moduleId)
+    const file = path.relative(TEST_SRC_ROOT, mod.moduleId).split(path.sep).join("/")
     const dur = this.fileDurations.get(file) ?? 0
     const fails = this.fileFails.get(file) ?? 0
     const hasHeavy = this.fileHasHeavy.get(file) ?? false


### PR DESCRIPTION
## Summary

- **Root cause 1 (primary):** The `merge-smart-cache` job used a shallow object spread to combine per-shard cache files. Every shard starts from the full base cache and updates only its ~30 assigned files. When merged with `{ ...mergedCache.files, ...shard.files }`, each subsequent shard's entry for every *other* file (all carrying `linux: {runs:0, avgMs:0}` from the base) overwrites the previous shards' freshly recorded Linux data. Only the last-processed shard's files retained non-zero Linux timing — explaining why `smart-shard-count.ts` printed "unknown" for nearly everything.

- **Root cause 2 (secondary):** Windows wrote cache keys with `\` path separators; Linux/macOS used `/`. The same file produced two separate entries in the merged cache. Since `shard-plan` always runs on Ubuntu, the backslash-keyed Windows entries were never found during shard-count lookups.

- **Fix 1 — deep merge ([merge-smart-cache.ts](test/vitest-scripts/merge-smart-cache.ts)):** Extracted the inline workflow JS into a proper TypeScript script (`pnpm ci:test:merge-cache`). It does a per-file, per-platform merge, keeping the record with the **higher `runs` count** — the shard that actually ran a file in this cycle has `runs = prevRuns + 1`; all other shards carry `runs = prevRuns` from the base, so the correct entry always wins. Also normalizes `\` → `/` on all keys during merge to consolidate Windows duplicates.

- **Fix 2 — path normalization ([vitest-smart-reporter.ts](test/vitest-scripts/vitest-smart-reporter.ts), [cache.ts](test/vitest-scripts/cache.ts)):** All `path.relative(...)` results used as cache keys are now normalized to forward slashes (`.split(path.sep).join("/")`), eliminating duplicate key namespaces at the source.

- **Fix 3 — local fetch script ([fetch-smart-cache.ts](test/vitest-scripts/fetch-smart-cache.ts)):** Added `pnpm ci:test:fetch-cache` — uses `gh` CLI to download the latest smart cache artifact for the current branch/PR (fallback to `master`). After fetching, `pnpm ci:test:count` shows real timing data locally with no push required.
