### PR TITLE
fix(mac): use native `zip` for macOS zip target to preserve `.framework` symlinks

### DIFF
--- a/.changeset/fix-mac-zip-symlink-preservation.md
+++ b/.changeset/fix-mac-zip-symlink-preservation.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): use native `zip` for macOS zip target to preserve `.framework` symlinks and fix Squirrel.Mac auto-update validation

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -22,14 +22,6 @@ runs:
         node-version: '22'
         cache: 'pnpm'
 
-    - name: Update npm to support OIDC token authentication for publishing
-      run: npm install -g npm@11.6.2
-      shell: bash
-
-    - name: Verify updated npm version
-      run: npm -v
-      shell: bash
-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -114,6 +114,15 @@ jobs:
             echo "Using default config: $CONFIG_PATH (no symlink needed)"
           fi
 
+      - name: Update npm to support OIDC token authentication for publishing
+        run: |
+          for i in 1 2 3; do
+            npm install -g npm@11.6.2 && break
+            [ $i -lt 3 ] && echo "npm install failed (attempt $i/3), retrying in 15s…" && sleep 15
+          done
+          npm -v
+        shell: bash
+
       - name: Create versions PR & prepare publish
         id: changesets
         uses: changesets/action@7af85527bb2f43a404b5823a6cad47661be255c1 # v1.5.3 - @marshallofsound fork

--- a/packages/app-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/app-builder-lib/src/targets/ArchiveTarget.ts
@@ -67,6 +67,7 @@ export class ArchiveTarget extends Target {
         const archiveOptions = {
           compression: packager.compression,
           withoutDir,
+          preserveSymlinks: isMac,
         }
         await archive(format, artifactPath, dirToArchive, archiveOptions)
 

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -86,6 +86,12 @@ export interface ArchiveOptions {
   method?: "Copy" | "LZMA" | "Deflate" | "DEFAULT"
 
   isRegularFile?: boolean
+
+  /**
+   * Use native macOS `zip` to preserve symlinks. Required for .framework bundles.
+   * @default false
+   */
+  preserveSymlinks?: boolean
 }
 
 export function compute7zCompressArgs(format: string, options: ArchiveOptions = {}) {
@@ -162,10 +168,11 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     return outFile
   }
 
-  // On macOS, always use native `zip` for zip archives: 7zip dereferences symlinks,
-  // corrupting .framework bundles and breaking codesign on the extracted app.
-  // Native `zip -y` stores symlinks as-is and also handles NFD-normalized filenames.
-  const use7z = !(process.platform === "darwin" && format === "zip")
+  // On macOS, use native `zip` when symlink preservation is required (e.g. .framework bundles).
+  // 7zip dereferences symlinks, corrupting .framework structure and breaking codesign.
+  // Only opt in via preserveSymlinks — Windows zip targets built on macOS still use 7z
+  // so that the UTF-8 bit (-mcu) is set correctly in the zip header.
+  const use7z = !(process.platform === "darwin" && format === "zip" && options.preserveSymlinks)
 
   if (use7z) {
     const args = compute7zCompressArgs(format, options)

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -162,11 +162,10 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     return outFile
   }
 
-  let use7z = true
-  if (process.platform === "darwin" && format === "zip" && dirToArchive.normalize("NFC") !== dirToArchive) {
-    log.warn({ reason: "7z doesn't support NFD-normalized filenames" }, `using zip`)
-    use7z = false
-  }
+  // On macOS, always use native `zip` for zip archives: 7zip dereferences symlinks,
+  // corrupting .framework bundles and breaking codesign on the extracted app.
+  // Native `zip -y` stores symlinks as-is and also handles NFD-normalized filenames.
+  const use7z = !(process.platform === "darwin" && format === "zip")
 
   if (use7z) {
     const args = compute7zCompressArgs(format, options)
@@ -191,7 +190,7 @@ export async function archive(format: string, outFile: string, dirToArchive: str
       }
     }
   } else {
-    // NFD fallback: macOS native zip handles NFD-normalized Unicode paths correctly
+    // macOS native zip: -y preserves symlinks (required for .framework bundles)
     const args = ["-q", "-r", "-y"]
     if (debug7z.enabled) {
       args.push("-v")
@@ -205,6 +204,9 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     args.push(outFile, options.withoutDir ? "." : path.basename(dirToArchive))
     if (options.excluded != null) {
       for (const mask of options.excluded) {
+        if (mask.includes("..")) {
+          throw new Error(`Excluded archive pattern contains path traversal sequence: "${mask}"`)
+        }
         args.push(`-x${mask}`)
       }
     }

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -153,7 +153,7 @@ describe("compute7zCompressArgs", () => {
 // ─── archive() — path-level guards (no binary needed) ───────────────────────
 
 describe("archive() guards", () => {
-  test("excluded pattern with '..' throws before reaching 7za", async ({ expect }) => {
+  test("excluded pattern with '..' throws", async ({ expect }) => {
     const src = await makeSrcDir()
     await expect(archive("zip", path.join(tmpDir, "out.zip"), src, { excluded: ["../secret"] })).rejects.toThrow("path traversal sequence")
   })
@@ -168,5 +168,37 @@ describe("archive() guards", () => {
     const result = await archive("zip", outFile, src)
     expect(result).toBe(outFile)
     expect(await fs.readFile(outFile, "utf8")).toBe("sentinel")
+  })
+})
+
+// ─── archive() — macOS zip symlink preservation ──────────────────────────────
+
+describe.runIf(process.platform === "darwin")("archive() macOS zip symlink preservation", () => {
+  test("zip archive preserves symlinks (not dereferenced)", async ({ expect }) => {
+    const src = path.join(tmpDir, "src")
+    await fs.mkdir(src, { recursive: true })
+    await fs.writeFile(path.join(src, "real.txt"), "content")
+    await fs.symlink("real.txt", path.join(src, "link.txt"))
+
+    const outFile = path.join(tmpDir, "out.zip")
+    await archive("zip", outFile, src, { withoutDir: true })
+
+    // Extract and verify symlink is preserved
+    const extractDir = path.join(tmpDir, "extracted")
+    await fs.mkdir(extractDir, { recursive: true })
+    const { exec: cpExec } = await import("child_process")
+    const { promisify } = await import("util")
+    const execAsync = promisify(cpExec)
+    await execAsync(`unzip -q "${outFile}" -d "${extractDir}"`)
+
+    const linkStat = await fs.lstat(path.join(extractDir, "link.txt"))
+    expect(linkStat.isSymbolicLink()).toBe(true)
+    const target = await fs.readlink(path.join(extractDir, "link.txt"))
+    expect(target).toBe("real.txt")
+  })
+
+  test("excluded pattern with '..' throws in native zip path", async ({ expect }) => {
+    const src = await makeSrcDir()
+    await expect(archive("zip", path.join(tmpDir, "out.zip"), src, { excluded: ["../secret"] })).rejects.toThrow("path traversal sequence")
   })
 })

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -181,7 +181,7 @@ describe.runIf(process.platform === "darwin")("archive() macOS zip symlink prese
     await fs.symlink("real.txt", path.join(src, "link.txt"))
 
     const outFile = path.join(tmpDir, "out.zip")
-    await archive("zip", outFile, src, { withoutDir: true })
+    await archive("zip", outFile, src, { withoutDir: true, preserveSymlinks: true })
 
     // Extract and verify symlink is preserved
     const extractDir = path.join(tmpDir, "extracted")
@@ -199,6 +199,6 @@ describe.runIf(process.platform === "darwin")("archive() macOS zip symlink prese
 
   test("excluded pattern with '..' throws in native zip path", async ({ expect }) => {
     const src = await makeSrcDir()
-    await expect(archive("zip", path.join(tmpDir, "out.zip"), src, { excluded: ["../secret"] })).rejects.toThrow("path traversal sequence")
+    await expect(archive("zip", path.join(tmpDir, "out.zip"), src, { excluded: ["../secret"], preserveSymlinks: true })).rejects.toThrow("path traversal sequence")
   })
 })


### PR DESCRIPTION
Fixes #9846