### PR TITLE
chore(tests): fix test sourcemaps, enable test `fileParallelism`, increase test timeout, and update GHA

### DIFF
--- a/.changeset/dull-suns-dig.md
+++ b/.changeset/dull-suns-dig.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+chore(test): disable sourcemaps during Vitest runs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
         with: { fetch-depth: 0 }
 
       - name: Determine if Dockerfiles changed
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -12,7 +12,11 @@ import _fsExtra from "fs-extra"
 const { mkdir } = _fsExtra
 import { isEmptyOrSpaces } from "./stringUtil.js"
 
-if (process.env.JEST_WORKER_ID == null) {
+// Vitest install their own source-map-aware stack-trace handling. Letting
+// source-map-support also override Error.prepareStackTrace clobbers the test runner's
+// remapping and yields wrong file:line frames (it resolves transpiled positions instead of
+// the runner's in-memory source maps). Only install in the shipped runtime, not under tests.
+if (process.env.VITEST == null) {
   installSourceMap()
 }
 

--- a/test/src/updater/blackboxUpdateLinuxSuite.ts
+++ b/test/src/updater/blackboxUpdateLinuxSuite.ts
@@ -13,7 +13,7 @@ export function registerBlackboxLinuxTests(toolset: Required<Pick<ToolsetConfig,
     })
 
     // only works on x64, so this will fail on arm64 macs due to arch mismatch
-    test.ifEnv(process.env.RUN_APP_IMAGE_TEST === "true" && process.arch === "x64")("AppImage - x64", async (context: TestContext) => {
+    test.ifEnv(process.env.RUN_APP_IMAGE_TEST === "true" && process.arch === "x64")("AppImage - x64", optionsForFlakyE2E, async (context: TestContext) => {
       await runTest(context, "AppImage", "appimage", Arch.x64, { appimage })
     })
   })

--- a/test/src/updater/blackboxUpdateMacSuite.ts
+++ b/test/src/updater/blackboxUpdateMacSuite.ts
@@ -1,16 +1,16 @@
 import { Arch } from "electron-builder"
 import { TestContext } from "vitest"
-import { runTest } from "./blackboxUpdateHelpers"
+import { optionsForFlakyE2E, runTest } from "./blackboxUpdateHelpers"
 
 export function registerBlackboxMacTests(): void {
-  test("x64", async (context: TestContext) => {
+  test("x64", optionsForFlakyE2E, async (context: TestContext) => {
     await runTest(context, "zip", "", Arch.x64)
   })
-  test("universal", async (context: TestContext) => {
+  test("universal", optionsForFlakyE2E, async (context: TestContext) => {
     await runTest(context, "zip", "", Arch.universal)
   })
   // only will update on arm64 mac
-  test.ifEnv(process.arch === "arm64")("arm64", async (context: TestContext) => {
+  test.ifEnv(process.arch === "arm64")("arm64", optionsForFlakyE2E, async (context: TestContext) => {
     await runTest(context, "zip", "", Arch.arm64)
   })
 }

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -110,10 +110,9 @@ async function main() {
       runner: __dirname + "/vitest-config/vitest-network-retry-runner.ts",
       reporters: ["default", __dirname + "/vitest-config/vitest-smart-reporter.ts"],
 
-      // 2 on Windows (heavy MSI/Squirrel builds saturate the vitest main-thread RPC at 3); 3 elsewhere
-      maxWorkers: process.platform === "win32" ? 2 : 3,
+      maxWorkers: "20%",
 
-      fileParallelism: false,
+      fileParallelism: true,
       sequence: {
         sequencer: SmartSequencer,
         concurrent: true,

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -106,7 +106,6 @@ async function main() {
       setupFiles: [__dirname + "/vitest-config/vitest-setup.ts", __dirname + "/vitest-config/vitest-heavy-mutex.ts"],
       include: [`test/src/**/${includeGlob}.ts`],
 
-      printConsoleTrace: true,
       runner: __dirname + "/vitest-config/vitest-network-retry-runner.ts",
       reporters: ["default", __dirname + "/vitest-config/vitest-smart-reporter.ts"],
 

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -110,7 +110,7 @@ async function main() {
       runner: __dirname + "/vitest-config/vitest-network-retry-runner.ts",
       reporters: ["default", __dirname + "/vitest-config/vitest-smart-reporter.ts"],
 
-      maxWorkers: "20%",
+      maxWorkers: "40%",
 
       fileParallelism: true,
       sequence: {

--- a/test/vitest-scripts/vitest-config/cache.ts
+++ b/test/vitest-scripts/vitest-config/cache.ts
@@ -1,8 +1,16 @@
 import * as fs from "fs"
 import * as path from "path"
 import { TestSpecification } from "vitest/node"
-import { CACHE_FILE, SupportedPlatforms } from "./smart-config.js"
+import { CACHE_FILE, SMART_REPORTER_VERBOSE, SupportedPlatforms } from "./smart-config.js"
 import { TEST_SRC_ROOT } from "./vitest-smart-reporter.js"
+
+// Informational cache chatter is opt-in (see SMART_REPORTER_VERBOSE); real errors below
+// still use console.error unconditionally.
+const logv = (...args: unknown[]) => {
+  if (SMART_REPORTER_VERBOSE) {
+    console.log(...args)
+  }
+}
 
 export interface TestStats {
   platformRuns?: Record<
@@ -37,7 +45,7 @@ interface SmartCache {
 export function loadCache(): SmartCache {
   // Check if file exists BEFORE trying to read it
   if (!fs.existsSync(CACHE_FILE)) {
-    console.log(`[loadCache] Cache file does not exist, starting fresh`)
+    logv(`[loadCache] Cache file does not exist, starting fresh`)
     return { tests: {}, files: {} }
   }
 
@@ -47,7 +55,7 @@ export function loadCache(): SmartCache {
 
     const testCount = Object.keys(cache.tests || {}).length
     const fileCount = Object.keys(cache.files || {}).length
-    console.log(`[loadCache] ✓ Loaded cache - Tests: ${testCount}, Files: ${fileCount}`)
+    logv(`[loadCache] ✓ Loaded cache - Tests: ${testCount}, Files: ${fileCount}`)
 
     return cache
   } catch (err: any) {
@@ -61,13 +69,13 @@ export function saveCache(cache: SmartCache) {
   const testCount = Object.keys(cache.tests || {}).length
   const fileCount = Object.keys(cache.files || {}).length
 
-  console.log(`[saveCache] Saving cache - Tests: ${testCount}, Files: ${fileCount}`)
-  console.log(`[saveCache] Target: ${CACHE_FILE}`)
+  logv(`[saveCache] Saving cache - Tests: ${testCount}, Files: ${fileCount}`)
+  logv(`[saveCache] Target: ${CACHE_FILE}`)
 
   // Ensure directory exists
   const dir = path.dirname(CACHE_FILE)
   if (!fs.existsSync(dir)) {
-    console.log(`[saveCache] Creating directory: ${dir}`)
+    logv(`[saveCache] Creating directory: ${dir}`)
     fs.mkdirSync(dir, { recursive: true })
   }
 
@@ -79,7 +87,7 @@ export function saveCache(cache: SmartCache) {
     fs.writeFileSync(tempFile, content, "utf8")
     fs.renameSync(tempFile, CACHE_FILE)
 
-    console.log(`[saveCache] ✓ Cache saved successfully (${(content.length / 1024).toFixed(2)} KB)`)
+    logv(`[saveCache] ✓ Cache saved successfully (${(content.length / 1024).toFixed(2)} KB)`)
   } catch (err: any) {
     console.error(`[saveCache] ✗ Error saving cache:`, err.message)
     throw err

--- a/test/vitest-scripts/vitest-config/smart-config.ts
+++ b/test/vitest-scripts/vitest-config/smart-config.ts
@@ -1,4 +1,4 @@
-import * as path from "path"
+  import * as path from "path"
 
 export type TargetPlatform = "darwin" | "win32" | "linux" | "current"
 export type SupportedPlatforms = Exclude<TargetPlatform, "current">
@@ -7,6 +7,13 @@ export const TEST_ROOT = "test/src"
 export const TEST_FILES_PATTERN = process.env.TEST_FILES?.trim() || "*Test,*test"
 
 export const CACHE_FILE = process.env.VITEST_SMART_CACHE_FILE || path.resolve(__dirname, "_vitest-smart-cache.json")
+
+// The smart reporter, cache, and sequencer are data-collection plumbing. Their per-test
+// progress lines, in-progress heartbeat, cache load/save chatter, and plan dump duplicate
+// vitest's default reporter and interleave with its output (especially failure summaries),
+// so they're silent by default. Set SMART_REPORTER_VERBOSE=true to restore them for local
+// debugging. Cache-collection and sorting still run regardless of this flag.
+export const SMART_REPORTER_VERBOSE = process.env.SMART_REPORTER_VERBOSE !== "false" && !process.env.CI
 
 export const DEFAULT_FILE_MS = 2 * 60 * 1000
 export const DEFAULT_TARGET_MS = 20 * 60 * 1000

--- a/test/vitest-scripts/vitest-config/vitest-smart-reporter.ts
+++ b/test/vitest-scripts/vitest-config/vitest-smart-reporter.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import type { Reporter, TestCase, TestModule } from "vitest/node"
 import { FileStats, loadCache, saveCache, TestStats } from "./cache.js"
-import { UNSTABLE_FAIL_RATIO, SupportedPlatforms } from "./smart-config.js"
+import { UNSTABLE_FAIL_RATIO, SupportedPlatforms, SMART_REPORTER_VERBOSE } from "./smart-config.js"
 
 const defaultStat: TestStats = {
   platformRuns: {
@@ -28,6 +28,9 @@ export default class SmarterReporter implements Reporter {
   currentPlatform = process.platform as SupportedPlatforms
 
   onInit() {
+    if (!SMART_REPORTER_VERBOSE) {
+      return
+    }
     this.heartbeatTimer = setInterval(() => {
       const now = Date.now()
       const running = [...this.inProgressTests.entries()]
@@ -42,7 +45,9 @@ export default class SmarterReporter implements Reporter {
   onTestCaseReady(test: TestCase) {
     const id = `${path.relative(TEST_SRC_ROOT, test.module.moduleId).split(path.sep).join("/")}::${test.fullName}`
     this.inProgressTests.set(id, Date.now())
-    process.stdout.write(`\n[test ready] 🏃 ${test.fullName}\n`)
+    if (SMART_REPORTER_VERBOSE) {
+      process.stdout.write(`\n[test ready] 🏃 ${test.fullName}\n`)
+    }
   }
 
   onTestCaseResult(test: TestCase) {
@@ -50,19 +55,21 @@ export default class SmarterReporter implements Reporter {
     this.inProgressTests.delete(id)
     const dur = test.diagnostic()?.duration ?? 0
     const testResult = test.result().state
-    const status = (() => {
-      switch (testResult) {
-        case "passed":
-          return "✅"
-        case "failed":
-          return "❌"
-        case "skipped":
-          return "⏭️"
-        default:
-          return "❔"
-      }
-    })()
-    process.stdout.write(`\n${status} ${id} (${Math.round(dur / 1000)}s)\n`)
+    if (SMART_REPORTER_VERBOSE) {
+      const status = (() => {
+        switch (testResult) {
+          case "passed":
+            return "✅"
+          case "failed":
+            return "❌"
+          case "skipped":
+            return "⏭️"
+          default:
+            return "❔"
+        }
+      })()
+      process.stdout.write(`\n${status} ${id} (${Math.round(dur / 1000)}s)\n`)
+    }
 
     const meta = (test as any).meta || {}
 


### PR DESCRIPTION
**Test runner and configuration improvements:**

* Disabled source map installation during Vitest test runs by checking for the `VITEST` environment variable in `util.ts`, preventing stack trace remapping conflicts.
* Made verbose output from the smart reporter and cache opt-in via the `SMART_REPORTER_VERBOSE` flag (defaulting to off in CI), silencing progress lines and cache chatter unless enabled for debugging.
* Increased test parallelism by setting `maxWorkers` to `"40%"` and enabling `fileParallelism` in Vitest config, improving test run speed.
* Marked Mac and Linux updater blackbox tests as flaky by passing `optionsForFlakyE2E`, enabling retries for known-flaky E2E tests. [[1]](diffhunk://#diff-d8d22f8d2a0832dea69a54c99b61cac5da20e44092dbccb7d275787fbca4327aL3-R13) [[2]](diffhunk://#diff-ad85f46c8f6513ac9310ea8f33490b595fefa01317a1d921e578f51f9d3d002eL16-R16)
* Updated the `dorny/paths-filter` GitHub Action from v3.0.2 to v4.0.1 in the workflow.
