### PR TITLE
fix: resolve `merge-smart-cache` CI step failures on branch names with `/`

### DIFF
--- a/.github/actions/pretest/action.yml
+++ b/.github/actions/pretest/action.yml
@@ -45,7 +45,10 @@ runs:
         if [ -n "$PR_NUM" ]; then
           echo "VITEST_CACHE_REF=PR-${PR_NUM}" >> "$GITHUB_ENV"
         else
-          echo "VITEST_CACHE_REF=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          # Artifact names cannot contain "/", so sanitize slashes in branch
+          # names like "release/v26" -> "release-v26" (keep in sync with detectRef in fetch-smart-cache.ts).
+          REF_NAME="${{ github.ref_name }}"
+          echo "VITEST_CACHE_REF=${REF_NAME//\//-}" >> "$GITHUB_ENV"
         fi
       shell: bash
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -531,7 +531,10 @@ jobs:
           if [ -n "$PR_NUM" ]; then
             echo "VITEST_CACHE_REF=PR-${PR_NUM}" >> "$GITHUB_ENV"
           else
-            echo "VITEST_CACHE_REF=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            # Artifact names cannot contain "/", so sanitize slashes in branch
+            # names like "release/v26" -> "release-v26" (keep in sync with detectRef in fetch-smart-cache.ts).
+            REF_NAME="${{ github.ref_name }}"
+            echo "VITEST_CACHE_REF=${REF_NAME//\//-}" >> "$GITHUB_ENV"
           fi
 
       - name: Upload vitest smart cache artifact

--- a/test/vitest-scripts/fetch-smart-cache.ts
+++ b/test/vitest-scripts/fetch-smart-cache.ts
@@ -33,6 +33,13 @@ function ghJson(endpoint: string): any {
   }
 }
 
+// Artifact names cannot contain "/", so branch names like "release/v26" are
+// uploaded as "release-v26". Mirror that sanitization here (keep in sync with
+// the "Compute Vitest smart cache ref" steps in the CI workflows).
+function sanitizeRef(ref: string): string {
+  return ref.replace(/\//g, "-")
+}
+
 function detectRef(): string {
   // Check for open PR for the current branch
   try {
@@ -90,7 +97,7 @@ function main() {
   }
   if (!ref) ref = detectRef()
 
-  const cacheName = `vitest-smart-cache-${ref}`
+  const cacheName = `vitest-smart-cache-${sanitizeRef(ref)}`
   const fallbackName = "vitest-smart-cache-master"
   const dest = CACHE_FILE
 


### PR DESCRIPTION
* Updated the `VITEST_CACHE_REF` computation in `.github/actions/pretest/action.yml` and `.github/workflows/test.yaml` to replace slashes in branch names with hyphens, ensuring artifact names are valid and consistent with the fetch script. [[1]](diffhunk://#diff-f42be241105336453396205c7a4d1f542d4173595f94813982cc78cb052122bfL48-R51) [[2]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L534-R537)
* Added a `sanitizeRef` function to `test/vitest-scripts/fetch-smart-cache.ts` to mirror the slash-to-hyphen replacement logic used in CI workflows.
* Updated the cache artifact naming in `fetch-smart-cache.ts` to use the sanitized branch name, ensuring cache lookups use the correct artifact name.