### PR TITLE
feat(nsis): add Hebrew (he) translations and bundle he_IL for installer messages

### DIFF
--- a/.changeset/he-nsis-translations.md
+++ b/.changeset/he-nsis-translations.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+feat(nsis): add Hebrew (he) translations for one-click and assisted installer messages

--- a/.changeset/he-nsis-translations.md
+++ b/.changeset/he-nsis-translations.md
@@ -3,3 +3,5 @@
 ---
 
 feat(nsis): add Hebrew (he) translations for one-click and assisted installer messages
+
+Also add `he_IL` to `bundledLanguages` so Hebrew strings actually reach the built installer (fixes a pre-existing bug where Hebrew was never included in the default multi-language set).

--- a/packages/app-builder-lib/src/util/langs.ts
+++ b/packages/app-builder-lib/src/util/langs.ts
@@ -22,6 +22,7 @@ export const bundledLanguages = [
   "sk_SK",
   "hu_HU",
   "ar_SA",
+  "he_IL",
   "tr_TR",
   "th_TH",
   "vi_VN",

--- a/packages/app-builder-lib/templates/nsis/assistedMessages.yml
+++ b/packages/app-builder-lib/templates/nsis/assistedMessages.yml
@@ -6,6 +6,7 @@ chooseInstallationOptions:
   sk: Vyberte možnosti inštalácie
   cs: Vyberte možnosti instalace
   fr: Choisis les options d'installation
+  he: בחירת אפשרויות התקנה
   hu_HU: Telepítési opciók kiválasztása
   pt_BR: Escolha uma opção de instalação
   zh_CN: 安装选项
@@ -28,6 +29,7 @@ chooseUninstallationOptions:
   sk: Vyberte možnosti odinštalovania
   cs: Vyberte možnosti odinstalace
   fr: Choisis les options de désinstallation
+  he: בחירת אפשרויות הסרה
   hu_HU: Eltávolítási opciók kiválasztása
   pt_BR: Escolha uma opção de desinstalação
   zh_CN: 卸载选项
@@ -50,6 +52,7 @@ whichInstallationShouldBeRemoved:
   sk: Ktorá inštalácia by mala byt odstránená?
   cs: Která instalace by měla být odstraněna?
   fr: Quelle installation doit être supprimée ?
+  he: איזו התקנה יש להסיר?
   hu_HU: Melyik telepítést távolítsuk el?
   pt_BR: Qual instalação deve ser removida?
   zh_CN: 需要移除哪个安装？
@@ -72,6 +75,7 @@ whoShouldThisApplicationBeInstalledFor:
   sk: Pre koho sa ma táto aplikacia inštalovať?
   cs: Pro koho se má tato aplikace instalovat?
   fr: Pour qui cette application doit-elle être installée ?
+  he: עבור מי יש להתקין יישום זה?
   hu_HU: Kinek legyen ez az alkalmazás telepítve?
   pt_BR: Para quem esta aplicação deve ser instalada?
   zh_CN: 为哪位用户安装该应用？
@@ -94,6 +98,7 @@ selectUserMode:
   sk: Prosím vyberte či sa ma tento softvér inštalovať len pre Vás alebo pre všetkých uživateľov
   cs: Prosím vyberte, zda se má tento software instalovat jen pro Vás, nebo pro všechny uživatele
   fr: "Choisis pour qui ce logiciel doit être accessible : pour tous les utilisateurs ou juste pour toi ?"
+  he: אנא בחר אם ברצונך להפוך תוכנה זו לזמינה לכל המשתמשים או רק עבורך
   hu_HU: Válaszd ki, hogy a szoftver elérhető legyen-e minden felhasználó számára, vagy csak neked
   pt_BR: Por favor, selecione se este software deve estar disponível apenas para você ou para todos usuários
   zh_CN: 请选择为当前用户还是所有用户安装该软件
@@ -116,6 +121,7 @@ whichInstallationRemove:
   sk: Tento softvér je nainštalovaný pre Vás a súčasne pre všetkých uživateľov.\nKtorú inštaláciu si želáte odstraniť?
   cs: Tento software je nainstalovaný pro Vás a současně pro všechny uživatele.\nKterou instalaci si přejete odstranit?
   fr: Ce logiciel est installé à la fois par machine (tous les utilisateurs) et par utilisateur.\nQuelle installation veux-tu supprimer ?
+  he: תוכנה זו מותקנת הן עבור כל המחשב (כל המשתמשים) והן עבור משתמש בודד.\nאיזו התקנה ברצונך להסיר?
   hu_HU: Ez a szoftver számítógépenként (minden felhasználó) és felhasználónként is telepítve van.\nMelyik telepítést szeretnéd eltávolítani?
   pt_BR: Este software é instalado por máquina (todos os usuários) e por usuário. Qual instalação você deseja remover?
   zh_CN: 该软件已为所有用户和当前用户安装.\n您希望移除哪个安装?
@@ -138,6 +144,7 @@ freshInstallForAll:
   sk: Nová inštalácia pre všetkých uživateľov. (Bude potrebovať prihlásenie administrátora)
   cs: Nová instalace pro všechny uživatele. (Bude vyžadovat přihlášení administrátora)
   fr: Nouvelle installation pour tous les utilisateurs. (demandera les identifiants administrateur)
+  he: התקנה חדשה עבור כל המשתמשים. (תופיע בקשה לפרטי מנהל מערכת)
   hu_HU: Új telepítés minden felhasználó számára. (Az adminisztrátor hitelesítő adataira lesz szükség.)
   pt_BR: Instalação limpa para todos os usuários. (irá solicitar credenciais de administrador)
   zh_CN: 为所有用户进行全新安装. (需要管理员资格)
@@ -159,6 +166,7 @@ freshInstallForCurrent:
   ru: Новая установка только для текущего пользователя.
   cs: Nová instalace pro aktuálního uživatele.
   fr: Nouvelle installation uniquement pour l'utilisateur actuel.
+  he: התקנה חדשה עבור המשתמש הנוכחי בלבד.
   hu_HU: Új telepítés csak a jelenlegi felhasználó számára.
   pt_BR: Instalação limpa somente para o usuário atual.
   zh_CN: 仅为当前用户进行全新安装.
@@ -181,6 +189,7 @@ onlyForMe:
   sk: Iba pre mňa
   cs: Pouze pro &mě
   fr: Juste pour moi
+  he: רק עבורי
   hu_HU: Csak az én számomra
   pt_BR: Apenas para &mim
   zh_CN: 仅为我安装
@@ -203,6 +212,7 @@ forAll:
   sk: Pre každého kto použiva tento počitač (všetci uživatelia)
   cs: Pro každého, kdo používá tento počítač (všichni uživatelé)
   fr: Pour tous ceux qui utilisent cet ordinateur (tous les utilisateurs)
+  he: כל מי שמשתמש במחשב זה (כל המשתמשים)
   hu_HU: Bárki számára, aki ezt a számítógépet használja (minden felhasználó)
   pt_BR: Para todos que usam esta máquina (&todos os usuários)
   zh_CN: 为使用这台电脑的任何人安装 (所有用户)
@@ -225,6 +235,7 @@ loginWithAdminAccount:
   sk: Pre pokračovanie sa musíte zalogovať s účtom ktorý patrí do skupiny adminstrátorov...
   cs: Pro pokračování se musíte přihlásit účtem, který patří do skupiny administrátorů...
   fr: Tu dois te connecter avec un compte ayant des droits d'administrateur pour continuer...
+  he: עליך להתחבר באמצעות חשבון שהוא חבר בקבוצת מנהלי המערכת כדי להמשיך...
   hu_HU: A folytatáshoz adminisztrátori jogokkal rendelkező fiókkal kell bejelentkezned...
   pt_BR: Você precisa realizar o login com uma conta que é membro do grupo de administração para continuar...
   zh_CN: 您需要用属于管理员群组的用户账户登录来继续...
@@ -246,6 +257,7 @@ perUserInstallExists:
   ru: Уже есть установленная программа для отдельного пользователя.
   cs: Již existuje instalace pro uživatele.
   fr: Il y a déjà une installation par utilisateur.
+  he: כבר קיימת התקנה עבור משתמש בודד.
   hu_HU: Már van egy felhasználónkénti telepítés.
   pt_BR: Já existe uma instalação por usuário.
   zh_CN: 已经存在一个安装到当前用户的安装.
@@ -267,6 +279,7 @@ perUserInstall:
   ru: Есть установленная программа для отдельного пользователя.
   cs: Instalace pro uživatele.
   fr: Il y a une installation par utilisateur.
+  he: קיימת התקנה עבור משתמש בודד.
   hu_HU: Van felhasználónkénti telepítés.
   pt_BR: Existe uma instalação por usuário.
   zh_CN: 存在一个安装到当前用户的安装.
@@ -288,6 +301,7 @@ perMachineInstallExists:
   ru: Уже есть установленная программа для всего компьютера.
   cs: Již existuje instalace pro tento počítač.
   fr: Il y a déjà une installation par machine.
+  he: כבר קיימת התקנה עבור כל המחשב.
   hu_HU: Már van egy számítógépenkénti telepítés.
   pt_BR: Já existe uma instalação por máquina.
   zh_CN: 已经存在一个安装到所有用户的安装.
@@ -309,6 +323,7 @@ perMachineInstall:
   ru: Есть установленная программа для всего компьютера.
   cs: Instalace pro tento počítač.
   fr: Il y a une installation par machine.
+  he: קיימת התקנה עבור כל המחשב.
   hu_HU: Van számítógépenkénti telepítés.
   pt_BR: Existe uma instalação por máquina.
   zh_CN: 存在一个安装到所有用户的安装.
@@ -330,6 +345,7 @@ reinstallUpgrade:
   ru: Приложение будет переустановлено/обновлено.
   cs: Bude přeinstalováno/aktualizováno.
   fr: Va réinstaller/mettre à jour.
+  he: יותקן מחדש/ישודרג.
   hu_HU: Újratelepít/frissít.
   pt_BR: Irá reinstalar/atualizar.
   zh_CN: 即将重新安装/升级.
@@ -351,6 +367,7 @@ uninstall:
   ru: Приложение будет удалено.
   cs: Odinstaluje se.
   fr: Va désinstaller.
+  he: יוסר.
   hu_HU: Eltávolít.
   pt_BR: Irá desinstalar.
   zh_CN: 即将卸载.

--- a/packages/app-builder-lib/templates/nsis/messages.yml
+++ b/packages/app-builder-lib/templates/nsis/messages.yml
@@ -5,6 +5,7 @@ win7Required:
   de: Windows 7 oder höher wird vorausgesetzt
   it: È necessario disporre del sistema operativo Windows 7 e successivi
   fr: Windows 7 (ou une version ultérieure) est requis
+  he: נדרש Windows 7 ומעלה
   ja: Windows 7 以降が必要です
   ko: Windows 7 이상이 필요합니다
   ru: Требуется Windows 7 и выше
@@ -27,6 +28,7 @@ x64WinRequired:
   de: 64-Bit-Windows wird vorausgesetzt
   it: È necessario disporre di un sistema operativo Windows a 64 bit
   fr: Windows 64 bits est requis
+  he: נדרש Windows בגרסת 64 סיביות
   ja: 64 ビット バージョンの Windows が必要です
   ko: 64 비트 버전의 Windows가 필요합니다
   ru: Требуется Windows 64-bit
@@ -132,6 +134,7 @@ installing:
   de: Installation läuft, bitte warten...
   it: Attendere prego. Installazione in corso...
   fr: En cours d’installation... Veuillez patienter s'il vous plaît.
+  he: מתקין, נא להמתין...
   ja: インストールしています。しばらくお待ちください...
   ko: 설치하고 있습니다. 잠시 기다려주십시오...
   ru: Установка, пожалуйста, подождите...
@@ -154,6 +157,7 @@ areYouSureToUninstall:
   de: Sind Sie sicher, dass Sie ${PRODUCT_NAME} deinstallieren möchten?
   it: Sicuro di voler procedere alla disinstallazione di ${PRODUCT_NAME}?
   fr: Etes-vous sûr(e) de vouloir désinstaller ${PRODUCT_NAME}?
+  he: האם אתה בטוח שברצונך להסיר את ${PRODUCT_NAME}?
   ja: ${PRODUCT_NAME} をアンインストールしてもよろしいですか？
   ko: ${PRODUCT_NAME}을(를) 제거 하시겠습니까?
   ru: Вы уверены, что хотите удалить ${PRODUCT_NAME}?
@@ -238,3 +242,4 @@ uninstallFailed:
 appClosing:
   en: "Closing running ${PRODUCT_NAME}..."
   cs: "Ukončuji aplikaci ${PRODUCT_NAME}..."
+  he: "סוגר את ${PRODUCT_NAME} הפעיל..."


### PR DESCRIPTION
## Summary

Completes the Hebrew (`he`) localization for the NSIS installer message templates **and ensures those strings actually reach the built installer**.

- **`messages.yml`** — adds `he` for the 5 keys that were still missing it: `win7Required`, `x64WinRequired`, `installing`, `areYouSureToUninstall`, `appClosing`. (`appRunning`, `appCannotBeClosed`, `decompressionFailed` and `uninstallFailed` already had Hebrew.)
- **`assistedMessages.yml`** — adds `he` for all 17 keys (the file previously had no Hebrew at all).
- **`langs.ts`** — adds `he_IL` to `bundledLanguages`, fixing a pre-existing bug where Hebrew was never included in the default multi-language set. Without this, `toLangWithRegion("he")` did not map to `he_IL` and none of the Hebrew strings (new or pre-existing) reached the built installer.

The `${PRODUCT_NAME}` placeholders and `\n` line breaks are preserved, and the new entries are placed right after the existing `fr` line, matching the convention already used for the `he` entries in `messages.yml`.

## Notes

- These are the only two YAML files in the repo that carry per-language installer strings, so Hebrew installer coverage is now complete.
- Both files were validated as parseable YAML and every top-level key now has a `he` value.
- `en` remains first in every block (per #2517).