### PR TITLE
chore: set up `release/v26` branch release CD

### DIFF
--- a/.changeset/config.release-v26.json
+++ b/.changeset/config.release-v26.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": ["changesets-changelog-clean", { "repo": "electron-userland/electron-builder" }],
+  "commit": false,
+  "linked": [[
+    "app-builder-lib",
+    "builder-util",
+    "dmg-builder",
+    "electron-builder",
+    "electron-builder-squirrel-windows",
+    "electron-forge-maker-appimage",
+    "electron-forge-maker-nsis",
+    "electron-forge-maker-nsis-web",
+    "electron-forge-maker-snap",
+    "electron-publish"
+  ]],
+  "access": "public",
+  "baseBranch": "release/v26",
+  "updateInternalDependencies": "patch",
+  "ignore": [
+    "@electron-builder/test",
+    "@electron-builder/website"
+  ]
+}


### PR DESCRIPTION
This commit establishes `release/v26` as the stable, CommonJS (CJS) maintenance branch for electron-builder, branched from master at v26.15.3.

## Background

electron-builder v26.x is fully CommonJS. The upcoming v27 major release (tracked on `chore/esm-migration`) rewrites the entire package suite to native ESM, targeting Node 22+ with ES module semantics, subpath exports, and top-level await. That migration is a breaking change: consumers who cannot yet move to ESM-only toolchains, older Electron versions, or bundlers that require CJS interop will need a supported maintenance line.

`release/v26` serves that role. It receives backported bug fixes and security patches while `master` moves toward v27 ESM general availability.

## What this branch provides

- **CJS compatibility**: all packages ship as CommonJS, compatible with Node 14+ and any bundler that can consume CJS modules.
- **Stable API surface**: no breaking changes will be introduced on this branch. Only patch-level fixes and critical dependency updates.
- **Changeset-driven releases**: `.changeset/config.release-v26.json` points `baseBranch` at `release/v26` so that changesets merged here publish under the `v26` dist-tag rather than `next` or `esm`.
- **Continuous delivery**: the `pr-release.yml` workflow triggers on pushes to `release/v26` and publishes to npm with tag `v26`.

## Versioning

Releases on this branch continue the `26.x.y` semver line. Patch releases are cut automatically by the changeset bot after a maintainer approves a changeset PR targeting `release/v26`.