### PR TITLE
fix(nsis): preserve `$(...)` LangString references in escaped NSIS define values

### DIFF
--- a/.changeset/nsis-langstring-references.md
+++ b/.changeset/nsis-langstring-references.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): preserve `$(...)` LangString references in escaped NSIS define values (e.g. `shortcutName: "$(customSN)"`)

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -620,9 +620,9 @@ export class NsisTarget extends Target {
         //      would terminate the current script line and let whatever follows
         //      be parsed as a new preprocessor directive (e.g. !system, !include).
         //   2. bare $ → escaped to $$; unescaped $ in a define value would cause
-        //      NSIS to expand an unintended variable reference.  ${...} references
-        //      are left intact so NSIS compile-time defines like ${NSISDIR} still
-        //      expand correctly.
+        //      NSIS to expand an unintended variable reference.  ${...} define
+        //      references (e.g. ${NSISDIR}) and $(...) LangString references
+        //      (e.g. $(customSN)) are left intact so they still expand correctly.
         //   3. " chars   → escaped to $\"; an unescaped " would break out of
         //      double-quoted NSIS string literals where ${DEFINE} is expanded.
         args.push(`-D${name}=${nsisEscapeString(String(value))}`)

--- a/packages/app-builder-lib/src/targets/nsis/nsisScriptGenerator.ts
+++ b/packages/app-builder-lib/src/targets/nsis/nsisScriptGenerator.ts
@@ -48,7 +48,7 @@ export class NsisScriptGenerator {
 export function nsisEscapeString(s: string): string {
   const escaped = s
     .replace(/\r\n|\r|\n/g, " ") // newlines break NSIS string literals
-    .replace(/\$(?!\{)/g, "$$$$") // bare $ → $$ (prevents NSIS variable expansion); ${...} references are left intact
+    .replace(/\$(?![{(])/g, "$$$$") // bare $ → $$ (prevents NSIS variable expansion); ${...} define and $(...) LangString references are left intact
     .replace(/"/g, '$\\"') // " → $\" (NSIS escape for double-quote)
   if (escaped !== s) {
     log.debug({ original: s, final: escaped }, "nsis was escaped")

--- a/test/src/windows/nsisScriptGeneratorTest.ts
+++ b/test/src/windows/nsisScriptGeneratorTest.ts
@@ -51,6 +51,22 @@ describe("nsisEscapeString", () => {
     expect(nsisEscapeString("${INSTDIR}\\price $9.99")).toBe("${INSTDIR}\\price $$9.99")
   })
 
+  test("preserves $(...) LangString references unchanged", ({ expect }) => {
+    expect(nsisEscapeString("$(customSN)")).toBe("$(customSN)")
+  })
+
+  test("preserves $(...) LangString references mixed with text", ({ expect }) => {
+    expect(nsisEscapeString("My App $(customSN) Setup")).toBe("My App $(customSN) Setup")
+  })
+
+  test("leaves both ${...} and $(...) references intact while escaping bare $", ({ expect }) => {
+    expect(nsisEscapeString("${DEFINE} $(LangStr) costs $5")).toBe("${DEFINE} $(LangStr) costs $$5")
+  })
+
+  test("escapes bare $ followed by a space before a paren-like token", ({ expect }) => {
+    expect(nsisEscapeString("$ (not a ref)")).toBe("$$ (not a ref)")
+  })
+
   test("escapes multiple consecutive dollar signs", ({ expect }) => {
     expect(nsisEscapeString("$$")).toBe("$$$$")
   })


### PR DESCRIPTION
### Summary

Fixes #9915 — NSIS `LangString` translations referenced via `$(...)` syntax (e.g. `shortcutName: "$(customSN)"`) stopped working in v26.12.x and rendered literally (the shortcut was named `$(customSN)` instead of the translated string).

- `nsisEscapeString` escapes a bare `$` to `$$` to prevent unintended NSIS variable expansion in generated define values. The negative lookahead that whitelisted compile-time `${...}` define references did not also whitelist NSIS `$(...)` LangString references, so any user-supplied value containing a LangString reference was escaped and rendered as literal text.
- Widened the lookahead so both delimited NSIS reference forms pass through untouched:

```ts
// before
.replace(/\$(?!\{)/g, "$$$$")
// after
.replace(/\$(?![{(])/g, "$$$$")
```

- Bare `$VAR` variable references (e.g. `$INSTDIR`, `$0`) remain escaped to `$$VAR` — only the two delimited reference forms (`${...}` defines and `$(...)` LangStrings) are preserved.

### Notes

- The two delimited NSIS reference forms are `${...}` (compile-time defines/macros) and `$(...)` (runtime LangStrings); both are now preserved. There are no other delimited reference forms to handle. Bare `$VAR` runtime-variable references are intentionally left escaped.
- The newline-stripping and double-quote escaping behavior of `nsisEscapeString` is unchanged.
