### PR TITLE
fix(publish): set `x-amz-content-sha256: UNSIGNED-PAYLOAD` before SigV4 signing

### DIFF
--- a/.changeset/breezy-wasps-cross.md
+++ b/.changeset/breezy-wasps-cross.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix(publish): set x-amz-content-sha256: UNSIGNED-PAYLOAD before SigV4 signing so S3 accepts streaming PutObject uploads

--- a/packages/electron-publish/src/s3/s3UploadHelper.ts
+++ b/packages/electron-publish/src/s3/s3UploadHelper.ts
@@ -54,6 +54,9 @@ export function startS3PutObject(params: S3PutObjectParams): { req: http.ClientR
   const headers: Record<string, string> = {
     "Content-Type": params.contentType,
     "Content-Length": String(stat.size),
+    // Declare the payload as unsigned so aws4 signs over this literal string
+    // rather than defaulting to SHA256("") — which would not match the streamed body.
+    "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
   }
   if (params.acl != null) {
     headers["x-amz-acl"] = params.acl

--- a/test/src/s3PublishTest.ts
+++ b/test/src/s3PublishTest.ts
@@ -321,6 +321,20 @@ describe("BaseS3Publisher.upload — key construction and S3 request", () => {
     expect(capturedOpts()?.headers?.Authorization).toMatch(/^AWS4-HMAC-SHA256/)
   })
 
+  it("sets x-amz-content-sha256 to UNSIGNED-PAYLOAD for streaming uploads", async () => {
+    const { capturedOpts } = mockSuccessfulUpload()
+    await makeS3Publisher().upload(makeTask(testFile))
+    expect(capturedOpts()?.headers?.["x-amz-content-sha256"]).toBe("UNSIGNED-PAYLOAD")
+  })
+
+  it("Authorization header covers x-amz-content-sha256 (UNSIGNED-PAYLOAD in signed headers)", async () => {
+    const { capturedOpts } = mockSuccessfulUpload()
+    await makeS3Publisher().upload(makeTask(testFile))
+    const auth: string = capturedOpts()?.headers?.Authorization ?? ""
+    // aws4 includes x-amz-content-sha256 in SignedHeaders when present
+    expect(auth).toMatch(/x-amz-content-sha256/)
+  })
+
   it("cancellation destroys the request", async () => {
     let destroyCalled = false
     vi.mocked(https.request).mockImplementationOnce((_opts: unknown, _cb: unknown) => {
@@ -452,5 +466,17 @@ describe("publish-s3 parity — Go binary flag mapping to HTTP request", () => {
     const { capturedOpts } = mockSuccessfulUpload()
     await makeS3Publisher({ endpoint: "https://s3.custom.io" }).upload(makeTask(testFile))
     expect(capturedOpts()?.hostname).toBe("s3.custom.io")
+  })
+
+  it("x-amz-content-sha256 is UNSIGNED-PAYLOAD regardless of endpoint or path style", async () => {
+    for (const opts of [
+      { endpoint: "https://minio.local:9000" },
+      { forcePathStyle: true as const },
+      { region: "ap-southeast-1" },
+    ]) {
+      const { capturedOpts } = mockSuccessfulUpload()
+      await makeS3Publisher(opts).upload(makeTask(testFile))
+      expect(capturedOpts()?.headers?.["x-amz-content-sha256"]).toBe("UNSIGNED-PAYLOAD")
+    }
   })
 })


### PR DESCRIPTION
Fixes #9862

- **Root cause**: `startS3PutObject` in `s3UploadHelper.ts` called `aws4.sign()` without a body and without setting `x-amz-content-sha256`. The `aws4` library defaulted the payload hash to `SHA256("") = e3b0c442…`, but the actual file bytes **are streamed to S3 afterward**. S3 computes the real file hash on receipt and compares it against the signed hash — they never match for any non-empty upload, resulting in `XAmzContentSHA256Mismatch` (HTTP 400).

- **Fix**: Set `"x-amz-content-sha256": "UNSIGNED-PAYLOAD"` in the request headers **before** calling `aws4.sign()`. With this header present, `aws4` incorporates the literal string `"UNSIGNED-PAYLOAD"` into the canonical request's payload-hash field and includes `x-amz-content-sha256` in `SignedHeaders`. S3 recognises `UNSIGNED-PAYLOAD` as the standard streaming-upload declaration and skips payload-hash verification while still validating the request signature, date, and all other signed headers. This is the AWS-documented approach for streaming/piped uploads.
https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
