### PR TITLE
chore(test): Shared per-test `tmpDir` for tests; eliminate `new TmpDir()` / `mkdtemp` boilerplate

### DIFF
--- a/test/src/ExtraBuildResourcesTest.ts
+++ b/test/src/ExtraBuildResourcesTest.ts
@@ -2,7 +2,6 @@ import { Arch, build, PackagerOptions, Platform } from "electron-builder"
 import * as fs from "fs"
 import { readdir } from "fs/promises"
 import * as path from "path"
-import { TmpDir } from "temp-file"
 import * as unzipper from "unzipper"
 import { ExpectStatic } from "vitest"
 import { assertThat } from "./helpers/fileAssert"
@@ -179,8 +178,7 @@ test.ifWindows("override targets in the config - only arch", ({ expect }) =>
 // test on all CI to check path separators
 test("do not exclude build entirely (respect files)", ({ expect }) => assertPack(expect, "test-app-build-sub", { targets: linuxDirTarget }))
 
-test.ifNotWindows("electronDist as path to local folder with electron builds zipped ", async ({ expect }) => {
-  const tmpDir = new TmpDir()
+test.ifNotWindows("electronDist as path to local folder with electron builds zipped ", async ({ expect, tmpDir }) => {
   const cacheDir = await tmpDir.createTempDir({ prefix: "electronDistCache" })
   const file = await downloadArtifact({
     artifactName: "electron",
@@ -201,7 +199,6 @@ test.ifNotWindows("electronDist as path to local folder with electron builds zip
       tmpDir,
     }
   )
-  await tmpDir.cleanup()
 })
 
 test.ifNotWindows("electronDist as callback function for path to local electron zipped artifact ", async ({ expect }) => {

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -1,6 +1,5 @@
 import { archive, compute7zCompressArgs } from "app-builder-lib/src/targets/archive"
 import * as fs from "fs/promises"
-import * as os from "os"
 import * as path from "path"
 import { afterEach, beforeEach, vi } from "vitest"
 
@@ -142,11 +141,8 @@ describe("compute7zCompressArgs", { sequential: true }, () => {
 
 describe("archive() guards", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-archive-test-"))
-  })
-  afterEach(async () => {
-    await fs.rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   test("excluded pattern with '..' throws", async ({ expect }) => {
@@ -171,11 +167,8 @@ describe("archive() guards", { sequential: true }, () => {
 
 describe.runIf(process.platform === "darwin")("archive() macOS zip symlink preservation", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-archive-test-"))
-  })
-  afterEach(async () => {
-    await fs.rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   test("zip archive preserves symlinks (not dereferenced)", async ({ expect }) => {

--- a/test/src/blockmapTest.ts
+++ b/test/src/blockmapTest.ts
@@ -1,9 +1,8 @@
 import { createHash } from "crypto"
-import { mkdtemp, readFile, rm, writeFile } from "fs/promises"
-import * as os from "os"
+import { readFile, writeFile } from "fs/promises"
 import * as path from "path"
 import * as zlib from "zlib"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 import { buildBlockMap } from "app-builder-lib/src/targets/blockmap/blockmap.js"
 
 function sha512(data: Buffer): string {
@@ -23,11 +22,8 @@ function makeTestData(size: number, seed = 12345): Buffer {
 
 describe("buildBlockMap", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "blockmap-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
   it("file output mode: returns correct sha512 and size for small file", async () => {
     const data = Buffer.from("hello world. ".repeat(1024))
@@ -206,11 +202,8 @@ describe("buildBlockMap", { sequential: true }, () => {
 
 describe("buildBlockMap — JS snapshots and binary golden-output", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "blockmap-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
   it("single-chunk file (< MIN): sizes, checksums and sha512 are snapshotted", async () => {
     const data = Buffer.from("hello world. ".repeat(1024)) // 13 312 bytes < RABIN_MIN

--- a/test/src/certInfoTest.ts
+++ b/test/src/certInfoTest.ts
@@ -1,10 +1,9 @@
-import * as os from "os"
 import * as path from "path"
 import { execSync } from "child_process"
 import { writeFileSync, readFileSync } from "fs"
-import { mkdtemp } from "fs/promises"
+import { TmpDir } from "temp-file"
 import { afterAll, beforeAll, describe, it, expect } from "vitest"
-import { writeFile, remove } from "fs-extra"
+import { writeFile } from "fs-extra"
 import { readCertInfo, _testingOnly } from "app-builder-lib/internal"
 
 const { pkcs12PbeDeriveKey, pkcs12PasswordToUtf16, rc2CbcDecrypt, MAX_PKCS12_PBE_ITERATIONS } = _testingOnly
@@ -17,6 +16,7 @@ const itLegacyPbe = it.skipIf(!legacyPbeSupported)
 
 // ─── Test fixture paths ───────────────────────────────────────────────────────
 
+const sharedTmpDir = new TmpDir("certinfo-test")
 let tmpDir: string
 let FULL_SUBJECT_PFX: string
 let CN_ONLY_PFX: string
@@ -103,7 +103,7 @@ function genLegacyPbePfx(subj: string, password: string, certpbe: string, name: 
 }
 
 beforeAll(async () => {
-  tmpDir = await mkdtemp(path.join(os.tmpdir(), "certinfo-test-"))
+  tmpDir = await sharedTmpDir.createTempDir()
 
   FULL_SUBJECT_PFX = genSigningPfx("/CN=Test Publisher/O=Test Org/L=San Francisco/ST=California/C=US", "testpassword", "full")
   CN_ONLY_PFX = genSigningPfx("/CN=My Company Inc.", "pw", "cn")
@@ -130,9 +130,7 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
-  if (tmpDir) {
-    await remove(tmpDir).catch(() => null)
-  }
+  await sharedTmpDir.cleanup()
 })
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/test/src/electronGetTest.ts
+++ b/test/src/electronGetTest.ts
@@ -5,6 +5,7 @@ import * as net from "net"
 import * as os from "os"
 import * as path from "path"
 import * as tar from "tar"
+import { TmpDir } from "temp-file"
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest"
 import {
   ArtifactDownloadOptions,
@@ -25,16 +26,17 @@ import { ELECTRON_VERSION } from "./helpers/testConfig"
  * Entry layout: inner/<name> — strip:1 extracts <name> directly into the target dir.
  */
 async function createMinimalTarGz(archivePath: string, files: Record<string, string>): Promise<void> {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-test-tar-"))
+  const tmpDir = new TmpDir("eb-test-tar")
   try {
-    const innerDir = path.join(tmpDir, "inner")
+    const dir = await tmpDir.createTempDir()
+    const innerDir = path.join(dir, "inner")
     await fs.mkdir(innerDir)
     for (const [name, content] of Object.entries(files)) {
       await fs.writeFile(path.join(innerDir, name), content)
     }
-    await tar.create({ gzip: true, file: archivePath, cwd: tmpDir }, ["inner"])
+    await tar.create({ gzip: true, file: archivePath, cwd: dir }, ["inner"])
   } finally {
-    await fs.rm(tmpDir, { recursive: true, force: true })
+    await tmpDir.cleanup()
   }
 }
 
@@ -225,15 +227,16 @@ describe("getBinariesMirrorUrl", () => {
 
 // ─── Shared temp cache dir for functional tests ───────────────────────────────
 
+const sharedCacheTmpDir = new TmpDir("eb-electronGet-test")
 let testCacheDir: string
 
 beforeAll(async () => {
-  testCacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-electronGet-test-"))
+  testCacheDir = await sharedCacheTmpDir.createTempDir()
   process.env.ELECTRON_BUILDER_CACHE = testCacheDir
 })
 
 afterAll(async () => {
-  await fs.rm(testCacheDir, { recursive: true, force: true })
+  await sharedCacheTmpDir.cleanup()
 })
 
 // ─── downloadArtifact: generic artifacts (.tar.gz) ───────────────────────────
@@ -323,8 +326,8 @@ describe("downloadBuilderToolset", { sequential: true }, () => {
   // Using resolveAssetURL bypasses that env var check entirely.
   // This test routes downloads through a local server and verifies the server is hit (not
   // ELECTRON_MIRROR's unreachable URL), proving resolveAssetURL controls the final fetch target.
-  test("ELECTRON_MIRROR env var does not corrupt builder-binaries download URL (#9752)", { timeout: 15_000 }, async ({ expect }) => {
-    const freshTestCache = await fs.mkdtemp(path.join(os.tmpdir(), "eb-mirror-test-"))
+  test("ELECTRON_MIRROR env var does not corrupt builder-binaries download URL (#9752)", { timeout: 15_000 }, async ({ expect, tmpDir }) => {
+    const freshTestCache = await tmpDir.createTempDir()
     vi.stubEnv("ELECTRON_BUILDER_CACHE", freshTestCache)
     // Point ELECTRON_MIRROR at an unreachable address — if @electron/get used it instead of
     // resolveAssetURL, the fetch would fail with ECONNREFUSED before reaching any assertion.
@@ -342,7 +345,6 @@ describe("downloadBuilderToolset", { sequential: true }, () => {
       expect(server.requestedPaths.some(p => p.includes("dmg-builder@1.2.2"))).toBe(true)
     } finally {
       await server.close()
-      await fs.rm(freshTestCache, { recursive: true, force: true })
     }
   })
 })
@@ -368,14 +370,13 @@ describe("downloadBuilderToolset: filenameWithExt validation", () => {
 describe("toolset archive cache", { sequential: true }, () => {
   let freshCache: string
 
-  beforeEach(async () => {
-    freshCache = await fs.mkdtemp(path.join(os.tmpdir(), "eb-archive-cache-test-"))
+  beforeEach(async context => {
+    freshCache = await context.tmpDir.createTempDir()
     vi.stubEnv("ELECTRON_BUILDER_CACHE", freshCache)
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.unstubAllEnvs()
-    await fs.rm(freshCache, { recursive: true, force: true })
   })
 
   // Seed the archive cache path that downloadBuilderToolset checks before hitting @electron/get.
@@ -643,9 +644,9 @@ async function startRecordingProxy() {
 }
 
 describe("proxy integration", () => {
-  test("routes download requests through HTTPS_PROXY when set", { timeout: 15_000 }, async ({ expect }) => {
+  test("routes download requests through HTTPS_PROXY when set", { timeout: 15_000 }, async ({ expect, tmpDir }) => {
     const proxy = await startRecordingProxy()
-    const freshCache = await fs.mkdtemp(path.join(os.tmpdir(), "eb-proxy-integration-"))
+    const freshCache = await tmpDir.createTempDir()
     vi.stubEnv("HTTPS_PROXY", `http://127.0.0.1:${proxy.port}`)
     vi.stubEnv("ELECTRON_BUILDER_CACHE", freshCache)
 

--- a/test/src/electronVersionTest.ts
+++ b/test/src/electronVersionTest.ts
@@ -1,5 +1,4 @@
 import * as nodeFs from "fs/promises"
-import * as os from "os"
 import * as path from "path"
 import { afterEach, beforeEach, describe, test, vi } from "vitest"
 import { log } from "builder-util"
@@ -22,16 +21,15 @@ function rangeErrorMessage(version: string): string {
 describe("getElectronVersion (version resolution from package.json)", { sequential: true }, () => {
   let tmpDir: string
 
-  beforeEach(async () => {
-    tmpDir = await nodeFs.mkdtemp(path.join(os.tmpdir(), "electron-version-test-"))
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
     // Spy on the shared log singleton so the same instance used by electronVersion.ts is intercepted.
     vi.spyOn(log, "error").mockImplementation(() => {})
     vi.spyOn(log, "info").mockImplementation(() => {})
     vi.spyOn(log, "warn").mockImplementation(() => {})
   })
 
-  afterEach(async () => {
-    await nodeFs.rm(tmpDir, { recursive: true, force: true })
+  afterEach(() => {
     vi.restoreAllMocks()
   })
 

--- a/test/src/extractArchiveTest.ts
+++ b/test/src/extractArchiveTest.ts
@@ -116,11 +116,8 @@ function buildZipWithSymlinkEntry(linkName: string, target: string): Buffer {
 
 describe("extractArchive ZIP security guards", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-extract-test-"))
-  })
-  afterEach(async () => {
-    await fs.rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   test("blocks a path traversal entry (../escape.txt)", async ({ expect }) => {
@@ -207,11 +204,8 @@ describe("isSafeExtractPath", () => {
 
 describe("moveDirAtomic", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-extract-test-"))
-  })
-  afterEach(async () => {
-    await fs.rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   test("moves a directory with files to the destination", async ({ expect }) => {

--- a/test/src/filesTest.ts
+++ b/test/src/filesTest.ts
@@ -1,4 +1,4 @@
-import { TmpDir, archFromString, copyDir } from "builder-util"
+import { archFromString, copyDir } from "builder-util"
 import { DIR_TARGET, Platform } from "electron-builder"
 import fsExtra from "fs-extra"
 import * as fs from "fs/promises"
@@ -230,8 +230,7 @@ test.ifNotWindows("extraResources - two-package", ({ expect }) => {
 
 // https://github.com/electron-userland/electron-builder/pull/998
 // copyDir walks to a symlink referencing a file that has not yet been copied by postponing the linking step until after the full walk is complete
-test.ifNotWindows("postpone symlink", async () => {
-  const tmpDir = new TmpDir("files-test")
+test.ifNotWindows("postpone symlink", async ({ tmpDir }) => {
   const source = await tmpDir.getTempDir()
   const aSourceFile = path.join(source, "z", "Z")
   const bSourceFileLink = path.join(source, "B")
@@ -240,8 +239,6 @@ test.ifNotWindows("postpone symlink", async () => {
 
   const dest = await tmpDir.getTempDir()
   await copyDir(source, dest)
-
-  await tmpDir.cleanup()
 })
 
 async function allCan(file: string, execute: boolean) {

--- a/test/src/fsTest.ts
+++ b/test/src/fsTest.ts
@@ -1,21 +1,16 @@
 import { ensureDir } from "builder-util/src/fs"
 import { vi } from "vitest"
 import * as fs from "fs/promises"
-import * as os from "os"
 import * as path from "path"
 
 const codeError = (code: string) => Object.assign(new Error(`${code}: simulated`), { code })
 
 describe("ensureDir", () => {
-  test("creates the directory (recursive) on the happy path", async ({ expect }) => {
-    const base = await fs.mkdtemp(path.join(os.tmpdir(), "eb-ensuredir-"))
-    try {
-      const nested = path.join(base, "a", "b", "c")
-      await ensureDir(nested)
-      expect((await fs.stat(nested)).isDirectory()).toBe(true)
-    } finally {
-      await fs.rm(base, { recursive: true, force: true })
-    }
+  test("creates the directory (recursive) on the happy path", async ({ expect, tmpDir }) => {
+    const base = await tmpDir.createTempDir()
+    const nested = path.join(base, "a", "b", "c")
+    await ensureDir(nested)
+    expect((await fs.stat(nested)).isDirectory()).toBe(true)
   })
 
   test("retries through the spurious ENOENT thrown by concurrent recursive mkdir", async ({ expect }) => {
@@ -26,15 +21,11 @@ describe("ensureDir", () => {
     expect(mkdir).toHaveBeenCalledTimes(3)
   })
 
-  test("treats a spurious EEXIST as success when the path is already a directory", async ({ expect }) => {
-    const base = await fs.mkdtemp(path.join(os.tmpdir(), "eb-ensuredir-"))
-    try {
-      // The dir genuinely exists (real fs.stat → directory); the race makes mkdir throw EEXIST.
-      const mkdir = vi.fn().mockRejectedValue(codeError("EEXIST"))
-      await expect(ensureDir(base, 8, mkdir)).resolves.toBeUndefined()
-    } finally {
-      await fs.rm(base, { recursive: true, force: true })
-    }
+  test("treats a spurious EEXIST as success when the path is already a directory", async ({ expect, tmpDir }) => {
+    const base = await tmpDir.createTempDir()
+    // The dir genuinely exists (real fs.stat → directory); the race makes mkdir throw EEXIST.
+    const mkdir = vi.fn().mockRejectedValue(codeError("EEXIST"))
+    await expect(ensureDir(base, 8, mkdir)).resolves.toBeUndefined()
   })
 
   test("gives up after maxAttempts so a persistent ENOENT is not masked forever", async ({ expect }) => {

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -145,16 +145,16 @@ export async function assertPack(expect: ExpectStatic, fixtureName: string, pack
   let configuration = packagerOptions.config as Configuration
   if (configuration == null) {
     configuration = {}
-      ; (packagerOptions as any).config = configuration
+    ;(packagerOptions as any).config = configuration
   }
 
   if (checkOptions.signedMac) {
-    packagerOptions = await signed(packagerOptions, 'mac')
+    packagerOptions = await signed(packagerOptions, "mac")
   } else if (process.env.CSC_LINK == null && process.platform === "darwin") {
     packagerOptions = deepAssign({}, packagerOptions, { config: { mac: { sign: { identity: null } } } })
   }
   if (checkOptions.signedWin) {
-    packagerOptions = await signed(packagerOptions, 'win')
+    packagerOptions = await signed(packagerOptions, "win")
   }
 
   let projectDir = path.join(__dirname, "..", "..", "fixtures", fixtureName)
@@ -445,7 +445,7 @@ async function packAndCheck(
 ): Promise<{ packager: Packager; outDir: string }> {
   const cancellationToken = new CancellationToken()
   const packager = new Packager(packagerOptions, cancellationToken)
-    ; (packager as any).runtimeEnvironmentVariables = runtimeEnv
+  ;(packager as any).runtimeEnvironmentVariables = runtimeEnv
   const publishManager = new PublishManager(packager, { publish: "publish" in checkOptions ? checkOptions.publish : "never" })
 
   const artifacts: Map<Platform, Array<ArtifactCreated>> = new Map()
@@ -628,7 +628,7 @@ async function checkMacResult(expect: ExpectStatic, packager: Packager, packager
 
   if (checksumData != null) {
     for (const name of Object.keys(checksumData)) {
-      ; (checksumData as Record<string, any>)[name] = { algorithm: "SHA256", hash: "hash" }
+      ;(checksumData as Record<string, any>)[name] = { algorithm: "SHA256", hash: "hash" }
     }
     snapshot.ElectronAsarIntegrity = checksumData
   }
@@ -836,8 +836,8 @@ export async function getWindowsSigningIdentity(): Promise<SelfSignedIdentity> {
   return await winSigningCredentialsInfo.value
 }
 
-async function signed(packagerOptions: PackagerOptions, platform: 'win' | 'mac'): Promise<PackagerOptions> {
-  if (platform === 'mac' && process.platform !== "darwin") {
+async function signed(packagerOptions: PackagerOptions, platform: "win" | "mac"): Promise<PackagerOptions> {
+  if (platform === "mac" && process.platform !== "darwin") {
     // codesign only runs on macOS; off-darwin the build is left unsigned (mac signing tests are .ifMac-gated).
     // Also avoids generating a self-signed identity (and spawning openssl) where it isn't available — e.g. the
     // minimal Linux package-manager updater containers that have no openssl on PATH.
@@ -848,7 +848,7 @@ async function signed(packagerOptions: PackagerOptions, platform: 'win' | 'mac')
   // app comes out unsigned and the signing assertions fail with "code object is not signed at all". These are
   // our own builds with an ephemeral identity, so opt back into signing for the test.
   process.env.CSC_FOR_PULL_REQUEST = "true"
-  const { p12Base64, password } = platform === 'mac' ? await getMacSigningIdentity() : await getWindowsSigningIdentity()
+  const { p12Base64, password } = platform === "mac" ? await getMacSigningIdentity() : await getWindowsSigningIdentity()
   const options = deepAssign<PackagerOptions>({}, packagerOptions, { config: { cscLink: p12Base64, cscKeyPassword: password } })
   return options
 }

--- a/test/src/iconConverterTest.ts
+++ b/test/src/iconConverterTest.ts
@@ -1,8 +1,7 @@
 import { deflateSync } from "zlib"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises"
-import * as os from "os"
+import { mkdir, readFile, writeFile } from "fs/promises"
 import * as path from "path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 import { buildSourceCandidates, convertIcon, getPngSize } from "app-builder-lib/internal"
 
 const FIXTURES = path.join(__dirname, "../fixtures")
@@ -94,11 +93,8 @@ function parseIcns(data: Buffer): Map<string, Buffer> {
 
 describe("convertIcon – ICNS output", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "icon-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   it("converts a 512×512 PNG to a valid ICNS file", async () => {
@@ -193,11 +189,8 @@ describe("convertIcon – ICNS output", { sequential: true }, () => {
 
 describe("convertIcon – ICO output", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "icon-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   it("converts a 512×512 PNG to a valid ICO file", async () => {
@@ -292,11 +285,8 @@ describe("convertIcon – ICO output", { sequential: true }, () => {
 
 describe("convertIcon – set output (Linux)", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "icon-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   it("returns source PNG directly for set format (matches Go behavior)", async () => {
@@ -386,11 +376,8 @@ describe("convertIcon – set output (Linux)", { sequential: true }, () => {
 
 describe("convertIcon – file resolution", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "icon-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   it("resolves icon by name from roots directory", async () => {
@@ -431,11 +418,8 @@ describe("convertIcon – file resolution", { sequential: true }, () => {
 
 describe("convertIcon – collectIconsFromDir filename filtering", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "icon-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   it("only picks up files with a pure-digit basename (anchored regex)", async () => {
@@ -548,11 +532,8 @@ describe("buildSourceCandidates", () => {
 
 describe("getPngSize", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "icon-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   it("reads correct dimensions from a well-formed PNG", async () => {
@@ -586,11 +567,8 @@ describe("getPngSize", { sequential: true }, () => {
 
 describe("convertIcon – edge cases", { sequential: true }, () => {
   let tmpDir: string
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "icon-test-"))
-  })
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   it("resolves source by absolute path, ignoring roots", async () => {

--- a/test/src/linux/appImageTest.ts
+++ b/test/src/linux/appImageTest.ts
@@ -1,18 +1,11 @@
 import { Platform } from "app-builder-lib"
 import { copyMimeTypes, validateCriticalPathString } from "app-builder-lib/internal"
-import { Arch, InvalidConfigurationError, TmpDir } from "builder-util"
+import { Arch, InvalidConfigurationError } from "builder-util"
 import { execSync, spawnSync } from "child_process"
 import * as fs from "fs-extra"
 import * as path from "path"
-import { afterAll } from "vitest"
 import { assertPack } from "../helpers/packTester"
 import { verifyAsarFileTree } from "../helpers/asarVerifier"
-
-const tmpDir = new TmpDir("appimage-env-test")
-
-afterAll(async () => {
-  await tmpDir.cleanup()
-})
 
 describe("validateCriticalPathString", () => {
   test("rejects double quotes", ({ expect }) => {
@@ -59,7 +52,7 @@ describe("validateCriticalPathString", () => {
 describe("copyMimeTypes - invalid extension handling", () => {
   const valid = { mimeType: "application/x-test", ext: "txt" }
   const invalid = { mimeType: "application/x-test", ext: "my ext" }
-  test("skips extension containing a space", async ({ expect }) => {
+  test("skips extension containing a space", async ({ expect, tmpDir }) => {
     const dir = await tmpDir.getTempDir({ prefix: "mime-types-test" })
     const result = await copyMimeTypes(dir, {
       fileAssociations: [invalid, valid],
@@ -71,7 +64,7 @@ describe("copyMimeTypes - invalid extension handling", () => {
     expect(xml).not.toContain('<glob pattern="*.my ext"/>')
   })
 
-  test("includes valid alphanumeric extensions in the XML glob", async ({ expect }) => {
+  test("includes valid alphanumeric extensions in the XML glob", async ({ expect, tmpDir }) => {
     const dir = await tmpDir.getTempDir({ prefix: "mime-types-test" })
     const result = await copyMimeTypes(dir, {
       fileAssociations: [valid],
@@ -85,7 +78,7 @@ describe("copyMimeTypes - invalid extension handling", () => {
 })
 
 describe.heavy.ifLinux("AppImage", () => {
-  test.ifEnv(process.env.RUN_APP_IMAGE_TEST === "true")("AppRun entrypoint", async ({ expect }) => {
+  test.ifEnv(process.env.RUN_APP_IMAGE_TEST === "true")("AppRun entrypoint", async ({ expect, tmpDir }) => {
     await assertPack(
       expect,
       "test-app",

--- a/test/src/mac/dmgLicenseTest.ts
+++ b/test/src/mac/dmgLicenseTest.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test } from "vitest"
 import * as fs from "fs/promises"
-import * as os from "os"
 import * as path from "path"
 import { statSync } from "fs"
 
@@ -54,12 +53,8 @@ async function writeJson(dir: string, name: string, obj: object) {
 describe("addLicenseToDmg", { sequential: true }, () => {
   let tmpDir: string
 
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dmg-license-test-"))
-  })
-
-  afterEach(async () => {
-    await fs.rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   test("returns null when no license files are present", async () => {

--- a/test/src/mac/macCodeSignTest.ts
+++ b/test/src/mac/macCodeSignTest.ts
@@ -1,21 +1,16 @@
 import { createKeychain, removeKeychain } from "app-builder-lib/internal"
-import { removePassword, TmpDir } from "builder-util"
+import { removePassword } from "builder-util"
 import { getMacSigningIdentity } from "../helpers/packTester.js"
-import { afterEach } from "vitest"
 
 describe.ifMac("macos keychain", { sequential: true }, () => {
-  const tmpDir = new TmpDir("mac-code-sign-test")
-
-  afterEach(() => tmpDir.cleanup())
-
-  test("create keychain", async ({ expect }) => {
+  test("create keychain", async ({ expect, tmpDir }) => {
     const { p12Base64, password } = await getMacSigningIdentity()
     const result = await createKeychain({ tmpDir, cscLink: p12Base64, cscKeyPassword: password, currentDir: process.cwd() })
     expect(result.keychainFile).not.toEqual("")
     await removeKeychain(result.keychainFile!)
   })
 
-  test("create keychain with installers", async ({ expect }) => {
+  test("create keychain with installers", async ({ expect, tmpDir }) => {
     const { p12Base64, password } = await getMacSigningIdentity()
     const result = await createKeychain({ tmpDir, cscLink: p12Base64, cscKeyPassword: password, currentDir: process.cwd() })
     expect(result.keychainFile).not.toEqual("")

--- a/test/src/mac/selfSignedIdentityTest.ts
+++ b/test/src/mac/selfSignedIdentityTest.ts
@@ -9,15 +9,13 @@ import { createSelfSignedCodeSigningIdentity } from "../helpers/selfSignedIdenti
 // enabled. There is intentionally no env var or build-config option to enable it in production. No keychain
 // trust / sudo is required.
 describe.ifMac("self-signed identity discovery", { sequential: true }, () => {
-  const tmpDir = new TmpDir("self-signed-identity-test")
   const qualifier = "EB Test (TEAMID1234)"
 
   afterEach(() => {
     setAllowUntrustedSelfSignedIdentityForTesting(false)
-    return tmpDir.cleanup()
   })
 
-  async function importSelfSignedKeychain() {
+  async function importSelfSignedKeychain(tmpDir: TmpDir) {
     // legacy SHA1/3DES p12 — required for Apple's `security import` (used by createKeychain below).
     const identity = await createSelfSignedCodeSigningIdentity(`Developer ID Application: ${qualifier}`, tmpDir, { legacy: true })
     const { keychainFile } = await createKeychain({
@@ -29,9 +27,9 @@ describe.ifMac("self-signed identity discovery", { sequential: true }, () => {
     return { identity, keychainFile: keychainFile! }
   }
 
-  test("untrusted self-signed identity is ignored by default", async ({ expect }) => {
+  test("untrusted self-signed identity is ignored by default", async ({ expect, tmpDir }) => {
     setAllowUntrustedSelfSignedIdentityForTesting(false)
-    const { keychainFile } = await importSelfSignedKeychain()
+    const { keychainFile } = await importSelfSignedKeychain(tmpDir)
     try {
       const found = await findIdentity("Developer ID Application", qualifier, keychainFile)
       expect(found).toBeNull()
@@ -40,9 +38,9 @@ describe.ifMac("self-signed identity discovery", { sequential: true }, () => {
     }
   })
 
-  test("untrusted self-signed identity is found when the test seam is enabled", async ({ expect }) => {
+  test("untrusted self-signed identity is found when the test seam is enabled", async ({ expect, tmpDir }) => {
     setAllowUntrustedSelfSignedIdentityForTesting(true)
-    const { identity, keychainFile } = await importSelfSignedKeychain()
+    const { identity, keychainFile } = await importSelfSignedKeychain(tmpDir)
     try {
       const found = await findIdentity("Developer ID Application", qualifier, keychainFile)
       expect(found).not.toBeNull()

--- a/test/src/node-module-collector/moduleManagerTest.ts
+++ b/test/src/node-module-collector/moduleManagerTest.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, test } from "vitest"
 import * as fse from "fs-extra"
-import * as os from "os"
 import * as path from "path"
 import { ModuleManager, LogMessageByKey } from "app-builder-lib/src/node-module-collector/moduleManager"
+import { TmpDir } from "temp-file"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -12,8 +12,10 @@ import { ModuleManager, LogMessageByKey } from "app-builder-lib/src/node-module-
  * Writes a minimal package.json tree under a temp root and returns the root
  * path. The `packages` map is keyed by relative path from the root.
  */
+const projectTmpDir = new TmpDir("eb-mm-test")
+
 async function buildTempTree(packages: Record<string, { name: string; version: string; dependencies?: Record<string, string> }>): Promise<string> {
-  const root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-mm-test-"))
+  const root = await projectTmpDir.createTempDir()
   for (const [rel, pkg] of Object.entries(packages)) {
     const absPath = path.join(root, rel)
     await fse.ensureDir(path.dirname(absPath))

--- a/test/src/node-module-collector/pnpmHoistedTest.ts
+++ b/test/src/node-module-collector/pnpmHoistedTest.ts
@@ -1,6 +1,5 @@
 import { describe, test, vi, afterEach } from "vitest"
 import * as fse from "fs-extra"
-import * as os from "os"
 import * as path from "path"
 import { ModuleManager } from "app-builder-lib/src/node-module-collector/moduleManager"
 import { PnpmNodeModulesCollector } from "app-builder-lib/internal"
@@ -10,8 +9,10 @@ import { TmpDir } from "temp-file"
 // Helpers
 // ---------------------------------------------------------------------------
 
+const projectTmpDir = new TmpDir("eb-pnpm-hoisted-test")
+
 async function buildTempTree(packages: Record<string, { name: string; version: string; dependencies?: Record<string, string> }>): Promise<string> {
-  const root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-pnpm-hoisted-test-"))
+  const root = await projectTmpDir.createTempDir()
   for (const [rel, pkg] of Object.entries(packages)) {
     const absPath = path.join(root, rel)
     await fse.ensureDir(path.dirname(absPath))
@@ -96,11 +97,6 @@ describe("PnpmNodeModulesCollector hoisted mode", { sequential: true }, () => {
 
 describe("PnpmNodeModulesCollector.isHoisted (on-disk layout detection)", { sequential: true }, () => {
   let root = ""
-  afterEach(async () => {
-    if (root) {
-      await fse.rm(root, { recursive: true, force: true })
-    }
-  })
 
   const makeCollector = (rootDir: string): any => new (PnpmNodeModulesCollector as any)(rootDir, new TmpDir("test"))
 
@@ -113,22 +109,22 @@ describe("PnpmNodeModulesCollector.isHoisted (on-disk layout detection)", { sequ
     await fse.ensureSymlink(real, path.join(rootDir, "node_modules", name), "junction")
   }
 
-  test("returns false for the isolated .pnpm store (top-level package routes through .pnpm)", async ({ expect }) => {
-    root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-ishoisted-iso-"))
+  test("returns false for the isolated .pnpm store (top-level package routes through .pnpm)", async ({ expect, tmpDir }) => {
+    root = await tmpDir.createTempDir()
     await addIsolatedPackage(root, "fs-extra", "11.3.5")
     expect(await makeCollector(root).isHoisted.value).toBe(false)
   })
 
-  test("returns true for a hoisted layout (top-level package is a real directory)", async ({ expect }) => {
-    root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-ishoisted-ho-"))
+  test("returns true for a hoisted layout (top-level package is a real directory)", async ({ expect, tmpDir }) => {
+    root = await tmpDir.createTempDir()
     const dir = path.join(root, "node_modules", "fs-extra")
     await fse.ensureDir(dir)
     await fse.writeJson(path.join(dir, "package.json"), { name: "fs-extra", version: "11.3.5" })
     expect(await makeCollector(root).isHoisted.value).toBe(true)
   })
 
-  test("ignores link: packages (which resolve outside .pnpm) and still detects the isolated store", async ({ expect }) => {
-    root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-ishoisted-link-"))
+  test("ignores link: packages (which resolve outside .pnpm) and still detects the isolated store", async ({ expect, tmpDir }) => {
+    root = await tmpDir.createTempDir()
     // a link: dep resolves to a source dir outside node_modules — never under .pnpm
     const linkSrc = path.join(root, "packages", "my-linked")
     await fse.ensureDir(linkSrc)
@@ -139,8 +135,8 @@ describe("PnpmNodeModulesCollector.isHoisted (on-disk layout detection)", { sequ
     expect(await makeCollector(root).isHoisted.value).toBe(false)
   })
 
-  test("returns false when node_modules is empty or missing (flat default)", async ({ expect }) => {
-    root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-ishoisted-empty-"))
+  test("returns false when node_modules is empty or missing (flat default)", async ({ expect, tmpDir }) => {
+    root = await tmpDir.createTempDir()
     expect(await makeCollector(root).isHoisted.value).toBe(false)
   })
 })

--- a/test/src/node-module-collector/pnpmLinkDependencyTest.ts
+++ b/test/src/node-module-collector/pnpmLinkDependencyTest.ts
@@ -1,4 +1,4 @@
-import { describe, test, afterEach } from "vitest"
+import { describe, test } from "vitest"
 import * as fse from "fs-extra"
 import * as os from "os"
 import * as path from "path"
@@ -56,11 +56,6 @@ describe("PnpmNodeModulesCollector.resolveLinkTarget", () => {
 
 describe("PnpmNodeModulesCollector link: dependency bundling", () => {
   let root = ""
-  afterEach(async () => {
-    if (root) {
-      await fse.rm(root, { recursive: true, force: true }).catch(() => {})
-    }
-  })
 
   function flattenNames(deps: any[]): string[] {
     const names = new Set<string>()
@@ -77,8 +72,8 @@ describe("PnpmNodeModulesCollector link: dependency bundling", () => {
     return [...names].sort()
   }
 
-  test("bundles a link: package and its transitive deps, resolved to the real source dir", async ({ expect }) => {
-    root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-link-dep-"))
+  test("bundles a link: package and its transitive deps, resolved to the real source dir", async ({ expect, tmpDir }) => {
+    root = await tmpDir.createTempDir()
     const appDir = path.join(root, "app")
     await fse.ensureDir(appDir)
 

--- a/test/src/node-module-collector/traversalCollectorTest.ts
+++ b/test/src/node-module-collector/traversalCollectorTest.ts
@@ -1,10 +1,9 @@
 import { afterEach, describe, test, vi } from "vitest"
 import * as fse from "fs-extra"
-import * as os from "os"
 import * as path from "path"
 import { TraversalNodeModulesCollector } from "app-builder-lib/internal"
 import { LogMessageByKey } from "app-builder-lib/src/node-module-collector/moduleManager"
-import type { TmpDir } from "builder-util"
+import { TmpDir } from "builder-util"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,8 +16,10 @@ const mockTmpDir = { getTempFile: vi.fn(), getTempDir: vi.fn() } as unknown as T
  * Writes a package tree under a fresh temp directory.
  * Keys are relative paths to package.json files; values are the JSON contents.
  */
+const projectTmpDir = new TmpDir("eb-traversal-test")
+
 async function buildPackageTree(packages: Record<string, object>): Promise<string> {
-  const root = await fse.mkdtemp(path.join(os.tmpdir(), "eb-traversal-test-"))
+  const root = await projectTmpDir.createTempDir()
   for (const [rel, json] of Object.entries(packages)) {
     const abs = path.join(root, rel)
     await fse.ensureDir(path.dirname(abs))

--- a/test/src/publisher/snap/SnapStorePublisherTest.ts
+++ b/test/src/publisher/snap/SnapStorePublisherTest.ts
@@ -251,19 +251,14 @@ describe("SnapStorePublisher", { sequential: true }, () => {
       await expect(makePublisher(undefined, emptyBase64).upload(makeTask())).rejects.toThrow(/empty/)
     })
 
-    test("absolute file path → reads file and injects credentials", async ({ expect }) => {
-      const { writeFile, mkdtemp, rm } = await import("fs/promises")
-      const { tmpdir } = await import("os")
-      const dir = await mkdtemp(`${tmpdir()}/snap-csc-test-`)
+    test("absolute file path → reads file and injects credentials", async ({ expect, tmpDir }) => {
+      const { writeFile } = await import("fs/promises")
+      const dir = await tmpDir.createTempDir()
       const file = `${dir}/creds.txt`
-      try {
-        await writeFile(file, CREDS, "utf8")
-        await makePublisher(undefined, file).upload(makeTask())
-        const spawnEnv = vi.mocked(spawn).mock.calls[0][2] as any
-        expect(spawnEnv.env.SNAPCRAFT_STORE_CREDENTIALS).toBe(CREDS)
-      } finally {
-        await rm(dir, { recursive: true })
-      }
+      await writeFile(file, CREDS, "utf8")
+      await makePublisher(undefined, file).upload(makeTask())
+      const spawnEnv = vi.mocked(spawn).mock.calls[0][2] as any
+      expect(spawnEnv.env.SNAPCRAFT_STORE_CREDENTIALS).toBe(CREDS)
     })
   })
 

--- a/test/src/s3PublishTest.ts
+++ b/test/src/s3PublishTest.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events"
-import * as os from "os"
 import * as path from "path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -221,19 +220,17 @@ describe("BaseS3Publisher.upload — key construction and S3 request", { sequent
   let tmpDir: string
   let testFile: string
 
-  beforeEach(async () => {
+  beforeEach(async context => {
     vi.mocked(https.request).mockClear()
-    const { mkdtemp, writeFile } = await import("fs/promises")
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "s3-upload-test-"))
+    const { writeFile } = await import("fs/promises")
+    tmpDir = await context.tmpDir.createTempDir()
     testFile = path.join(tmpDir, "MyApp-1.0.0.exe")
     await writeFile(testFile, "fake exe content")
     delete process.env.__TEST_S3_PUBLISHER__
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     delete process.env.__TEST_S3_PUBLISHER__
-    const { rm } = await import("fs/promises")
-    await rm(tmpDir, { recursive: true, force: true })
     vi.clearAllMocks()
   })
 
@@ -365,22 +362,19 @@ describe("BaseS3Publisher.upload — __TEST_S3_PUBLISHER__ bypass", { sequential
   let srcDir: string
   let srcFile: string
 
-  beforeEach(async () => {
+  beforeEach(async context => {
     vi.mocked(https.request).mockClear()
-    const { mkdtemp, writeFile } = await import("fs/promises")
+    const { writeFile } = await import("fs/promises")
     // Keep source file and destination dir separate so symlink(src, dest) doesn't collide
-    testPublisherDir = await mkdtemp(path.join(os.tmpdir(), "s3-test-publisher-"))
-    srcDir = await mkdtemp(path.join(os.tmpdir(), "s3-src-"))
+    testPublisherDir = await context.tmpDir.createTempDir()
+    srcDir = await context.tmpDir.createTempDir()
     srcFile = path.join(srcDir, "source.exe")
     await writeFile(srcFile, "fake content")
     process.env.__TEST_S3_PUBLISHER__ = testPublisherDir
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     delete process.env.__TEST_S3_PUBLISHER__
-    const { rm } = await import("fs/promises")
-    await rm(testPublisherDir, { recursive: true, force: true })
-    await rm(srcDir, { recursive: true, force: true })
     vi.clearAllMocks()
   })
 
@@ -411,18 +405,16 @@ describe("publish-s3 parity — Go binary flag mapping to HTTP request", { seque
   let tmpDir: string
   let testFile: string
 
-  beforeEach(async () => {
+  beforeEach(async context => {
     vi.mocked(https.request).mockClear()
-    const { mkdtemp, writeFile } = await import("fs/promises")
-    tmpDir = await mkdtemp(path.join(os.tmpdir(), "s3-parity-test-"))
+    const { writeFile } = await import("fs/promises")
+    tmpDir = await context.tmpDir.createTempDir()
     testFile = path.join(tmpDir, "TestApp-1.0.0-setup.exe")
     await writeFile(testFile, "x")
     delete process.env.__TEST_S3_PUBLISHER__
   })
 
-  afterEach(async () => {
-    const { rm } = await import("fs/promises")
-    await rm(tmpDir, { recursive: true, force: true })
+  afterEach(() => {
     vi.clearAllMocks()
   })
 

--- a/test/src/updateInfoBuilderTest.ts
+++ b/test/src/updateInfoBuilderTest.ts
@@ -1,9 +1,8 @@
 import * as fsp from "fs/promises"
-import * as os from "os"
 import * as path from "path"
 import { createUpdateInfoTasks, writeUpdateInfoFiles, UpdateInfoFileTask } from "app-builder-lib/internal"
 import { Platform } from "app-builder-lib"
-import { Arch } from "builder-util"
+import { Arch, TmpDir } from "builder-util"
 import { load as yamlLoad } from "js-yaml"
 import { vi } from "vitest"
 
@@ -29,11 +28,11 @@ function makePackager() {
 }
 
 async function withTmpDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "eb-updateinfo-"))
+  const tmpDir = new TmpDir("eb-updateinfo")
   try {
-    return await fn(dir)
+    return await fn(await tmpDir.createTempDir())
   } finally {
-    await fsp.rm(dir, { recursive: true })
+    await tmpDir.cleanup()
   }
 }
 

--- a/test/src/updater/blackboxInstallTest.ts
+++ b/test/src/updater/blackboxInstallTest.ts
@@ -2,7 +2,7 @@ import { AppImageOptions, Configuration, DebOptions, PacmanOptions, RpmOptions, 
 import { PM } from "app-builder-lib/internal"
 import { Arch, Platform } from "electron-builder"
 import { DebUpdater, PacmanUpdater, RpmUpdater } from "electron-updater"
-import { archFromString, log, spawn, TmpDir } from "builder-util"
+import { archFromString, log, spawn } from "builder-util"
 import { deepAssign, GenericServerOptions } from "builder-util-runtime"
 import { execSync } from "child_process"
 import { move, outputFile, readJsonSync } from "fs-extra"
@@ -85,183 +85,178 @@ describe.heavy.ifLinux("linux install", optionsForInstall, () => {
 })
 
 async function runInstallTest(context: TestContext, target: ConstructorParameters<typeof Target>[0], arch: Arch, extraConfig: Configuration): Promise<void> {
-  const { expect } = context
-  const tmpDir = new TmpDir("blackbox-install-test")
+  const { expect, tmpDir } = context
 
-  try {
-    let artifactsDir: string | undefined
+  let artifactsDir: string | undefined
 
-    const config = deepAssign<Configuration>(
-      {
-        nativeModules: { npmRebuild: true },
-        productName: "TestApp",
-        executableName: "TestApp",
-        appId: "com.test.app",
-        artifactName: "${productName}.${ext}",
-        electronLanguages: ["en"],
-        extraMetadata: {
-          name: "testapp",
-          version: OLD_VERSION_NUMBER,
-        },
-        electronUpdaterCompatibility: "1.1",
-        electronFuses: {
-          runAsNode: false,
-          enableCookieEncryption: false, // don't enable cookie encryption for testing because it adds an additional decryption step to the update process which requires user interaction to unlock the keychain on macOS and can cause timeouts in CI, especially on older macOS versions with slower crypto performance
-          enableNodeOptionsEnvironmentVariable: false,
-          enableNodeCliInspectArguments: false,
-          enableEmbeddedAsarIntegrityValidation: true,
-          onlyLoadAppFromAsar: true,
-          loadBrowserProcessSpecificV8Snapshot: false,
-          grantFileProtocolExtraPrivileges: false,
-        },
-        publish: {
-          provider: "s3",
-          bucket: "develar",
-          path: "test",
-        },
-        files: ["**/*", "../**/node_modules/**", "!path/**"],
+  const config = deepAssign<Configuration>(
+    {
+      nativeModules: { npmRebuild: true },
+      productName: "TestApp",
+      executableName: "TestApp",
+      appId: "com.test.app",
+      artifactName: "${productName}.${ext}",
+      electronLanguages: ["en"],
+      extraMetadata: {
+        name: "testapp",
+        version: OLD_VERSION_NUMBER,
       },
-      extraConfig
-    )
-    await assertPack(
-      expect,
-      "test-app",
-      {
-        targets: Platform.LINUX.createTarget(target, arch),
-        config,
+      electronUpdaterCompatibility: "1.1",
+      electronFuses: {
+        runAsNode: false,
+        enableCookieEncryption: false, // don't enable cookie encryption for testing because it adds an additional decryption step to the update process which requires user interaction to unlock the keychain on macOS and can cause timeouts in CI, especially on older macOS versions with slower crypto performance
+        enableNodeOptionsEnvironmentVariable: false,
+        enableNodeCliInspectArguments: false,
+        enableEmbeddedAsarIntegrityValidation: true,
+        onlyLoadAppFromAsar: true,
+        loadBrowserProcessSpecificV8Snapshot: false,
+        grantFileProtocolExtraPrivileges: false,
       },
-      {
-        storeDepsLockfileSnapshot: false,
-        packageManager: PM.PNPM,
-        packed: async (ctx: PackedContext) => {
-          artifactsDir = await tmpDir.getTempDir({ prefix: "artifacts" })
-          await move(ctx.outDir, artifactsDir)
-        },
-        projectDirCreated: async (projectDir, _tmpDir, runtimeEnv) => {
-          // Write .npmrc to app/ — installDependencies runs pnpm with cwd=appDir, so pnpm 10
-          // reads this file and uses hoisted layout for the main install.
-          await outputFile(path.join(projectDir, "app", ".npmrc"), "node-linker=hoisted")
-
-          await modifyPackageJson(
-            projectDir,
-            data => {
-              data.devDependencies = {
-                electron: ELECTRON_VERSION,
-                "node-addon-api": "^8",
-              }
-              const ebPackagePath = (pkg: string) => path.resolve(__dirname, "../../../packages", pkg)
-              const updaterPath = ebPackagePath("electron-updater")
-              const utilPath = ebPackagePath("builder-util-runtime")
-              data.dependencies = {
-                ...data.dependencies,
-                sqlite3: "5.1.7",
-                "@electron/remote": "2.1.3",
-                "electron-updater": `link:${updaterPath}`,
-                ...readJsonSync(path.join(updaterPath, "package.json")).dependencies,
-                "builder-util-runtime": `link:${utilPath}`,
-                ...readJsonSync(path.join(utilPath, "package.json")).dependencies,
-              }
-            },
-            true
-          )
-          await modifyPackageJson(
-            projectDir,
-            data => {
-              data.pnpm = {
-                supportedArchitectures: {
-                  os: ["current"],
-                  cpu: ["x64", "arm64"],
-                },
-              }
-            },
-            false
-          )
-          // Return a post-install hook so the explicit flag runs AFTER installDependencies.
-          // pnpm 11 ignores node-linker from .npmrc; the CLI flag here handles that case.
-          return async () => {
-            await spawn("pnpm", ["install", "--config.node-linker=hoisted"], { cwd: path.join(projectDir, "app"), env: runtimeEnv })
-          }
-        },
-      }
-    )
-
-    if (!artifactsDir) {
-      throw new Error("Build did not produce an artifacts directory")
-    }
-
-    let appPath: string
-
-    if (target === "appImage") {
-      const artifactPath = path.join(artifactsDir, "TestApp.AppImage")
-
-      // Verify the compression header in the squashfs superblock matches the configured value
-      const actualCompression = await readAppImageCompression(artifactPath)
-      expect(actualCompression).toMatchSnapshot()
-
-      appPath = artifactPath
-    } else if (target === "deb") {
-      const debPath = path.join(artifactsDir, "TestApp.deb")
-      const actualCompression = await readDebCompression(debPath)
-      expect(actualCompression).toMatchSnapshot()
-      DebUpdater.installWithCommandRunner(
-        "dpkg",
-        debPath,
-        commandWithArgs => {
-          execSync(commandWithArgs.join(" "), { stdio: "inherit" })
-        },
-        console
-      )
-      appPath = "/opt/TestApp/TestApp"
-    } else if (target === "rpm") {
-      RpmUpdater.installWithCommandRunner(
-        "zypper",
-        path.join(artifactsDir, "TestApp.rpm"),
-        commandWithArgs => {
-          execSync(commandWithArgs.join(" "), { stdio: "inherit" })
-        },
-        console
-      )
-      appPath = "/opt/TestApp/TestApp"
-    } else if (target === "pacman") {
-      PacmanUpdater.installWithCommandRunner(
-        path.join(artifactsDir, "TestApp.pacman"),
-        commandWithArgs => {
-          execSync(commandWithArgs.join(" "), { stdio: "inherit" })
-        },
-        console
-      )
-      appPath = "/opt/TestApp/TestApp"
-    } else {
-      throw new Error(`Unsupported install test target: ${target}`)
-    }
-
-    // A dummy update config is required by launchAndWaitForQuit even when the updater is disabled.
-    // AUTO_UPDATER_TEST="" makes the test app print its version and exit immediately.
-    const updateConfigPath = await writeUpdateConfig<GenericServerOptions>({ provider: "generic", url: "http://localhost:0" })
-
-    const appimageToolset = (extraConfig as any).toolsets?.appimage
-    // FUSE2 AppImages require /dev/fuse to mount their squashfs, which isn't available in standard
-    // Docker containers. APPIMAGE_EXTRACT_AND_RUN=1 tells the legacy runtime to extract and run
-    // without FUSE, avoiding the "Syntax error" shell-fallback failure.
-    const isLegacyToolset = appimageToolset == null || appimageToolset === "0.0.0"
-    const result = await launchAndWaitForQuit({
-      appPath,
-      timeoutMs: 2 * 60 * 1000,
-      updateConfigPath,
-      packageManagerToTest: "",
-      env: {
-        AUTO_UPDATER_TEST: "",
-        ...(isLegacyToolset ? { APPIMAGE_EXTRACT_AND_RUN: "1" } : {}),
+      publish: {
+        provider: "s3",
+        bucket: "develar",
+        path: "test",
       },
-      waitForExit: true,
-    })
+      files: ["**/*", "../**/node_modules/**", "!path/**"],
+    },
+    extraConfig
+  )
+  await assertPack(
+    expect,
+    "test-app",
+    {
+      targets: Platform.LINUX.createTarget(target, arch),
+      config,
+    },
+    {
+      storeDepsLockfileSnapshot: false,
+      packageManager: PM.PNPM,
+      packed: async (ctx: PackedContext) => {
+        artifactsDir = await tmpDir.getTempDir({ prefix: "artifacts" })
+        await move(ctx.outDir, artifactsDir)
+      },
+      projectDirCreated: async (projectDir, _tmpDir, runtimeEnv) => {
+        // Write .npmrc to app/ — installDependencies runs pnpm with cwd=appDir, so pnpm 10
+        // reads this file and uses hoisted layout for the main install.
+        await outputFile(path.join(projectDir, "app", ".npmrc"), "node-linker=hoisted")
 
-    log.info({ version: result.version, compression: config[target]?.compression ?? config.compression, target }, "Install test launch completed")
-    if (result.version == null) {
-      throw new Error("App did not report version after launch")
+        await modifyPackageJson(
+          projectDir,
+          data => {
+            data.devDependencies = {
+              electron: ELECTRON_VERSION,
+              "node-addon-api": "^8",
+            }
+            const ebPackagePath = (pkg: string) => path.resolve(__dirname, "../../../packages", pkg)
+            const updaterPath = ebPackagePath("electron-updater")
+            const utilPath = ebPackagePath("builder-util-runtime")
+            data.dependencies = {
+              ...data.dependencies,
+              sqlite3: "5.1.7",
+              "@electron/remote": "2.1.3",
+              "electron-updater": `link:${updaterPath}`,
+              ...readJsonSync(path.join(updaterPath, "package.json")).dependencies,
+              "builder-util-runtime": `link:${utilPath}`,
+              ...readJsonSync(path.join(utilPath, "package.json")).dependencies,
+            }
+          },
+          true
+        )
+        await modifyPackageJson(
+          projectDir,
+          data => {
+            data.pnpm = {
+              supportedArchitectures: {
+                os: ["current"],
+                cpu: ["x64", "arm64"],
+              },
+            }
+          },
+          false
+        )
+        // Return a post-install hook so the explicit flag runs AFTER installDependencies.
+        // pnpm 11 ignores node-linker from .npmrc; the CLI flag here handles that case.
+        return async () => {
+          await spawn("pnpm", ["install", "--config.node-linker=hoisted"], { cwd: path.join(projectDir, "app"), env: runtimeEnv })
+        }
+      },
     }
-    expect(result.version).toMatch(OLD_VERSION_NUMBER)
-  } finally {
-    await tmpDir.cleanup()
+  )
+
+  if (!artifactsDir) {
+    throw new Error("Build did not produce an artifacts directory")
   }
+
+  let appPath: string
+
+  if (target === "appImage") {
+    const artifactPath = path.join(artifactsDir, "TestApp.AppImage")
+
+    // Verify the compression header in the squashfs superblock matches the configured value
+    const actualCompression = await readAppImageCompression(artifactPath)
+    expect(actualCompression).toMatchSnapshot()
+
+    appPath = artifactPath
+  } else if (target === "deb") {
+    const debPath = path.join(artifactsDir, "TestApp.deb")
+    const actualCompression = await readDebCompression(debPath)
+    expect(actualCompression).toMatchSnapshot()
+    DebUpdater.installWithCommandRunner(
+      "dpkg",
+      debPath,
+      commandWithArgs => {
+        execSync(commandWithArgs.join(" "), { stdio: "inherit" })
+      },
+      console
+    )
+    appPath = "/opt/TestApp/TestApp"
+  } else if (target === "rpm") {
+    RpmUpdater.installWithCommandRunner(
+      "zypper",
+      path.join(artifactsDir, "TestApp.rpm"),
+      commandWithArgs => {
+        execSync(commandWithArgs.join(" "), { stdio: "inherit" })
+      },
+      console
+    )
+    appPath = "/opt/TestApp/TestApp"
+  } else if (target === "pacman") {
+    PacmanUpdater.installWithCommandRunner(
+      path.join(artifactsDir, "TestApp.pacman"),
+      commandWithArgs => {
+        execSync(commandWithArgs.join(" "), { stdio: "inherit" })
+      },
+      console
+    )
+    appPath = "/opt/TestApp/TestApp"
+  } else {
+    throw new Error(`Unsupported install test target: ${target}`)
+  }
+
+  // A dummy update config is required by launchAndWaitForQuit even when the updater is disabled.
+  // AUTO_UPDATER_TEST="" makes the test app print its version and exit immediately.
+  const updateConfigPath = await writeUpdateConfig<GenericServerOptions>({ provider: "generic", url: "http://localhost:0" })
+
+  const appimageToolset = (extraConfig as any).toolsets?.appimage
+  // FUSE2 AppImages require /dev/fuse to mount their squashfs, which isn't available in standard
+  // Docker containers. APPIMAGE_EXTRACT_AND_RUN=1 tells the legacy runtime to extract and run
+  // without FUSE, avoiding the "Syntax error" shell-fallback failure.
+  const isLegacyToolset = appimageToolset == null || appimageToolset === "0.0.0"
+  const result = await launchAndWaitForQuit({
+    appPath,
+    timeoutMs: 2 * 60 * 1000,
+    updateConfigPath,
+    packageManagerToTest: "",
+    env: {
+      AUTO_UPDATER_TEST: "",
+      ...(isLegacyToolset ? { APPIMAGE_EXTRACT_AND_RUN: "1" } : {}),
+    },
+    waitForExit: true,
+  })
+
+  log.info({ version: result.version, compression: config[target]?.compression ?? config.compression, target }, "Install test launch completed")
+  if (result.version == null) {
+    throw new Error("App did not report version after launch")
+  }
+  expect(result.version).toMatch(OLD_VERSION_NUMBER)
 }

--- a/test/src/updater/downloadedUpdateHelperTest.ts
+++ b/test/src/updater/downloadedUpdateHelperTest.ts
@@ -1,9 +1,7 @@
 import { createTempUpdateFile, DownloadedUpdateHelper } from "electron-updater/src/DownloadedUpdateHelper"
 import { outputFile, outputJson, pathExists } from "fs-extra"
-import { mkdtemp, rm } from "fs/promises"
-import { tmpdir } from "os"
 import * as path from "path"
-import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test } from "vitest"
 import type { Logger } from "electron-updater/src/types"
 import type { UpdateInfo } from "builder-util-runtime"
 import type { ResolvedUpdateFileInfo } from "electron-updater/src/types"
@@ -37,13 +35,11 @@ describe("downloadedUpdateHelper", { sequential: true }, () => {
     let helper: DownloadedUpdateHelper
     let log: ReturnType<typeof makeLogger>
 
-    beforeEach(async () => {
-      cacheDir = await mkdtemp(path.join(tmpdir(), "eb-duh-test-"))
+    beforeEach(async context => {
+      cacheDir = await context.tmpDir.createTempDir()
       helper = new DownloadedUpdateHelper(cacheDir)
       log = makeLogger()
     })
-
-    afterEach(() => rm(cacheDir, { recursive: true, force: true }).catch(() => {}))
 
     test("returns null when update-info.json does not exist", async () => {
       const result = await (helper as any).getValidCachedUpdateFile(makeFileInfo("sha512abc"), log)
@@ -103,12 +99,10 @@ describe("downloadedUpdateHelper", { sequential: true }, () => {
     let cacheDir: string
     let log: ReturnType<typeof makeLogger>
 
-    beforeEach(async () => {
-      cacheDir = await mkdtemp(path.join(tmpdir(), "eb-tmp-test-"))
+    beforeEach(async context => {
+      cacheDir = await context.tmpDir.createTempDir()
       log = makeLogger()
     })
-
-    afterEach(() => rm(cacheDir, { recursive: true, force: true }).catch(() => {}))
 
     test("returns the path directly when no existing file blocks it", async () => {
       const result = await createTempUpdateFile("update.exe", cacheDir, log)
@@ -140,13 +134,11 @@ describe("downloadedUpdateHelper", { sequential: true }, () => {
     let helper: DownloadedUpdateHelper
     let log: ReturnType<typeof makeLogger>
 
-    beforeEach(async () => {
-      cacheDir = await mkdtemp(path.join(tmpdir(), "eb-validate-test-"))
+    beforeEach(async context => {
+      cacheDir = await context.tmpDir.createTempDir()
       helper = new DownloadedUpdateHelper(cacheDir)
       log = makeLogger()
     })
-
-    afterEach(() => rm(cacheDir, { recursive: true, force: true }).catch(() => {}))
 
     test("returns null when no cache exists", async () => {
       const fileInfo = makeFileInfo("sha512abc")

--- a/test/src/windows/nsisOutputValidationTest.ts
+++ b/test/src/windows/nsisOutputValidationTest.ts
@@ -1,7 +1,6 @@
 import { promises as fsp } from "fs"
-import * as os from "os"
 import * as path from "path"
-import { afterEach, beforeEach } from "vitest"
+import { beforeEach } from "vitest"
 import { checkMakensisOutput, verifyInstallerSize } from "app-builder-lib/internal"
 import type { Defines } from "app-builder-lib/internal"
 
@@ -49,12 +48,8 @@ describe("checkMakensisOutput", () => {
 describe("verifyInstallerSize", { sequential: true }, () => {
   let tmpDir: string
 
-  beforeEach(async () => {
-    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "eb-nsis-test-"))
-  })
-
-  afterEach(async () => {
-    await fsp.rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   async function writeFile(name: string, size: number): Promise<string> {

--- a/test/src/windows/squirrelWindowsSecurityTest.ts
+++ b/test/src/windows/squirrelWindowsSecurityTest.ts
@@ -1,8 +1,7 @@
 import SquirrelWindowsTarget from "electron-builder-squirrel-windows/src/SquirrelWindowsTarget"
-import { mkdtemp, realpath, rm } from "fs/promises"
-import { tmpdir } from "os"
+import { realpath } from "fs/promises"
 import * as path from "path"
-import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test } from "vitest"
 
 describe("SquirrelWindowsTarget.assertShellSafePath", () => {
   let t: any
@@ -37,15 +36,13 @@ describe("SquirrelWindowsTarget.ensurePathInside", { sequential: true }, () => {
   let t: any
   let base: string
 
-  beforeEach(async () => {
+  beforeEach(async context => {
     t = Object.create(SquirrelWindowsTarget.prototype)
-    base = await mkdtemp(path.join(tmpdir(), "eb-sec-test-"))
+    base = await context.tmpDir.createTempDir()
   })
 
-  afterEach(() => rm(base, { recursive: true, force: true }).catch(() => {}))
-
   test("accepts a path inside base", async () => {
-    // realpath is needed because on macOS mkdtemp returns /tmp/... but realpath resolves to /private/tmp/...
+    // realpath is needed because on macOS the temp dir resolves through a symlink (/tmp → /private/tmp)
     const resolvedBase = await realpath(base)
     const result = await t.ensurePathInside(base, path.join(base, "file.exe"), "file")
     expect(result).toBe(path.join(resolvedBase, "file.exe"))

--- a/test/src/windows/winReseditTest.ts
+++ b/test/src/windows/winReseditTest.ts
@@ -1,9 +1,8 @@
 import { ResourceEditOptions, editWindowsResources } from "app-builder-lib/internal"
 import * as fs from "fs/promises"
-import * as os from "os"
 import path from "path"
 import { NtExecutable, NtExecutableResource, Resource } from "resedit"
-import { afterEach, beforeEach } from "vitest"
+import { beforeEach } from "vitest"
 
 const FIXTURE_ICO = path.join(__dirname, "../../fixtures/test-app/build/icon.ico")
 
@@ -57,12 +56,8 @@ function makePeBuffer(opts: { withVersionInfo?: boolean; langs?: number[]; withM
 describe("editWindowsResources", { sequential: true }, () => {
   let tmpDir: string
 
-  beforeEach(async () => {
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "eb-resedit-test-"))
-  })
-
-  afterEach(async () => {
-    await fs.rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   async function writePe(buf: Buffer): Promise<string> {

--- a/test/src/windows/winSignToolManagerTest.ts
+++ b/test/src/windows/winSignToolManagerTest.ts
@@ -6,8 +6,7 @@ import { readCertInfoFromX509 } from "app-builder-lib/src/codeSign/certInfo"
 import { WindowsSignAzureManager } from "app-builder-lib/src/codeSign/win/windowsSignAzureManager"
 import { getAtsBundleDir, getDotnetRuntimeDir, getWindowsKitsBundle } from "app-builder-lib/src/toolsets/winCodeSign"
 import { Arch } from "builder-util"
-import { mkdtemp, rm, writeFile } from "fs/promises"
-import { tmpdir } from "os"
+import { writeFile } from "fs/promises"
 import * as path from "path"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
@@ -660,12 +659,8 @@ describe("addCertificateArgs throws InvalidConfigurationError for bad cert exten
 describe("readCertInfoFromX509", () => {
   let tmpDir: string
 
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(tmpdir(), "eb-x509-test-"))
-  })
-
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
   })
 
   test("parses a self-signed PEM certificate and extracts CN", async () => {
@@ -702,8 +697,8 @@ describe("WindowsSignAzureManager signFileWithDlib arch selection", { sequential
   let tmpDir: string
   const originalArch = process.arch
 
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(path.join(tmpdir(), "eb-azure-dlib-test-"))
+  beforeEach(async context => {
+    tmpDir = await context.tmpDir.createTempDir()
     vi.mocked(getWindowsKitsBundle).mockImplementation(async ({ arch }) => ({
       kit: path.resolve("/mock-kits", arch === Arch.ia32 ? "x86" : Arch[arch]),
       appxAssets: path.resolve("/mock-kits"),
@@ -712,12 +707,11 @@ describe("WindowsSignAzureManager signFileWithDlib arch selection", { sequential
     vi.mocked(getDotnetRuntimeDir).mockResolvedValue("/mock-dotnet-runtime")
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     Object.defineProperty(process, "arch", { value: originalArch })
     vi.mocked(getWindowsKitsBundle).mockReset()
     vi.mocked(getAtsBundleDir).mockReset()
     vi.mocked(getDotnetRuntimeDir).mockReset()
-    await rm(tmpDir, { recursive: true, force: true })
   })
 
   function makeAzureManager(execSpy: ReturnType<typeof vi.fn>, toVmFile = (f: string) => f): WindowsSignAzureManager {

--- a/test/typings/vitest.d.ts
+++ b/test/typings/vitest.d.ts
@@ -46,6 +46,10 @@ export declare const skip: ConditionalSkipAPI
 export declare const expect: ExpectStatic
 
 declare module "vitest" {
+  interface TestContext {
+    /** Per-test temp directory, auto-created and cleaned up by the `tmpDir` fixture in vitest-setup.ts. */
+    tmpDir: import("temp-file").TmpDir
+  }
   interface TestOptions {
     meta?: {
       platform?: "mac" | "win" | "linux"

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -103,7 +103,7 @@ async function main() {
 
       // Allow test metadata
       includeTaskLocation: true,
-      setupFiles: [__dirname + "/vitest-config/vitest-setup.ts", __dirname + "/vitest-config/vitest-heavy-mutex.ts"],
+      setupFiles: [__dirname + "/vitest-config/vitest-setup.ts", __dirname + "/vitest-config/vitest-heavy-mutex.ts", __dirname + "/vitest-config/vitest-tmpdir.ts"],
       include: [`test/src/**/${includeGlob}.ts`],
 
       runner: __dirname + "/vitest-config/vitest-network-retry-runner.ts",

--- a/test/vitest-scripts/vitest-config/smart-config.ts
+++ b/test/vitest-scripts/vitest-config/smart-config.ts
@@ -1,4 +1,4 @@
-  import * as path from "path"
+import * as path from "path"
 
 export type TargetPlatform = "darwin" | "win32" | "linux" | "current"
 export type SupportedPlatforms = Exclude<TargetPlatform, "current">

--- a/test/vitest-scripts/vitest-config/vitest-tmpdir.ts
+++ b/test/vitest-scripts/vitest-config/vitest-tmpdir.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach } from "vitest"
+import { TmpDir } from "temp-file"
+
+// Gives every test its own temp directory on the test context, cleaned up automatically:
+//
+//   test("writes files", async ({ tmpDir }) => {
+//     const dir = await tmpDir.getTempDir()
+//     ...
+//   })
+//
+// Tests no longer need their own `new TmpDir()` plus manual cleanup. `new TmpDir()` does no I/O until a temp
+// path is actually requested, and cleanup() is a no-op for tests that never touch `tmpDir`, so this stays
+// cheap for the (many) tests that don't use it.
+//
+// Implemented with context hooks rather than vitest's `test.extend()` fixtures on purpose: registering any
+// fixture makes vitest parse the first parameter of EVERY test and hook callback to detect fixture usage,
+// which rejects the non-destructured `ctx`/`context` parameters this suite relies on — the heavy-mutex hooks
+// in vitest-heavy-mutex.ts and the `async context => runInstallTest(context, …)` pattern in the updater tests.
+// Context hooks impose no such constraint.
+beforeEach(context => {
+  context.tmpDir = new TmpDir(context.task.name)
+})
+
+afterEach(async context => {
+  await context.tmpDir.cleanup()
+})


### PR DESCRIPTION
### Summary

Adds a per-test temporary directory that every test accesses on its context as `tmpDir`, created fresh per
test and cleaned up automatically — then migrates the test suite off the two boilerplate patterns it replaces:
`const tmpDir = new TmpDir()` + manual cleanup, and `await fs.mkdtemp(os.tmpdir(), …)` + manual `rm`.

- **New global setup hook** [test/vitest-scripts/vitest-config/vitest-tmpdir.ts](test/vitest-scripts/vitest-config/vitest-tmpdir.ts):

  ```ts
  beforeEach(context => {
    context.tmpDir = new TmpDir(context.task.name)
  })
  afterEach(async context => {
    await context.tmpDir.cleanup()
  })
  ```

  Registered in `setupFiles` in [test/vitest-scripts/run-vitest.ts](test/vitest-scripts/run-vitest.ts); `TestContext` is augmented with `tmpDir` in
  [test/typings/vitest.d.ts](test/typings/vitest.d.ts). Usage:

  ```ts
  test("writes files", async ({ tmpDir }) => {
    const dir = await tmpDir.createTempDir()  // creates the dir, like mkdtemp
    // ...no manual cleanup
  })
  // also available in a test-file beforeEach: beforeEach(async context => { dir = await context.tmpDir.createTempDir() })
  ```

- **Why context hooks, not `test.extend()` fixtures.** Registering *any* fixture makes vitest parse the first
  parameter of **every** test and hook callback to detect fixture usage, and it throws on non-destructured
  params (`FixtureParseError: ... received "ctx"`). The suite relies on non-destructured context params in the
  heavy-test mutex hooks ([vitest-heavy-mutex.ts](test/vitest-scripts/vitest-config/vitest-heavy-mutex.ts)) and the `async context => runInstallTest(context, …)` pattern.
  Context hooks impose no such constraint, compose with the custom network-retry runner, and are literally a
  "global setup config". `new TmpDir()` does no I/O until a path is requested and `cleanup()` is a no-op for
  tests that never touch `tmpDir`, so this is free for the many tests that don't use it.

- **`createTempDir()` vs `getTempDir()`:** `mkdtemp` *creates* the directory, so the migration uses
  `createTempDir()` (which `ensureDir`s); `getTempDir()` only returns a path and would break callers that write
  into it with plain `fs`.
