### PR TITLE
chore: backport fixes from `master` to `v26`

### DIFF
--- a/.changeset/cool-carrots-fix.md
+++ b/.changeset/cool-carrots-fix.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: resolve ENOENT on electron zip extraction in Windows Docker

--- a/.changeset/mac-7z-symlink-snl.md
+++ b/.changeset/mac-7z-symlink-snl.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: preserve symlinks in `zip` and `7z` archive targets on macOS and Linux via 7za `-snl` (Windows still dereferences). Restores pre-26.15 behavior after the bundled 7-Zip upgrade, which began dereferencing by default — corrupting macOS `.framework` bundles (codesign "bundle format is ambiguous", breaking Squirrel.Mac auto-update) and duplicating Linux symlink content.

--- a/packages/app-builder-lib/src/targets/ArchiveTarget.ts
+++ b/packages/app-builder-lib/src/targets/ArchiveTarget.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { Platform, Target, TargetSpecificOptions } from "../core"
 import { copyFiles, getFileMatchers } from "../fileMatcher"
 import { PlatformPackager } from "../platformPackager"
-import { archive, tar } from "./archive"
+import { archive, shouldPreserveSymlinks, tar } from "./archive"
 import { appendBlockmap, createBlockmap } from "./differentialUpdateInfoBuilder"
 
 export class ArchiveTarget extends Target {
@@ -67,7 +67,7 @@ export class ArchiveTarget extends Target {
         const archiveOptions = {
           compression: packager.compression,
           withoutDir,
-          preserveSymlinks: isMac,
+          preserveSymlinks: shouldPreserveSymlinks(packager.platform),
         }
         await archive(format, artifactPath, dirToArchive, archiveOptions)
 

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -4,7 +4,7 @@ import * as path from "path"
 import { create } from "tar"
 import { TarOptionsWithAliasesAsync } from "tar/dist/commonjs/options"
 import { TmpDir } from "temp-file"
-import { CompressionLevel } from "../core"
+import { CompressionLevel, Platform } from "../core"
 import { getLinuxToolsMacToolset } from "../toolsets/linux"
 import { getPath7za } from "../toolsets/7zip"
 
@@ -88,10 +88,21 @@ export interface ArchiveOptions {
   isRegularFile?: boolean
 
   /**
-   * Use native macOS `zip` to preserve symlinks. Required for .framework bundles.
+   * Preserve symlinks (e.g. macOS .framework `Versions/Current`) instead of dereferencing them.
+   * Passes `-snl` to 7za — modern 7-Zip derefs by default, which breaks bundle codesigning. See #9846.
    * @default false
    */
   preserveSymlinks?: boolean
+}
+
+/**
+ * Whether archives for the given target platform should preserve symlinks (i.e. pass `-snl`).
+ * Non-Windows targets preserve them: macOS `.framework` bundles need them for codesigning (#9846)
+ * and Linux bundles may legitimately contain them. Windows dereferences because restoring symlinks
+ * there requires elevated privileges. Keyed on the target platform, not the build host.
+ */
+export function shouldPreserveSymlinks(platform: Platform): boolean {
+  return platform !== Platform.WINDOWS
 }
 
 export function compute7zCompressArgs(format: string, options: ArchiveOptions = {}) {
@@ -168,14 +179,23 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     return outFile
   }
 
-  // On macOS, use native `zip` when symlink preservation is required (e.g. .framework bundles).
-  // 7zip dereferences symlinks, corrupting .framework structure and breaking codesign.
-  // Only opt in via preserveSymlinks — Windows zip targets built on macOS still use 7z
-  // so that the UTF-8 bit (-mcu) is set correctly in the zip header.
-  const use7z = !(process.platform === "darwin" && format === "zip" && options.preserveSymlinks)
+  // Use 7za for all formats (matches pre-26.15 behavior). Native macOS `zip` is only a
+  // fallback for NFD-normalized filenames, which 7za mangles.
+  let use7z = true
+  if (process.platform === "darwin" && format === "zip" && dirToArchive.normalize("NFC") !== dirToArchive) {
+    log.warn({ reason: "7z doesn't support NFD-normalized filenames" }, `using zip`)
+    use7z = false
+  }
 
   if (use7z) {
     const args = compute7zCompressArgs(format, options)
+    // Modern 7-Zip (24.09) dereferences symlinks by default; the 7-Zip 16.02 bundled before
+    // 26.15 stored them as links. Without -snl, a macOS .framework `Versions/Current` extracts
+    // as a real directory → codesign "bundle format is ambiguous" → breaks Squirrel.Mac
+    // auto-update (#9846). Callers enable it for all non-Windows targets (see ArchiveTarget).
+    if (options.preserveSymlinks) {
+      args.push("-snl")
+    }
     await unlinkIfExists(outFile)
     args.push(outFile, options.withoutDir ? "." : path.basename(dirToArchive))
     if (options.excluded != null) {
@@ -197,7 +217,7 @@ export async function archive(format: string, outFile: string, dirToArchive: str
       }
     }
   } else {
-    // macOS native zip: -y preserves symlinks (required for .framework bundles)
+    // macOS native zip (NFD fallback): -y preserves symlinks
     const args = ["-q", "-r", "-y"]
     if (debug7z.enabled) {
       args.push("-v")

--- a/packages/app-builder-lib/src/util/electronGet.ts
+++ b/packages/app-builder-lib/src/util/electronGet.ts
@@ -131,6 +131,22 @@ function resolveCacheMode(): ElectronDownloadCacheMode {
   return ElectronDownloadCacheMode.ReadWrite
 }
 
+/**
+ * Returns true when `destPath` is safely contained within `dir` (direct child or deeper).
+ * On Windows the filesystem is case-insensitive so the comparison is normalised to lowercase.
+ * @internal exported for unit testing
+ */
+export function isSafeExtractPath(destPath: string, dir: string): boolean {
+  const normalizedDest = path.resolve(destPath)
+  const normalizedDir = path.resolve(dir)
+  if (process.platform === "win32") {
+    const d = normalizedDest.toLowerCase()
+    const b = normalizedDir.toLowerCase()
+    return d.startsWith(b + path.sep) || d === b
+  }
+  return normalizedDest.startsWith(normalizedDir + path.sep) || normalizedDest === normalizedDir
+}
+
 async function extractZipStreaming(file: string, dir: string): Promise<void> {
   // Pass 1: read central directory once to collect Unix modes (one seek to EOF)
   const zipDir = await unzipper.Open.file(file)
@@ -143,35 +159,88 @@ async function extractZipStreaming(file: string, dir: string): Promise<void> {
   }
   const isSymlink = (mode: number) => (mode & 0o170000) === 0o120000
 
-  // Pass 2: stream from byte 0 — no per-entry seeks, no Docker hang
-  const entries = createReadStream(file).pipe(unzipper.Parse({ forceStream: true }))
-  for await (const entry of entries as AsyncIterable<unzipper.Entry>) {
-    const destPath = path.resolve(dir, entry.path)
-    if (!destPath.startsWith(dir + path.sep) && destPath !== dir) {
-      throw new Error(`Path traversal blocked: ${entry.path}`)
+  // Pass 2: stream from byte 0 — no per-entry seeks, no Docker hang.
+  // Destroy the read stream in a finally block so the file handle is always released,
+  // including when the loop exits early due to a thrown error.
+  const readStream = createReadStream(file)
+  try {
+    const entries = readStream.pipe(unzipper.Parse({ forceStream: true }))
+    for await (const entry of entries as AsyncIterable<unzipper.Entry>) {
+      const destPath = path.resolve(dir, entry.path)
+      if (!isSafeExtractPath(destPath, dir)) {
+        throw new Error(`Path traversal blocked: ${entry.path}`)
+      }
+      const mode = entryModes.get(entry.path) ?? 0
+      if (mode > 0 && isSymlink(mode)) {
+        const target = (await entry.buffer()).toString()
+        if (path.isAbsolute(target)) {
+          throw new Error(`Absolute symlink target blocked: ${target}`)
+        }
+        const resolvedTarget = path.resolve(path.dirname(destPath), target)
+        if (!isSafeExtractPath(resolvedTarget, dir)) {
+          throw new Error(`Symlink target escapes extraction dir: ${target}`)
+        }
+        await fs.mkdir(path.dirname(destPath), { recursive: true })
+        await fs.symlink(target, destPath)
+      } else if (entry.type === "Directory") {
+        await fs.mkdir(destPath, { recursive: true })
+        entry.autodrain()
+      } else {
+        await fs.mkdir(path.dirname(destPath), { recursive: true })
+        await pipeline(entry, createWriteStream(destPath))
+        if (mode > 0) {
+          await fs.chmod(destPath, mode & 0o7777)
+        }
+      }
     }
-    const mode = entryModes.get(entry.path) ?? 0
-    if (mode > 0 && isSymlink(mode)) {
-      const target = (await entry.buffer()).toString()
-      if (path.isAbsolute(target)) {
-        throw new Error(`Absolute symlink target blocked: ${target}`)
-      }
-      const resolvedTarget = path.resolve(path.dirname(destPath), target)
-      if (!resolvedTarget.startsWith(dir + path.sep) && resolvedTarget !== dir) {
-        throw new Error(`Symlink target escapes extraction dir: ${target}`)
-      }
-      await fs.mkdir(path.dirname(destPath), { recursive: true })
-      await fs.symlink(target, destPath)
-    } else if (entry.type === "Directory") {
-      await fs.mkdir(destPath, { recursive: true })
-      entry.autodrain()
-    } else {
-      await fs.mkdir(path.dirname(destPath), { recursive: true })
-      await pipeline(entry, createWriteStream(destPath))
-      if (mode > 0) {
-        await fs.chmod(destPath, mode & 0o7777)
-      }
+  } finally {
+    readStream.destroy()
+  }
+}
+
+const TRANSIENT_RENAME_CODES = new Set(["ENOENT", "EPERM", "EBUSY", "EXDEV"])
+
+/**
+ * @internal exported for unit testing
+ *
+ * Atomically moves `src` to `dest` by rename, retrying on transient Windows errors (ENOENT,
+ * EPERM, EBUSY) before falling back to a copy+delete when all retries are exhausted.
+ *
+ * On Windows Docker / Windows Server containers, MoveFileEx can spuriously return
+ * ERROR_FILE_NOT_FOUND (ENOENT) or a sharing-violation even when both paths are valid.
+ * Retrying with back-off resolves the majority of these transient failures; the copy+delete
+ * fallback handles the rare case where the rename keeps failing (e.g. cross-device move).
+ */
+export async function moveDirAtomic(src: string, dest: string): Promise<void> {
+  // 4 retries → 5 total attempts; interval+backoff*attempt gives 250/500/750/1000 ms delays.
+  let lastErr: (Error & { code?: string }) | undefined
+  try {
+    await retry(() => fs.rename(src, dest), {
+      retries: 4,
+      interval: 250,
+      backoff: 250,
+      shouldRetry: (err: any) => {
+        if (TRANSIENT_RENAME_CODES.has(err.code ?? "")) {
+          log.warn({ src: log.filePath(src), dest: log.filePath(dest), code: err.code }, "directory rename failed, retrying")
+          return true
+        }
+        return false
+      },
+    })
+    return
+  } catch (err: any) {
+    lastErr = err
+    if (!TRANSIENT_RENAME_CODES.has(err.code ?? "")) {
+      throw err
     }
+  }
+  // All rename retries exhausted on a transient error — fall back to copy + delete
+  log.warn({ src: log.filePath(src), dest: log.filePath(dest) }, "directory rename failed repeatedly; falling back to copy+delete")
+  try {
+    await fs.cp(src, dest, { recursive: true })
+    await fs.rm(src, { recursive: true, force: true })
+  } catch (err: any) {
+    throw new Error(`Failed to move directory from ${src} to ${dest}: ${err.message}${lastErr ? `; last rename error: ${lastErr.message}` : ""}`)
   }
 }
 
@@ -229,7 +298,7 @@ export async function extractArchive(file: string, dir: string) {
         // Check if extraction actually failed or just had benign warnings
         const files = await fs.readdir(tmpDir)
         if (files.length === 0) {
-          log.warn({ file, tmpDir, error: e.message }, "7z extraction produced no output")
+          log.warn({ file: log.filePath(file), tmpDir: log.filePath(tmpDir), error: e.message }, "7z extraction produced no output")
           throw new Error(`7z extraction failed for ${file}: ${e.message}`)
         }
         // If files were extracted despite the error, log and continue
@@ -246,7 +315,7 @@ export async function extractArchive(file: string, dir: string) {
     }
 
     await fs.rm(dir, { recursive: true, force: true })
-    await fs.rename(tmpDir, dir)
+    await moveDirAtomic(tmpDir, dir)
   } finally {
     await release().catch(err => log.warn({ err }, "failed to release lockfile"))
   }

--- a/test/snapshots/mac/macArchiveTest.js.snap
+++ b/test/snapshots/mac/macArchiveTest.js.snap
@@ -1,5 +1,66 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`7z preserves .framework symlinks (#9846) 1`] = `
+{
+  "mac": [
+    {
+      "arch": "x64",
+      "file": "Test App ßW-1.1.0-mac.7z",
+      "safeArtifactName": "TestApp-1.1.0-mac.7z",
+    },
+  ],
+}
+`;
+
+exports[`7z preserves .framework symlinks (#9846) 2`] = `
+{
+  "CFBundleDisplayName": "Test App ßW",
+  "CFBundleExecutable": "Test App ßW",
+  "CFBundleIconFile": "icon.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "Test App ßW",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.1.0",
+  "ElectronAsarIntegrity": {
+    "Resources/app.asar": {
+      "algorithm": "SHA256",
+      "hash": "hash",
+    },
+  },
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSEnvironment": {
+    "MallocNanoZone": "0",
+  },
+  "NSAppTransportSecurity": {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": {
+      "127.0.0.1": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSAudioCaptureUsageDescription": "This app needs access to audio capture",
+  "NSBluetoothAlwaysUsageDescription": "This app needs access to Bluetooth",
+  "NSBluetoothPeripheralUsageDescription": "This app needs access to Bluetooth",
+  "NSHighResolutionCapable": true,
+  "NSPrefersDisplaySafeAreaCompatibilityMode": false,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
 exports[`empty installLocation 1`] = `
 {
   "mac": [
@@ -1416,6 +1477,79 @@ exports[`tar.gz 1`] = `
 `;
 
 exports[`tar.gz 2`] = `
+{
+  "CFBundleDisplayName": "Test App ßW",
+  "CFBundleExecutable": "Test App ßW",
+  "CFBundleIconFile": "icon.icns",
+  "CFBundleIdentifier": "org.electron-builder.testApp",
+  "CFBundleInfoDictionaryVersion": "6.0",
+  "CFBundleName": "Test App ßW",
+  "CFBundlePackageType": "APPL",
+  "CFBundleShortVersionString": "1.1.0",
+  "ElectronAsarIntegrity": {
+    "Resources/app.asar": {
+      "algorithm": "SHA256",
+      "hash": "hash",
+    },
+  },
+  "LSApplicationCategoryType": "your.app.category.type",
+  "LSEnvironment": {
+    "MallocNanoZone": "0",
+  },
+  "NSAppTransportSecurity": {
+    "NSAllowsLocalNetworking": true,
+    "NSExceptionDomains": {
+      "127.0.0.1": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+      "localhost": {
+        "NSIncludesSubdomains": false,
+        "NSTemporaryExceptionAllowsInsecureHTTPLoads": true,
+        "NSTemporaryExceptionAllowsInsecureHTTPSLoads": false,
+        "NSTemporaryExceptionMinimumTLSVersion": "1.0",
+        "NSTemporaryExceptionRequiresForwardSecrecy": false,
+      },
+    },
+  },
+  "NSAudioCaptureUsageDescription": "This app needs access to audio capture",
+  "NSBluetoothAlwaysUsageDescription": "This app needs access to Bluetooth",
+  "NSBluetoothPeripheralUsageDescription": "This app needs access to Bluetooth",
+  "NSHighResolutionCapable": true,
+  "NSPrefersDisplaySafeAreaCompatibilityMode": false,
+  "NSPrincipalClass": "AtomApplication",
+  "NSSupportsAutomaticGraphicsSwitching": true,
+}
+`;
+
+exports[`zip preserves .framework symlinks (#9846) 1`] = `
+{
+  "mac": [
+    {
+      "arch": "x64",
+      "file": "Test App ßW-1.1.0-mac.zip",
+      "safeArtifactName": "TestApp-1.1.0-mac.zip",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    {
+      "file": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "safeArtifactName": "Test App ßW-1.1.0-mac.zip.blockmap",
+      "updateInfo": {
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+  ],
+}
+`;
+
+exports[`zip preserves .framework symlinks (#9846) 2`] = `
 {
   "CFBundleDisplayName": "Test App ßW",
   "CFBundleExecutable": "Test App ßW",

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -2,8 +2,9 @@
 // Import as namespace then cast to any so vitest's TypeScript transform still resolves
 // the real source exports while TypeScript type-checking is satisfied.
 import * as archiveModule from "app-builder-lib/src/targets/archive"
+import { Platform } from "app-builder-lib/src/core"
 
-const { archive, compute7zCompressArgs } = archiveModule as any
+const { archive, compute7zCompressArgs, shouldPreserveSymlinks } = archiveModule as any
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
@@ -171,9 +172,27 @@ describe("archive() guards", () => {
   })
 })
 
-// ─── archive() — macOS zip symlink preservation ──────────────────────────────
+// ─── shouldPreserveSymlinks — target platform → -snl policy ──────────────────
+// Regression guard for #9846 and its Linux follow-up: keyed on the target platform (not the build
+// host), so a Linux distributable built on a Windows machine still preserves symlinks, and a Windows
+// distributable built on macOS/Linux still dereferences. Catches narrowing the policy back to mac-only.
 
-describe.runIf(process.platform === "darwin")("archive() macOS zip symlink preservation", () => {
+describe("shouldPreserveSymlinks", () => {
+  test("preserves symlinks for macOS and Linux targets", ({ expect }) => {
+    expect(shouldPreserveSymlinks(Platform.MAC)).toBe(true)
+    expect(shouldPreserveSymlinks(Platform.LINUX)).toBe(true)
+  })
+
+  test("dereferences symlinks for Windows targets", ({ expect }) => {
+    expect(shouldPreserveSymlinks(Platform.WINDOWS)).toBe(false)
+  })
+})
+
+// ─── archive() — symlink preservation (non-Windows hosts) ────────────────────
+// Runs on macOS and Linux: both are non-Windows archive targets that pass -snl (see ArchiveTarget).
+// Windows is excluded — symlink restore there needs elevated privileges and the target dereferences.
+
+describe.runIf(process.platform !== "win32")("archive() symlink preservation", { sequential: true }, () => {
   test("zip archive preserves symlinks (not dereferenced)", async ({ expect }) => {
     const src = path.join(tmpDir, "src")
     await fs.mkdir(src, { recursive: true })
@@ -197,7 +216,33 @@ describe.runIf(process.platform === "darwin")("archive() macOS zip symlink prese
     expect(target).toBe("real.txt")
   })
 
-  test("excluded pattern with '..' throws in native zip path", async ({ expect }) => {
+  // Regression for #9846: the 7z target must also preserve symlinks (-snl). Modern 7-Zip
+  // dereferences them by default, which corrupts .framework bundles and breaks codesign.
+  test("7z archive preserves symlinks (not dereferenced)", async ({ expect }) => {
+    const src = path.join(tmpDir, "src7z")
+    await fs.mkdir(src, { recursive: true })
+    await fs.writeFile(path.join(src, "real.txt"), "content")
+    await fs.symlink("real.txt", path.join(src, "link.txt"))
+
+    const outFile = path.join(tmpDir, "out.7z")
+    await archive("7z", outFile, src, { withoutDir: true, preserveSymlinks: true })
+
+    // Extract with the same 7za toolset binary and verify the symlink survived
+    const extractDir = path.join(tmpDir, "extracted7z")
+    await fs.mkdir(extractDir, { recursive: true })
+    const { getPath7za } = await import("app-builder-lib/src/toolsets/7zip")
+    const { exec: cpExec } = await import("child_process")
+    const { promisify } = await import("util")
+    const execAsync = promisify(cpExec)
+    await execAsync(`"${await getPath7za()}" x -o"${extractDir}" "${outFile}"`)
+
+    const linkStat = await fs.lstat(path.join(extractDir, "link.txt"))
+    expect(linkStat.isSymbolicLink()).toBe(true)
+    const target = await fs.readlink(path.join(extractDir, "link.txt"))
+    expect(target).toBe("real.txt")
+  })
+
+  test("excluded pattern with '..' throws when preserveSymlinks is set", async ({ expect }) => {
     const src = await makeSrcDir()
     await expect(archive("zip", path.join(tmpDir, "out.zip"), src, { excluded: ["../secret"], preserveSymlinks: true })).rejects.toThrow("path traversal sequence")
   })

--- a/test/src/extractArchiveTest.ts
+++ b/test/src/extractArchiveTest.ts
@@ -1,8 +1,12 @@
-import { extractArchive } from "app-builder-lib/src/util/electronGet"
+// isSafeExtractPath/moveDirAtomic are @internal and stripped from type declarations by
+// stripInternal:true. Import as namespace then cast to any so vitest's TypeScript transform
+// still resolves the real source exports while TypeScript type-checking is satisfied.
+import * as electronGet from "app-builder-lib/src/util/electronGet"
+const { extractArchive, isSafeExtractPath, moveDirAtomic } = electronGet as any
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
-import { afterEach, beforeEach, describe, test } from "vitest"
+import { afterEach, beforeEach, describe, test, vi } from "vitest"
 
 let tmpDir: string
 
@@ -11,6 +15,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await fs.rm(tmpDir, { recursive: true, force: true })
 })
 
@@ -139,5 +144,110 @@ describe("extractArchive ZIP security guards", () => {
     await fs.writeFile(zipPath, buildZipWithSymlinkEntry("link.txt", "../../outside"))
     const extractDir = path.join(tmpDir, "out")
     await expect(extractArchive(zipPath, extractDir)).rejects.toThrow("Symlink target escapes extraction dir")
+  })
+
+  test("extracts a valid zip entry to the correct destination", async ({ expect }) => {
+    const content = Buffer.from("hello world")
+    const zipPath = path.join(tmpDir, "valid.zip")
+    await fs.writeFile(zipPath, buildZipWithFileEntry("hello.txt", content))
+    const extractDir = path.join(tmpDir, "out")
+    await extractArchive(zipPath, extractDir)
+    const result = await fs.readFile(path.join(extractDir, "hello.txt"))
+    expect(result.toString()).toBe("hello world")
+  })
+})
+
+// ─── isSafeExtractPath ────────────────────────────────────────────────────────
+
+describe("isSafeExtractPath", () => {
+  const sep = path.sep
+
+  test("allows a direct child of dir", ({ expect }) => {
+    const dir = path.join(os.tmpdir(), "base")
+    expect(isSafeExtractPath(path.join(dir, "file.txt"), dir)).toBe(true)
+  })
+
+  test("allows a nested child of dir", ({ expect }) => {
+    const dir = path.join(os.tmpdir(), "base")
+    expect(isSafeExtractPath(path.join(dir, "sub", "file.txt"), dir)).toBe(true)
+  })
+
+  test("blocks a sibling of dir (same-length prefix attack)", ({ expect }) => {
+    const dir = path.join(os.tmpdir(), "base")
+    // e.g. /tmp/base-evil — starts with /tmp/base but is not inside it
+    const sibling = dir + "-evil" + sep + "file.txt"
+    expect(isSafeExtractPath(sibling, dir)).toBe(false)
+  })
+
+  test("allows destPath === dir (directory entry)", ({ expect }) => {
+    const dir = path.join(os.tmpdir(), "base")
+    expect(isSafeExtractPath(dir, dir)).toBe(true)
+  })
+
+  test("blocks a path traversal that escapes via ..", ({ expect }) => {
+    const dir = path.join(os.tmpdir(), "base")
+    // path.resolve would have already normalised the .. away, giving a path outside dir
+    const escaped = path.resolve(dir, "..", "outside", "file.txt")
+    expect(isSafeExtractPath(escaped, dir)).toBe(false)
+  })
+
+  // Windows case-insensitivity: simulate by checking with uppercase dir on win32.
+  // On non-Windows platforms the check remains case-sensitive (by design).
+  test("is case-insensitive on win32, case-sensitive on posix", ({ expect }) => {
+    if (process.platform === "win32") {
+      const dir = "C:\\builds\\dist\\win-unpacked.tmp"
+      expect(isSafeExtractPath("C:\\Builds\\Dist\\Win-Unpacked.tmp\\electron.exe", dir)).toBe(true)
+    } else {
+      const dir = "/tmp/base"
+      // On POSIX, different case is a genuinely different path — must not be treated as safe
+      expect(isSafeExtractPath("/tmp/BASE/file.txt", dir)).toBe(false)
+    }
+  })
+})
+
+// ─── moveDirAtomic ────────────────────────────────────────────────────────────
+
+describe("moveDirAtomic", () => {
+  test("moves a directory with files to the destination", async ({ expect }) => {
+    const src = path.join(tmpDir, "src")
+    const dest = path.join(tmpDir, "dest")
+    await fs.mkdir(src)
+    await fs.writeFile(path.join(src, "file.txt"), "content")
+
+    await moveDirAtomic(src, dest)
+
+    const destStat = await fs.stat(dest)
+    expect(destStat.isDirectory()).toBe(true)
+    const content = await fs.readFile(path.join(dest, "file.txt"), "utf-8")
+    expect(content).toBe("content")
+    // source must be gone
+    await expect(fs.access(src)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  test("moves when destination was pre-removed before the call", async ({ expect }) => {
+    const src = path.join(tmpDir, "src")
+    const dest = path.join(tmpDir, "dest")
+    await fs.mkdir(src)
+    await fs.writeFile(path.join(src, "new.txt"), "new")
+    await fs.mkdir(dest)
+    await fs.writeFile(path.join(dest, "old.txt"), "old")
+
+    // Rename on most systems will fail when dest already exists as a directory;
+    // moveDirAtomic is expected to be called after fs.rm(dest) in extractArchive.
+    // But if dest was already removed, this should work fine.
+    await fs.rm(dest, { recursive: true, force: true })
+    await moveDirAtomic(src, dest)
+
+    const files = await fs.readdir(dest)
+    expect(files).toContain("new.txt")
+    expect(files).not.toContain("old.txt")
+  })
+
+  test("throws when source does not exist", async ({ expect }) => {
+    const src = path.join(tmpDir, "nonexistent")
+    const dest = path.join(tmpDir, "dest")
+    // Should throw (and not loop forever). We don't care about the exact code since
+    // multiple retries produce the same error class.
+    await expect(moveDirAtomic(src, dest)).rejects.toThrow()
   })
 })

--- a/test/src/mac/macArchiveTest.ts
+++ b/test/src/mac/macArchiveTest.ts
@@ -1,3 +1,4 @@
+import { getPath7za } from "app-builder-lib/src/toolsets/7zip"
 import { Arch, exec } from "builder-util"
 import { parseXml } from "builder-util-runtime"
 import { Platform } from "electron-builder"
@@ -5,6 +6,7 @@ import { outputFile } from "fs-extra"
 import * as fs from "fs/promises"
 import * as path from "path"
 import pathSorter from "path-sort"
+import type { ExpectStatic } from "vitest"
 import { assertThat } from "../helpers/fileAssert"
 import { app, copyTestAsset, createMacTargetTest, getFixtureDir, parseFileList } from "../helpers/packTester"
 
@@ -15,6 +17,49 @@ test.ifNotWindows("only zip", ({ expect }) => createMacTargetTest(expect, ["zip"
 test.ifNotWindows("tar.gz", ({ expect }) => createMacTargetTest(expect, ["tar.gz"]))
 
 // test.ifNotWindows("tar.xz", createTargetTest(["tar.xz"], ["Test App ßW-1.1.0-mac.tar.xz"]))
+
+// Regression for #9846: the macOS zip and 7z targets must preserve .framework `Versions/Current`
+// symlinks through the archive round-trip. Modern 7-Zip dereferences symlinks unless passed -snl;
+// a dereferenced framework makes codesign report "bundle format is ambiguous" and breaks Squirrel.Mac
+// auto-update. These build a real app, archive it, extract, and assert every framework symlink survived.
+function createMacFrameworkSymlinkTest(expect: ExpectStatic, format: "zip" | "7z") {
+  return app(
+    expect,
+    {
+      targets: Platform.MAC.createTarget(format, Arch.x64),
+      config: { mac: { target: format }, publish: null },
+    },
+    {
+      signed: false,
+      packed: async context => {
+        const artifactName = (await fs.readdir(context.outDir)).find(name => name.endsWith(`.${format}`))
+        expect(artifactName, `expected a .${format} artifact in ${context.outDir}`).toBeTruthy()
+        const artifactPath = path.join(context.outDir, artifactName!)
+
+        const extractDir = await context.tmpDir.createTempDir({ prefix: `mac-${format}-symlink` })
+        if (format === "zip") {
+          // `ditto -x -k` mirrors how Squirrel.Mac extracts the auto-update payload
+          await exec("ditto", ["-x", "-k", artifactPath, extractDir])
+        } else {
+          await exec(await getPath7za(), ["x", `-o${extractDir}`, "-y", artifactPath])
+        }
+
+        const frameworksDir = path.join(extractDir, `${context.packager.appInfo.productFilename}.app`, "Contents", "Frameworks")
+        const frameworks = (await fs.readdir(frameworksDir)).filter(name => name.endsWith(".framework"))
+        expect(frameworks.length, "app should contain .framework bundles").toBeGreaterThan(0)
+        for (const framework of frameworks) {
+          const current = path.join(frameworksDir, framework, "Versions", "Current")
+          const stat = await fs.lstat(current)
+          expect(stat.isSymbolicLink(), `${framework}/Versions/Current must remain a symlink after ${format} round-trip`).toBe(true)
+        }
+      },
+    }
+  )
+}
+
+test.heavy.ifMac("zip preserves .framework symlinks (#9846)", ({ expect }) => createMacFrameworkSymlinkTest(expect, "zip"))
+
+test.heavy.ifMac("7z preserves .framework symlinks (#9846)", ({ expect }) => createMacFrameworkSymlinkTest(expect, "7z"))
 
 const it = process.env.CSC_KEY_PASSWORD == null ? test.skip : test.ifMac
 


### PR DESCRIPTION
Backports:
https://github.com/electron-userland/electron-builder/pull/9891
https://github.com/electron-userland/electron-builder/pull/9847