### PR TITLE
fix(download): persist toolset archives in a predictable cache path

### DIFF
--- a/.changeset/offline-binaries-local-dir.md
+++ b/.changeset/offline-binaries-local-dir.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(download): persist toolset archives in a predictable cache path so repeated builds and offline environments skip the @electron/get network round-trip

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -261,9 +261,7 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
     .digest("hex")
     .slice(0, 20)
   const artifactLockPath = path.join(os.tmpdir(), `eb-dl-${artifactLockKey}.lock`)
-  // This lock is taken even for cache hits (the cache-hit check lives inside @electron/get), so under
-  // heavy concurrency many builds serialize here. 30 retries (~137s of backoff) is too few — waiters
-  // were exhausting it and failing with ELOCKED while the holder fetched a large artifact. 100 retries
+  // This lock is taken when the artifact is not yet in @electron/get's download cache. 100 retries
   // matches the other toolset locks; stale (10min) + proper-lockfile's update heartbeat keep a live
   // downloader's lock fresh so the longer wait never falsely steals an in-progress download.
   const releaseArtifactLock = await lockfile.lock(artifactLockPath, {
@@ -346,11 +344,51 @@ async function downloadArtifactToFile(config: Parameters<typeof get.downloadArti
 }
 
 /**
+ * Checks electron-builder's own archive cache for a previously downloaded archive.
+ * Validates the SHA-256 checksum when one is known. Returns the cached path on hit,
+ * null on miss or checksum mismatch (mismatch also deletes the stale file).
+ */
+async function resolveFromArchiveCache(archiveCachePath: string, label: string, expectedSha256: string | undefined): Promise<string | null> {
+  if (!(await exists(archiveCachePath))) {
+    return null
+  }
+  if (expectedSha256) {
+    const hash = await new Promise<string>((resolve, reject) => {
+      const h = crypto.createHash("sha256")
+      const s = createReadStream(archiveCachePath)
+      s.on("error", reject)
+      s.on("data", (chunk: Buffer | string) => h.update(chunk))
+      s.on("end", () => resolve(h.digest("hex")))
+    })
+    if (hash !== expectedSha256) {
+      log.warn({ file: label, archiveCachePath }, "cached archive checksum mismatch — removing and re-downloading")
+      await fs.rm(archiveCachePath).catch(() => {})
+      return null
+    }
+  }
+  log.debug({ file: label, archiveCachePath }, "using cached archive — skipping download")
+  return archiveCachePath
+}
+
+/**
+ * Copies a freshly downloaded archive into electron-builder's own archive cache so that
+ * future builds (including offline environments) can skip the network request entirely.
+ */
+async function persistToArchiveCache(sourcePath: string, archiveCachePath: string): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(archiveCachePath), { recursive: true })
+    await fs.copyFile(sourcePath, archiveCachePath)
+  } catch (err) {
+    log.warn({ err, archiveCachePath }, "failed to persist archive to cache — will re-download next time")
+  }
+}
+
+/**
  * Core download + extract engine. Handles lockfile, cache-hit short-circuit,
  * progress bar, extraction (.zip or .tar.gz), and completion marker.
  * Both public download functions delegate here after building their respective configs.
  */
-async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact>[0], extractDir: string, label: string): Promise<string> {
+async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact>[0], extractDir: string, label: string, archiveCachePath?: string): Promise<string> {
   await fs.mkdir(extractDir, { recursive: true })
 
   // Pre-lock fast path: only short-circuit for a definitively complete and valid cache.
@@ -392,10 +430,25 @@ async function downloadAndExtract(config: Parameters<typeof get.downloadArtifact
     await cleanupCacheDirectory(extractDir, { skipLockFiles: true })
     await fs.mkdir(extractDir, { recursive: true })
 
-    log.debug({ file: label }, "downloading")
-    downloadedFile = await downloadArtifactToFile(config, label)
+    // Check electron-builder's own archive cache before touching @electron/get.
+    // The cache lives alongside the extract dir: <cacheDir>/<releaseName>/<filename>.
+    // This lets repeated builds (or offline environments) skip the download entirely once
+    // the archive has been fetched at least once.
+    if (archiveCachePath) {
+      downloadedFile = await resolveFromArchiveCache(archiveCachePath, label, (config as any).checksums?.[label])
+    }
+
     if (!downloadedFile) {
-      throw new Error(`Failed to download artifact: ${label}`)
+      log.debug({ file: label }, "downloading")
+      downloadedFile = await downloadArtifactToFile(config, label)
+      if (!downloadedFile) {
+        throw new Error(`Failed to download artifact: ${label}`)
+      }
+      // Persist the downloaded archive so future builds (and offline environments) can
+      // skip the network request entirely.
+      if (archiveCachePath) {
+        await persistToArchiveCache(downloadedFile, archiveCachePath)
+      }
     }
 
     await writeCacheState(extractDir, CacheState.downloaded)
@@ -433,6 +486,10 @@ export async function downloadBuilderToolset(options: {
 }): Promise<string> {
   const { releaseName, filenameWithExt, checksums, githubOrgRepo = "electron-userland/electron-builder-binaries", overrideUrl } = options
 
+  if (/[/\\]|\.\./.test(filenameWithExt)) {
+    throw new Error(`downloadBuilderToolset: unsafe filenameWithExt "${filenameWithExt}" — must be a plain filename with no path separators or traversal sequences`)
+  }
+
   const baseUrl = getBinariesMirrorUrl(githubOrgRepo)
   const fullUrl = overrideUrl ? `${overrideUrl}/${filenameWithExt}` : `${baseUrl}${releaseName}/${filenameWithExt}`
   const suffix = hashUrlSafe(fullUrl, 5)
@@ -445,6 +502,11 @@ export async function downloadBuilderToolset(options: {
     resolveAssetURL: async () => Promise.resolve(fullUrl),
   }
 
+  // Predictable archive cache: <cacheDir>/<releaseName>/<filename>, next to the extract dir.
+  // downloadAndExtract checks here before touching @electron/get and persists the archive here
+  // after every successful download, so subsequent builds never need a network round-trip.
+  const archiveCachePath = path.join(getCacheDirectory({ allowEnvVarOverride: true }), releaseName, filenameWithExt)
+
   const config: ElectronDownloadRequest & ElectronDownloadRequestOptions & { isGeneric: true } = {
     version: "9.9.9", // must be >1.3.2 to bypass @electron/get validation shortcut
     artifactName: filenameWithExt,
@@ -454,7 +516,7 @@ export async function downloadBuilderToolset(options: {
     mirrorOptions,
     isGeneric: true,
   }
-  return downloadAndExtract(config, extractDir, filenameWithExt)
+  return downloadAndExtract(config, extractDir, filenameWithExt, archiveCachePath)
 }
 
 // Keys present in ElectronGetOptions but absent from ElectronDownloadOptions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       stat-mode:
         specifier: ^1.0.0
         version: 1.0.0
+      tar:
+        specifier: ^7.5.7
+        version: 7.5.11
       temp-file:
         specifier: ^3.4.0
         version: 3.4.0

--- a/test/package.json
+++ b/test/package.json
@@ -16,6 +16,7 @@
     "@types/request": "^2.48.12",
     "@types/semver": "7.7.1",
     "@types/unzipper": "^0.10.11",
+    "tar": "^7.5.7",
     "@types/which": "^3.0.4",
     "@types/yargs": "^17.0.33",
     "adm-zip": "0.5.16",

--- a/test/src/electronGetTest.ts
+++ b/test/src/electronGetTest.ts
@@ -38,7 +38,6 @@ async function createMinimalTarGz(archivePath: string, files: Record<string, str
   }
 }
 
-
 // ─── getCacheDirectory ────────────────────────────────────────────────────────
 
 describe("getCacheDirectory", () => {
@@ -386,15 +385,13 @@ describe("toolset archive cache", () => {
     await fs.writeFile(archiveCachePath, "corrupt data")
 
     let downloadArtifactCalled = false
-    vi.spyOn(get, "downloadArtifact").mockImplementation(async () => {
+    vi.spyOn(get, "downloadArtifact").mockImplementation(() => {
       downloadArtifactCalled = true
       throw new Error("expected-download-attempt")
     })
 
     const correctSha256 = "0000000000000000000000000000000000000000000000000000000000000000"
-    await expect(
-      downloadBuilderToolset({ releaseName, filenameWithExt: fileName, checksums: { [fileName]: correctSha256 } })
-    ).rejects.toThrow("expected-download-attempt")
+    await expect(downloadBuilderToolset({ releaseName, filenameWithExt: fileName, checksums: { [fileName]: correctSha256 } })).rejects.toThrow("expected-download-attempt")
 
     expect(downloadArtifactCalled).toBe(true)
   })
@@ -408,9 +405,9 @@ describe("toolset archive cache", () => {
     const networkArchive = path.join(freshCache, "fake-network-download.tar.gz")
     await createMinimalTarGz(networkArchive, { "network-file": "content" })
     let callCount = 0
-    vi.spyOn(get, "downloadArtifact").mockImplementation(async () => {
+    vi.spyOn(get, "downloadArtifact").mockImplementation(() => {
       callCount++
-      return networkArchive
+      return Promise.resolve(networkArchive)
     })
 
     await downloadBuilderToolset({ releaseName, filenameWithExt: fileName })

--- a/test/src/electronGetTest.ts
+++ b/test/src/electronGetTest.ts
@@ -4,7 +4,8 @@ import * as http from "http"
 import * as net from "net"
 import * as os from "os"
 import * as path from "path"
-import { afterAll, afterEach, beforeAll, vi } from "vitest"
+import * as tar from "tar"
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest"
 import {
   ArtifactDownloadOptions,
   ElectronDownloadOptions,
@@ -16,6 +17,27 @@ import {
 } from "app-builder-lib/out/util/electronGet"
 import { CacheState } from "app-builder-lib/out/util/cacheState"
 import { ELECTRON_VERSION } from "./helpers/testConfig"
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Creates a minimal tar.gz with a nested directory so tar.extract({ strip: 1 }) works.
+ * Entry layout: inner/<name> — strip:1 extracts <name> directly into the target dir.
+ */
+async function createMinimalTarGz(archivePath: string, files: Record<string, string>): Promise<void> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-test-tar-"))
+  try {
+    const innerDir = path.join(tmpDir, "inner")
+    await fs.mkdir(innerDir)
+    for (const [name, content] of Object.entries(files)) {
+      await fs.writeFile(path.join(innerDir, name), content)
+    }
+    await tar.create({ gzip: true, file: archivePath, cwd: tmpDir }, ["inner"])
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  }
+}
+
 
 // ─── getCacheDirectory ────────────────────────────────────────────────────────
 
@@ -301,6 +323,110 @@ describe("downloadBuilderToolset", { sequential: true }, () => {
     expect(resolvedUrl).not.toContain("cdn.npmmirror.com/binaries/electron")
 
     spy.mockRestore()
+  })
+})
+
+// ─── downloadBuilderToolset: filenameWithExt validation ──────────────────────
+
+describe("downloadBuilderToolset: filenameWithExt validation", () => {
+  const cases: Array<[string, string]> = [
+    ["Unix path separator", "subdir/evil.tar.gz"],
+    ["Windows path separator", "subdir\\evil.tar.gz"],
+    ["dotdot traversal", "../etc/passwd"],
+    ["dotdot embedded", "foo/../bar.tar.gz"],
+  ]
+  for (const [label, filenameWithExt] of cases) {
+    test(`rejects unsafe filenameWithExt: ${label}`, async ({ expect }) => {
+      await expect(downloadBuilderToolset({ releaseName: "x", filenameWithExt })).rejects.toThrow(/unsafe filenameWithExt/)
+    })
+  }
+})
+
+// ─── Toolset archive cache (no network) ──────────────────────────────────────
+
+describe("toolset archive cache", () => {
+  let freshCache: string
+
+  beforeEach(async () => {
+    freshCache = await fs.mkdtemp(path.join(os.tmpdir(), "eb-archive-cache-test-"))
+    vi.stubEnv("ELECTRON_BUILDER_CACHE", freshCache)
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    await fs.rm(freshCache, { recursive: true, force: true })
+  })
+
+  test("uses pre-existing archive and does not call downloadArtifact", async ({ expect }) => {
+    const releaseName = "cache-test@0.1"
+    const fileName = "cache-artifact.tar.gz"
+    // Seed the predictable archive cache path
+    const archiveCachePath = path.join(freshCache, releaseName, fileName)
+    await fs.mkdir(path.dirname(archiveCachePath), { recursive: true })
+    await createMinimalTarGz(archiveCachePath, { sentinel: "ok" })
+
+    const spy = vi.spyOn(get, "downloadArtifact").mockImplementation(() => {
+      throw new Error("downloadArtifact must not be called — archive is already cached")
+    })
+
+    const result = await downloadBuilderToolset({ releaseName, filenameWithExt: fileName })
+
+    expect(spy).not.toHaveBeenCalled()
+    const entries = await fs.readdir(result)
+    expect(entries).toContain("sentinel")
+  })
+
+  test("re-downloads and replaces archive when checksum does not match", async ({ expect }) => {
+    const releaseName = "checksum-test@0.1"
+    const fileName = "bad-checksum.tar.gz"
+    const archiveCachePath = path.join(freshCache, releaseName, fileName)
+    await fs.mkdir(path.dirname(archiveCachePath), { recursive: true })
+    // Write a corrupt (wrong-checksum) archive
+    await fs.writeFile(archiveCachePath, "corrupt data")
+
+    let downloadArtifactCalled = false
+    vi.spyOn(get, "downloadArtifact").mockImplementation(async () => {
+      downloadArtifactCalled = true
+      throw new Error("expected-download-attempt")
+    })
+
+    const correctSha256 = "0000000000000000000000000000000000000000000000000000000000000000"
+    await expect(
+      downloadBuilderToolset({ releaseName, filenameWithExt: fileName, checksums: { [fileName]: correctSha256 } })
+    ).rejects.toThrow("expected-download-attempt")
+
+    expect(downloadArtifactCalled).toBe(true)
+  })
+
+  test("persists downloaded archive to cache so subsequent builds skip the download", async ({ expect }) => {
+    const releaseName = "persist-test@0.1"
+    const fileName = "persist-artifact.tar.gz"
+    const archiveCachePath = path.join(freshCache, releaseName, fileName)
+
+    // First call: downloadArtifact returns a real archive
+    const networkArchive = path.join(freshCache, "fake-network-download.tar.gz")
+    await createMinimalTarGz(networkArchive, { "network-file": "content" })
+    let callCount = 0
+    vi.spyOn(get, "downloadArtifact").mockImplementation(async () => {
+      callCount++
+      return networkArchive
+    })
+
+    await downloadBuilderToolset({ releaseName, filenameWithExt: fileName })
+    expect(callCount).toBe(1)
+    // Archive must have been persisted
+    await expect(fs.access(archiveCachePath)).resolves.toBeUndefined()
+
+    // Second call: archive is cached — downloadArtifact must not be called
+    vi.restoreAllMocks()
+    vi.spyOn(get, "downloadArtifact").mockImplementation(() => {
+      throw new Error("downloadArtifact must not be called on second build")
+    })
+
+    const result2 = await downloadBuilderToolset({ releaseName, filenameWithExt: fileName })
+    const entries = await fs.readdir(result2)
+    expect(entries).toContain("network-file")
   })
 })
 

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -136,6 +136,14 @@ asarUnpack:
 **Out-of-memory error during packaging**
 : Large apps can exhaust memory during ASAR creation. Set `NODE_OPTIONS=--max-old-space-size=4096` before running electron-builder.
 
+**Build fails in an offline / air-gapped environment**
+: electron-builder downloads build toolsets (e.g. WinCodeSign, AppImage tools) the first time they are needed, then caches the archive at `<ELECTRON_BUILDER_CACHE>/<releaseName>/<filename>`. On every subsequent build it reads from that cache and makes no network request.
+
+For a first-time setup in a fully air-gapped environment, run the build once on a machine with internet access so the cache is populated, then copy the entire `ELECTRON_BUILDER_CACHE` directory to the air-gapped machine. Point both machines at the same directory with `ELECTRON_BUILDER_CACHE=/path/to/shared/cache`.
+
+**"Downloading" progress appears for an artifact that should be cached**
+: The toolset archive cache lives inside `ELECTRON_BUILDER_CACHE` (default: `~/Library/Caches/electron-builder` on macOS, `%LOCALAPPDATA%/electron-builder/Cache` on Windows, `~/.cache/electron-builder` on Linux). If this directory is cleared or not persisted between builds (common on ephemeral CI runners), the archive is re-downloaded. Persist the cache directory across CI runs to avoid repeated downloads.
+
 ---
 
 ## Linux-Specific


### PR DESCRIPTION
Fixes: #9860

- **Predictable archive cache** — after each toolset download (winCodeSign, AppImage tools, etc.) electron-builder persists the archive at `<ELECTRON_BUILDER_CACHE>/<releaseName>/<filename>` alongside the extracted directory. On every subsequent build it checks this path first; if the archive is present (and its SHA-256 checksum matches when one is configured) the download and all `@electron/get` interaction is skipped entirely — no network call, no progress bar, no lock contention.
- **Checksum validation on cache hit** — if a known-good SHA-256 was supplied and the cached archive doesn't match, the stale file is deleted and a fresh download is triggered automatically.
- **`filenameWithExt` path-traversal guard** — `downloadBuilderToolset` rejects filenames containing `/`, `\`, or `..` before any I/O.