### PR TITLE
chore(deploy): add `--publish-branch ${GITHUB_REF_NAME:-master}`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ci:test:merge-cache": "ts-node test/vitest-scripts/merge-smart-cache.ts",
     "ci:validate": "pnpm compile && pnpm pretest && pnpm generate:all",
     "ci:version": "pnpm i && changeset version && node scripts/update-package-version-export.js && pnpm changelog && pnpm compile && pnpm generate:all && git add .",
-    "ci:publish": "pnpm i && pnpm build && pnpm publish -r --tag ${NPM_DIST_TAG:-next} && changeset tag",
+    "ci:publish": "pnpm i && pnpm compile && pnpm publish -r --tag ${NPM_DIST_TAG:-next} --publish-branch ${GITHUB_REF_NAME:-master} < /dev/null && changeset tag",
     "docker-images": "bash docker/build.sh",
     "docker-push": "bash docker/push.sh",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -t electron-builder@ --pkg packages/electron-builder/package.json && git add CHANGELOG.md",


### PR DESCRIPTION
* Updated the `ci:publish` script to use `pnpm compile` instead of `pnpm build`, added the `--publish-branch` option with a default to `${GITHUB_REF_NAME:-master}`, and redirected input to ensure non-interactive publishing.