### PR TITLE
fix(win): retry the spurious "The batch file cannot be found." cmd.exe race condition

### DIFF
--- a/.changeset/retry-windows-batch-file-install.md
+++ b/.changeset/retry-windows-batch-file-install.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(win): retry the spurious "The batch file cannot be found." cmd.exe race during dependency install (idempotent, win32-guarded — real install failures still fail fast)

--- a/packages/app-builder-lib/src/util/yarn.ts
+++ b/packages/app-builder-lib/src/util/yarn.ts
@@ -87,6 +87,30 @@ export function getGypEnv(frameworkInfo: DesktopFrameworkInfo, platform: NodeJS.
   }
 }
 
+/**
+ * Whether a failed dependency-install spawn should be retried. Everything not matched here fails fast —
+ * a genuine install error (E404, ERESOLVE, EACCES, …) must surface immediately, not after 3 backoff
+ * retries. Two transient classes are retriable:
+ *   - Network blips while fetching from the registry.
+ *   - A Windows-only cmd.exe race: cross-spawn invokes the package manager's `.cmd`/`.CMD` shim via
+ *     `cmd.exe /d /s /c`, and cmd.exe re-opens the batch file between commands. Under CI load (Defender
+ *     scan locks, an 8.3/temp cwd, heavy parallel I/O) that re-open intermittently fails with
+ *     "The batch file cannot be found." *after* the package manager has already finished — a spurious
+ *     exit code, not a missing file. The install is idempotent (a no-op once node_modules is up to
+ *     date), so re-running is safe. Guarded to win32 so the narrow message match can't affect other
+ *     platforms. (Durable fix: stop routing install through cmd.exe, mirroring the collector's
+ *     powershell.exe -EncodedCommand spawn — tracked separately.)
+ */
+export function isRetriableInstallError(message: string): boolean {
+  if (/ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED/.test(message)) {
+    return true
+  }
+  if (process.platform === "win32" && /The batch file cannot be found/i.test(message)) {
+    return true
+  }
+  return false
+}
+
 export async function installDependencies(
   config: Configuration,
   { appDir, projectDir, workspaceRoot }: DirectoryPaths,
@@ -126,11 +150,12 @@ export async function installDependencies(
     interval: 1000,
     backoff: 2000,
     shouldRetry: (e: any) => {
-      const isTransient = /ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED/.test(e?.message ?? "")
-      if (isTransient) {
-        log.warn({ error: String(e?.message).split("\n")[0] }, "transient network error during package install, retrying")
+      const message = e?.message ?? ""
+      const retriable = isRetriableInstallError(message)
+      if (retriable) {
+        log.warn({ error: String(message).split("\n")[0] }, "transient error during package install, retrying")
       }
-      return isTransient
+      return retriable
     },
   })
 

--- a/test/src/installRetryTest.ts
+++ b/test/src/installRetryTest.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, test } from "vitest"
+import { isRetriableInstallError } from "app-builder-lib/src/util/yarn"
+
+// isRetriableInstallError reads process.platform at call time, so we toggle it per test rather than
+// re-importing the module.
+const originalPlatform = process.platform
+
+function setPlatform(p: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: p, configurable: true })
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+})
+
+describe("isRetriableInstallError", () => {
+  test("retries transient network errors on any platform", ({ expect }) => {
+    setPlatform("linux")
+    for (const code of ["ENOTFOUND", "ECONNRESET", "ETIMEDOUT", "EAI_AGAIN", "ECONNREFUSED"]) {
+      expect(isRetriableInstallError(`npm error ${code} request to registry failed`)).toBe(true)
+    }
+  })
+
+  test("retries the Windows cmd.exe batch-file race (spurious exit after a successful install)", ({ expect }) => {
+    setPlatform("win32")
+    // Verbatim shape of the ExecError thrown from the failing CI run: npm completed ("up to date,
+    // audited 1 package"), but cmd.exe still exited 1 with "The batch file cannot be found.".
+    const ciMessage = [
+      "C:\\hostedtoolcache\\windows\\node\\22.22.3\\x64\\npm.CMD process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE",
+      "Exit code:\n1",
+      "Output:\n\nup to date, audited 1 package in 439ms\n\nfound 0 vulnerabilities",
+      "Error output:\nThe batch file cannot be found.",
+    ].join("\n")
+    expect(isRetriableInstallError(ciMessage)).toBe(true)
+  })
+
+  test("does NOT match the batch-file message off Windows (win32-guarded)", ({ expect }) => {
+    setPlatform("darwin")
+    expect(isRetriableInstallError("The batch file cannot be found.")).toBe(false)
+    setPlatform("linux")
+    expect(isRetriableInstallError("The batch file cannot be found.")).toBe(false)
+  })
+
+  test("fails fast on a real install error (no added retry latency)", ({ expect }) => {
+    setPlatform("win32")
+    expect(isRetriableInstallError("npm error code E404\nnpm error 404 Not Found - GET https://registry.npmjs.org/foo")).toBe(false)
+    expect(isRetriableInstallError("npm error ERESOLVE unable to resolve dependency tree")).toBe(false)
+    expect(isRetriableInstallError("EACCES: permission denied")).toBe(false)
+  })
+
+  test("empty message is not retriable", ({ expect }) => {
+    setPlatform("win32")
+    expect(isRetriableInstallError("")).toBe(false)
+  })
+})


### PR DESCRIPTION
### Summary

Fixes a flaky Windows-only CI failure where dependency install spuriously fails with `ERR_ELECTRON_BUILDER_CANNOT_EXECUTE … The batch file cannot be found.` even though the package manager already finished successfully (log shows `up to date, audited 1 package … found 0 vulnerabilities`).

Root cause: `installDependencies` resolves the package manager via `which` to a `.CMD` shim (`C:\…\npm.CMD`) and spawns it through cross-spawn, which wraps the call in `cmd.exe /d /s /c`. `cmd.exe` re-opens the batch file between commands as it interprets it; under CI load (Windows Defender scan locks, an 8.3/temp `cwd`, heavy parallel I/O) that re-open intermittently fails *after* the install has already completed — a spurious exit code, not a missing file.

This change extends the existing install retry to also treat that exact cmd.exe message as transient, guarded to Windows. The install is idempotent (a no-op once `node_modules` is up to date), so re-running is safe. The match is deliberately narrow so genuine install errors (E404, ERESOLVE, EACCES, …) are NOT retried and still fail immediately with no added latency.

Changes:

- packages/app-builder-lib/src/util/yarn.ts
  - Extracted the install-retry predicate into an exported pure function isRetriableInstallError(message).
  - Added a win32-guarded branch matching /The batch file cannot be found/i (in addition to the
    existing transient-network matches ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED).
  - Wired it into the existing retry(...) shouldRetry around the install spawn; generalized the retry
    log message from "transient network error …" to "transient error …".

    ```ts
    export function isRetriableInstallError(message: string): boolean {
      if (/ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED/.test(message)) {
        return true
      }
      if (process.platform === "win32" && /The batch file cannot be found/i.test(message)) {
        return true
      }
      return false
    }
    ```

- test/src/installRetryTest.ts (new)
  - Unit coverage for isRetriableInstallError: transient network codes retry on any platform; the
    verbatim CI batch-file message retries on win32; the same message is NOT matched off-Windows
    (guard); real install errors (E404/ERESOLVE/EACCES) and empty messages fail fast.

### Design notes

- The retry already existed in installDependencies; this only widens its shouldRetry predicate, so no new retry machinery or behavior change for the network case.
- Why a retry is acceptable in production code: the predicate is narrow and win32-only, the install is idempotent, and non-matching errors are unaffected — so real failures keep their fast-fail behavior.
