### PR TITLE
chore(deploy): mark `.changeset/config.json` as skip-worktree for publishing

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -110,6 +110,14 @@ jobs:
               echo "::error::Symlink points to wrong target: $LINK_TARGET (expected: $CONFIG_FILE)"
               exit 1
             fi
+
+            # Swapping the tracked config.json for a symlink dirties the working
+            # tree, which makes `pnpm publish -r` abort with ERR_PNPM_GIT_UNCLEAN.
+            # Hide ONLY this intentional, branch-local change from git so pnpm's
+            # publish git-checks stay enabled — any *other* accidental change to
+            # the tree still blocks the publish.
+            git update-index --skip-worktree .changeset/config.json
+            echo "Marked .changeset/config.json as skip-worktree (excluded from pnpm git-checks)"
           else
             echo "Using default config: $CONFIG_PATH (no symlink needed)"
           fi

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ci:test:refresh:start:windows": "tsx test/vitest-scripts/refresh-tests.ts start --target windows",
     "ci:test:refresh:start:linux": "tsx test/vitest-scripts/refresh-tests.ts start --target linux",
     "ci:version": "pnpm i && changeset version && node scripts/update-package-version-export.js && pnpm changelog && pnpm compile && pnpm generate:all && git add .",
-    "ci:publish": "pnpm i && pnpm compile && pnpm publish -r --tag ${NPM_DIST_TAG:-next} && changeset tag",
+    "ci:publish": "pnpm i && pnpm compile && pnpm publish -r --tag ${NPM_DIST_TAG:-next} --publish-branch ${GITHUB_REF_NAME:-master} < /dev/null && changeset tag",
     "docker-images": "bash docker/build.sh",
     "docker-push": "bash docker/push.sh",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -t electron-builder@ --pkg packages/electron-builder/package.json && git add CHANGELOG.md",


### PR DESCRIPTION
Swapping the tracked config.json for a symlink dirties the working tree, which makes `pnpm publish -r` abort with ERR_PNPM_GIT_UNCLEAN. Hide ONLY this intentional, branch-local change from git so pnpm's publish git-checks stay enabled — any *other* accidental change to the tree still blocks the publish.