### PR TITLE
fix: resolve `merge-smart-cache` CI job failing to upload vitest smart cache

### DIFF
--- a/.github/actions/pretest/action.yml
+++ b/.github/actions/pretest/action.yml
@@ -45,7 +45,10 @@ runs:
         if [ -n "$PR_NUM" ]; then
           echo "VITEST_CACHE_REF=PR-${PR_NUM}" >> "$GITHUB_ENV"
         else
-          echo "VITEST_CACHE_REF=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          # Artifact names cannot contain "/", so sanitize slashes in branch
+          # names like "release/v26" -> "release-v26" (keep in sync with detectRef in fetch-smart-cache.ts).
+          REF_NAME="${{ github.ref_name }}"
+          echo "VITEST_CACHE_REF=${REF_NAME//\//-}" >> "$GITHUB_ENV"
         fi
       shell: bash
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -529,7 +529,10 @@ jobs:
           if [ -n "$PR_NUM" ]; then
             echo "VITEST_CACHE_REF=PR-${PR_NUM}" >> "$GITHUB_ENV"
           else
-            echo "VITEST_CACHE_REF=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            # Artifact names cannot contain "/", so sanitize slashes in branch
+            # names like "release/v26" -> "release-v26" (keep in sync with detectRef in fetch-smart-cache.ts).
+            REF_NAME="${{ github.ref_name }}"
+            echo "VITEST_CACHE_REF=${REF_NAME//\//-}" >> "$GITHUB_ENV"
           fi
 
       - name: Upload vitest smart cache artifact

--- a/test/vitest-scripts/fetch-smart-cache.ts
+++ b/test/vitest-scripts/fetch-smart-cache.ts
@@ -35,6 +35,13 @@ function ghJson(endpoint: string): any {
   }
 }
 
+// Artifact names cannot contain "/", so branch names like "release/v26" are
+// uploaded as "release-v26". Mirror that sanitization here (keep in sync with
+// the "Compute Vitest smart cache ref" steps in the CI workflows).
+function sanitizeRef(ref: string): string {
+  return ref.replace(/\//g, "-")
+}
+
 function detectRef(): string {
   // Check for open PR for the current branch
   try {
@@ -107,7 +114,7 @@ function main() {
     ref = detectRef()
   }
 
-  const cacheName = `vitest-smart-cache-${ref}`
+  const cacheName = `vitest-smart-cache-${sanitizeRef(ref)}`
   const fallbackName = "vitest-smart-cache-master"
   const dest = CACHE_FILE
 


### PR DESCRIPTION
**CI workflow updates:**

* [`.github/actions/pretest/action.yml`](diffhunk://#diff-f42be241105336453396205c7a4d1f542d4173595f94813982cc78cb052122bfL48-R51): Updated the logic that sets the `VITEST_CACHE_REF` environment variable to replace slashes with dashes in branch names, ensuring artifact names are valid.
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L532-R535): Applied the same sanitization to the `VITEST_CACHE_REF` variable in the main test workflow.

**Script updates:**

* [`test/vitest-scripts/fetch-smart-cache.ts`](diffhunk://#diff-86020974694a891c967b345e555d579d1b58febece6edcb6dd435fb57213a893R38-R44): Added a `sanitizeRef` function to replace slashes with dashes in branch names, and updated the cache name generation to use this function. This keeps the script in sync with the CI workflow logic. [[1]](diffhunk://#diff-86020974694a891c967b345e555d579d1b58febece6edcb6dd435fb57213a893R38-R44) [[2]](diffhunk://#diff-86020974694a891c967b345e555d579d1b58febece6edcb6dd435fb57213a893L110-R117)