### PR TITLE
fix(icons): replace png2icons with wasm-vips Lanczos3 resampling for high-quality icon conversion

### DIFF
--- a/.changeset/moody-eels-drive.md
+++ b/.changeset/moody-eels-drive.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(icons): replace png2icons with wasm-vips Lanczos3 resampling for high-quality icon conversion

--- a/packages/app-builder-lib/src/toolsets/icons.ts
+++ b/packages/app-builder-lib/src/toolsets/icons.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { downloadBuilderToolset } from "../util/electronGet"
 
 const iconsToolsChecksums = {
-  "icons-bundle.tar.gz": "a96b7322c2562dfa53e675c343b17326b79709b793fe8023314584a7891d2b44",
+  "icons-bundle.tar.gz": "2241c9501aa5ddd19317956449f50a1bc311df2c34058aae9bf8bfe62081eaec",
 } as const
 
 export async function getIconsToolsetPath(): Promise<string> {
@@ -12,7 +12,7 @@ export async function getIconsToolsetPath(): Promise<string> {
     return envPath
   }
   return downloadBuilderToolset({
-    releaseName: "icons@1.0.1",
+    releaseName: "icons@1.1.0",
     filenameWithExt: "icons-bundle.tar.gz",
     checksums: iconsToolsChecksums,
     githubOrgRepo: "electron-userland/electron-builder-binaries",


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/9849

Pulls in the updated toolset bundle from https://github.com/electron-userland/electron-builder-binaries/pull/204