### PR TITLE
fix(win): serialize concurrent signtool invocations with lockfile

### DIFF
--- a/.changeset/signtool-concurrency-lock.md
+++ b/.changeset/signtool-concurrency-lock.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(win): serialize concurrent signtool invocations to avoid intermittent "An error occurred while attempting to load the signing certificate"

--- a/packages/app-builder-lib/src/codeSign/win/signtoolBaseSignManager.ts
+++ b/packages/app-builder-lib/src/codeSign/win/signtoolBaseSignManager.ts
@@ -15,6 +15,7 @@ import AppXTarget from "../../targets/win/AppxTarget.js"
 import { getSignToolPath } from "../../toolsets/winCodeSign.js"
 import { ToolInfo } from "../../util/bundledTool.js"
 import { resolveFunction } from "../../util/resolve.js"
+import { withSigntoolLock } from "../../util/toolsetLock.js"
 import { readCertInfo, readCertInfoFromX509 } from "../certInfo.js"
 import { VmManager } from "../../vm/vm.js"
 import type { WinPackager } from "../../winPackager.js"
@@ -428,7 +429,10 @@ export abstract class SigntoolBaseSignManager implements SignManager {
       args = configuration.computeSignToolArgs(isWin)
     }
 
-    await retry(() => vm.exec(tool, args, { timeout, env: { ...process.env, ...(toolInfo.env || {}) } }), {
+    // signtool.exe (`/f`) is not safe to run concurrently — it races on the shared per-user crypto store.
+    // Serialize real-Windows signtool invocations across processes; osslsigncode (`!isWin`) is file-isolated.
+    const execSign = () => vm.exec(tool, args, { timeout, env: { ...process.env, ...(toolInfo.env || {}) } })
+    await retry(() => (isWin ? withSigntoolLock(execSign) : execSign()), {
       retries: 2,
       interval: 15000,
       backoff: 10000,
@@ -436,7 +440,10 @@ export abstract class SigntoolBaseSignManager implements SignManager {
         if (
           e.message.includes("The file is being used by another process") ||
           e.message.includes("The specified timestamp server either could not be reached") ||
-          e.message.includes("No certificates were found that met all the given criteria.")
+          e.message.includes("No certificates were found that met all the given criteria.") ||
+          // Transient failure of SignerSignEx after cert selection, typically a concurrent-signtool race
+          // on the per-user crypto store; the cross-process lock above makes this rare, retry covers the rest.
+          e.message.includes("An error occurred while attempting to load the signing certificate")
         ) {
           log.warn(`Attempt to code sign failed, another attempt will be made in 15 seconds: ${e.message}`)
           return true

--- a/packages/app-builder-lib/src/util/toolsetLock.ts
+++ b/packages/app-builder-lib/src/util/toolsetLock.ts
@@ -4,17 +4,34 @@ import * as lockfile from "proper-lockfile"
 import * as os from "os"
 import * as path from "path"
 
-const LOCK_FILE = path.join(os.tmpdir(), ".electron-builder-toolset.lock")
+const TOOLSET_LOCK_FILE = path.join(os.tmpdir(), ".electron-builder-toolset.lock")
+const SIGNTOOL_LOCK_FILE = path.join(os.tmpdir(), ".electron-builder-signtool.lock")
 
-export async function withToolsetLock<T>(task: () => Promise<T>): Promise<T> {
-  await writeFile(LOCK_FILE, "", { flag: "a" })
-  const release = await lockfile.lock(LOCK_FILE, {
+async function withLock<T>(lockFile: string, task: () => Promise<T>): Promise<T> {
+  await writeFile(lockFile, "", { flag: "a" })
+  const release = await lockfile.lock(lockFile, {
     retries: { retries: 100, minTimeout: 1000, maxTimeout: 5000 },
     stale: 120_000,
   })
   try {
     return await task()
   } finally {
-    await release().catch((err: Error) => log.warn({ err }, "failed to release toolset lock"))
+    await release().catch((err: Error) => log.warn({ err }, "failed to release lock"))
   }
+}
+
+export function withToolsetLock<T>(task: () => Promise<T>): Promise<T> {
+  return withLock(TOOLSET_LOCK_FILE, task)
+}
+
+// `signtool sign /f <pfx>` imports the PFX via PFXImportCertStore, which mutates the per-user
+// CryptoAPI/CNG key+cert storage — a process-global resource that is not safe for concurrent access.
+// winPackager already serializes signing within a single packager (signingQueue), but parallel builds
+// (e.g. the test harness running multiple packagers across vitest workers that share one Windows user
+// profile) race on that shared store and intermittently fail, after cert selection, with
+// "SignTool Error: An error occurred while attempting to load the signing certificate". A dedicated
+// cross-process lock (separate from the toolset lock so it does not block MSI/Squirrel builds)
+// serializes signtool invocations. No-op overhead for real single builds, which are already serial.
+export function withSigntoolLock<T>(task: () => Promise<T>): Promise<T> {
+  return withLock(SIGNTOOL_LOCK_FILE, task)
 }

--- a/test/src/toolsetLockTest.ts
+++ b/test/src/toolsetLockTest.ts
@@ -1,0 +1,25 @@
+import { withSigntoolLock } from "app-builder-lib/src/util/toolsetLock"
+
+// signtool is not safe to run concurrently (it races on the per-user crypto store), so withSigntoolLock
+// must serialize overlapping invocations across the process. Verify two concurrent holders never interleave.
+test("withSigntoolLock serializes concurrent invocations", async ({ expect }) => {
+  const events: string[] = []
+  const makeTask = (id: string) => async () => {
+    events.push(`start-${id}`)
+    await new Promise(resolve => setTimeout(resolve, 30))
+    events.push(`end-${id}`)
+    return id
+  }
+
+  const results = await Promise.all([withSigntoolLock(makeTask("a")), withSigntoolLock(makeTask("b"))])
+  expect(results.sort()).toEqual(["a", "b"])
+
+  // Serialized execution => events are paired (start-X immediately followed by end-X), never interleaved
+  // (e.g. start-a, start-b, end-a, end-b would mean both held the lock at once).
+  expect(events).toHaveLength(4)
+  for (let i = 0; i < events.length; i += 2) {
+    const id = events[i].replace("start-", "")
+    expect(events[i]).toBe(`start-${id}`)
+    expect(events[i + 1]).toBe(`end-${id}`)
+  }
+})


### PR DESCRIPTION
### Summary

Fixes intermittent Windows code-signing failures in CI that surfaced after the test suite began signing builds in parallel (runtime-generated self-signed cert + de-sequenced tests):

    SignTool Error: An error occurred while attempting to load the signing certificate from: <file being signed>

Root cause: the message is misleading. signtool loads the certificate and private key successfully every time (the /debug output shows "After Private Key filter, 1 certs were left" and a selected cert); the failure happens afterward, during the actual signing step. `signtool sign /f <pfx>` imports the PFX via PFXImportCertStore, which mutates the per-user CryptoAPI/CNG key+cert store — a process-global OS resource that is not safe for concurrent use. winPackager already serializes signing within a single packager (signingQueue), but parallel builds (multiple packagers across vitest workers sharing one Windows user profile) race on that shared store and intermittently fail after cert selection. The error hits arbitrary signed files (main exe, uninstaller, Squirrel.exe, the Squirrel ExecutionStub) and only on some runs — the signature of a concurrency race, not a cert/file defect.

Note: the ß in "Test App ßW.exe" appearing dropped in signtool's error text ("Test App W.exe") is a cosmetic stderr-decoding artifact (signtool writes OEM code page, captured output is decoded as UTF-8); the path is passed to signtool correctly via execFile arg arrays. This was confirmed because plainly-named files (Squirrel.exe, ExecutionStub.exe) fail identically.

### Design notes

- The lock is applied per signtool attempt (inside the existing retry), so retry backoff sleeps happen outside the lock rather than holding it idle.
- Production single builds are already serial (one packager), so the cross-process lock is effectively free there; it only throttles the parallel multi-build case, which is exactly the racing scenario.
- The lock is gated to the real-Windows signtool path (isWin); the osslsigncode path on Linux signs to a separate output file with a file-based key and is not affected by the shared-store race.
