### PR TITLE
fix(linux): write `executableArgs` verbatim into the `.desktop` Exec

### DIFF
--- a/.changeset/linux-exec-args-verbatim.md
+++ b/.changeset/linux-exec-args-verbatim.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(linux): write `executableArgs` verbatim into the `.desktop` Exec line so packaged apps (deb/rpm) still appear in the application menu

--- a/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/LinuxTargetHelper.ts
@@ -35,39 +35,18 @@ function desktopStringEscape(value: string): string {
 }
 
 /**
- * Characters that require an Exec argument to be double-quoted per the
- * freedesktop Desktop Entry Specification.  Plain alphanumeric args and
- * field codes must NOT be wrapped in quotes.
+ * Build the argument portion of a .desktop Exec line.
+ *
+ * executableArgs are written verbatim — matching AppImage and the behavior that
+ * shipped for years — so an arg like `--js-flags="--max-old-space-size=12288"`
+ * reaches the launcher exactly as the developer specified. Only carriage-return
+ * and newline characters are removed: the Exec key is a single line, and an
+ * embedded line break would split it into additional .desktop entries.
  *
  * @see https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
  */
-const EXEC_RESERVED_RE = /[\s"'`\\<>~|&;$*?#()]/
-
-/**
- * Quote a single argument for use in a .desktop file Exec key.
- *
- * Field codes (`%f`, `%u`, `%F`, `%U`, etc.) MUST be left unquoted — the
- * desktop launcher only expands them in unquoted token positions.  Wrapping
- * them in `"…"` causes the launcher to treat them as literal strings, which
- * breaks file-association / drag-and-drop functionality.
- *
- * For all other arguments, double-quoting is used when the argument contains
- * any character that would be misinterpreted by the launcher without quoting
- * (spaces, shell metacharacters, etc.).  Safe plain-word args are passed
- * through unchanged to keep the Exec line readable.
- *
- * @see https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
- */
-function desktopExecArgEscape(arg: string): string {
-  // Field codes (%f, %u, %F, %U, %i, %c, %k, …) must never be quoted.
-  if (/^%[a-zA-Z]$/.test(arg)) {
-    return arg
-  }
-  // Only quote when the arg actually contains characters that need it.
-  if (EXEC_RESERVED_RE.test(arg)) {
-    return `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
-  }
-  return arg
+export function buildExecArgs(executableArgs: ReadonlyArray<string>): string {
+  return executableArgs.map(arg => arg.replace(/[\r\n]+/g, "")).join(" ")
 }
 
 function mapLinuxCompressionToSnap(level: CompressionLevel | null | undefined): "xz" | "lzo" | undefined {
@@ -271,11 +250,8 @@ export class LinuxTargetHelper {
       if (!/^[/0-9A-Za-z._-]+$/.test(exec)) {
         exec = `"${exec}"`
       }
-      if (executableArgs) {
-        exec += " "
-        // Each arg is double-quoted per the freedesktop Exec key spec so that
-        // spaces, $, ;, & and other reserved characters are not misinterpreted.
-        exec += executableArgs.map(desktopExecArgEscape).join(" ")
+      if (executableArgs && executableArgs.length > 0) {
+        exec += " " + buildExecArgs(executableArgs)
       }
       // https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables
       const execCodes = ["%f", "%u", "%F", "%U"]

--- a/packages/app-builder-lib/src/targets/appimage/AppImageTarget.ts
+++ b/packages/app-builder-lib/src/targets/appimage/AppImageTarget.ts
@@ -7,7 +7,7 @@ import { LinuxPackager } from "../../linuxPackager"
 import { AppImageOptions } from "../../options/linuxOptions"
 import { getAppUpdatePublishConfiguration } from "../../publish/PublishManager"
 import { getNotLocalizedLicenseFile } from "../../util/license"
-import { LinuxTargetHelper } from "../LinuxTargetHelper"
+import { buildExecArgs, LinuxTargetHelper } from "../LinuxTargetHelper"
 import { createStageDir } from "../targetUtil"
 import { buildLegacyFuse2AppImage, buildStaticRuntimeAppImage } from "./appImageUtil"
 import { BlockMapDataHolder, deepAssign } from "builder-util-runtime"
@@ -33,7 +33,7 @@ export default class AppImageTarget extends Target {
       const appimageTool = packager.config.toolsets?.appimage
       const defaultArgs = appimageTool == null || appimageTool === "0.0.0" ? ["--no-sandbox"] : []
       const args = this.options.executableArgs ?? defaultArgs
-      const exec = [APP_RUN_ENTRYPOINT, ...args, "%U"].join(" ")
+      const exec = [APP_RUN_ENTRYPOINT, buildExecArgs(args), "%U"].filter(Boolean).join(" ")
       return helper.computeDesktopEntry(this.options, exec, {
         "X-AppImage-Version": `${packager.appInfo.buildVersion}`,
       })

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
@@ -129,6 +129,23 @@ exports[`LinuxPackager > AppImage - desktopName without .desktop suffix is used 
 }
 `;
 
+exports[`LinuxPackager > AppImage - executableArgs are written verbatim into the Exec line 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Test App ßW-1.1.0.AppImage",
+      "safeArtifactName": "TestApp-1.1.0-x86_64.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - explicit zstd compression override 1`] = `
 {
   "linux": [

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.2__Test.js.snap
@@ -129,6 +129,23 @@ exports[`LinuxPackager > AppImage - desktopName without .desktop suffix is used 
 }
 `;
 
+exports[`LinuxPackager > AppImage - executableArgs are written verbatim into the Exec line 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Test App ßW-1.1.0.AppImage",
+      "safeArtifactName": "TestApp-1.1.0-x86_64.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - explicit zstd compression override 1`] = `
 {
   "linux": [

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
@@ -129,6 +129,23 @@ exports[`LinuxPackager > AppImage - desktopName without .desktop suffix is used 
 }
 `;
 
+exports[`LinuxPackager > AppImage - executableArgs are written verbatim into the Exec line 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "Test App ßW-1.1.0.AppImage",
+      "safeArtifactName": "TestApp-1.1.0-x86_64.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
 exports[`LinuxPackager > AppImage - explicit zstd compression override 1`] = `
 {
   "linux": [

--- a/test/src/linux/linuxPackagerTestSuite.ts
+++ b/test/src/linux/linuxPackagerTestSuite.ts
@@ -239,6 +239,27 @@ export function registerLinuxPackagerTests(toolsets: ToolsetConfig): void {
       }
     ))
 
+  test("AppImage - executableArgs are written verbatim into the Exec line", ({ expect }) =>
+    // https://github.com/electron-userland/electron-builder/issues/9914
+    app(expect, {
+      targets: appImageTarget,
+      config: {
+        toolsets,
+        publish: null,
+        linux: {
+          executableArgs: ['--js-flags="--max-old-space-size=12288"'],
+        },
+      },
+      effectiveOptionComputed: async it => {
+        const content: string = it.desktop
+        const execLine = content.split("\n").find(line => line.startsWith("Exec="))
+        expect(execLine).toContain('--js-flags="--max-old-space-size=12288"')
+        // must NOT wrap the whole arg in outer quotes with escaped inner quotes
+        expect(execLine).not.toContain('"--js-flags=\\"')
+        return Promise.resolve(false)
+      },
+    }))
+
   test("icons from ICNS (mac)", ({ expect }) =>
     app(
       expect,

--- a/test/src/linuxDesktopEntryTest.ts
+++ b/test/src/linuxDesktopEntryTest.ts
@@ -1,0 +1,30 @@
+import { buildExecArgs } from "app-builder-lib/src/targets/LinuxTargetHelper"
+
+describe("buildExecArgs", () => {
+  test("passes a quoted arg through verbatim (no outer wrapping, no escaping)", ({ expect }) => {
+    // https://github.com/electron-userland/electron-builder/issues/9914
+    const arg = '--js-flags="--max-old-space-size=12288"'
+    expect(buildExecArgs([arg])).toBe(arg)
+  })
+
+  test("joins multiple args with a single space", ({ expect }) => {
+    expect(buildExecArgs(["--first", "--second=value"])).toBe("--first --second=value")
+  })
+
+  test("does not auto-quote args containing spaces", ({ expect }) => {
+    expect(buildExecArgs(["--foo=a b"])).toBe("--foo=a b")
+  })
+
+  test("leaves field codes untouched", ({ expect }) => {
+    expect(buildExecArgs(["%U"])).toBe("%U")
+  })
+
+  test("strips carriage-return / newline so the Exec key stays a single line", ({ expect }) => {
+    expect(buildExecArgs(["a\nExec=evil"])).toBe("aExec=evil")
+    expect(buildExecArgs(["a\r\nb"])).toBe("ab")
+  })
+
+  test("returns an empty string for no args", ({ expect }) => {
+    expect(buildExecArgs([])).toBe("")
+  })
+})


### PR DESCRIPTION
Fixes #9914

### Summary

- Linux `.desktop` files are once again generated with `executableArgs` written **verbatim** into the `Exec=` line, restoring the long-standing behavior. Previously each argument was wrapped in an outer pair of double quotes whenever it contained certain characters, which produced an `Exec` line that recent Ubuntu/GNOME refuses to list in the applications menu.

  For example, with:

  ```yaml
  linux:
    executableArgs:
      - '--js-flags="--max-old-space-size=12288"'
  ```

  the generated entry is now:

  ```
  Exec=/opt/MyApp/myapp --js-flags="--max-old-space-size=12288" %U
  ```

  instead of the previous menu-breaking form:

  ```
  Exec=/opt/MyApp/myapp "--js-flags=\"--max-old-space-size=12288\"" %U
  ```

- Extracted a small shared helper `buildExecArgs(executableArgs)` in the Linux target helper that joins the arguments verbatim and strips only carriage-return / newline characters (the `Exec` key is a single line, so an embedded line break would otherwise split it into additional entries).

- The DEB/RPM (`fpm`) path and the AppImage path now both run their arguments through this single helper, so the two targets produce identical `Exec` argument formatting. Previously, only the AppImage path joined arguments verbatim, while the `fpm` path applied the extra quoting — the source of the regression.

- Field codes (`%U`, `%f`, etc.) and the executable-path quoting are unchanged. String fields such as `Name`, `Comment`, and `StartupWMClass` continue to be escaped per the freedesktop string rules.

### Notes

- Argument grouping remains the developer's responsibility, matching the historical behavior: an argument intended to contain spaces should be provided as a single `executableArgs` entry, exactly as it was before.
- No snapshot output changes for existing default configurations (e.g. the default `--no-sandbox`), confirmed by the existing AppImage suite passing unchanged.
