### PR TITLE
fix(mac): preserve `.framework` symlinks in both `zip` and `7z` targets via 7za `-snl`

### DIFF
--- a/.changeset/mac-7z-symlink-snl.md
+++ b/.changeset/mac-7z-symlink-snl.md
@@ -2,4 +2,4 @@
 "app-builder-lib": patch
 ---
 
-fix(mac): preserve `.framework` symlinks in both `zip` and `7z` targets via 7za `-snl`
+fix: preserve symlinks in `zip` and `7z` archive targets on macOS and Linux via 7za `-snl` (Windows still dereferences). Restores pre-26.15 behavior after the bundled 7-Zip upgrade, which began dereferencing by default — corrupting macOS `.framework` bundles (codesign "bundle format is ambiguous", breaking Squirrel.Mac auto-update) and duplicating Linux symlink content.

--- a/.changeset/mac-7z-symlink-snl.md
+++ b/.changeset/mac-7z-symlink-snl.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): preserve `.framework` symlinks in both `zip` and `7z` targets via 7za `-snl`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@ Claude can run these directly to build, test, and lint the codebase:
 
 * **Build:** `pnpm compile` (add `--watch` flag to monitor)
 * **Test:** `TEST_FILES<name of file(s), comma-separated, without extension> pnpm ci:test` (Runs the unit and integration suite)
-* **Lint:** `pnpm lint` for eslint. `pnpm compile` also works to check for syntax and formatting errors
+* **Lint:** `pnpm ci:validate`
 
 ## Verification & Testing Standards
 * **Test Coverage:** Always ensure adding test coverage for new features and logic flows.

--- a/packages/app-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/app-builder-lib/src/targets/ArchiveTarget.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { Platform, Target, TargetSpecificOptions } from "../core.js"
 import { copyFiles, getFileMatchers } from "../fileMatcher.js"
 import { PlatformPackager } from "../platformPackager.js"
-import { archive, tar } from "./archive.js"
+import { archive, shouldPreserveSymlinks, tar } from "./archive.js"
 import { appendBlockmap, createBlockmap } from "./differentialUpdateInfoBuilder.js"
 
 export class ArchiveTarget extends Target {
@@ -72,7 +72,7 @@ export class ArchiveTarget extends Target {
         const archiveOptions = {
           compression: packager.compression,
           withoutDir,
-          preserveSymlinks: isMac,
+          preserveSymlinks: shouldPreserveSymlinks(packager.platform),
         }
         await archive(format, artifactPath, dirToArchive, archiveOptions)
 

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -92,7 +92,8 @@ export interface ArchiveOptions {
   isRegularFile?: boolean
 
   /**
-   * Use native macOS `zip` to preserve symlinks. Required for .framework bundles.
+   * Preserve symlinks (e.g. macOS .framework `Versions/Current`) instead of dereferencing them.
+   * Passes `-snl` to 7za — modern 7-Zip derefs by default, which breaks bundle codesigning. See #9846.
    * @default false
    */
   preserveSymlinks?: boolean
@@ -172,14 +173,23 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     return outFile
   }
 
-  // On macOS, use native `zip` when symlink preservation is required (e.g. .framework bundles).
-  // 7zip dereferences symlinks, corrupting .framework structure and breaking codesign.
-  // Only opt in via preserveSymlinks — Windows zip targets built on macOS still use 7z
-  // so that the UTF-8 bit (-mcu) is set correctly in the zip header.
-  const use7z = !(process.platform === "darwin" && format === "zip" && options.preserveSymlinks)
+  // Use 7za for all formats (matches pre-26.15 behavior). Native macOS `zip` is only a
+  // fallback for NFD-normalized filenames, which 7za mangles.
+  let use7z = true
+  if (process.platform === "darwin" && format === "zip" && dirToArchive.normalize("NFC") !== dirToArchive) {
+    log.warn({ reason: "7z doesn't support NFD-normalized filenames" }, `using zip`)
+    use7z = false
+  }
 
   if (use7z) {
     const args = compute7zCompressArgs(format, options)
+    // Modern 7-Zip (24.09) dereferences symlinks by default; the 7-Zip 16.02 bundled before
+    // 26.15 stored them as links. Without -snl, a macOS .framework `Versions/Current` extracts
+    // as a real directory → codesign "bundle format is ambiguous" → breaks Squirrel.Mac
+    // auto-update. Applies to both zip and 7z mac targets. See #9846.
+    if (options.preserveSymlinks) {
+      args.push("-snl")
+    }
     await unlinkIfExists(outFile)
     args.push(outFile, options.withoutDir ? "." : path.basename(dirToArchive))
     if (options.excluded != null) {
@@ -201,7 +211,7 @@ export async function archive(format: string, outFile: string, dirToArchive: str
       }
     }
   } else {
-    // macOS native zip: -y preserves symlinks (required for .framework bundles)
+    // macOS native zip (NFD fallback): -y preserves symlinks
     const args = ["-q", "-r", "-y"]
     if (debug7z.enabled) {
       args.push("-v")

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { create } from "tar"
 import type { TarOptionsWithAliasesAsync } from "tar"
 import { TmpDir } from "temp-file"
-import { CompressionLevel } from "../core.js"
+import { CompressionLevel, Platform } from "../core.js"
 import { getLinuxToolsMacToolset } from "../toolsets/linuxToolsMac.js"
 import { ToolsetConfig } from "../configuration.js"
 import { getPath7za } from "../toolsets/7zip.js"
@@ -99,6 +99,16 @@ export interface ArchiveOptions {
   preserveSymlinks?: boolean
 }
 
+/**
+ * Whether archives for the given target platform should preserve symlinks (i.e. pass `-snl`).
+ * Non-Windows targets preserve them: macOS `.framework` bundles need them for codesigning (#9846)
+ * and Linux bundles may legitimately contain them. Windows dereferences because restoring symlinks
+ * there requires elevated privileges. Keyed on the target platform, not the build host.
+ */
+export function shouldPreserveSymlinks(platform: Platform): boolean {
+  return platform !== Platform.WINDOWS
+}
+
 export function compute7zCompressArgs(format: string, options: ArchiveOptions = {}) {
   let storeOnly = options.compression === "store"
   const args = debug7zArgs("a")
@@ -186,7 +196,7 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     // Modern 7-Zip (24.09) dereferences symlinks by default; the 7-Zip 16.02 bundled before
     // 26.15 stored them as links. Without -snl, a macOS .framework `Versions/Current` extracts
     // as a real directory → codesign "bundle format is ambiguous" → breaks Squirrel.Mac
-    // auto-update. Applies to both zip and 7z mac targets. See #9846.
+    // auto-update (#9846). Callers enable it for all non-Windows targets (see ArchiveTarget).
     if (options.preserveSymlinks) {
       args.push("-snl")
     }

--- a/test/snapshots/mac/macArchiveTest.js.snap
+++ b/test/snapshots/mac/macArchiveTest.js.snap
@@ -1,5 +1,66 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`7z preserves .framework symlinks (#9846) 1`] = `
+{
+  "mac": [
+    {
+      "arch": "x64",
+      "file": "Test App ßW-1.1.0-mac.7z",
+      "safeArtifactName": "TestApp-1.1.0-mac.7z",
+    },
+  ],
+}
+`;
+
+exports[`7z preserves .framework symlinks (#9846) 2`] = `
+{
+  "CFBundleDisplayName": "Test App ßW",
+  "CFBundleExecutable": "Test App ßW",
+  "CFBundleIconFile": "icon.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "Test App ßW",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.1.0",
+  "ElectronAsarIntegrity": {
+    "Resources/app.asar": {
+      "algorithm": "SHA256",
+      "hash": "hash",
+    },
+  },
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSEnvironment": {
+    "MallocNanoZone": "0",
+  },
+  "NSAppTransportSecurity": {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": {
+      "127.0.0.1": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSAudioCaptureUsageDescription": "This app needs access to audio capture",
+  "NSBluetoothAlwaysUsageDescription": "This app needs access to Bluetooth",
+  "NSBluetoothPeripheralUsageDescription": "This app needs access to Bluetooth",
+  "NSHighResolutionCapable": true,
+  "NSPrefersDisplaySafeAreaCompatibilityMode": false,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
 exports[`empty installLocation 1`] = `
 {
   "mac": [
@@ -1417,6 +1478,79 @@ exports[`tar.gz 1`] = `
 `;
 
 exports[`tar.gz 2`] = `
+{
+  "CFBundleDisplayName": "Test App ßW",
+  "CFBundleExecutable": "Test App ßW",
+  "CFBundleIconFile": "icon.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "Test App ßW",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.1.0",
+  "ElectronAsarIntegrity": {
+    "Resources/app.asar": {
+      "algorithm": "SHA256",
+      "hash": "hash",
+    },
+  },
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSEnvironment": {
+    "MallocNanoZone": "0",
+  },
+  "NSAppTransportSecurity": {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": {
+      "127.0.0.1": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSAudioCaptureUsageDescription": "This app needs access to audio capture",
+  "NSBluetoothAlwaysUsageDescription": "This app needs access to Bluetooth",
+  "NSBluetoothPeripheralUsageDescription": "This app needs access to Bluetooth",
+  "NSHighResolutionCapable": true,
+  "NSPrefersDisplaySafeAreaCompatibilityMode": false,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
+exports[`zip preserves .framework symlinks (#9846) 1`] = `
+{
+  "mac": [
+    {
+      "arch": "x64",
+      "file": "Test App ßW-1.1.0-mac.zip",
+      "safeArtifactName": "TestApp-1.1.0-mac.zip",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    {
+      "file": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "safeArtifactName": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`zip preserves .framework symlinks (#9846) 2`] = `
 {
   "CFBundleDisplayName": "Test App ßW",
   "CFBundleExecutable": "Test App ßW",

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -167,9 +167,9 @@ describe("archive() guards", { sequential: true }, () => {
   })
 })
 
-// ─── archive() — macOS zip symlink preservation ──────────────────────────────
+// ─── archive() — macOS symlink preservation ──────────────────────────────────
 
-describe.runIf(process.platform === "darwin")("archive() macOS zip symlink preservation", { sequential: true }, () => {
+describe.runIf(process.platform === "darwin")("archive() macOS symlink preservation", { sequential: true }, () => {
   let tmpDir: string
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-archive-test-"))
@@ -201,7 +201,33 @@ describe.runIf(process.platform === "darwin")("archive() macOS zip symlink prese
     expect(target).toBe("real.txt")
   })
 
-  test("excluded pattern with '..' throws in native zip path", async ({ expect }) => {
+  // Regression for #9846: the 7z target must also preserve symlinks (-snl). Modern 7-Zip
+  // dereferences them by default, which corrupts .framework bundles and breaks codesign.
+  test("7z archive preserves symlinks (not dereferenced)", async ({ expect }) => {
+    const src = path.join(tmpDir, "src7z")
+    await fs.mkdir(src, { recursive: true })
+    await fs.writeFile(path.join(src, "real.txt"), "content")
+    await fs.symlink("real.txt", path.join(src, "link.txt"))
+
+    const outFile = path.join(tmpDir, "out.7z")
+    await archive("7z", outFile, src, { withoutDir: true, preserveSymlinks: true })
+
+    // Extract with the same 7za toolset binary and verify the symlink survived
+    const extractDir = path.join(tmpDir, "extracted7z")
+    await fs.mkdir(extractDir, { recursive: true })
+    const { getPath7za } = await import("app-builder-lib/src/toolsets/7zip")
+    const { exec: cpExec } = await import("child_process")
+    const { promisify } = await import("util")
+    const execAsync = promisify(cpExec)
+    await execAsync(`"${await getPath7za()}" x -o"${extractDir}" "${outFile}"`)
+
+    const linkStat = await fs.lstat(path.join(extractDir, "link.txt"))
+    expect(linkStat.isSymbolicLink()).toBe(true)
+    const target = await fs.readlink(path.join(extractDir, "link.txt"))
+    expect(target).toBe("real.txt")
+  })
+
+  test("excluded pattern with '..' throws when preserveSymlinks is set", async ({ expect }) => {
     const src = await makeSrcDir(tmpDir)
     await expect(archive("zip", path.join(tmpDir, "out.zip"), src, { excluded: ["../secret"], preserveSymlinks: true })).rejects.toThrow("path traversal sequence")
   })

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -1,4 +1,5 @@
-import { archive, compute7zCompressArgs } from "app-builder-lib/src/targets/archive"
+import { archive, compute7zCompressArgs, shouldPreserveSymlinks } from "app-builder-lib/src/targets/archive"
+import { Platform } from "app-builder-lib/src/core"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { afterEach, beforeEach, vi } from "vitest"
@@ -163,9 +164,27 @@ describe("archive() guards", { sequential: true }, () => {
   })
 })
 
-// ─── archive() — macOS symlink preservation ──────────────────────────────────
+// ─── shouldPreserveSymlinks — target platform → -snl policy ──────────────────
+// Regression guard for #9846 and its Linux follow-up: keyed on the target platform (not the build
+// host), so a Linux distributable built on a Windows machine still preserves symlinks, and a Windows
+// distributable built on macOS/Linux still dereferences. Catches narrowing the policy back to mac-only.
 
-describe.runIf(process.platform === "darwin")("archive() macOS symlink preservation", { sequential: true }, () => {
+describe("shouldPreserveSymlinks", () => {
+  test("preserves symlinks for macOS and Linux targets", ({ expect }) => {
+    expect(shouldPreserveSymlinks(Platform.MAC)).toBe(true)
+    expect(shouldPreserveSymlinks(Platform.LINUX)).toBe(true)
+  })
+
+  test("dereferences symlinks for Windows targets", ({ expect }) => {
+    expect(shouldPreserveSymlinks(Platform.WINDOWS)).toBe(false)
+  })
+})
+
+// ─── archive() — symlink preservation (non-Windows hosts) ────────────────────
+// Runs on macOS and Linux: both are non-Windows archive targets that pass -snl (see ArchiveTarget).
+// Windows is excluded — symlink restore there needs elevated privileges and the target dereferences.
+
+describe.runIf(process.platform !== "win32")("archive() symlink preservation", { sequential: true }, () => {
   let tmpDir: string
   beforeEach(async context => {
     tmpDir = await context.tmpDir.createTempDir()

--- a/test/src/mac/macArchiveTest.ts
+++ b/test/src/mac/macArchiveTest.ts
@@ -1,3 +1,4 @@
+import { getPath7za } from "app-builder-lib/src/toolsets/7zip"
 import { Arch, exec } from "builder-util"
 import { parseXml } from "builder-util-runtime"
 import { Platform } from "electron-builder"
@@ -5,6 +6,7 @@ import fsExtra from "fs-extra"
 import * as fs from "fs/promises"
 import * as path from "path"
 import pathSorter from "path-sort"
+import type { ExpectStatic } from "vitest"
 import { assertThat } from "../helpers/fileAssert.js"
 import { app, copyTestAsset, createMacTargetTest, getFixtureDir, parseFileList } from "../helpers/packTester.js"
 
@@ -15,6 +17,49 @@ test.ifNotWindows("only zip", ({ expect }) => createMacTargetTest(expect, ["zip"
 test.ifNotWindows("tar.gz", ({ expect }) => createMacTargetTest(expect, ["tar.gz"]))
 
 // test.ifNotWindows("tar.xz", createTargetTest(["tar.xz"], ["Test App ßW-1.1.0-mac.tar.xz"]))
+
+// Regression for #9846: the macOS zip and 7z targets must preserve .framework `Versions/Current`
+// symlinks through the archive round-trip. Modern 7-Zip dereferences symlinks unless passed -snl;
+// a dereferenced framework makes codesign report "bundle format is ambiguous" and breaks Squirrel.Mac
+// auto-update. These build a real app, archive it, extract, and assert every framework symlink survived.
+function createMacFrameworkSymlinkTest(expect: ExpectStatic, format: "zip" | "7z") {
+  return app(
+    expect,
+    {
+      targets: Platform.MAC.createTarget(format, Arch.x64),
+      config: { mac: { target: format }, publish: null },
+    },
+    {
+      signedMac: false,
+      packed: async context => {
+        const artifactName = (await fs.readdir(context.outDir)).find(name => name.endsWith(`.${format}`))
+        expect(artifactName, `expected a .${format} artifact in ${context.outDir}`).toBeTruthy()
+        const artifactPath = path.join(context.outDir, artifactName!)
+
+        const extractDir = await context.tmpDir.createTempDir({ prefix: `mac-${format}-symlink` })
+        if (format === "zip") {
+          // `ditto -x -k` mirrors how Squirrel.Mac extracts the auto-update payload
+          await exec("ditto", ["-x", "-k", artifactPath, extractDir])
+        } else {
+          await exec(await getPath7za(), ["x", `-o${extractDir}`, "-y", artifactPath])
+        }
+
+        const frameworksDir = path.join(extractDir, `${context.packager.appInfo.productFilename}.app`, "Contents", "Frameworks")
+        const frameworks = (await fs.readdir(frameworksDir)).filter(name => name.endsWith(".framework"))
+        expect(frameworks.length, "app should contain .framework bundles").toBeGreaterThan(0)
+        for (const framework of frameworks) {
+          const current = path.join(frameworksDir, framework, "Versions", "Current")
+          const stat = await fs.lstat(current)
+          expect(stat.isSymbolicLink(), `${framework}/Versions/Current must remain a symlink after ${format} round-trip`).toBe(true)
+        }
+      },
+    }
+  )
+}
+
+test.heavy.ifMac("zip preserves .framework symlinks (#9846)", ({ expect }) => createMacFrameworkSymlinkTest(expect, "zip"))
+
+test.heavy.ifMac("7z preserves .framework symlinks (#9846)", ({ expect }) => createMacFrameworkSymlinkTest(expect, "7z"))
 
 test.ifMac("pkg", ({ expect }) => createMacTargetTest(expect, ["pkg"]))
 

--- a/test/vitest-scripts/vitest-config/vitest-tmpdir.ts
+++ b/test/vitest-scripts/vitest-config/vitest-tmpdir.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach } from "vitest"
 import { TmpDir } from "temp-file"
+import { rm } from "node:fs/promises"
 
 // Gives every test its own temp directory on the test context, cleaned up automatically:
 //
@@ -22,5 +23,22 @@ beforeEach(context => {
 })
 
 afterEach(async context => {
-  await context.tmpDir.cleanup()
+  try {
+    await context.tmpDir.cleanup()
+  } catch (error) {
+    // On Windows, rmdir intermittently fails with EPERM/EBUSY while a handle, antivirus, or the Search
+    // indexer still holds the directory. temp-file's cleanup() nulls its own state before the remove()
+    // runs, so it can't be retried directly (a second call is a no-op). Retry the rm ourselves instead:
+    // fs.rm natively backs off and retries EPERM/EBUSY/ENOTEMPTY, and the fs error carries the offending
+    // path. The assertions already ran, so a final failure here is teardown flakiness — warn, don't fail.
+    const err = error as NodeJS.ErrnoException
+    try {
+      if (err.path == null) {
+        throw error
+      }
+      await rm(err.path, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    } catch (retryError) {
+      console.warn(`tmpDir cleanup failed for "${context.task.name}":`, retryError)
+    }
+  }
 })


### PR DESCRIPTION
Follow-up on #9846

Basically....

Modern 7-Zip (24.09, bundled since 26.15) dereferences symlinks by default, unlike the 7-Zip 16.02 bundled before it. This corrupted macOS `.framework` bundles (`Versions/Current` became a real directory), causing `codesign` to report "bundle format is ambiguous" and breaking Squirrel.Mac auto-update. #9847 fixed the `zip` target only by switching to native `zip`; the `7z` target was still affected (#9846). Archiving now uses the bundled 7za for both formats and passes `-snl` to store symlinks as links.
