### PR TITLE
fix: add `ELECTRON_BUILDER_BINARIES_ALLOW_HTTP` opt-in for parsing env vars targeting non-localhost HTTP

### DIFF
--- a/.changeset/free-views-sink.md
+++ b/.changeset/free-views-sink.md
@@ -2,4 +2,4 @@
 "builder-util": patch
 ---
 
-fix: reverting breaking change that forced env vars to be https protocol
+fix: harden HTTP mirror validation — reject non-localhost HTTP by default, add ELECTRON_BUILDER_BINARIES_ALLOW_HTTP opt-in

--- a/.changeset/free-views-sink.md
+++ b/.changeset/free-views-sink.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: reverting breaking change that forced env vars to be https protocol

--- a/packages/app-builder-lib/src/binDownload.ts
+++ b/packages/app-builder-lib/src/binDownload.ts
@@ -56,7 +56,8 @@ export function getBinFromUrl(releaseName: string, filenameWithExt: string, chec
     throw new Error(`getBinFromUrl: unsafe filenameWithExt "${filenameWithExt}" — must be a plain filename with no path separators or traversal sequences`)
   }
   let url: string
-  const overrideUrl = parseValidEnvVarUrl("ELECTRON_BUILDER_BINARIES_DOWNLOAD_OVERRIDE_URL")
+  const allowHttp = process.env["ELECTRON_BUILDER_BINARIES_ALLOW_HTTP"] === "true"
+  const overrideUrl = parseValidEnvVarUrl("ELECTRON_BUILDER_BINARIES_DOWNLOAD_OVERRIDE_URL", allowHttp)
   if (overrideUrl != null) {
     url = overrideUrl + "/" + filenameWithExt
   } else {

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -538,13 +538,14 @@ export async function downloadElectronArtifact(options: ArtifactDownloadOptions)
  * Supports various npm config formats and falls back to GitHub.
  */
 export function getBinariesMirrorUrl(githubOrgRepo: string): string {
+  const allowHttp = process.env["ELECTRON_BUILDER_BINARIES_ALLOW_HTTP"] === "true"
   for (const envVar of [
     "NPM_CONFIG_ELECTRON_BUILDER_BINARIES_MIRROR",
     "npm_config_electron_builder_binaries_mirror",
     "npm_package_config_electron_builder_binaries_mirror",
     "ELECTRON_BUILDER_BINARIES_MIRROR",
   ]) {
-    const url = parseValidEnvVarUrl(envVar)
+    const url = parseValidEnvVarUrl(envVar, allowHttp)
     if (url) {
       return url.endsWith("/") ? url : `${url}/`
     }

--- a/packages/builder-util/src/envUtil.ts
+++ b/packages/builder-util/src/envUtil.ts
@@ -39,7 +39,9 @@ export async function resolveEnvToolsetPath(envVarKey: string, expectedType: "di
   return p
 }
 
-export function parseValidEnvVarUrl(envVarName: string, allowHttp: boolean = true): string | null {
+const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"])
+
+export function parseValidEnvVarUrl(envVarName: string, allowHttp: boolean = false): string | null {
   const url = process.env[envVarName]?.trim()
   if (url == null || url === "") {
     return null
@@ -50,8 +52,13 @@ export function parseValidEnvVarUrl(envVarName: string, allowHttp: boolean = tru
   } catch {
     throw new Error(`${envVarName} is not a valid URL: ${url}`)
   }
-  if (!allowHttp && parsed.protocol !== "https:") {
-    throw new Error(`${envVarName} must use https:// (got ${parsed.protocol})`)
+  if (parsed.protocol !== "https:") {
+    // Always permit plain HTTP to loopback addresses (local dev / air-gapped CI mirrors
+    // running on the build machine itself).  For any other host, require opt-in.
+    const isLocalhost = parsed.protocol === "http:" && LOCALHOST_HOSTNAMES.has(parsed.hostname)
+    if (!isLocalhost && !allowHttp) {
+      throw new Error(`${envVarName} must use https:// (got ${parsed.protocol}). For non-localhost HTTP mirrors set ELECTRON_BUILDER_BINARIES_ALLOW_HTTP=true`)
+    }
   }
   return url
 }

--- a/packages/builder-util/src/envUtil.ts
+++ b/packages/builder-util/src/envUtil.ts
@@ -39,7 +39,7 @@ export async function resolveEnvToolsetPath(envVarKey: string, expectedType: "di
   return p
 }
 
-export function parseValidEnvVarUrl(envVarName: string): string | null {
+export function parseValidEnvVarUrl(envVarName: string, allowHttp: boolean = true): string | null {
   const url = process.env[envVarName]?.trim()
   if (url == null || url === "") {
     return null
@@ -50,7 +50,7 @@ export function parseValidEnvVarUrl(envVarName: string): string | null {
   } catch {
     throw new Error(`${envVarName} is not a valid URL: ${url}`)
   }
-  if (parsed.protocol !== "https:") {
+  if (!allowHttp && parsed.protocol !== "https:") {
     throw new Error(`${envVarName} must use https:// (got ${parsed.protocol})`)
   }
   return url

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -69,7 +69,7 @@ describe("validateEnvVarUrl", () => {
     expect(() => parseValidEnvVarUrl(VAR)).toThrow(`${VAR} is not a valid URL`)
   })
 
-  test("throws when protocol is http (non-https)", ({ expect }) => {
+  test("throws when protocol is http for external host (default allowHttp=false)", ({ expect }) => {
     vi.stubEnv(VAR, "http://example.com/")
     expect(() => parseValidEnvVarUrl(VAR)).toThrow(`${VAR} must use https://`)
   })
@@ -87,6 +87,26 @@ describe("validateEnvVarUrl", () => {
   test("returns the URL string unchanged when it has a path and query", ({ expect }) => {
     vi.stubEnv(VAR, "https://mirror.example.com/path?q=1")
     expect(parseValidEnvVarUrl(VAR)).toBe("https://mirror.example.com/path?q=1")
+  })
+
+  test("allows http for localhost by default (local dev exemption)", ({ expect }) => {
+    vi.stubEnv(VAR, "http://localhost:8080/mirror/")
+    expect(parseValidEnvVarUrl(VAR)).toBe("http://localhost:8080/mirror/")
+  })
+
+  test("allows http for 127.0.0.1 by default (loopback exemption)", ({ expect }) => {
+    vi.stubEnv(VAR, "http://127.0.0.1:3000/")
+    expect(parseValidEnvVarUrl(VAR)).toBe("http://127.0.0.1:3000/")
+  })
+
+  test("allows http for [::1] by default (IPv6 loopback exemption)", ({ expect }) => {
+    vi.stubEnv(VAR, "http://[::1]:9000/")
+    expect(parseValidEnvVarUrl(VAR)).toBe("http://[::1]:9000/")
+  })
+
+  test("allows http for external host when allowHttp=true (air-gapped opt-in)", ({ expect }) => {
+    vi.stubEnv(VAR, "http://internal-mirror.corp.example/")
+    expect(parseValidEnvVarUrl(VAR, true)).toBe("http://internal-mirror.corp.example/")
   })
 })
 


### PR DESCRIPTION
Closes / addresses [#9854](https://github.com/electron-userland/electron-builder/issues/9854)

### Summary

- **Automatic localhost exemption** — HTTP is unconditionally allowed for `localhost`, `127.0.0.1`, and `[::1]` regardless of the `allowHttp` flag. No config change needed for local dev mirrors or loopback-based CI setups.
- **`ELECTRON_BUILDER_BINARIES_ALLOW_HTTP=true`** env var opts the entire binaries download path (mirror env vars + override URL) into HTTP, solving the air-gapped / internal-HTTP-mirror case reported in #9854.
- **`electronDownload.mirror`** (existing) already bypasses `parseValidEnvVarUrl` and can be set to an HTTP URL in `electron-builder.config.*` — this path is unchanged and remains the config-based escape hatch for the Electron binary download.
- **`electronBuilderBinariesDownload` config object** — no equivalent config object is needed for builder binaries; the env var opt-in is sufficient and avoids threading a new config prop through every `getBinFromUrl` / `getBinariesMirrorUrl` call site.

### Changed Files

| File | Change |
|------|--------|
| [packages/builder-util/src/envUtil.ts](packages/builder-util/src/envUtil.ts) | Change `allowHttp` default `true→false`; add loopback-hostname exemption; improve error message to mention the opt-in env var |
| [packages/app-builder-lib/src/util/electronGet.ts](packages/app-builder-lib/src/util/electronGet.ts) | Read `ELECTRON_BUILDER_BINARIES_ALLOW_HTTP` and pass as `allowHttp` to `parseValidEnvVarUrl` inside `getBinariesMirrorUrl` |
| [packages/app-builder-lib/src/binDownload.ts](packages/app-builder-lib/src/binDownload.ts) | Same for `ELECTRON_BUILDER_BINARIES_DOWNLOAD_OVERRIDE_URL` in `getBinFromUrl` |
| [test/src/builder-util/utilTest.ts](test/src/builder-util/utilTest.ts) | Update existing test description; add tests for localhost/loopback exemptions and `allowHttp=true` opt-in |

### Design notes

**Why automatic localhost exemption?**
Loopback addresses are physically incapable of being intercepted by a third party, so rejecting HTTP there provides zero security benefit while creating friction for local development setups and containerized CI mirrors.

**Why an env var and not a config prop for binaries?**
`getBinFromUrl` is called from a dozen isolated tool-fetch sites with no shared config object. Adding a `allowHttp` config prop would require threading it through every call chain. The env var is set once at the process/npm-script level and is the natural mechanism for this kind of build-environment opt-in. For the Electron binary itself, `electronDownload.mirror` in the builder config already works.

**Why not auto-detect internal/private IPs?**
RFC-1918 ranges (10.x, 192.168.x, etc.) are "internal" by convention but not by protocol guarantee — a misconfigured mirror or SSRF gadget could still point at them. Requiring explicit opt-in keeps the security model explicit.