### PR TITLE
chore: migrate `mkdtemp` usages to `TmpDir` (unify temp-directory usage)

### DIFF
--- a/.changeset/free-rats-turn.md
+++ b/.changeset/free-rats-turn.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+chore: migrate usages of mkdtemp to utilize TmpDir to unify temp directory usage

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -22,7 +22,6 @@ import { Lazy } from "lazy-val"
 import { Minimatch } from "minimatch"
 import * as path from "path"
 import * as fs from "fs/promises"
-import * as os from "os"
 import type { TmpDir } from "temp-file"
 import type { Metadata } from "./options/metadata.js"
 import type { ArtifactBuildStarted, ArtifactCreated } from "./packagerApi.js"
@@ -874,7 +873,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       return cachedPromise
     }
 
-    const promise = generateAssetCatalogForIcon(iconPath)
+    const promise = generateAssetCatalogForIcon(this.tempDirManager, iconPath)
     this.assetCatalogResults.set(iconPath, promise)
     return promise
   }
@@ -890,7 +889,7 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
       const { icnsFile } = await this.generateAssetCatalogData(iconPath)
 
       // Generate icns file
-      const tempDir = await fs.mkdtemp(path.resolve(os.tmpdir(), "icon-compile-"))
+      const tempDir = await this.tempDirManager.createTempDir({ prefix: "icns-from-icon" })
       const tempIcnsPath = path.resolve(tempDir, "Icon.icns")
       await fs.writeFile(tempIcnsPath, icnsFile)
 

--- a/packages/app-builder-lib/src/util/mac/macosIconComposer.ts
+++ b/packages/app-builder-lib/src/util/mac/macosIconComposer.ts
@@ -1,8 +1,7 @@
 // Adapted from https://github.com/electron/packager/pull/1806
 
-import { spawn } from "builder-util"
+import { spawn, TmpDir } from "builder-util"
 import * as fs from "fs/promises"
-import * as os from "node:os"
 import * as path from "node:path"
 import plist from "plist"
 import * as semver from "semver"
@@ -51,66 +50,51 @@ async function checkActoolVersion(tmpDir: string) {
  * @param inputPath The path to the `.icon` file
  * @returns The asset catalog and extra assets
  */
-export async function generateAssetCatalogForIcon(inputPath: string): Promise<AssetCatalogResult> {
-  const tmpDir = await fs.mkdtemp(path.resolve(os.tmpdir(), "icon-compile-"))
-  const cleanup = async () => {
-    await fs.rm(tmpDir, {
-      recursive: true,
-      force: true,
-    })
-  }
+export async function generateAssetCatalogForIcon(tmpDir: TmpDir, inputPath: string): Promise<AssetCatalogResult> {
+  const tmpDirPath = await tmpDir.createTempDir({ prefix: "macos-icon-composer" })
 
-  try {
-    await checkActoolVersion(tmpDir)
-  } catch (error) {
-    await cleanup()
-    throw error
-  }
+  await checkActoolVersion(tmpDirPath)
 
-  const iconPath = path.resolve(tmpDir, "Icon.icon")
-  const outputPath = path.resolve(tmpDir, "out")
+  const iconPath = path.resolve(tmpDirPath, "Icon.icon")
+  const outputPath = path.resolve(tmpDirPath, "out")
 
-  try {
-    await fs.cp(inputPath, iconPath, {
-      recursive: true,
-    })
+  await fs.cp(inputPath, iconPath, {
+    recursive: true,
+  })
 
-    await fs.mkdir(outputPath, {
-      recursive: true,
-    })
+  await fs.mkdir(outputPath, {
+    recursive: true,
+  })
 
-    await spawn("actool", [
-      iconPath,
-      "--compile",
-      outputPath,
-      "--output-format",
-      "human-readable-text",
-      "--notices",
-      "--warnings",
-      "--output-partial-info-plist",
-      path.resolve(outputPath, "assetcatalog_generated_info.plist"),
-      "--app-icon",
-      "Icon",
-      "--include-all-app-icons",
-      "--accent-color",
-      "AccentColor",
-      "--enable-on-demand-resources",
-      "NO",
-      "--development-region",
-      "en",
-      "--target-device",
-      "mac",
-      "--minimum-deployment-target",
-      "26.0",
-      "--platform",
-      "macosx",
-    ])
+  await spawn("actool", [
+    iconPath,
+    "--compile",
+    outputPath,
+    "--output-format",
+    "human-readable-text",
+    "--notices",
+    "--warnings",
+    "--output-partial-info-plist",
+    path.resolve(outputPath, "assetcatalog_generated_info.plist"),
+    "--app-icon",
+    "Icon",
+    "--include-all-app-icons",
+    "--accent-color",
+    "AccentColor",
+    "--enable-on-demand-resources",
+    "NO",
+    "--development-region",
+    "en",
+    "--target-device",
+    "mac",
+    "--minimum-deployment-target",
+    "26.0",
+    "--platform",
+    "macosx",
+  ])
 
-    const assetCatalog = await fs.readFile(path.resolve(outputPath, "Assets.car"))
-    const icnsFile = await fs.readFile(path.resolve(outputPath, "Icon.icns"))
+  const assetCatalog = await fs.readFile(path.resolve(outputPath, "Assets.car"))
+  const icnsFile = await fs.readFile(path.resolve(outputPath, "Icon.icns"))
 
-    return { assetCatalog, icnsFile }
-  } finally {
-    await cleanup()
-  }
+  return { assetCatalog, icnsFile }
 }

--- a/test/src/customToolsetTest.ts
+++ b/test/src/customToolsetTest.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 
 describe("getCustomToolsetPath memoization", { sequential: true }, () => {
   test("returns same Promise for identical args", async ({ expect, tmpDir }) => {
-    const dir = await tmpDir.getTempDir()
+    const dir = await tmpDir.createTempDir()
     const toolset = dirToolset(dir)
     const p1 = getCustomToolsetPath(toolset, "")
     const p2 = getCustomToolsetPath(toolset, "")
@@ -24,7 +24,7 @@ describe("getCustomToolsetPath memoization", { sequential: true }, () => {
   })
 
   test("concurrent calls resolve to the same path", async ({ expect, tmpDir }) => {
-    const dir = await tmpDir.getTempDir()
+    const dir = await tmpDir.createTempDir()
     const toolset = dirToolset(dir)
     const [r1, r2, r3] = await Promise.all([getCustomToolsetPath(toolset, ""), getCustomToolsetPath(toolset, ""), getCustomToolsetPath(toolset, "")])
     expect(r1).toBe(r2)
@@ -33,15 +33,15 @@ describe("getCustomToolsetPath memoization", { sequential: true }, () => {
   })
 
   test("different url produces different cache entry", async ({ expect, tmpDir }) => {
-    const dir1 = await tmpDir.getTempDir()
-    const dir2 = await tmpDir.getTempDir()
+    const dir1 = await tmpDir.createTempDir()
+    const dir2 = await tmpDir.createTempDir()
     const p1 = getCustomToolsetPath(dirToolset(dir1), "")
     const p2 = getCustomToolsetPath(dirToolset(dir2), "")
     expect(p1).not.toBe(p2)
   })
 
   test("different resourcesDir produces different cache entry", async ({ expect, tmpDir }) => {
-    const dir = await tmpDir.getTempDir()
+    const dir = await tmpDir.createTempDir()
     const toolset = dirToolset(dir)
     const p1 = getCustomToolsetPath(toolset, "")
     const p2 = getCustomToolsetPath(toolset, "/some/other/resources")
@@ -49,7 +49,7 @@ describe("getCustomToolsetPath memoization", { sequential: true }, () => {
   })
 
   test("clearCustomToolsetCache forces re-resolution", async ({ expect, tmpDir }) => {
-    const dir = await tmpDir.getTempDir()
+    const dir = await tmpDir.createTempDir()
     const toolset = dirToolset(dir)
     const p1 = getCustomToolsetPath(toolset, "")
     clearCustomToolsetCache()
@@ -58,7 +58,7 @@ describe("getCustomToolsetPath memoization", { sequential: true }, () => {
   })
 
   test("directory type resolves to the directory path", async ({ expect, tmpDir }) => {
-    const dir = await tmpDir.getTempDir()
+    const dir = await tmpDir.createTempDir()
     const result = await getCustomToolsetPath(dirToolset(dir), "")
     expect(result).toBe(dir)
   })

--- a/test/src/customToolsetTest.ts
+++ b/test/src/customToolsetTest.ts
@@ -1,66 +1,65 @@
 import { afterEach, beforeEach } from "vitest"
-import * as path from "path"
-import * as os from "os"
-import { mkdir, rm } from "fs/promises"
 import { clearCustomToolsetCache, getCustomToolsetPath } from "app-builder-lib/src/toolsets/custom"
 import type { ToolsetCustom } from "app-builder-lib/internal"
 
-const FAKE_DIR = path.join(os.tmpdir(), "custom-toolset-memo-test")
-const FAKE_DIR_2 = path.join(os.tmpdir(), "custom-toolset-memo-test-2")
-
-function dirToolset(dir = FAKE_DIR): ToolsetCustom {
+function dirToolset(dir: string): ToolsetCustom {
   return { url: `file://${dir}` }
 }
 
-beforeEach(async () => {
+beforeEach(() => {
   clearCustomToolsetCache()
-  await Promise.all([mkdir(FAKE_DIR, { recursive: true }), mkdir(FAKE_DIR_2, { recursive: true })])
 })
 
-afterEach(async () => {
+afterEach(() => {
   clearCustomToolsetCache()
-  await Promise.all([rm(FAKE_DIR, { recursive: true, force: true }), rm(FAKE_DIR_2, { recursive: true, force: true })])
 })
 
 describe("getCustomToolsetPath memoization", { sequential: true }, () => {
-  test("returns same Promise for identical args", ({ expect }) => {
-    const toolset = dirToolset()
+  test("returns same Promise for identical args", async ({ expect, tmpDir }) => {
+    const dir = await tmpDir.getTempDir()
+    const toolset = dirToolset(dir)
     const p1 = getCustomToolsetPath(toolset, "")
     const p2 = getCustomToolsetPath(toolset, "")
     expect(p1).toBe(p2)
   })
 
-  test("concurrent calls resolve to the same path", async ({ expect }) => {
-    const toolset = dirToolset()
+  test("concurrent calls resolve to the same path", async ({ expect, tmpDir }) => {
+    const dir = await tmpDir.getTempDir()
+    const toolset = dirToolset(dir)
     const [r1, r2, r3] = await Promise.all([getCustomToolsetPath(toolset, ""), getCustomToolsetPath(toolset, ""), getCustomToolsetPath(toolset, "")])
     expect(r1).toBe(r2)
     expect(r2).toBe(r3)
-    expect(r1).toBe(FAKE_DIR)
+    expect(r1).toBe(dir)
   })
 
-  test("different url produces different cache entry", ({ expect }) => {
-    const p1 = getCustomToolsetPath(dirToolset(FAKE_DIR), "")
-    const p2 = getCustomToolsetPath(dirToolset(FAKE_DIR_2), "")
+  test("different url produces different cache entry", async ({ expect, tmpDir }) => {
+    const dir1 = await tmpDir.getTempDir()
+    const dir2 = await tmpDir.getTempDir()
+    const p1 = getCustomToolsetPath(dirToolset(dir1), "")
+    const p2 = getCustomToolsetPath(dirToolset(dir2), "")
     expect(p1).not.toBe(p2)
   })
 
-  test("different resourcesDir produces different cache entry", ({ expect }) => {
-    const toolset = dirToolset()
+  test("different resourcesDir produces different cache entry", async ({ expect, tmpDir }) => {
+    const dir = await tmpDir.getTempDir()
+    const toolset = dirToolset(dir)
     const p1 = getCustomToolsetPath(toolset, "")
     const p2 = getCustomToolsetPath(toolset, "/some/other/resources")
     expect(p1).not.toBe(p2)
   })
 
-  test("clearCustomToolsetCache forces re-resolution", ({ expect }) => {
-    const toolset = dirToolset()
+  test("clearCustomToolsetCache forces re-resolution", async ({ expect, tmpDir }) => {
+    const dir = await tmpDir.getTempDir()
+    const toolset = dirToolset(dir)
     const p1 = getCustomToolsetPath(toolset, "")
     clearCustomToolsetCache()
     const p2 = getCustomToolsetPath(toolset, "")
     expect(p1).not.toBe(p2)
   })
 
-  test("directory type resolves to the directory path", async ({ expect }) => {
-    const result = await getCustomToolsetPath(dirToolset(), "")
-    expect(result).toBe(FAKE_DIR)
+  test("directory type resolves to the directory path", async ({ expect, tmpDir }) => {
+    const dir = await tmpDir.getTempDir()
+    const result = await getCustomToolsetPath(dirToolset(dir), "")
+    expect(result).toBe(dir)
   })
 })

--- a/test/src/electronGetTest.ts
+++ b/test/src/electronGetTest.ts
@@ -93,24 +93,24 @@ describe("getCacheDirectory", () => {
     }
   })
 
-  test("respects XDG_CACHE_HOME on linux", ({ expect }) => {
+  test("respects XDG_CACHE_HOME on linux", context => {
     if (process.platform !== "linux") {
-      expect(true).toBe(true) // skip assertion on non-linux
+      context.skip() // test is Linux-specific, skip on other platforms
       return
     }
     vi.stubEnv("ELECTRON_BUILDER_CACHE", "")
     vi.stubEnv("XDG_CACHE_HOME", "/xdg/cache")
-    expect(getCacheDirectory({ allowEnvVarOverride: true })).toBe("/xdg/cache/electron-builder")
+    context.expect(getCacheDirectory({ allowEnvVarOverride: true })).toBe("/xdg/cache/electron-builder")
   })
 
-  test("falls back to tmpdir when LOCALAPPDATA is absent on Windows", ({ expect }) => {
+  test("falls back to tmpdir when LOCALAPPDATA is absent on Windows", context => {
     if (process.platform !== "win32") {
-      expect(true).toBe(true)
+      context.skip() // test is Windows-specific, skip on other platforms
       return
     }
     vi.stubEnv("LOCALAPPDATA", "")
     const result = getCacheDirectory({ isAvoidSystemOnWindows: true, allowEnvVarOverride: false })
-    expect(result).toContain(os.tmpdir())
+    context.expect(result).toContain(os.tmpdir())
   })
 
   test("allowEnvVarOverride:false ignores ELECTRON_BUILDER_CACHE even when set", ({ expect }) => {
@@ -127,38 +127,38 @@ describe("getCacheDirectory", () => {
     expect(result).toContain("electron-builder")
   })
 
-  test("falls back to tmpdir when USERNAME is 'system' (isAvoidSystemOnWindows defaults to true)", ({ expect }) => {
+  test("falls back to tmpdir when USERNAME is 'system' (isAvoidSystemOnWindows defaults to true)", context => {
     if (process.platform !== "win32") {
-      expect(true).toBe(true)
+      context.skip() // test is Windows-specific, skip on other platforms
       return
     }
     vi.stubEnv("LOCALAPPDATA", "C:\\Users\\system\\AppData\\Local")
     vi.stubEnv("USERNAME", "system")
     const result = getCacheDirectory({ allowEnvVarOverride: false })
-    expect(result).toContain(os.tmpdir())
+    context.expect(result).toContain(os.tmpdir())
   })
 
-  test("falls back to tmpdir when LOCALAPPDATA path contains \\windows\\system32\\", ({ expect }) => {
+  test("falls back to tmpdir when LOCALAPPDATA path contains \\windows\\system32\\", context => {
     if (process.platform !== "win32") {
-      expect(true).toBe(true)
+      context.skip() // test is Windows-specific, skip on other platforms
       return
     }
     vi.stubEnv("LOCALAPPDATA", "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local")
     vi.stubEnv("USERNAME", "not-system")
     const result = getCacheDirectory({ allowEnvVarOverride: false })
-    expect(result).toContain(os.tmpdir())
+    context.expect(result).toContain(os.tmpdir())
   })
 
-  test("isAvoidSystemOnWindows:false does not fall back to tmpdir for USERNAME=system", ({ expect }) => {
+  test("isAvoidSystemOnWindows:false does not fall back to tmpdir for USERNAME=system", context => {
     if (process.platform !== "win32") {
-      expect(true).toBe(true)
+      context.skip() // test is Windows-specific, skip on other platforms
       return
     }
     vi.stubEnv("LOCALAPPDATA", "C:\\Users\\system\\AppData\\Local")
     vi.stubEnv("USERNAME", "system")
     const result = getCacheDirectory({ isAvoidSystemOnWindows: false, allowEnvVarOverride: false })
-    expect(result).not.toContain(os.tmpdir())
-    expect(result).toContain("electron-builder")
+    context.expect(result).not.toContain(os.tmpdir())
+    context.expect(result).toContain("electron-builder")
   })
 })
 

--- a/test/src/mac/pkgTargetUnitTest.ts
+++ b/test/src/mac/pkgTargetUnitTest.ts
@@ -1,18 +1,11 @@
-import { afterEach, beforeEach } from "vitest"
-import * as os from "os"
+import { beforeEach } from "vitest"
 import * as path from "path"
-import { mkdir, rm, writeFile } from "fs/promises"
+import { mkdir, writeFile } from "fs/promises"
 import { prepareProductBuildArgs, resolvePkgBuildVersion, resolveScriptsDir } from "app-builder-lib/src/targets/mac/pkg"
 
 // Only run these tests on macOS since they rely on macOS-specific filesystem structure and conventions.
 // The functions being tested are also only relevant in the context of building macOS pkg installers.
 describe.ifMac("mac pkg", () => {
-  async function makeTempDir(): Promise<string> {
-    const dir = path.join(os.tmpdir(), `eb-pkg-unit-${Date.now()}`)
-    await mkdir(dir, { recursive: true })
-    return dir
-  }
-
   function plistXml(data: Record<string, string | number | boolean>): string {
     const entries = Object.entries(data)
       .map(([key, value]) => {
@@ -38,12 +31,8 @@ ${entries}
   describe("resolvePkgBuildVersion", () => {
     let tmpDir: string
 
-    beforeEach(async () => {
-      tmpDir = await makeTempDir()
-    })
-
-    afterEach(async () => {
-      await rm(tmpDir, { recursive: true, force: true })
+    beforeEach(async context => {
+      tmpDir = await context.tmpDir.createTempDir()
     })
 
     test("returns CFBundleShortVersionString from Info.plist when present", async ({ expect }) => {

--- a/test/src/mac/wineEnvUnitTest.ts
+++ b/test/src/mac/wineEnvUnitTest.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach } from "vitest"
 import type { ToolsetCustom } from "app-builder-lib/internal"
-import * as os from "os"
 import * as path from "path"
 import { mkdir, rm, writeFile } from "fs/promises"
 import { getWineToolset } from "app-builder-lib/src/toolsets/wine"
@@ -8,7 +7,7 @@ import { getWineToolset } from "app-builder-lib/src/toolsets/wine"
 // Unit tests for wine env merging via ToolsetCustom with a file:// directory path.
 // A minimal fake wine directory is created in /tmp for each test.
 
-const FAKE_WINE_DIR = path.join(os.tmpdir(), "wine-env-unit-test")
+let FAKE_WINE_DIR = ""
 
 function fakeToolset(): ToolsetCustom {
   return { url: `file://${FAKE_WINE_DIR}`, checksum: "test" }
@@ -25,10 +24,11 @@ async function setupFakeWineDir(): Promise<void> {
 const ENV_KEYS = ["DYLD_FALLBACK_LIBRARY_PATH", "LD_LIBRARY_PATH", "USE_SYSTEM_WINE"]
 const SAVED_ENV: Record<string, string | undefined> = {}
 
-beforeEach(async () => {
+beforeEach(async context => {
   for (const k of ENV_KEYS) {
     SAVED_ENV[k] = process.env[k]
   }
+  FAKE_WINE_DIR = await context.tmpDir.createTempDir()
   await setupFakeWineDir()
   delete process.env.USE_SYSTEM_WINE
 })
@@ -41,7 +41,6 @@ afterEach(async () => {
       process.env[k] = SAVED_ENV[k]
     }
   }
-  await rm(FAKE_WINE_DIR, { recursive: true, force: true })
 })
 
 describe.ifNotWindows("getWineToolset — ToolsetCustom file:// directory env merging", { sequential: true }, () => {

--- a/test/src/node-module-collector/streamCollectorTest.ts
+++ b/test/src/node-module-collector/streamCollectorTest.ts
@@ -6,10 +6,6 @@ import * as childProcess from "child_process"
 import * as nodeFs from "node:fs"
 import { EventEmitter } from "events"
 import type { TmpDir } from "builder-util"
-import * as os from "os"
-import * as path from "path"
-import { randomBytes } from "crypto"
-import { existsSync, unlinkSync } from "fs"
 
 vi.mock("child_process", async importOriginal => {
   const actual = await importOriginal<typeof import("child_process")>()
@@ -71,8 +67,8 @@ async function waitForCloseCb() {
   }
 }
 
-beforeEach(() => {
-  OUTPUT_FILE = path.join(os.tmpdir(), `output-${randomBytes(4).toString("hex")}.json`)
+beforeEach(async context => {
+  OUTPUT_FILE = await context.tmpDir.getTempFile({ suffix: ".json" })
   closeCb = undefined
   stderrDataCb = undefined
 
@@ -110,9 +106,6 @@ beforeEach(() => {
 afterEach(() => {
   Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
   vi.clearAllMocks()
-  if (existsSync(OUTPUT_FILE)) {
-    unlinkSync(OUTPUT_FILE)
-  }
 })
 
 describe("streamCollectorCommandToFile", { sequential: true }, () => {

--- a/test/vitest-scripts/vitest-config/vitest-tmpdir.ts
+++ b/test/vitest-scripts/vitest-config/vitest-tmpdir.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach } from "vitest"
 import { TmpDir } from "temp-file"
+import { rm } from "node:fs/promises"
 
 // Gives every test its own temp directory on the test context, cleaned up automatically:
 //
@@ -22,5 +23,22 @@ beforeEach(context => {
 })
 
 afterEach(async context => {
-  await context.tmpDir.cleanup()
+  try {
+    await context.tmpDir.cleanup()
+  } catch (error) {
+    // On Windows, rmdir intermittently fails with EPERM/EBUSY while a handle, antivirus, or the Search
+    // indexer still holds the directory. temp-file's cleanup() nulls its own state before the remove()
+    // runs, so it can't be retried directly (a second call is a no-op). Retry the rm ourselves instead:
+    // fs.rm natively backs off and retries EPERM/EBUSY/ENOTEMPTY, and the fs error carries the offending
+    // path. The assertions already ran, so a final failure here is teardown flakiness — warn, don't fail.
+    const err = error as NodeJS.ErrnoException
+    try {
+      if (err.path == null) {
+        throw error
+      }
+      await rm(err.path, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    } catch (retryError) {
+      console.warn(`tmpDir cleanup failed for "${context.task.name}":`, retryError)
+    }
+  }
 })


### PR DESCRIPTION
### Summary

Replaces ad-hoc `fs.mkdtemp(os.tmpdir(), …)` + manual `rm` cleanup with the project's `TmpDir` abstraction
(`temp-file`), so temp directories are created and torn down consistently — in both `app-builder-lib` source
and the test suite.

- **Source (`app-builder-lib`)** — the macOS icon → asset-catalog / `.icns` path now uses the packager's
  shared `tempDirManager` (a `TmpDir` scoped to the whole build) instead of rolling its own `mkdtemp` and
  cleaning it up by hand. This is the publishable change (see changeset).
  - [macosIconComposer.ts](packages/app-builder-lib/src/util/mac/macosIconComposer.ts): `generateAssetCatalogForIcon(inputPath)` → `generateAssetCatalogForIcon(tmpDir: TmpDir, inputPath)`. The internal `mkdtemp` + `cleanup()` closure + `try/catch/finally` collapse to `tmpDir.createTempDir({ prefix: "macos-icon-composer" })` (the caller's `tempDirManager` owns cleanup). Net: the function body shrinks substantially.
  - [platformPackager.ts](packages/app-builder-lib/src/platformPackager.ts): threads `this.tempDirManager` into that call, and swaps its own `mkdtemp(os.tmpdir(), "icon-compile-")` for `this.tempDirManager.createTempDir({ prefix: "icns-from-icon" })`. Drops the now-unused `os` import.

- **Tests** — the remaining per-test `os.tmpdir()` temp dirs/files now come from `context.tmpDir` (the
  per-test `TmpDir` the global setup hook provides), so cleanup is automatic.
  - [customToolsetTest](test/src/customToolsetTest.ts) — each test gets its own dir via `tmpDir.createTempDir()`; dropped the module-level `FAKE_DIR` consts + `mkdir`/`rm` hooks. (`createTempDir`, not `getTempDir`: `validateCustomToolset` rejects a `file://` URL whose directory doesn't exist, so the dir must actually be created.)
  - [mac/pkgTargetUnitTest](test/src/mac/pkgTargetUnitTest.ts) — deleted the `makeTempDir()` helper; `beforeEach` uses `tmpDir.createTempDir()`, cleanup-only `afterEach` removed.
  - [mac/wineEnvUnitTest](test/src/mac/wineEnvUnitTest.ts) — `FAKE_WINE_DIR` is now a per-test `createTempDir()`. Also fixes a latent bug: it had used a single **fixed** path, so concurrent tests shared one directory.
  - [node-module-collector/streamCollectorTest](test/src/node-module-collector/streamCollectorTest.ts) — temp output-file → `tmpDir.getTempFile({ suffix: ".json" })`; removed the `os`/`randomBytes`/`existsSync`/`unlinkSync` plumbing and the defensive `unlink`.

- **Hook** — [vitest-tmpdir.ts](test/vitest-scripts/vitest-config/vitest-tmpdir.ts): per-test `cleanup()` now catches Windows `EPERM`/`EBUSY` (a handle/AV/Search-indexer still holding the dir) and retries the `rm` itself with backoff, using the path from the fs error; a final failure `console.warn`s rather than failing the test (teardown flakiness only).

- **Minor** — [electronGetTest](test/src/electronGetTest.ts): the platform-specific cache tests now call `context.skip()` instead of asserting `expect(true).toBe(true)` as a fake skip (and use `context.expect`). The `os.tmpdir()` here intentionally stays — those tests assert the cache path falls *under* the system temp dir.