### PR TITLE
fix: retry package install on transient network errors

### DIFF
--- a/.changeset/sour-laws-end.md
+++ b/.changeset/sour-laws-end.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: retry package install on transient network errors

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -313,8 +313,15 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
         retries: 3,
         interval: 2000,
         backoff: 2000,
-        shouldRetry: (e: any) =>
-          e instanceof HttpError ? e.isServerError() : typeof e?.code === "string" && ["ENOTFOUND", "ETIMEDOUT", "ECONNRESET", "EPIPE", "ENOENT"].includes(e.code),
+        shouldRetry: (e: any) => {
+          if (e instanceof HttpError) {
+            return e.isServerError()
+          }
+          if (typeof e?.response?.statusCode === "number") {
+            return e.response.statusCode >= 500
+          }
+          return typeof e?.code === "string" && ["ENOTFOUND", "ETIMEDOUT", "ECONNRESET", "EPIPE", "ENOENT"].includes(e.code)
+        },
       })
     } catch (err) {
       if (typeof (err as any)?.message === "string" && (err as any).message.includes("dest already exists")) {

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -1,4 +1,4 @@
-import { asArray, log, spawn, stripSensitiveEnvVars } from "builder-util"
+import { asArray, log, retry, spawn, stripSensitiveEnvVars } from "builder-util"
 import { pathExists } from "fs-extra"
 import { homedir } from "os"
 import * as path from "path"
@@ -114,11 +114,20 @@ export async function installDependencies(
     execArgs.push(...additionalArgs)
   }
 
-  await spawn(execPath, execArgs, {
-    cwd: appDir,
-    env: {
-      ...getGypEnv(options.frameworkInfo, platform, arch, options.buildFromSource === true),
-      ...env,
+  const spawnEnv = {
+    ...getGypEnv(options.frameworkInfo, platform, arch, options.buildFromSource === true),
+    ...env,
+  }
+  await retry(() => spawn(execPath, execArgs, { cwd: appDir, env: spawnEnv }), {
+    retries: 3,
+    interval: 1000,
+    backoff: 2000,
+    shouldRetry: (e: any) => {
+      const isTransient = /ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED/.test(e?.message ?? "")
+      if (isTransient) {
+        log.warn({ error: String(e?.message).split("\n")[0] }, "transient network error during package install, retrying")
+      }
+      return isTransient
     },
   })
 


### PR DESCRIPTION
- Wraps the `spawn` call in `installDependencies` ([yarn.ts:121](packages/app-builder-lib/src/util/yarn.ts#L121)) with the existing `retry` utility from `builder-util-runtime`
- Retries up to 3 times (4 total attempts) with a 1s base interval and 2s backoff per attempt (delays: 1s, 3s, 5s)
- Only retries on known transient network error codes: `ENOTFOUND`, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`, `ECONNREFUSED` — these appear in the subprocess stderr captured by `ExecError.message`
- Logs a `warn` with the first line of the error message on each retried attempt
- Permanent failures (e.g. missing package, bad lockfile) are not retried and still surface immediately

**Root cause:** CI jobs were failing intermittently because `electron`'s `install.js` post-install script makes a network request to download the electron binary from GitHub. When CI's DNS resolver briefly fails (`getaddrinfo ENOTFOUND github.com`), the entire `yarn install` subprocess exits with code 1, which previously was a hard failure with no retry.

Ref: https://github.com/electron-userland/electron-builder/actions/runs/27098085522/job/79973882675?pr=9848
```
FAIL  test/src/packageManagerTest.ts > Package Managers > yarn multi-package workspace
Error: yarn process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
Exit code:
1
Output:
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

Error output:

error /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/t-EkIVHO/test_project-u/node_modules/electron: Command failed.
Exit code: 1
Command: node install.js
Arguments: 
Directory: /private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/t-EkIVHO/test_project-u/node_modules/electron
Output:
RequestError: getaddrinfo ENOTFOUND github.com
    at ClientRequest.<anonymous> (/private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/t-EkIVHO/test_project-u/node_modules/got/dist/source/core/index.js:970:111)
    at Object.onceWrapper (node:events:634:26)
    at ClientRequest.emit (node:events:531:35)
    at origin.emit (/private/var/folders/8j/sfr9qqcj73j4p6nhwcfpr0th0000gn/T/t-EkIVHO/test_project-u/node_modules/@szmarczak/http-timer/dist/source/index.js:43:20)
    at emitErrorEvent (node:_http_client:108:11)
    at TLSSocket.socketErrorListener (node:_http_client:575:5)
    at TLSSocket.emit (node:events:519:28)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)
```