### PR TITLE
chore(refactor): consolidate ASAR config under `asar?: AsarOptions | false | null` (BREAKING)

### DIFF
--- a/.changeset/eighty-bottles-tell.md
+++ b/.changeset/eighty-bottles-tell.md
@@ -1,0 +1,6 @@
+---
+"electron-builder": major
+"app-builder-lib": major
+---
+
+chore(refactor): consolidate ASAR config under `asar?: AsarOptions | false | null` (BREAKING)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,7 +17,7 @@ electron-builder migrate-schema           # apply changes
 electron-builder migrate-schema --dry-run # preview only
 ```
 
-It handles **every config-level breaking change** automatically: `electronCompile`, `framework`/`nodeVersion`/`launchUiVersion`, the `nativeModules` grouping, legacy `asar` keys, `appImage.systemIntegration`, `vPrefixedTagName`, `win.azureSignOptions` extras, `snap` → `snapcraft`, `helper-bundle-id`, `squirrelWindows.noMsi`, and root-level `directories`. Programmatic configs (`.js`/`.ts`/`.cjs`/`.mjs`) and TOML are detected and printed as manual steps instead.
+It handles **every config-level breaking change** automatically: `electronCompile`, `framework`/`nodeVersion`/`launchUiVersion`, the `nativeModules` grouping, ASAR consolidation (`asarUnpack` → `asar.unpack`, `disableSanityCheckAsar` → `asar.disableSanityCheck`, `disableAsarIntegrity` → `asar.disableIntegrity`, legacy `asar-unpack`/`asar.unpackDir` keys), `appImage.systemIntegration`, `vPrefixedTagName`, `win.azureSignOptions` extras, `snap` → `snapcraft`, `helper-bundle-id`, `squirrelWindows.noMsi`, and root-level `directories`. Programmatic configs (`.js`/`.ts`/`.cjs`/`.mjs`) and TOML are detected and printed as manual steps instead.
 
 ### Breaking changes at a glance
 
@@ -28,7 +28,7 @@ It handles **every config-level breaking change** automatically: `electronCompil
 | `electronCompile` removed | ✓ | Remove from config; migrate to a modern bundler |
 | `framework`, `nodeVersion`, `launchUiVersion` removed | ✓ | Removed automatically (Electron is the only framework) |
 | Native-module options grouped under `nativeModules` | ✓ | `nativeRebuilder` → `rebuildMode`; `npmSkipBuildFromSource` → `buildDependenciesFromSource` |
-| Legacy `asar-unpack` / `asar.unpack*` keys removed | ✓ | Replaced by `asarUnpack` |
+| Legacy `asar-unpack` / `asar.unpack*` keys consolidated | ✓ | All ASAR config moved under `asar` object: `asar.unpack`, `asar.disableSanityCheck`, `asar.disableIntegrity` |
 | `appImage.systemIntegration` removed | ✓ | Removed automatically |
 | `GithubOptions.vPrefixedTagName` removed | ✓ | Replaced by `tagNamePrefix` |
 | `win.azureSignOptions` index-signature keys | ✓ | Moved into `additionalMetadata` |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ See the full documentation on [electron.build](https://www.electron.build).
 
 ## Requirements
 
-**Node.js >=22.12.0** is required. Upgrading from v26? See the **[v26 to v27 migration guide](./MIGRATION.md)** (also at [electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)).
+**Node.js >=22.12.0** is required for v27.
+
+> **Upgrading from v26?** Run the automated migration command first — it rewrites your static config in place:
+> ```bash
+> electron-builder migrate-schema
+> ```
+> Full details: **[v26 → v27 migration guide](./MIGRATION.md)** · [electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)
 
 ## Installation
 ```

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -407,6 +407,16 @@
     "AsarOptions": {
       "additionalProperties": false,
       "properties": {
+        "disableIntegrity": {
+          "default": false,
+          "description": "Whether to skip computing the ASAR integrity hash.\n\nNormally electron-builder computes and embeds a SHA-256 hash of `app.asar` so that Electron\ncan verify it at startup (when the `embeddedAsarIntegrityValidation` fuse is enabled). Set to\n`true` only for custom Electron forks with encrypted ASAR support where the header is not\nreadable by standard tools.",
+          "type": "boolean"
+        },
+        "disableSanityCheck": {
+          "default": false,
+          "description": "Whether to skip the ASAR package integrity sanity check.\n\nSet to `true` only when using a custom Electron fork that implements its own encrypted or\nnon-standard ASAR integrity validation that is not compatible with electron-builder's default\ncheck. Standard builds should leave this `false`.",
+          "type": "boolean"
+        },
         "ordering": {
           "description": "Path to a file containing the order in which files should be packed into the asar archive.\nEach line of the file is a relative path from the app directory. Files listed first are\npacked first, which can improve app startup time by front-loading frequently accessed modules.\nSee the [asar documentation](https://github.com/electron/asar) for details.",
           "type": [
@@ -418,6 +428,23 @@
           "default": true,
           "description": "Whether to automatically unpack executables files.",
           "type": "boolean"
+        },
+        "unpack": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ],
+          "description": "A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories),\nwhich specifies which files to unpack when creating the asar archive."
         }
       },
       "type": "object"
@@ -1537,7 +1564,7 @@
           "type": "boolean"
         },
         "enableEmbeddedAsarIntegrityValidation": {
-          "description": "Enables ASAR integrity validation — Electron verifies the embedded SHA-256 hash of\n`app.asar` before loading it.\n\nPlatform support:\n- macOS: Electron ≥ 16.0.0\n- Windows: Electron ≥ 30.0.0\n\nFor this fuse to be meaningful, {@link Configuration.disableAsarIntegrity} must **not** be\n`true` (otherwise the hash is not embedded).\n\nSee the [ASAR Integrity guide](https://www.electronjs.org/docs/latest/tutorial/asar-integrity).",
+          "description": "Enables ASAR integrity validation — Electron verifies the embedded SHA-256 hash of\n`app.asar` before loading it.\n\nPlatform support:\n- macOS: Electron ≥ 16.0.0\n- Windows: Electron ≥ 30.0.0\n\nFor this fuse to be meaningful, `asar.disableIntegrity` must **not** be\n`true` (otherwise the hash is not embedded).\n\nSee the [ASAR Integrity guide](https://www.electronjs.org/docs/latest/tutorial/asar-integrity).",
           "type": "boolean"
         },
         "enableNodeCliInspectArguments": {
@@ -1991,31 +2018,15 @@
               "$ref": "#/definitions/AsarOptions"
             },
             {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "const": false,
+              "type": "boolean"
+            },
+            {
+              "type": "null"
             }
           ],
           "default": true,
-          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules, that must be unpacked, will be detected automatically, you don't need to explicitly set [asarUnpack](#asarUnpack) - please file an issue if this doesn't work."
-        },
-        "asarUnpack": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          ],
-          "description": "A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories), which specifies which files to unpack when creating the [asar](http://electron.atom.io/docs/tutorial/application-packaging/) archive."
+          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules that must be unpacked will be detected automatically. Use {@link AsarOptions.unpack} to specify additional files to unpack."
         },
         "category": {
           "description": "The [application category](https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry).",
@@ -2660,31 +2671,15 @@
               "$ref": "#/definitions/AsarOptions"
             },
             {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "const": false,
+              "type": "boolean"
+            },
+            {
+              "type": "null"
             }
           ],
           "default": true,
-          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules, that must be unpacked, will be detected automatically, you don't need to explicitly set [asarUnpack](#asarUnpack) - please file an issue if this doesn't work."
-        },
-        "asarUnpack": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          ],
-          "description": "A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories), which specifies which files to unpack when creating the [asar](http://electron.atom.io/docs/tutorial/application-packaging/) archive."
+          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules that must be unpacked will be detected automatically. Use {@link AsarOptions.unpack} to specify additional files to unpack."
         },
         "binaries": {
           "anyOf": [
@@ -3298,31 +3293,15 @@
               "$ref": "#/definitions/AsarOptions"
             },
             {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "const": false,
+              "type": "boolean"
+            },
+            {
+              "type": "null"
             }
           ],
           "default": true,
-          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules, that must be unpacked, will be detected automatically, you don't need to explicitly set [asarUnpack](#asarUnpack) - please file an issue if this doesn't work."
-        },
-        "asarUnpack": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          ],
-          "description": "A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories), which specifies which files to unpack when creating the [asar](http://electron.atom.io/docs/tutorial/application-packaging/) archive."
+          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules that must be unpacked will be detected automatically. Use {@link AsarOptions.unpack} to specify additional files to unpack."
         },
         "binaries": {
           "anyOf": [
@@ -8193,31 +8172,15 @@
               "$ref": "#/definitions/AsarOptions"
             },
             {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "const": false,
+              "type": "boolean"
+            },
+            {
+              "type": "null"
             }
           ],
           "default": true,
-          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules, that must be unpacked, will be detected automatically, you don't need to explicitly set [asarUnpack](#asarUnpack) - please file an issue if this doesn't work."
-        },
-        "asarUnpack": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          ],
-          "description": "A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories), which specifies which files to unpack when creating the [asar](http://electron.atom.io/docs/tutorial/application-packaging/) archive."
+          "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules that must be unpacked will be detected automatically. Use {@link AsarOptions.unpack} to specify additional files to unpack."
         },
         "azureSignOptions": {
           "anyOf": [
@@ -8837,31 +8800,15 @@
           "$ref": "#/definitions/AsarOptions"
         },
         {
-          "type": [
-            "null",
-            "boolean"
-          ]
+          "const": false,
+          "type": "boolean"
+        },
+        {
+          "type": "null"
         }
       ],
       "default": true,
-      "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules, that must be unpacked, will be detected automatically, you don't need to explicitly set [asarUnpack](#asarUnpack) - please file an issue if this doesn't work."
-    },
-    "asarUnpack": {
-      "anyOf": [
-        {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      ],
-      "description": "A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories), which specifies which files to unpack when creating the [asar](http://electron.atom.io/docs/tutorial/application-packaging/) archive."
+      "description": "Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).\n\nNode modules that must be unpacked will be detected automatically. Use {@link AsarOptions.unpack} to specify additional files to unpack."
     },
     "beforeBuild": {
       "anyOf": [
@@ -8984,11 +8931,6 @@
       ],
       "description": "Overrides for input/output directory paths used during the build."
     },
-    "disableAsarIntegrity": {
-      "default": false,
-      "description": "Whether to skip computing the ASAR integrity hash.\n\nNormally electron-builder computes and embeds a SHA-256 hash of `app.asar` so that Electron\ncan verify it at startup (when the `embeddedAsarIntegrityValidation` fuse is enabled). Set to\n`true` only for custom Electron forks with encrypted ASAR support where the header is not\nreadable by standard tools.",
-      "type": "boolean"
-    },
     "disableDefaultIgnoredFiles": {
       "default": false,
       "description": "Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.",
@@ -8996,11 +8938,6 @@
         "null",
         "boolean"
       ]
-    },
-    "disableSanityCheckAsar": {
-      "default": false,
-      "description": "Whether to skip the ASAR package integrity sanity check.\n\nSet to `true` only when using a custom Electron fork that implements its own encrypted or\nnon-standard ASAR integrity validation that is not compatible with electron-builder's default\ncheck. Standard builds should leave this `false`.",
-      "type": "boolean"
     },
     "dmg": {
       "anyOf": [

--- a/packages/app-builder-lib/src/configuration.ts
+++ b/packages/app-builder-lib/src/configuration.ts
@@ -458,29 +458,6 @@ export interface Configuration extends CommonConfiguration, PlatformSpecificBuil
    * `dependencies`. Set `extends: null` to opt out of automatic preset detection.
    */
   extends?: Array<string> | string | null
-
-  /**
-   * Whether to skip the ASAR package integrity sanity check.
-   *
-   * Set to `true` only when using a custom Electron fork that implements its own encrypted or
-   * non-standard ASAR integrity validation that is not compatible with electron-builder's default
-   * check. Standard builds should leave this `false`.
-   *
-   * @default false
-   */
-  readonly disableSanityCheckAsar?: boolean
-
-  /**
-   * Whether to skip computing the ASAR integrity hash.
-   *
-   * Normally electron-builder computes and embeds a SHA-256 hash of `app.asar` so that Electron
-   * can verify it at startup (when the `embeddedAsarIntegrityValidation` fuse is enabled). Set to
-   * `true` only for custom Electron forks with encrypted ASAR support where the header is not
-   * readable by standard tools.
-   *
-   * @default false
-   */
-  readonly disableAsarIntegrity?: boolean
 }
 
 /**
@@ -1031,7 +1008,7 @@ export interface FuseOptionsV1 {
    * - macOS: Electron ≥ 16.0.0
    * - Windows: Electron ≥ 30.0.0
    *
-   * For this fuse to be meaningful, {@link Configuration.disableAsarIntegrity} must **not** be
+   * For this fuse to be meaningful, `asar.disableIntegrity` must **not** be
    * `true` (otherwise the hash is not embedded).
    *
    * See the [ASAR Integrity guide](https://www.electronjs.org/docs/latest/tutorial/asar-integrity).

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -283,7 +283,7 @@ export interface GetFileMatchersOptions {
 
 export function getFileMatchers(
   config: Configuration,
-  name: "files" | "extraFiles" | "extraResources" | "asarUnpack" | "extraDistFiles",
+  name: "files" | "extraFiles" | "extraResources" | "extraDistFiles",
   defaultDestination: string,
   options: GetFileMatchersOptions
 ): Array<FileMatcher> | null {
@@ -305,8 +305,6 @@ export function getFileMatchers(
       if (typeof pattern === "string") {
         // use normalize to transform ./foo to foo
         defaultMatcher.addPattern(pattern)
-      } else if (name === "asarUnpack") {
-        throw new Error(`Advanced file copying not supported for "${name}"`)
       } else {
         const from = pattern.from == null ? options.defaultSrc : path.resolve(options.defaultSrc, pattern.from)
         const to = pattern.to == null ? defaultDestination : path.resolve(defaultDestination, pattern.to)

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -38,6 +38,35 @@ export interface AsarOptions {
    * See the [asar documentation](https://github.com/electron/asar) for details.
    */
   ordering?: string | null
+
+  /**
+   * A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories),
+   * which specifies which files to unpack when creating the asar archive.
+   */
+  unpack?: Array<string> | string | null
+
+  /**
+   * Whether to skip the ASAR package integrity sanity check.
+   *
+   * Set to `true` only when using a custom Electron fork that implements its own encrypted or
+   * non-standard ASAR integrity validation that is not compatible with electron-builder's default
+   * check. Standard builds should leave this `false`.
+   *
+   * @default false
+   */
+  disableSanityCheck?: boolean
+
+  /**
+   * Whether to skip computing the ASAR integrity hash.
+   *
+   * Normally electron-builder computes and embeds a SHA-256 hash of `app.asar` so that Electron
+   * can verify it at startup (when the `embeddedAsarIntegrityValidation` fuse is enabled). Set to
+   * `true` only for custom Electron forks with encrypted ASAR support where the header is not
+   * readable by standard tools.
+   *
+   * @default false
+   */
+  disableIntegrity?: boolean
 }
 
 export interface FilesBuildOptions {
@@ -133,15 +162,10 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions, Fil
   /**
    * Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).
    *
-   * Node modules, that must be unpacked, will be detected automatically, you don't need to explicitly set [asarUnpack](#asarUnpack) - please file an issue if this doesn't work.
+   * Node modules that must be unpacked will be detected automatically. Use {@link AsarOptions.unpack} to specify additional files to unpack.
    * @default true
    */
-  readonly asar?: AsarOptions | boolean | null
-
-  /**
-   * A [glob patterns](https://www.electron.build/file-patterns) relative to the [app directory](#directories), which specifies which files to unpack when creating the [asar](http://electron.atom.io/docs/tutorial/application-packaging/) archive.
-   */
-  readonly asarUnpack?: Array<string> | string | null
+  readonly asar?: AsarOptions | false | null
 
   /** @private */
   readonly icon?: string | null

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -406,7 +406,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       const resourcesRelativePath = this.platform === Platform.MAC ? "Resources" : isElectronBased(framework) ? "resources" : ""
 
       let asarIntegrity: AsarIntegrity | null = null
-      if (!(asarOptions == null || options?.disableAsarIntegrity || this.config.disableAsarIntegrity)) {
+      if (!(asarOptions == null || options?.disableAsarIntegrity || asarOptions.disableIntegrity)) {
         asarIntegrity = await computeData({ resourcesPath, resourcesRelativePath, resourcesDestinationPath: this.getResourcesDir(appOutDir), extraResourceMatchers })
       }
 
@@ -437,7 +437,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     }
 
     const isAsar = asarOptions != null
-    await this.sanityCheckPackage(appOutDir, isAsar, framework, !!this.config.disableSanityCheckAsar)
+    await this.sanityCheckPackage(appOutDir, isAsar, framework, !!asarOptions?.disableSanityCheck)
 
     if (!options?.disableFuses) {
       await this.doAddElectronFuses(packContext)
@@ -603,13 +603,16 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
         await taskManager.awaitTasks()
       })
     } else {
-      const unpackPattern = getFileMatchers(config, "asarUnpack", defaultDestination, {
-        macroExpander,
-        customBuildOptions: platformSpecificBuildOptions,
-        globalOutDir: packContext.outDir,
-        defaultSrc: appDir,
-      })
-      const fileMatcher = unpackPattern == null ? null : unpackPattern[0]
+      const unpackPatterns = asarOptions.unpack
+      let fileMatcher: FileMatcher | null = null
+      if (unpackPatterns != null) {
+        fileMatcher = new FileMatcher(appDir, defaultDestination, macroExpander)
+        const pats = Array.isArray(unpackPatterns) ? unpackPatterns : [unpackPatterns]
+        pats.forEach(p => fileMatcher!.addPattern(p))
+        if (fileMatcher.isEmpty()) {
+          fileMatcher = null
+        }
+      }
       taskManager.addTask(
         _computeFileSets(mainMatchers).then(async fileSets => {
           for (const fileSet of fileSets) {
@@ -649,7 +652,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       if (appAsarStat == null || !appAsarStat.isFile()) {
         log.warn(
           {
-            solution: "enable asar and use asarUnpack to unpack files that must be externally available",
+            solution: "enable asar and use asar.unpack to unpack files that must be externally available",
           },
           "asar usage is disabled — this is strongly not recommended"
         )
@@ -657,7 +660,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       return null
     }
 
-    if (result == null || result === true) {
+    if (result == null || (result as unknown) === true) {
       return {}
     }
 

--- a/packages/app-builder-lib/src/util/config/schemaValidator.ts
+++ b/packages/app-builder-lib/src/util/config/schemaValidator.ts
@@ -45,7 +45,7 @@ export function validateSchema(schema: unknown, data: unknown, config: Validatio
   const guidance = [
     `Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration`,
     `If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.`,
-    `Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27`
+    `Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27`,
   ]
   throw new Error(`${header}\n${formatted.join("\n")}\n${guidance.join("\n")}`)
 }

--- a/packages/app-builder-lib/src/util/config/schemaValidator.ts
+++ b/packages/app-builder-lib/src/util/config/schemaValidator.ts
@@ -42,9 +42,12 @@ export function validateSchema(schema: unknown, data: unknown, config: Validatio
   })
 
   const header = `Invalid configuration object. ${name} has been initialized using a configuration object that does not match the API schema.`
-  const guidance = `Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration`
-  const migration = `If you recently upgraded electron-builder to v27, please check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27`
-  throw new Error(`${header}\n${formatted.join("\n")}\n${guidance}\n${migration}`)
+  const guidance = [
+    `Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration`,
+    `If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.`,
+    `Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27`
+  ]
+  throw new Error(`${header}\n${formatted.join("\n")}\n${guidance.join("\n")}`)
 }
 
 /**

--- a/packages/electron-builder/src/cli/migrate-schema.ts
+++ b/packages/electron-builder/src/cli/migrate-schema.ts
@@ -86,14 +86,12 @@ export function migrateConfig(raw: Record<string, any>): MigrationResult {
       changes.push({ key: old, description: `renamed ${old} → asarUnpack` })
     }
   }
-  // Nested asar.unpack / asar.unpackDir
+  // Nested asar.unpackDir (legacy pre-v26; asar.unpack is now the canonical location, handled in step 11)
   if (c.asar != null && typeof c.asar === "object") {
-    for (const nested of ["unpack", "unpackDir"] as const) {
-      if (nested in c.asar) {
-        c.asarUnpack = mergeAsarUnpack(c.asarUnpack, c.asar[nested])
-        delete c.asar[nested]
-        changes.push({ key: `asar.${nested}`, description: `moved asar.${nested} → asarUnpack` })
-      }
+    if ("unpackDir" in c.asar) {
+      c.asarUnpack = mergeAsarUnpack(c.asarUnpack, c.asar.unpackDir)
+      delete c.asar.unpackDir
+      changes.push({ key: "asar.unpackDir", description: "moved asar.unpackDir → asarUnpack" })
     }
     if (Object.keys(c.asar).length === 0) {
       delete c.asar
@@ -146,7 +144,39 @@ export function migrateConfig(raw: Record<string, any>): MigrationResult {
     changes.push({ key: "squirrelWindows.noMsi", description: "replaced squirrelWindows.noMsi → squirrelWindows.msi (inverted boolean)" })
   }
 
-  // ── 11. azureSignOptions: index-signature extra keys → additionalMetadata ─
+  // ── 11. asar consolidation ───────────────────────────────────────────────
+  // Move root-level asarUnpack / disableSanityCheckAsar / disableAsarIntegrity
+  // into the asar object. Skip entirely when asar === false (all would be no-ops).
+  if (c.asar !== false) {
+    const asarSub: Record<string, any> = typeof c.asar === "object" && c.asar != null ? { ...c.asar } : {}
+    if ("asarUnpack" in c) {
+      asarSub.unpack = mergeAsarUnpack(asarSub.unpack, c.asarUnpack)
+      delete c.asarUnpack
+      changes.push({ key: "asarUnpack", description: "moved asarUnpack → asar.unpack" })
+    }
+    if ("disableSanityCheckAsar" in c) {
+      asarSub.disableSanityCheck = c.disableSanityCheckAsar
+      delete c.disableSanityCheckAsar
+      changes.push({ key: "disableSanityCheckAsar", description: "moved disableSanityCheckAsar → asar.disableSanityCheck" })
+    }
+    if ("disableAsarIntegrity" in c) {
+      asarSub.disableIntegrity = c.disableAsarIntegrity
+      delete c.disableAsarIntegrity
+      changes.push({ key: "disableAsarIntegrity", description: "moved disableAsarIntegrity → asar.disableIntegrity" })
+    }
+    if (c.asar === true) {
+      if (Object.keys(asarSub).length > 0) {
+        c.asar = asarSub
+      } else {
+        delete c.asar
+      }
+      changes.push({ key: "asar", description: "replaced asar: true with asar object (true is no longer a valid value)" })
+    } else if (Object.keys(asarSub).length > 0) {
+      c.asar = asarSub
+    }
+  }
+
+  // ── 12. azureSignOptions: index-signature extra keys → additionalMetadata ─
   if (c.win?.azureSignOptions != null) {
     const azure: Record<string, any> = c.win.azureSignOptions
     const extra: Record<string, string> = {}
@@ -457,7 +487,10 @@ function printManualSteps() {
     "• Remove framework, nodeVersion, launchUiVersion",
     "• Rename npmSkipBuildFromSource → buildDependenciesFromSource",
     "• Move buildDependenciesFromSource, nodeGypRebuild, npmRebuild, nativeRebuilder into nativeModules (rename nativeRebuilder → rebuildMode)",
-    "• Rename asar-unpack / asar-unpack-dir / asar.unpack / asar.unpackDir → asarUnpack",
+    "• Rename asar-unpack / asar-unpack-dir / asar.unpack / asar.unpackDir → asarUnpack; then move asarUnpack → asar.unpack",
+    "• Move disableSanityCheckAsar → asar.disableSanityCheck",
+    "• Move disableAsarIntegrity → asar.disableIntegrity",
+    "• Replace asar: true with an asar object (e.g. asar: {})",
     "• Remove appImage.systemIntegration",
     "• Rename snap → snapcraft; nest options under a base-named sub-key (default base: core20)",
     "• Replace vPrefixedTagName with tagNamePrefix on GitHub publish entries",

--- a/test/snapshots/configurationValidationTest.js.snap
+++ b/test/snapshots/configurationValidationTest.js.snap
@@ -20,7 +20,8 @@ exports[`appId as object 1`] = `
        * Found? Check that the option in the appropriate place. e.g. "title" only in the "dmg", not in the root.
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
-If you recently upgraded electron-builder to v27, please check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
 `;
 
 exports[`extraFiles 1`] = `

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
@@ -50,7 +50,8 @@ exports[`LinuxPackager > AppImage - deprecated systemIntegration 1`] = `
        * Found? Check that the option in the appropriate place. e.g. "title" only in the "dmg", not in the root.
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
-If you recently upgraded electron-builder to v27, please check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
 `;
 
 exports[`LinuxPackager > AppImage - desktopName sets StartupWMClass 1`] = `

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
@@ -50,7 +50,8 @@ exports[`LinuxPackager > AppImage - deprecated systemIntegration 1`] = `
        * Found? Check that the option in the appropriate place. e.g. "title" only in the "dmg", not in the root.
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
-If you recently upgraded electron-builder to v27, please check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
 `;
 
 exports[`LinuxPackager > AppImage - desktopName sets StartupWMClass 1`] = `

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
@@ -50,7 +50,8 @@ exports[`LinuxPackager > AppImage - deprecated systemIntegration 1`] = `
        * Found? Check that the option in the appropriate place. e.g. "title" only in the "dmg", not in the root.
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
-If you recently upgraded electron-builder to v27, please check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
 `;
 
 exports[`LinuxPackager > AppImage - desktopName sets StartupWMClass 1`] = `

--- a/test/src/BuildTest.ts
+++ b/test/src/BuildTest.ts
@@ -39,9 +39,11 @@ test.ifLinux("cli", ({ expect }) => {
   expect(parse("--prepackaged someDir -w --x64")).toMatchSnapshot()
   expect(parse("--project someDir -w --x64")).toMatchSnapshot()
 
-  expect(parse("-c.compress=store -c.asar -c ./config.json")).toMatchObject({
+  expect(parse("-c.compress=store -c.asar.unpack -c ./config.json")).toMatchObject({
     config: {
-      asar: true,
+      asar: {
+        unpack: true,
+      },
       compress: "store",
       extends: "./config.json",
     },

--- a/test/src/ExtraBuildResourcesTest.ts
+++ b/test/src/ExtraBuildResourcesTest.ts
@@ -211,7 +211,7 @@ test.ifNotWindows("electronDist as callback function for path to local electron 
       electronDist: async context => {
         const { platformName, arch, version, packager } = context
 
-        const cacheDir = await packager.info.tempDirManager.createTempDir({ prefix: "electronDistCache" })
+        const cacheDir = await packager.tempDirManager.createTempDir({ prefix: "electronDistCache" })
         const zipFile = await downloadArtifact({
           artifactName: "electron",
           platform: platformName,
@@ -263,7 +263,7 @@ test.ifNotWindows("electronDist as callback function for path to locally unzippe
           const fileName = `electron-v${version}-${platformName}-${arch}.zip`
           const electronUrl = `https://github.com/electron/electron/releases/download/v${version}/${fileName}`
 
-          const tempDir = await packager.info.tempDirManager.createTempDir({ prefix: "electronDistUnzip" })
+          const tempDir = await packager.tempDirManager.createTempDir({ prefix: "electronDistUnzip" })
           const electronPath = path.join(tempDir, "electron-dist")
 
           const directory = await unzipper.Open.url(require("request"), electronUrl)

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -218,7 +218,6 @@ describe("node_module collectors", () => {
       targets: Platform.current().createTarget("dir", Arch.x64),
       projectDir: "app",
       config: {
-        asar: true,
         electronVersion: ELECTRON_VERSION,
       },
     }

--- a/test/src/HoistedNodeModuleTest.ts
+++ b/test/src/HoistedNodeModuleTest.ts
@@ -62,7 +62,7 @@ describe("node_module collectors", () => {
         targets: linuxDirTarget,
         projectDir: "packages/test-app",
         config: {
-          asarUnpack: ["**/node_modules/ms/**/*"],
+          asar: { unpack: ["**/node_modules/ms/**/*"] },
         },
       },
       {

--- a/test/src/extraMetadataTest.ts
+++ b/test/src/extraMetadataTest.ts
@@ -7,7 +7,7 @@ import { assertThat } from "./helpers/fileAssert.js"
 import { app, linuxDirTarget, modifyPackageJson } from "./helpers/packTester.js"
 import { ExpectStatic } from "vitest"
 
-function createExtraMetadataTest(expect: ExpectStatic, asar: boolean) {
+function createExtraMetadataTest(expect: ExpectStatic, asar: false | null) {
   return app(
     expect,
     {
@@ -51,7 +51,7 @@ function createExtraMetadataTest(expect: ExpectStatic, asar: boolean) {
   )
 }
 
-test("extra metadata", ({ expect }) => createExtraMetadataTest(expect, true))
+test("extra metadata", ({ expect }) => createExtraMetadataTest(expect, null))
 test("extra metadata (no asar)", ({ expect }) => createExtraMetadataTest(expect, false))
 
 test("cli", ({ expect }) => {

--- a/test/src/filesTest.ts
+++ b/test/src/filesTest.ts
@@ -54,7 +54,6 @@ test.ifNotWindows("files.from asar", ({ expect }) =>
     {
       targets: linuxDirTarget,
       config: {
-        asar: true,
         files: [
           {
             from: ".",
@@ -178,7 +177,6 @@ test.ifNotWindows("extraResources - two-package", ({ expect }) => {
       // to check NuGet package
       targets: platform.createTarget(DIR_TARGET),
       config: {
-        asar: true,
         extraResources: ["foo", "bar/hello.txt", "bar/${arch}.txt", "${os}/${arch}.txt", "executable*"],
         [osName]: {
           extraResources: ["platformSpecificR"],

--- a/test/src/filterTest.ts
+++ b/test/src/filterTest.ts
@@ -311,12 +311,6 @@ describe("getFileMatchers – string patterns in config.files", () => {
     expect(result![0].patterns).toContain("extra/**")
   })
 
-  test("asarUnpack with object pattern throws", ({ expect }) => {
-    expect(() => getFileMatchers({ asarUnpack: [{ from: ".", filter: ["*.node"] }] } as any, "asarUnpack", "/out", opts)).toThrow(
-      'Advanced file copying not supported for "asarUnpack"'
-    )
-  })
-
   test("extraDistFiles skips config[name] and only reads customBuildOptions", ({ expect }) => {
     const customOpts = { ...opts, customBuildOptions: { extraDistFiles: ["installer.nsis"] } as any }
     // config.extraDistFiles is ignored for extraDistFiles

--- a/test/src/globTest.ts
+++ b/test/src/globTest.ts
@@ -33,7 +33,7 @@ test.ifNotWindows("unpackDir one", ({ expect }) =>
     {
       targets: linuxDirTarget,
       config: {
-        asarUnpack: ["assets", "b2", "do-not-unpack-dir/file.json"],
+        asar: { unpack: ["assets", "b2", "do-not-unpack-dir/file.json"] },
       },
     },
     {
@@ -63,7 +63,7 @@ test.ifNotWindows("unpackDir", ({ expect }) => {
     {
       targets: linuxDirTarget,
       config: {
-        asarUnpack: ["assets", "b2", "do-not-unpack-dir/file.json"],
+        asar: { unpack: ["assets", "b2", "do-not-unpack-dir/file.json"] },
       },
     },
     {
@@ -80,7 +80,7 @@ test.ifNotWindows("asarUnpack and files ignore", ({ expect }) => {
     {
       targets: linuxDirTarget,
       config: {
-        asarUnpack: ["!**/ffprobe-static/bin/darwin/x64/ffprobe"],
+        asar: { unpack: ["!**/ffprobe-static/bin/darwin/x64/ffprobe"] },
       },
     },
     {
@@ -229,7 +229,7 @@ test.ifNotWindows("asarUnpack node_modules", ({ expect }) => {
     {
       targets: linuxDirTarget,
       config: {
-        asarUnpack: "node_modules",
+        asar: { unpack: "node_modules" },
       },
     },
     {

--- a/test/src/mac/macPackagerTest.ts
+++ b/test/src/mac/macPackagerTest.ts
@@ -225,7 +225,7 @@ describe("macPackager", { sequential: true }, () => {
         targets: Platform.MAC.createTarget(DIR_TARGET, Arch.x64),
         config: {
           mac: { notarize: false },
-          disableAsarIntegrity: true,
+          asar: { disableIntegrity: true },
         },
       },
       {

--- a/test/src/migrateSchemaTest.ts
+++ b/test/src/migrateSchemaTest.ts
@@ -7,7 +7,7 @@ describe("migrateConfig — no-op cases", () => {
       appId: "com.example.app",
       productName: "My App",
       nativeModules: { npmRebuild: true, rebuildMode: "sequential" },
-      asarUnpack: ["**/*.node"],
+      asar: { unpack: ["**/*.node"] },
     }
     const result = migrateConfig(input)
     expect(result.modified).toBe(false)
@@ -114,44 +114,48 @@ describe("migrateConfig — nativeModules grouping", () => {
 })
 
 describe("migrateConfig — asar legacy keys", () => {
-  test("renames asar-unpack → asarUnpack", () => {
+  test("renames asar-unpack → asar.unpack", () => {
     const result = migrateConfig({ "asar-unpack": "**/*.node" })
     expect("asar-unpack" in result.migrated).toBe(false)
-    expect(result.migrated.asarUnpack).toBe("**/*.node")
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar?.unpack).toBe("**/*.node")
   })
 
-  test("renames asar-unpack-dir → asarUnpack", () => {
+  test("renames asar-unpack-dir → asar.unpack", () => {
     const result = migrateConfig({ "asar-unpack-dir": "resources/**" })
     expect("asar-unpack-dir" in result.migrated).toBe(false)
-    expect(result.migrated.asarUnpack).toBe("resources/**")
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar?.unpack).toBe("resources/**")
   })
 
-  test("merges asar-unpack and asar-unpack-dir into array", () => {
+  test("merges asar-unpack and asar-unpack-dir into asar.unpack array", () => {
     const result = migrateConfig({ "asar-unpack": "**/*.node", "asar-unpack-dir": "resources/**" })
-    expect(result.migrated.asarUnpack).toEqual(["**/*.node", "resources/**"])
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar?.unpack).toEqual(["**/*.node", "resources/**"])
   })
 
-  test("moves asar.unpack → asarUnpack and removes empty asar", () => {
+  test("moves legacy asar.unpack to asar.unpack (round-trip idempotent)", () => {
     const result = migrateConfig({ asar: { unpack: "**/*.node" } })
-    expect(result.migrated.asarUnpack).toBe("**/*.node")
-    expect("asar" in result.migrated).toBe(false)
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar?.unpack).toBe("**/*.node")
   })
 
-  test("moves asar.unpackDir → asarUnpack", () => {
+  test("moves asar.unpackDir → asar.unpack", () => {
     const result = migrateConfig({ asar: { unpackDir: "resources/**" } })
-    expect(result.migrated.asarUnpack).toBe("resources/**")
-    expect("asar" in result.migrated).toBe(false)
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar?.unpack).toBe("resources/**")
   })
 
-  test("preserves other asar fields when removing unpack", () => {
+  test("preserves other asar fields when moving unpack", () => {
     const result = migrateConfig({ asar: { unpack: "**/*.node", smartUnpack: true } })
-    expect(result.migrated.asarUnpack).toBe("**/*.node")
-    expect(result.migrated.asar).toEqual({ smartUnpack: true })
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar).toEqual({ smartUnpack: true, unpack: "**/*.node" })
   })
 
-  test("merges with existing asarUnpack array", () => {
+  test("merges legacy asar-unpack with existing asarUnpack into asar.unpack", () => {
     const result = migrateConfig({ "asar-unpack": "**/*.node", asarUnpack: ["existing/**"] })
-    expect(result.migrated.asarUnpack).toEqual(["existing/**", "**/*.node"])
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar?.unpack).toEqual(["existing/**", "**/*.node"])
   })
 })
 
@@ -365,10 +369,77 @@ describe("migrateConfig — full migration (multiple changes at once)", () => {
       npmRebuild: true,
       rebuildMode: "sequential",
     })
-    expect(result.migrated.asarUnpack).toEqual(["**/*.node", "resources/**"])
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar?.unpack).toEqual(["**/*.node", "resources/**"])
     expect("appImage" in result.migrated).toBe(false)
     expect(result.migrated.publish).toEqual({ provider: "github", tagNamePrefix: "" })
     expect(result.modified).toBe(true)
+  })
+})
+
+describe("migrateConfig — asar consolidation", () => {
+  test("moves root-level asarUnpack → asar.unpack", () => {
+    const result = migrateConfig({ asarUnpack: "**/*.node" })
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar).toEqual({ unpack: "**/*.node" })
+    expect(result.changes.some(c => c.key === "asarUnpack")).toBe(true)
+  })
+
+  test("merges asarUnpack into existing asar object", () => {
+    const result = migrateConfig({ asar: { smartUnpack: false }, asarUnpack: "**/*.node" })
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar).toEqual({ smartUnpack: false, unpack: "**/*.node" })
+  })
+
+  test("moves disableSanityCheckAsar → asar.disableSanityCheck", () => {
+    const result = migrateConfig({ disableSanityCheckAsar: true })
+    expect("disableSanityCheckAsar" in result.migrated).toBe(false)
+    expect(result.migrated.asar).toEqual({ disableSanityCheck: true })
+    expect(result.changes.some(c => c.key === "disableSanityCheckAsar")).toBe(true)
+  })
+
+  test("moves disableAsarIntegrity → asar.disableIntegrity", () => {
+    const result = migrateConfig({ disableAsarIntegrity: true })
+    expect("disableAsarIntegrity" in result.migrated).toBe(false)
+    expect(result.migrated.asar).toEqual({ disableIntegrity: true })
+    expect(result.changes.some(c => c.key === "disableAsarIntegrity")).toBe(true)
+  })
+
+  test("replaces asar: true with absent asar key when no sub-fields", () => {
+    const result = migrateConfig({ asar: true })
+    expect("asar" in result.migrated).toBe(false)
+    expect(result.changes.some(c => c.key === "asar")).toBe(true)
+  })
+
+  test("replaces asar: true with asar object when sub-fields are present", () => {
+    const result = migrateConfig({ asar: true, asarUnpack: "**/*.node" })
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect(result.migrated.asar).toEqual({ unpack: "**/*.node" })
+  })
+
+  test("skips consolidation when asar: false", () => {
+    const result = migrateConfig({ asar: false, asarUnpack: "**/*.node", disableSanityCheckAsar: true })
+    expect(result.migrated.asar).toBe(false)
+    expect("asarUnpack" in result.migrated).toBe(true)
+    expect("disableSanityCheckAsar" in result.migrated).toBe(true)
+  })
+
+  test("consolidates all three properties together", () => {
+    const result = migrateConfig({
+      asar: { ordering: "order.txt" },
+      asarUnpack: "**/*.node",
+      disableSanityCheckAsar: true,
+      disableAsarIntegrity: true,
+    })
+    expect("asarUnpack" in result.migrated).toBe(false)
+    expect("disableSanityCheckAsar" in result.migrated).toBe(false)
+    expect("disableAsarIntegrity" in result.migrated).toBe(false)
+    expect(result.migrated.asar).toEqual({
+      ordering: "order.txt",
+      unpack: "**/*.node",
+      disableSanityCheck: true,
+      disableIntegrity: true,
+    })
   })
 })
 

--- a/test/src/packageManagerTest.ts
+++ b/test/src/packageManagerTest.ts
@@ -468,7 +468,7 @@ describe("Package Managers", () => {
             targets: linuxDirTarget,
             config: {
               files: ["**/*"],
-              asarUnpack: ["**/node_modules/foo/**/*"],
+              asar: { unpack: ["**/node_modules/foo/**/*"] },
             },
           },
           {

--- a/test/src/rebuilderTest.ts
+++ b/test/src/rebuilderTest.ts
@@ -24,7 +24,7 @@ const packageConfig = (data: any) => {
 const extraFile = "./node_modules/better-sqlite3-multiple-ciphers/build/Release/better_sqlite3.node"
 const config: Configuration = {
   nativeModules: { npmRebuild: true },
-  asarUnpack: ["**/better_sqlite3.node"],
+  asar: { unpack: ["**/better_sqlite3.node"] },
 }
 
 describe.ifLinux("Rebuilder Test", () => {

--- a/test/src/windows/winCodeSignTest.ts
+++ b/test/src/windows/winCodeSignTest.ts
@@ -81,7 +81,7 @@ for (const winCodeSign of winCodeSignVersions) {
           targets: Platform.WINDOWS.createTarget(DIR_TARGET),
           config: {
             publish: "never",
-            asarUnpack: ["assets"],
+            asar: { unpack: ["assets"] },
             toolsets: {
               winCodeSign,
             },

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -100,7 +100,13 @@ See the full documentation on [electron.build](https://www.electron.build).
 
 ## Requirements
 
-**Node.js >=22.12.0** is required. Upgrading from v26? See the **[v26 to v27 migration guide](./MIGRATION.md)** (also at [electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)).
+**Node.js >=22.12.0** is required for v27.
+
+> **Upgrading from v26?** Run the automated migration command first — it rewrites your static config in place:
+> ```bash
+> electron-builder migrate-schema
+> ```
+> Full details: **[v26 → v27 migration guide](./MIGRATION.md)** · [electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)
 
 ## Installation
 ```

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -8,6 +8,16 @@ v27 migrates the entire electron-builder package ecosystem to native ES modules 
 
 **Most projects need only a Node.js version bump.** The `build()` API, all runtime configuration options, and all exported types are unchanged. CJS `require()` continues to work without any code changes on supported Node.js versions.
 
+:::tip[Run the automated migrator first]
+Before reading further, run the built-in command to automatically rewrite your config:
+
+```bash
+electron-builder migrate-schema
+```
+
+Use `--dry-run` to preview changes without writing. This handles every config-level breaking change automatically — see [what it migrates](#automated-migration-tool) for the full list.
+:::
+
 This guide is organized by purpose:
 
 - [Automated migration tool](#automated-migration-tool) — run this first

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -50,7 +50,11 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | Native-module options grouped | `"npmRebuild": true` | `"nativeModules": { "npmRebuild": true }` |
 | `nativeRebuilder` renamed | `"nativeRebuilder": "parallel"` | `"nativeModules": { "rebuildMode": "parallel" }` |
 | `appImage.systemIntegration` removed | `"appImage": { "systemIntegration": "ask" }` | *(deleted)* |
-| Legacy asar keys | `"asar-unpack": "**/*.node"` | `"asarUnpack": ["**/*.node"]` |
+| Legacy asar keys | `"asar-unpack": "**/*.node"` | `"asar": { "unpack": ["**/*.node"] }` |
+| `asarUnpack` consolidated | `"asarUnpack": ["**/*.node"]` | `"asar": { "unpack": ["**/*.node"] }` |
+| `disableSanityCheckAsar` moved | `"disableSanityCheckAsar": true` | `"asar": { "disableSanityCheck": true }` |
+| `disableAsarIntegrity` moved | `"disableAsarIntegrity": true` | `"asar": { "disableIntegrity": true }` |
+| `asar: true` removed | `"asar": true` | *(deleted — absence means enabled)* |
 | `GithubOptions.vPrefixedTagName` | `"vPrefixedTagName": false` | `"tagNamePrefix": ""` |
 | `GitlabOptions.vPrefixedTagName` | `"vPrefixedTagName": true` | *(deleted)* |
 | Azure extra sign keys | `"azureSignOptions": { "ExcludeCredentials": "X" }` | `"azureSignOptions": { "additionalMetadata": { "ExcludeCredentials": "X" } }` |
@@ -84,7 +88,11 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | `npmSkipBuildFromSource` removed | ✓ | Replaced by `nativeModules.buildDependenciesFromSource` |
 | `buildDependenciesFromSource`, `nodeGypRebuild`, `npmRebuild`, `nativeRebuilder` moved | ✓ | Grouped under `nativeModules`; `nativeRebuilder` → `rebuildMode` |
 | `appImage.systemIntegration` removed | ✓ | Removed automatically |
-| `asar-unpack`, `asar-unpack-dir`, `asar.unpackDir`, `asar.unpack` removed | ✓ | Replaced by `asarUnpack` |
+| Legacy asar keys removed | ✓ | `asar-unpack`, `asar-unpack-dir`, `asar.unpackDir` replaced by `asar.unpack` |
+| `asarUnpack` moved into `asar` object | ✓ | Use `asar.unpack` |
+| `disableSanityCheckAsar` moved | ✓ | Use `asar.disableSanityCheck` |
+| `disableAsarIntegrity` moved | ✓ | Use `asar.disableIntegrity` |
+| `asar: true` removed | ✓ | Removed automatically (absence means enabled) |
 | `directories` at package.json root removed | ✓ | Specify under `build.directories` |
 | `build.helper-bundle-id` removed | ✓ | Moved to `mac.helperBundleId` |
 | `squirrelWindows.noMsi` removed | ✓ | Replaced by `msi` (inverted) |
@@ -251,21 +259,88 @@ Removed. Use `buildDependenciesFromSource` (now under `nativeModules` — see [R
 { "nativeModules": { "buildDependenciesFromSource": false } }
 ```
 
-### Legacy `asar` options
+### ASAR options consolidated under `asar`
 
-These asar-related keys are removed (they have thrown since v22). Use `asarUnpack` in all cases.
+All ASAR-related configuration is now nested under a single `asar` key. Flat root-level properties are removed.
+
+**Unpack patterns** (`asarUnpack` and the older hyphenated aliases):
 
 | Removed key | Replacement |
 |---|---|
-| `asar-unpack` | `asarUnpack` |
-| `asar-unpack-dir` | `asarUnpack` |
-| `asar.unpackDir` | `asarUnpack` |
-| `asar.unpack` | `asarUnpack` |
+| `asar-unpack` | `asar.unpack` |
+| `asar-unpack-dir` | `asar.unpack` |
+| `asar.unpackDir` | `asar.unpack` |
+| `asarUnpack` | `asar.unpack` |
+
+```json5
+// Before
+{
+  "build": {
+    "asarUnpack": ["**/*.node", "resources/**"]
+  }
+}
+
+// After
+{
+  "build": {
+    "asar": {
+      "unpack": ["**/*.node", "resources/**"]
+    }
+  }
+}
+```
+
+**Integrity and sanity-check flags** (`disableSanityCheckAsar`, `disableAsarIntegrity`):
+
+| Removed key | Replacement |
+|---|---|
+| `disableSanityCheckAsar` | `asar.disableSanityCheck` |
+| `disableAsarIntegrity` | `asar.disableIntegrity` |
+
+```json5
+// Before
+{
+  "build": {
+    "disableSanityCheckAsar": true,
+    "disableAsarIntegrity": true
+  }
+}
+
+// After
+{
+  "build": {
+    "asar": {
+      "disableSanityCheck": true,
+      "disableIntegrity": true
+    }
+  }
+}
+```
+
+**`asar: true` is no longer valid.** Simply omit the `asar` key entirely to enable ASAR with defaults, or specify an object:
+
+```json5
+// Before — enabling ASAR with defaults
+{ "build": { "asar": true } }
+
+// After — omit entirely (ASAR is enabled by default) or use an object
+{ "build": { "asar": {} } }
+```
+
+When `asar: false` all the sub-options are irrelevant and the migrator skips them.
+
+The `asar` type is now `AsarOptions | false | null`. All options combined:
 
 ```json5
 {
   "build": {
-    "asarUnpack": ["**/*.node", "resources/**"]
+    "asar": {
+      "unpack": ["**/*.node"],
+      "smartUnpack": true,
+      "ordering": "packing-order.txt",
+      "disableSanityCheck": false,
+      "disableIntegrity": false
+    }
   }
 }
 ```
@@ -637,7 +712,11 @@ Run `electron-builder migrate-schema` first — it handles the items marked ✓ 
 - [ ] ✓ `npmSkipBuildFromSource` → `nativeModules.buildDependenciesFromSource` (if present)
 - [ ] ✓ `buildDependenciesFromSource`, `nodeGypRebuild`, `npmRebuild` moved into `nativeModules` (if present)
 - [ ] ✓ `nativeRebuilder` → `nativeModules.rebuildMode` (if present)
-- [ ] ✓ Legacy asar keys → `asarUnpack` (if present)
+- [ ] ✓ Legacy asar keys (`asar-unpack`, `asar-unpack-dir`, `asar.unpackDir`) → `asar.unpack` (if present)
+- [ ] ✓ `asarUnpack` → `asar.unpack` (if present)
+- [ ] ✓ `disableSanityCheckAsar` → `asar.disableSanityCheck` (if present)
+- [ ] ✓ `disableAsarIntegrity` → `asar.disableIntegrity` (if present)
+- [ ] ✓ `asar: true` → removed (absence means enabled) (if present)
 - [ ] ✓ `appImage.systemIntegration` removed (if present)
 - [ ] ✓ `GithubOptions.vPrefixedTagName` → `tagNamePrefix` (if present)
 - [ ] ✓ `win.azureSignOptions` extra keys → `additionalMetadata` (if present)
@@ -703,6 +782,12 @@ The `snapcraft` shape makes the `base` explicit and nests per-base options under
 - **TOML**: The `toml` npm package is read-only (parse only). `migrate-schema` detects TOML configs, prints the required changes, and exits without writing.
 - **YAML**: `js-yaml` preserves key order when round-tripping but does not preserve comments.
 - **Programmatic configs** (`.js`, `.ts`, `.cjs`, `.mjs`): Cannot be safely transformed — the command prints manual steps instead.
+
+### Why consolidate ASAR options under `asar`?
+
+In v26, `asarUnpack` lived alongside `asar` on `PlatformSpecificBuildOptions`, and `disableSanityCheckAsar` / `disableAsarIntegrity` lived at the root of `Configuration`. This was confusing: `asarUnpack` is meaningless when `asar: false`, yet nothing in the type system expressed that relationship. Moving all options under a single `asar` key makes the dependency explicit — if `asar` is absent or `false`, none of the sub-options apply. It also brings per-platform asar control in line with other per-platform sub-objects (`nativeModules`, `toolsets`, `directories`).
+
+The `asar: true` sentinel was removed because having both `true` (enable with defaults) and `{}` (same meaning, but object) was redundant. Absent `asar` key means enabled; `asar: false` means disabled. `migrate-schema` removes bare `asar: true` automatically.
 
 ### `PlatformPackager.info` deprecation strategy
 


### PR DESCRIPTION
### Summary

- **Merged scattered ASAR properties** into a single `asar` root key, so all ASAR configuration is co-located and irrelevant when `asar: false`
- **Removed three root-level properties** from `Configuration` / `PlatformSpecificBuildOptions`:
  - `asarUnpack` → `asar.unpack`
  - `disableSanityCheckAsar` → `asar.disableSanityCheck`
  - `disableAsarIntegrity` → `asar.disableIntegrity`
- **Changed `asar` type** from `AsarOptions | boolean | null` → `AsarOptions | false | null` (`true` is no longer valid at the TypeScript level; the runtime still accepts it gracefully for un-migrated configs)
- **Removed `"asarUnpack"` from `getFileMatchers`** (no longer needed; unpack patterns are now read directly from the resolved `asarOptions.unpack` at the call site)
- **Added migration step** in `migrate-schema.ts` (step 11) that moves all three root-level properties into the `asar` object, and converts `asar: true` → absent/object
- **Updated migration docs** in `MIGRATION.md` and `website/docs/migration/v26-to-v27.md`: added rows for all four ASAR consolidation changes, rewrote the "ASAR options" section with before/after examples, updated the summary checklist, added a design-note rationale, and added a prominent `:::tip` callout at the top of the migration page pointing users to `migrate-schema` before reading further
- **Updated `README.md`**: expanded the Requirements section to prominently call out `electron-builder migrate-schema` with a blockquote and code example for users upgrading from v26
- **Added 8 new migration test cases** covering all consolidation scenarios, edge cases, and the `asar: false` skip guard

### Changed Files

| File | Change |
|---|---|
| [`packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts`](packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts) | Added `unpack`, `disableSanityCheck`, `disableIntegrity` to `AsarOptions`; changed `asar` type; removed `asarUnpack` |
| [`packages/app-builder-lib/src/configuration.ts`](packages/app-builder-lib/src/configuration.ts) | Removed `disableSanityCheckAsar` and `disableAsarIntegrity`; updated JSDoc reference |
| [`packages/app-builder-lib/src/platformPackager.ts`](packages/app-builder-lib/src/platformPackager.ts) | Updated 3 read sites (`disableIntegrity`, `disableSanityCheck`, `unpack`); replaced `getFileMatchers("asarUnpack")` call with direct `FileMatcher` construction from `asarOptions.unpack` |
| [`packages/app-builder-lib/src/fileMatcher.ts`](packages/app-builder-lib/src/fileMatcher.ts) | Removed `"asarUnpack"` from `getFileMatchers` name union and associated throw guard |
| [`packages/electron-builder/src/cli/migrate-schema.ts`](packages/electron-builder/src/cli/migrate-schema.ts) | Added step 11 (asar consolidation); updated step 5 to no longer re-locate `asar.unpack` (now canonical); updated `printManualSteps()` |
| [`website/docs/migration/v26-to-v27.md`](website/docs/migration/v26-to-v27.md) | Added `:::tip` callout at top of page; updated tables, rewrote "ASAR options" section, updated checklist, added design note |
| [`MIGRATION.md`](MIGRATION.md) | Updated asar row; updated `migrate-schema` capabilities description |
| [`README.md`](README.md) | Added blockquote callout in Requirements section with `migrate-schema` command for v26 upgraders |
