### PR TITLE
feat: Remove `linux.syncDesktopName` — always sync the installed `.desktop` filename (BREAKING)

### DIFF
--- a/.changeset/chatty-maps-go.md
+++ b/.changeset/chatty-maps-go.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: Remove `linux.syncDesktopName` — always sync the installed `.desktop` filename

--- a/.changeset/chatty-maps-go.md
+++ b/.changeset/chatty-maps-go.md
@@ -1,5 +1,5 @@
 ---
-"app-builder-lib": minor
+"app-builder-lib": major
 ---
 
 feat: Remove `linux.syncDesktopName` — always sync the installed `.desktop` filename

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2421,11 +2421,6 @@
           "$ref": "#/definitions/ReleaseInfo",
           "description": "The release info. Intended for command line usage:\n\n```\n-c.releaseInfo.releaseNotes=\"new features\"\n```"
         },
-        "syncDesktopName": {
-          "default": false,
-          "description": "When `true`, the installed `.desktop` filename is derived from `desktopName` in `package.json`\n(minus the `.desktop` suffix) so that it matches `StartupWMClass` and Electron's `app_id`.\nFalls back to `executableName` when `desktopName` is absent.",
-          "type": "boolean"
-        },
         "synopsis": {
           "description": "The [short description](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Description).",
           "type": [

--- a/packages/app-builder-lib/src/options/linuxOptions.ts
+++ b/packages/app-builder-lib/src/options/linuxOptions.ts
@@ -62,17 +62,6 @@ export interface LinuxConfiguration extends CommonLinuxOptions, PlatformSpecific
    * For user-facing category configuration use the target-specific options (e.g. {@link DebOptions}).
    */
   readonly packageCategory?: string | null
-
-  /**
-   * When `true`, the installed `.desktop` filename is derived from `desktopName` in `package.json`
-   * (minus the `.desktop` suffix) so that it matches `StartupWMClass` and Electron's `app_id`.
-   * Falls back to `executableName` when `desktopName` is absent.
-   *
-   * @default false
-   * @see https://github.com/electron-userland/electron-builder/issues/9103
-   * @remarks In v27 the default will change to `true`.
-   */
-  readonly syncDesktopName?: boolean
 }
 
 /**

--- a/packages/app-builder-lib/src/targets/linux/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/linux/LinuxTargetHelper.ts
@@ -226,17 +226,30 @@ export class LinuxTargetHelper {
     return file
   }
 
-  getDesktopFileName(fallback: string = this.packager.executableName): string {
+  // Emit the "desktopName not set" warning at most once per build, even though both
+  // getDesktopFileName() and computeDesktopEntry() resolve the desktop name.
+  private desktopNameWarningEmitted = false
+
+  // https://github.com/electron-userland/electron-builder/issues/9103
+  // Electron derives app_id / WM_CLASS from desktopName in package.json; the installed
+  // .desktop filename and StartupWMClass must match it for window association to work.
+  // https://github.com/electron/electron/blob/9a7b73b5334f1d72c08e2d5e94106706ed751186/lib/browser/init.ts#L128-L133
+  // Returns the validated base name (desktopName minus the .desktop suffix), or null when
+  // desktopName is unset — callers apply their own fallback (filename vs WM_CLASS).
+  private resolveDesktopName(): string | null {
     const trimmedDesktopName = this.packager.metadata.desktopName?.trim()
     if (isEmptyOrSpaces(trimmedDesktopName)) {
-      log.warn(
-        {
-          reason: "desktopName is not set in package.json",
-          docs: "https://www.electron.build/docs/linux/#window-association-desktopname--syncdesktopname",
-        },
-        "desktopName is used to generate the .desktop filename and app_id for window association. Set desktopName in package.json to fix."
-      )
-      return fallback
+      if (!this.desktopNameWarningEmitted) {
+        this.desktopNameWarningEmitted = true
+        log.warn(
+          {
+            reason: "desktopName is not set in package.json",
+            docs: "https://www.electron.build/docs/linux/#window-association-desktopname",
+          },
+          'Electron derives the app_id / WM_CLASS used for Linux window association from desktopName. Without it, desktop environments may not link the running window to its launcher entry (taskbar grouping, dock icon, etc.). Set desktopName to a reverse-DNS identifier in package.json, e.g. "com.myapp.MyApp".'
+        )
+      }
+      return null
     }
     const basename = trimmedDesktopName.replace(/\.desktop$/, "")
     // Guard against path traversal: desktopName flows into filesystem paths
@@ -245,6 +258,10 @@ export class LinuxTargetHelper {
       throw new InvalidConfigurationError(`desktopName "${trimmedDesktopName}" produces an invalid .desktop filename — remove any path separators or NUL characters`)
     }
     return basename
+  }
+
+  getDesktopFileName(fallback: string = this.packager.executableName): string {
+    return this.resolveDesktopName() ?? fallback
   }
 
   computeDesktopEntry(targetSpecificOptions: CommonLinuxOptions, exec?: string, extra?: Record<string, string>): Promise<string> {
@@ -278,20 +295,10 @@ export class LinuxTargetHelper {
       }
     }
 
-    // https://github.com/electron-userland/electron-builder/issues/9103
-    // Electron derives app_id from desktopName in package.json; StartupWMClass must match.
-    // https://github.com/electron/electron/blob/9a7b73b5334f1d72c08e2d5e94106706ed751186/lib/browser/init.ts#L128-L133
-    const trimmedDesktopName = packager.metadata.desktopName?.trim()
-    if (isEmptyOrSpaces(trimmedDesktopName)) {
-      log.warn(
-        {
-          reason: "desktopName is not set in package.json",
-          docs: "https://www.electron.build/linux#window-association-desktopname",
-        },
-        "electron uses desktopName as app_id / WM_CLASS for window association. Without it desktop environments may not link running windows to this .desktop entry. Set desktopName in package.json to fix."
-      )
-    }
-    const wmClass = !isEmptyOrSpaces(trimmedDesktopName) ? trimmedDesktopName.replace(/\.desktop$/, "") : appInfo.productName
+    // StartupWMClass must match Electron's app_id (derived from desktopName) for window
+    // association; resolveDesktopName() handles the shared warning and validation.
+    // Falls back to productName for apps that don't set desktopName.
+    const wmClass = this.resolveDesktopName() ?? appInfo.productName
 
     const desktopMeta = deepAssign<any>(
       {

--- a/packages/app-builder-lib/src/targets/linux/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/linux/LinuxTargetHelper.ts
@@ -227,11 +227,15 @@ export class LinuxTargetHelper {
   }
 
   getDesktopFileName(fallback: string = this.packager.executableName): string {
-    if (!this.packager.platformOptions.syncDesktopName) {
-      return fallback
-    }
     const trimmedDesktopName = this.packager.metadata.desktopName?.trim()
     if (isEmptyOrSpaces(trimmedDesktopName)) {
+      log.warn(
+        {
+          reason: "desktopName is not set in package.json",
+          docs: "https://www.electron.build/docs/linux/#window-association-desktopname--syncdesktopname",
+        },
+        "desktopName is used to generate the .desktop filename and app_id for window association. Set desktopName in package.json to fix."
+      )
       return fallback
     }
     const basename = trimmedDesktopName.replace(/\.desktop$/, "")
@@ -282,9 +286,9 @@ export class LinuxTargetHelper {
       log.warn(
         {
           reason: "desktopName is not set in package.json",
-          docs: "https://www.electron.build/linux#window-association-desktopname--syncdesktopname",
+          docs: "https://www.electron.build/linux#window-association-desktopname",
         },
-        "electron uses desktopName as app_id / WM_CLASS for window association. Without it desktop environments may not link running windows to this .desktop entry. Set desktopName in package.json and linux.syncDesktopName: true to fix."
+        "electron uses desktopName as app_id / WM_CLASS for window association. Without it desktop environments may not link running windows to this .desktop entry. Set desktopName in package.json to fix."
       )
     }
     const wmClass = !isEmptyOrSpaces(trimmedDesktopName) ? trimmedDesktopName.replace(/\.desktop$/, "") : appInfo.productName

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
@@ -54,6 +54,38 @@ If you recently upgraded electron-builder to v27, please run \`electron-builder 
 Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
 `;
 
+exports[`LinuxPackager > AppImage - desktopName drives installed filename (reverse-DNS) 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - desktopName drives installed filename 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - desktopName sets StartupWMClass 1`] = `
 "[Desktop Entry]
 Name=Signal
@@ -175,6 +207,22 @@ exports[`LinuxPackager > AppImage - explicit zstd compression override 1`] = `
 }
 `;
 
+exports[`LinuxPackager > AppImage - missing desktopName falls back to executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - no desktopName falls back to productName for StartupWMClass 1`] = `
 "[Desktop Entry]
 Name=My App
@@ -233,54 +281,6 @@ exports[`LinuxPackager > AppImage - store compression maps to gzip 1`] = `
         "releaseDate": "@releaseDate",
         "sha512": "@sha512",
         "version": "1.1.0",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName true without desktopName falls back to executableName 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName uses desktopName for installed filename 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName without flag keeps executableName 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
       },
     },
   ],

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
@@ -54,6 +54,38 @@ If you recently upgraded electron-builder to v27, please run \`electron-builder 
 Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
 `;
 
+exports[`LinuxPackager > AppImage - desktopName drives installed filename (reverse-DNS) 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - desktopName drives installed filename 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - desktopName sets StartupWMClass 1`] = `
 "[Desktop Entry]
 Name=Signal
@@ -175,6 +207,22 @@ exports[`LinuxPackager > AppImage - explicit zstd compression override 1`] = `
 }
 `;
 
+exports[`LinuxPackager > AppImage - missing desktopName falls back to executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - no desktopName falls back to productName for StartupWMClass 1`] = `
 "[Desktop Entry]
 Name=My App
@@ -233,54 +281,6 @@ exports[`LinuxPackager > AppImage - store compression maps to gzip 1`] = `
         "releaseDate": "@releaseDate",
         "sha512": "@sha512",
         "version": "1.1.0",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName true without desktopName falls back to executableName 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName uses desktopName for installed filename 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName without flag keeps executableName 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
       },
     },
   ],

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
@@ -54,6 +54,38 @@ If you recently upgraded electron-builder to v27, please run \`electron-builder 
 Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
 `;
 
+exports[`LinuxPackager > AppImage - desktopName drives installed filename (reverse-DNS) 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`LinuxPackager > AppImage - desktopName drives installed filename 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - desktopName sets StartupWMClass 1`] = `
 "[Desktop Entry]
 Name=Signal
@@ -175,6 +207,22 @@ exports[`LinuxPackager > AppImage - explicit zstd compression override 1`] = `
 }
 `;
 
+exports[`LinuxPackager > AppImage - missing desktopName falls back to executableName 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Signal-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - no desktopName falls back to productName for StartupWMClass 1`] = `
 "[Desktop Entry]
 Name=My App
@@ -233,54 +281,6 @@ exports[`LinuxPackager > AppImage - store compression maps to gzip 1`] = `
         "releaseDate": "@releaseDate",
         "sha512": "@sha512",
         "version": "1.1.0",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName true without desktopName falls back to executableName 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName uses desktopName for installed filename 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
-      },
-    },
-  ],
-}
-`;
-
-exports[`LinuxPackager > AppImage - syncDesktopName without flag keeps executableName 1`] = `
-{
-  "linux": [
-    {
-      "arch": "x64",
-      "file": "Signal-1.1.0.AppImage",
-      "updateInfo": {
-        "blockMapSize": "@blockMapSize",
-        "sha512": "@sha512",
-        "size": "@size",
       },
     },
   ],

--- a/test/src/linux/linuxPackagerTestSuite.ts
+++ b/test/src/linux/linuxPackagerTestSuite.ts
@@ -493,7 +493,7 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       {}
     ))
 
-  test("AppImage - syncDesktopName uses desktopName for installed filename", ({ expect }) =>
+  test("AppImage - desktopName drives installed filename", ({ expect }) =>
     app(
       expect,
       {
@@ -501,7 +501,6 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
         config: {
           toolsets,
           productName: "Signal",
-          linux: { syncDesktopName: true },
         },
         effectiveOptionComputed: async it => {
           expect(it.desktopFileName).toBe("signal.desktop")
@@ -516,7 +515,7 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       }
     ))
 
-  test("AppImage - syncDesktopName without flag keeps executableName", ({ expect }) =>
+  test("AppImage - desktopName drives installed filename (reverse-DNS)", ({ expect }) =>
     app(
       expect,
       {
@@ -526,7 +525,7 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
           productName: "Signal",
         },
         effectiveOptionComputed: async it => {
-          expect(it.desktopFileName).toBe("testapp.desktop")
+          expect(it.desktopFileName).toBe("com.example.Signal.desktop")
           return Promise.resolve(false)
         },
       },
@@ -538,7 +537,7 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       }
     ))
 
-  test("AppImage - syncDesktopName true without desktopName falls back to executableName", ({ expect }) =>
+  test("AppImage - missing desktopName falls back to executableName", ({ expect }) =>
     app(
       expect,
       {
@@ -546,7 +545,6 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
         config: {
           toolsets,
           productName: "Signal",
-          linux: { syncDesktopName: true },
         },
         effectiveOptionComputed: async it => {
           expect(it.desktopFileName).toBe("testapp.desktop")
@@ -571,14 +569,13 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       },
     }))
 
-  test("AppImage - syncDesktopName rejects path traversal in desktopName", ({ expect }) =>
+  test("AppImage - desktopName rejects path traversal", ({ expect }) =>
     appThrows(
       expect,
       {
         targets: appImageTarget,
         config: {
           toolsets,
-          linux: { syncDesktopName: true },
         },
       },
       {
@@ -590,14 +587,13 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       err => expect(err.message).toContain("produces an invalid .desktop filename")
     ))
 
-  test("AppImage - syncDesktopName rejects absolute path in desktopName", ({ expect }) =>
+  test("AppImage - desktopName rejects absolute path", ({ expect }) =>
     appThrows(
       expect,
       {
         targets: appImageTarget,
         config: {
           toolsets,
-          linux: { syncDesktopName: true },
         },
       },
       {
@@ -609,14 +605,13 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       err => expect(err.message).toContain("produces an invalid .desktop filename")
     ))
 
-  test("AppImage - syncDesktopName rejects backslash in desktopName", ({ expect }) =>
+  test("AppImage - desktopName rejects backslash", ({ expect }) =>
     appThrows(
       expect,
       {
         targets: appImageTarget,
         config: {
           toolsets,
-          linux: { syncDesktopName: true },
         },
       },
       {

--- a/website/docs/linux.md
+++ b/website/docs/linux.md
@@ -71,29 +71,24 @@ linux:
 
 Standard freedesktop.org category values include: `AudioVideo`, `Audio`, `Video`, `Development`, `Education`, `Game`, `Graphics`, `Network`, `Office`, `Science`, `Settings`, `System`, `Utility`.
 
-## Window Association (`desktopName` + `syncDesktopName`)
+## Window Association (`desktopName`)
 
 Electron derives its [`app_id`](https://github.com/electron/electron/blob/main/lib/browser/init.ts) — which becomes the window's `WM_CLASS` — from the `desktopName` field in your root `package.json`. Desktop environments (GNOME, KDE, etc.) use `WM_CLASS` to match a running window to its `.desktop` entry for taskbar grouping, dock badges, and launcher highlighting.
 
 **Without `desktopName` set, this association can break**: the fallback `WM_CLASS` may not match the installed `.desktop` filename, so the DE treats the running app as an unknown window.
 
-To fix this, set `desktopName` in `package.json` and enable `linux.syncDesktopName`:
+To fix this, set `desktopName` in `package.json`:
 
 ```json title="package.json"
 {
-  "desktopName": "com.example.MyApp.desktop",
-  "build": {
-    "linux": {
-      "syncDesktopName": true
-    }
-  }
+  "desktopName": "com.example.MyApp.desktop"
 }
 ```
 
-With `syncDesktopName: true`, electron-builder installs the `.desktop` file as `com.example.MyApp.desktop` and sets `StartupWMClass=com.example.MyApp` — both matching Electron's `app_id`. Without the flag the filename continues to use `executableName` (the current default, preserved for backwards compatibility).
+electron-builder installs the `.desktop` file as `com.example.MyApp.desktop` (the `desktopName` minus the `.desktop` suffix) and sets `StartupWMClass=com.example.MyApp` — both matching Electron's `app_id`. When `desktopName` is absent, the filename falls back to `executableName`.
 
-:::note[v27]
-`syncDesktopName` will default to `true` in v27. If you rely on the current behaviour, set it explicitly to `false`.
+:::note[Changed in v27]
+The installed `.desktop` filename is now always derived from `desktopName`. The `linux.syncDesktopName` flag that previously gated this behaviour has been removed — see the [v26 → v27 migration guide](./migration/v26-to-v27.md#linuxsyncdesktopname-removed-always-synced).
 :::
 
 :::warning[`desktopName` is required for reliable window association]

--- a/website/docs/linux.md
+++ b/website/docs/linux.md
@@ -81,11 +81,11 @@ To fix this, set `desktopName` in `package.json`:
 
 ```json title="package.json"
 {
-  "desktopName": "com.example.MyApp.desktop"
+  "desktopName": "com.example.MyApp"
 }
 ```
 
-electron-builder installs the `.desktop` file as `com.example.MyApp.desktop` (the `desktopName` minus the `.desktop` suffix) and sets `StartupWMClass=com.example.MyApp` — both matching Electron's `app_id`. When `desktopName` is absent, the filename falls back to `executableName`.
+electron-builder installs the `.desktop` file as `${desktopName}.desktop` (here `com.example.MyApp.desktop`) and sets `StartupWMClass=com.example.MyApp`, both matching Electron's `app_id`. A trailing `.desktop` in `desktopName` is tolerated (stripped before the filename is composed), so configs written for earlier versions keep working. When `desktopName` is absent, the filename falls back to `executableName`.
 
 :::note[Changed in v27]
 The installed `.desktop` filename is now always derived from `desktopName`. The `linux.syncDesktopName` flag that previously gated this behaviour has been removed — see the [v26 → v27 migration guide](./migration/v26-to-v27.md#linuxsyncdesktopname-removed-always-synced).

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -120,6 +120,7 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | `squirrelWindows.noMsi` removed | ✓ | Replaced by `msi` (inverted) |
 | `<%= var %>` EJS template syntax in Linux scripts removed | — | Use `${var}` |
 | `CI_BUILD_TAG` environment variable removed | — | Use `CI_COMMIT_TAG` |
+| `linux.syncDesktopName` removed | — | Behaviour is now always on; remove the flag, set `desktopName` to control the filename |
 | `win.azureSignOptions` removed | ✓ | Replaced by `win.sign: { type: "azure", … }` |
 | `win.signtoolOptions` removed | ✓ | Replaced by `win.sign: { type: "signtool", … }` |
 | `win.sign` is now the unified signing entry point | — | Use a discriminated union with `type: "signtool" \| "hsm" \| "pkcs11" \| "azure"` |
@@ -463,6 +464,31 @@ The legacy `<%= varName %>` EJS interpolation in Linux maintainer scripts (e.g. 
 ### `CI_BUILD_TAG` environment variable
 
 Removed. Use `CI_COMMIT_TAG` (the standard GitLab CI variable) to provide the release tag.
+
+### `linux.syncDesktopName` removed (always synced)
+
+The `linux.syncDesktopName` flag is removed. The behaviour it gated is now **always on**: the installed `.desktop` filename is always derived from the `desktopName` field in `package.json` (minus the `.desktop` suffix), falling back to `executableName` only when `desktopName` is absent.
+
+```json5
+// Before (v26) — opt-in
+{
+  "build": {
+    "linux": {
+      "syncDesktopName": true  // ← delete this line; the behaviour is now the default
+    }
+  }
+}
+```
+
+No replacement is needed — simply remove the flag. To control the installed filename, set (or omit) `desktopName` in your root `package.json`:
+
+```json title="package.json"
+{
+  "desktopName": "com.example.MyApp.desktop"
+}
+```
+
+**Why this changed:** Electron derives its `app_id` / `WM_CLASS` from `desktopName`, and desktop environments match a running window to its launcher entry by comparing `WM_CLASS` against the installed `.desktop` filename. When the two diverged — which is exactly what happened with `syncDesktopName: false` (the v26 default) whenever a `desktopName` was set — GNOME, KDE, and others failed to associate the window with its launcher, breaking taskbar grouping, dock icons, and launcher highlighting (see [#9103](https://github.com/electron-userland/electron-builder/issues/9103)). Making the sync opt-in meant the default produced broken window association for any app that set a reverse-DNS `desktopName`, which is the recommended convention. The flag had no legitimate use case where leaving it `false` was correct: if `desktopName` is set you want the filename to match it, and if it is unset the behaviour is identical with or without the flag. Removing it eliminates a footgun rather than removing functionality. Path-traversal/NUL validation on the resulting filename is unchanged.
 
 ---
 
@@ -967,6 +993,7 @@ Run `electron-builder migrate-schema` first — it handles the items marked ✓ 
 - [ ] `devMetadata` / `extraMetadata` in programmatic API → `config.extraMetadata` (if applicable)
 - [ ] `--em.build` / `--em.directories` CLI flags → `-c` / `-c.directories` (if applicable)
 - [ ] `<%= var %>` Linux script syntax → `${var}` (if applicable)
+- [ ] `linux.syncDesktopName` removed — delete the flag; set `desktopName` to control the installed `.desktop` filename (if applicable)
 - [ ] `CI_BUILD_TAG` → `CI_COMMIT_TAG` (if applicable)
 - [ ] Toolset env-var overrides → `toolsets.X: { url, checksum }` (if applicable)
 - [ ] Toolset version pins validated — defaults are `winCodeSign: "1.1.0"`, `nsis: "1.2.1"`, `appimage: "1.0.3"`, `wine: "1.0.1"`; pin to `"0.0.0"` only if needed; set `winCodeSign: "1.3.0"` when using Azure Trusted Signing `signtool /dlib`

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -467,7 +467,7 @@ Removed. Use `CI_COMMIT_TAG` (the standard GitLab CI variable) to provide the re
 
 ### `linux.syncDesktopName` removed (always synced)
 
-The `linux.syncDesktopName` flag is removed. The behaviour it gated is now **always on**: the installed `.desktop` filename is always derived from the `desktopName` field in `package.json` (minus the `.desktop` suffix), falling back to `executableName` only when `desktopName` is absent.
+The `linux.syncDesktopName` flag is removed. The behaviour it gated is now **always on**: the installed `.desktop` filename is always derived from the `desktopName` field in `package.json` — installed as `${desktopName}.desktop`, with any trailing `.desktop` in the value stripped first — falling back to `executableName` only when `desktopName` is absent.
 
 ```json5
 // Before (v26) — opt-in
@@ -484,7 +484,7 @@ No replacement is needed — simply remove the flag. To control the installed fi
 
 ```json title="package.json"
 {
-  "desktopName": "com.example.MyApp.desktop"
+  "desktopName": "com.example.MyApp"
 }
 ```
 


### PR DESCRIPTION
Removes the `linux.syncDesktopName` configuration flag and makes the behaviour it gated unconditional: the installed `.desktop` filename is always derived from the `desktopName` field in `package.json`, falling back to `executableName` only when `desktopName` is absent. This is a major (breaking) change for `app-builder-lib`.

### Summary

- **Removed `linux.syncDesktopName`** from the `LinuxConfiguration` interface (`packages/app-builder-lib/src/options/linuxOptions.ts`) and from the generated JSON schema (`packages/app-builder-lib/scheme.json`).

- **`getDesktopFileName()` no longer checks the flag** — it always resolves from `desktopName` (`packages/app-builder-lib/src/targets/linux/LinuxTargetHelper.ts`):

  ```ts
  getDesktopFileName(fallback: string = this.packager.executableName): string {
    return this.resolveDesktopName() ?? fallback
  }
  ```

- **Centralized desktop-name resolution in a private `resolveDesktopName()` method.** It trims `desktopName`, strips an optional trailing `.desktop` suffix, validates the result against path separators and NUL characters (throwing `InvalidConfigurationError` on unsafe input), and returns the basename — or `null` when `desktopName` is unset, so callers apply their own fallback (filename vs `WM_CLASS`):

  ```ts
  const basename = trimmedDesktopName.replace(/\.desktop$/, "")
  if (/[/\\]/.test(basename) || [...basename].some(c => c.charCodeAt(0) === 0)) {
    throw new InvalidConfigurationError(`desktopName "${trimmedDesktopName}" produces an invalid .desktop filename — remove any path separators or NUL characters`)
  }
  ```

- **De-duplicated the warning/validation.** `computeDesktopEntry()` previously carried its own inline copy of the desktopName trim/strip/warn logic (with a stale docs URL). It now uses the same resolver for `StartupWMClass`, falling back to `productName`:

  ```ts
  const wmClass = this.resolveDesktopName() ?? appInfo.productName
  ```

- **Single warning per build.** A `desktopNameWarningEmitted` flag ensures the "set desktopName" guidance is logged at most once per build, even though both `getDesktopFileName()` and `computeDesktopEntry()` call `resolveDesktopName()`.

- **Improved warning message** (and corrected the docs-link anchor). When `desktopName` is absent it now explains the window-association impact and gives a concrete reverse-DNS example (`com.myapp.MyApp`).

- **Docs updated.** `website/docs/linux.md` ("Window Association") and the v26→v27 migration guide (`website/docs/migration/v26-to-v27.md`) describe the always-on behaviour. Per reviewer feedback, the `desktopName` examples use the suffix-free reverse-DNS form (`com.example.MyApp`) and the prose describes the installed file directly as `${desktopName}.desktop`; a note clarifies that a trailing `.desktop` is still tolerated (stripped before the filename is composed) so configs written for earlier versions keep working.

### Design notes

**Why remove the flag instead of flipping its default?** Electron derives its `app_id` / `WM_CLASS` from `desktopName`, and desktop environments associate a running window with its launcher entry by matching `WM_CLASS` against the installed `.desktop` filename. With `syncDesktopName: false` (the v26 default), any app that set a reverse-DNS `desktopName` got a filename/`WM_CLASS` mismatch, breaking taskbar grouping, dock icons, and launcher highlighting (issue #9103). There is no scenario where leaving it `false` is correct: if `desktopName` is set you want the filename to match it, and if it is unset the behaviour is identical with or without the flag — so the flag was a footgun, not functionality.

**Migration.** No automated migration is needed — users delete `linux.syncDesktopName` from their config. To control the installed filename they set (or omit) `desktopName` in their root `package.json`. Path-traversal / NUL validation on the resulting filename is unchanged.
