### PR TITLE
fix(snap): core24 now runs the app through a generated launcher script

### DIFF
--- a/.changeset/snap-core24-launcher-command.md
+++ b/.changeset/snap-core24-launcher-command.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(snap): core24 now runs the app through a generated launcher script, so `executableArgs`/`forceX11` flags containing `=` or quotes build correctly, and the unused `chrome-sandbox` helper is removed automatically when launching with `--no-sandbox`

--- a/packages/app-builder-lib/src/targets/snap/core24.ts
+++ b/packages/app-builder-lib/src/targets/snap/core24.ts
@@ -1,12 +1,19 @@
 import { Arch, archFromString, copyDir, InvalidConfigurationError, log, removeNullish, toLinuxArchString } from "builder-util"
-import { copy, mkdir, readdir, writeFile } from "fs-extra"
+import { deepAssign, isValidKey, Nullish } from "builder-util-runtime"
+import { chmod, copy, mkdir, readdir, remove, writeFile } from "fs-extra"
+import * as yaml from "js-yaml"
 import * as path from "path"
 import { PlugDescriptor, SlotDescriptor, SnapOptions24 } from "../../options/SnapOptions"
 import { SnapCore } from "./SnapTarget"
+import { buildSnapCommandLauncherScript } from "./snapCommand.js"
 import { App, Part, SnapcraftYAML } from "./snapcraft"
 import { buildSnap, DEFAULT_STAGE_PACKAGES, SNAPCRAFT_YAML_OPTIONS } from "./snapcraftBuilder"
-import * as yaml from "js-yaml"
-import { deepAssign, isValidKey, Nullish } from "builder-util-runtime"
+
+// Electron's setuid sandbox helper. Removed from the staged app when the snap runs with
+// `--no-sandbox` (snap confinement supplies its own sandbox via the browser-support interface).
+const CHROME_SANDBOX = "chrome-sandbox"
+// Launcher script name used when the app command cannot be expressed inline (see resolveSnapCommand).
+const SNAP_COMMAND_LAUNCHER = "command.sh"
 
 /** Snap build strategy for core24 — generates a native snapcraft.yaml and invokes the snapcraft CLI. */
 export class SnapCore24 extends SnapCore<SnapOptions24> {
@@ -19,6 +26,13 @@ export class SnapCore24 extends SnapCore<SnapOptions24> {
   // - Desktop files in meta/gui/ are used for menu integration
   readonly configRelativePath = "snap"
   readonly guiRelativePath = path.join(this.configRelativePath, "gui")
+
+  // Computed in createDescriptor (mapSnapOptionsToSnapcraftYAML) and consumed in buildSnap.
+  // getSnapCore() returns a fresh SnapCore24 per arch build, so this per-instance state is
+  // never shared across builds.
+  private removeChromeSandbox = false
+  // Args embedded into the generated launcher script (executableArgs + forceX11/no-sandbox flags).
+  private commandArgs: string[] = []
 
   async createDescriptor(arch: Arch): Promise<SnapcraftYAML> {
     return await this.mapSnapOptionsToSnapcraftYAML(arch)
@@ -69,6 +83,18 @@ export class SnapCore24 extends SnapCore<SnapOptions24> {
       await copyDir(appOutDir, appDir)
     }
 
+    // Drop the setuid chrome-sandbox helper before snapcraft stages the app — it is unusable under
+    // strict confinement when launching with --no-sandbox (mirrors SnapCoreLegacy).
+    if (this.removeChromeSandbox) {
+      await remove(path.join(appDir, CHROME_SANDBOX))
+    }
+
+    // Write the launcher script the command always points at (see SNAP_COMMAND_LAUNCHER).
+    // It lands at the snap root ($SNAP/command.sh) — it is intentionally not added to `organize`.
+    const launcherPath = path.join(appDir, SNAP_COMMAND_LAUNCHER)
+    await writeFile(launcherPath, buildSnapCommandLauncherScript({ execName: this.packager.executableName, args: this.commandArgs }), { mode: 0o755 })
+    await chmod(launcherPath, 0o755)
+
     // Auto-generate `organize` mapping for the app part so top-level helper
     // binaries and resources are placed under `app/` inside the snap. Update
     // the already-written `snapcraft.yaml` so the build sees the mapping.
@@ -76,9 +102,23 @@ export class SnapCore24 extends SnapCore<SnapOptions24> {
       const appPart = snap.parts[snap.name]
       if (appPart) {
         const entries = (await readdir(appOutDir)).sort()
-        const organize: Record<string, string> = (appPart.organize as Record<string, string>) || {}
+        // Null-prototype map: entry names come from the filesystem, so a top-level file named
+        // "__proto__" / "constructor" / "toString" must not read inherited keys (which would make
+        // the membership check below skip it) or interact with Object.prototype on assignment.
+        const organize: Record<string, string> = Object.assign(Object.create(null), appPart.organize)
         for (const entry of entries) {
           if (!entry) {
+            continue
+          }
+          // Skip files no longer present in the staged app dir (e.g. removed chrome-sandbox) so
+          // snapcraft doesn't fail trying to organize a missing source.
+          if (this.removeChromeSandbox && entry === CHROME_SANDBOX) {
+            continue
+          }
+          // Never organize the launcher under app/. It must stay at the snap root ($SNAP/command.sh)
+          // to match apps.<name>.command. This matters when appOutDir === appDir, where readdir
+          // would otherwise pick up the launcher we just wrote.
+          if (entry === SNAP_COMMAND_LAUNCHER) {
             continue
           }
           if (organize[entry]) {
@@ -235,17 +275,22 @@ export class SnapCore24 extends SnapCore<SnapOptions24> {
         extraArgs.push("--ozone-platform=x11")
       }
     }
-    if (this.helper.isElectronVersionGreaterOrEqualThan("5.0.0") && !this.isBrowserSandboxAllowed(rootPlugs)) {
-      if (!extraArgs.includes("--no-sandbox")) {
-        extraArgs.push("--no-sandbox")
-      }
+    const noSandbox = this.helper.isElectronVersionGreaterOrEqualThan("5.0.0") && !this.isBrowserSandboxAllowed(rootPlugs)
+    if (noSandbox && !extraArgs.includes("--no-sandbox")) {
+      extraArgs.push("--no-sandbox")
     }
-    const commandSuffix = extraArgs.length > 0 ? ` ${extraArgs.join(" ")}` : ""
+    // With --no-sandbox the setuid chrome-sandbox helper is unused; strip it from the snap.
+    this.removeChromeSandbox = noSandbox
+
+    // The command always points at a generated launcher script (written in buildSnap). This keeps a
+    // single uniform command path and sidesteps snapd's character/word-splitting rules for the
+    // command field (e.g. --ozone-platform=x11, --js-flags="...").
+    this.commandArgs = extraArgs
 
     // Create the app configuration
     const desktopBaseName = this.helper.getDesktopFileName(appName)
     const app: App = {
-      command: `app/${this.packager.executableName}${commandSuffix}`,
+      command: SNAP_COMMAND_LAUNCHER,
       "command-chain": undefined, // explicitly undefined so removeNullish strips it; extensions supply their own command-chain
       plugs: appPlugs,
       slots: appSlots,

--- a/packages/app-builder-lib/src/targets/snap/coreLegacy.ts
+++ b/packages/app-builder-lib/src/targets/snap/coreLegacy.ts
@@ -1,17 +1,21 @@
 import { replaceDefault as _replaceDefault, Arch, copyDir, exec, log, serializeToYaml, toLinuxArchString } from "builder-util"
 import { asArray, deepAssign, isValidKey, Nullish } from "builder-util-runtime"
-import { chmod, copyFile, mkdir, readdir, rename, rm, writeFile } from "fs/promises"
 import { outputFile, readFile } from "fs-extra"
+import { chmod, copyFile, mkdir, readdir, rename, rm, writeFile } from "fs/promises"
+import { load } from "js-yaml"
 import * as path from "path"
+import { validateShellEmbeddable } from "../../frameworks/LibUiFramework"
 import { PlugDescriptor, SnapOptions } from "../../options/SnapOptions"
 import { getAppImageTools } from "../../toolsets/linux"
 import { downloadBuilderToolset } from "../../util/electronGet"
 import { getTemplatePath } from "../../util/pathManager"
-import { validateShellEmbeddable } from "../../frameworks/LibUiFramework"
 import { SnapCore } from "./SnapTarget"
+import { shellQuote } from "./snapCommand.js"
 import { SnapcraftYAML } from "./snapcraft"
 import { DEFAULT_STAGE_PACKAGES } from "./snapcraftBuilder"
-import { load } from "js-yaml"
+
+// Re-exported for backwards compatibility with existing imports/tests.
+export { shellQuote }
 
 // Snap template release info from electron-userland/electron-builder-binaries
 const SNAP_TEMPLATES = {
@@ -440,11 +444,6 @@ async function readDirPaths(dir: string, filter?: (name: string) => boolean): Pr
     }
   }
   return result
-}
-
-/** Single-quote a shell argument, escaping any embedded single quotes. */
-export function shellQuote(arg: string): string {
-  return "'" + arg.replace(/'/g, "'\\''") + "'"
 }
 
 /**

--- a/packages/app-builder-lib/src/targets/snap/snapCommand.ts
+++ b/packages/app-builder-lib/src/targets/snap/snapCommand.ts
@@ -1,0 +1,29 @@
+import { validateShellEmbeddable } from "builder-util"
+
+// snapd restricts the value of `apps.<app-name>.command` to alphanumeric characters, spaces, and
+// `/ . _ # : $ -`, and splits it on whitespace. Rather than encode those rules per-arg, core24
+// always routes the command through a launcher script (see buildSnapCommandLauncherScript), which
+// sidesteps the character restrictions entirely and keeps a single, uniform command path.
+// See: https://documentation.ubuntu.com/snapcraft/stable/reference/snapcraft-yaml/#apps.%3Capp-name%3E.command
+
+/** Single-quote a shell argument, escaping any embedded single quotes. */
+export function shellQuote(arg: string): string {
+  return "'" + arg.replace(/'/g, "'\\''") + "'"
+}
+
+/**
+ * Builds the contents of the launcher script that execs `$SNAP/app/<execName>` with the given args.
+ * `$@` is forwarded so launch-time arguments still reach the app. The executable name is validated
+ * against shell metacharacters and each arg is single-quoted, so embedded characters (e.g. `=`, quotes)
+ * are passed literally.
+ */
+export function buildSnapCommandLauncherScript(opts: { execName: string; args: string[] }): string {
+  const { execName, args } = opts
+  validateShellEmbeddable(execName, "executableName")
+  let content = `#!/bin/sh\nexec "$SNAP/app/${execName}"`
+  if (args.length > 0) {
+    content += " " + args.map(shellQuote).join(" ")
+  }
+  content += ' "$@"\n'
+  return content
+}

--- a/packages/app-builder-lib/src/targets/snap/snapCommand.ts
+++ b/packages/app-builder-lib/src/targets/snap/snapCommand.ts
@@ -1,4 +1,15 @@
-import { validateShellEmbeddable } from "builder-util"
+/**
+ * Validates that a value is safe to embed in a double-quoted shell string.
+ * Rejects characters that would be interpreted as shell metacharacters inside `"..."`:
+ * `$`, backtick, `"`, `\`, and newlines.
+ */
+export function validateShellEmbeddable(value: string, fieldName: string): void {
+  if (/[$`"\\\n]/.test(value)) {
+    throw new Error(
+      `${fieldName} contains characters that are not safe in shell scripts: ${JSON.stringify(value)}. ` + `Avoid $, backtick, double-quote, backslash, and newline characters.`
+    )
+  }
+}
 
 // snapd restricts the value of `apps.<app-name>.command` to alphanumeric characters, spaces, and
 // `/ . _ # : $ -`, and splits it on whitespace. Rather than encode those rules per-arg, core24

--- a/packages/app-builder-lib/src/targets/snap/snapCommand.ts
+++ b/packages/app-builder-lib/src/targets/snap/snapCommand.ts
@@ -1,12 +1,15 @@
+import { InvalidConfigurationError } from "builder-util"
+
 /**
  * Validates that a value is safe to embed in a double-quoted shell string.
  * Rejects characters that would be interpreted as shell metacharacters inside `"..."`:
  * `$`, backtick, `"`, `\`, and newlines.
  */
 export function validateShellEmbeddable(value: string, fieldName: string): void {
-  if (/[$`"\\\n]/.test(value)) {
-    throw new Error(
-      `${fieldName} contains characters that are not safe in shell scripts: ${JSON.stringify(value)}. ` + `Avoid $, backtick, double-quote, backslash, and newline characters.`
+  if (/[$`"\\\r\n]/.test(value)) {
+    throw new InvalidConfigurationError(
+      `${fieldName} contains characters that are not safe in shell scripts: ${JSON.stringify(value)}. ` +
+        `Avoid $, backtick, double-quote, backslash, and newline characters.`
     )
   }
 }

--- a/packages/builder-util/src/envUtil.ts
+++ b/packages/builder-util/src/envUtil.ts
@@ -62,16 +62,3 @@ export function parseValidEnvVarUrl(envVarName: string, allowHttp: boolean = fal
   }
   return url
 }
-
-/**
- * Validates that a value is safe to embed in a double-quoted shell string.
- * Rejects characters that would be interpreted as shell metacharacters inside `"..."`:
- * `$`, backtick, `"`, `\`, and newlines.
- */
-export function validateShellEmbeddable(value: string, fieldName: string): void {
-  if (/[$`"\\\n]/.test(value)) {
-    throw new Error(
-      `${fieldName} contains characters that are not safe in shell scripts: ${JSON.stringify(value)}. ` + `Avoid $, backtick, double-quote, backslash, and newline characters.`
-    )
-  }
-}

--- a/packages/builder-util/src/envUtil.ts
+++ b/packages/builder-util/src/envUtil.ts
@@ -62,3 +62,16 @@ export function parseValidEnvVarUrl(envVarName: string, allowHttp: boolean = fal
   }
   return url
 }
+
+/**
+ * Validates that a value is safe to embed in a double-quoted shell string.
+ * Rejects characters that would be interpreted as shell metacharacters inside `"..."`:
+ * `$`, backtick, `"`, `\`, and newlines.
+ */
+export function validateShellEmbeddable(value: string, fieldName: string): void {
+  if (/[$`"\\\n]/.test(value)) {
+    throw new Error(
+      `${fieldName} contains characters that are not safe in shell scripts: ${JSON.stringify(value)}. ` + `Avoid $, backtick, double-quote, backslash, and newline characters.`
+    )
+  }
+}

--- a/test/snapshots/linux/snapcraftTest.js.snap
+++ b/test/snapshots/linux/snapcraftTest.js.snap
@@ -1765,11 +1765,44 @@ exports[`snapcraft > core22: per-core description overrides linux.description 1`
 }
 `;
 
+exports[`snapcraft > core24 Multipass real build > core24 useMultipass full build 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "TestApp_1.1.0_amd64.snap",
+    },
+  ],
+}
+`;
+
+exports[`snapcraft > core24 Multipass real build > core24 useMultipass full build with launcher script + no-sandbox 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "TestApp_1.1.0_amd64.snap",
+    },
+  ],
+}
+`;
+
+exports[`snapcraft > core24 command always points at the launcher script and keeps it at the snap root 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "sep_1.1.0_amd64.snap",
+    },
+  ],
+}
+`;
+
 exports[`snapcraft > core24 custom plugs with default expansion 1`] = `
 {
   "apps": {
     "testapp": {
-      "command": "app/testapp --no-sandbox",
+      "command": "command.sh",
       "desktop": "meta/gui/testapp.desktop",
       "extensions": [
         "gnome",
@@ -1804,7 +1837,6 @@ exports[`snapcraft > core24 custom plugs with default expansion 1`] = `
       "organize": {
         "LICENSE.electron.txt": "app/LICENSE.electron.txt",
         "LICENSES.chromium.html": "app/LICENSES.chromium.html",
-        "chrome-sandbox": "app/chrome-sandbox",
         "chrome_100_percent.pak": "app/chrome_100_percent.pak",
         "chrome_200_percent.pak": "app/chrome_200_percent.pak",
         "chrome_crashpad_handler": "app/chrome_crashpad_handler",
@@ -1847,7 +1879,7 @@ exports[`snapcraft > core24 default (gnome extension) 1`] = `
 {
   "apps": {
     "testapp": {
-      "command": "app/testapp",
+      "command": "command.sh",
       "desktop": "meta/gui/testapp.desktop",
       "extensions": [
         "gnome",
@@ -1919,11 +1951,22 @@ exports[`snapcraft > core24 default (gnome extension) 2`] = `
 
 exports[`snapcraft > core24 gnome extension throws in destructive-mode 1`] = `"ERR_ELECTRON_BUILDER_INVALID_CONFIGURATION"`;
 
+exports[`snapcraft > core24 keeps chrome-sandbox when browser-support sandbox is allowed 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "sep_1.1.0_amd64.snap",
+    },
+  ],
+}
+`;
+
 exports[`snapcraft > core24 no gnome extension 1`] = `
 {
   "apps": {
     "testapp": {
-      "command": "app/testapp",
+      "command": "command.sh",
       "desktop": "meta/gui/testapp.desktop",
       "plugs": [
         "desktop",
@@ -2053,6 +2096,17 @@ exports[`snapcraft > core24 remoteBuild build mode 1`] = `
 }
 `;
 
+exports[`snapcraft > core24 removes chrome-sandbox when launching with --no-sandbox 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "sep_1.1.0_amd64.snap",
+    },
+  ],
+}
+`;
+
 exports[`snapcraft > core24 useLXD build mode 1`] = `
 {
   "linux": [
@@ -2079,7 +2133,7 @@ exports[`snapcraft > core24 wayland disabled 1`] = `
 {
   "apps": {
     "sep": {
-      "command": "app/sep --ozone-platform=x11",
+      "command": "command.sh",
       "desktop": "meta/gui/sep.desktop",
       "extensions": [
         "gnome",

--- a/test/src/linux/snapCommandTest.ts
+++ b/test/src/linux/snapCommandTest.ts
@@ -1,0 +1,43 @@
+import { describe } from "vitest"
+import { buildSnapCommandLauncherScript, shellQuote } from "app-builder-lib/out/targets/snap/snapCommand.js"
+
+// Pure unit tests for the snap launcher-script helpers shared by the snap cores.
+// Full snap build flows are exercised by snapcraftTest.ts.
+
+describe.sequential("snapCommand helpers", () => {
+  describe("buildSnapCommandLauncherScript", () => {
+    test("execs the app binary under $SNAP/app with forwarded args", ({ expect }) => {
+      const content = buildSnapCommandLauncherScript({ execName: "sep", args: [] })
+      expect(content).toContain("#!/bin/sh")
+      expect(content).toContain('exec "$SNAP/app/sep"')
+      expect(content.trimEnd().endsWith('"$@"')).toBe(true)
+    })
+
+    test("single-quotes embedded args so forbidden characters are passed literally", ({ expect }) => {
+      const content = buildSnapCommandLauncherScript({ execName: "sep", args: ['--js-flags="--max-old-space-size=4096"', "--ozone-platform=x11"] })
+      expect(content).toContain(shellQuote('--js-flags="--max-old-space-size=4096"'))
+      expect(content).toContain(shellQuote("--ozone-platform=x11"))
+    })
+
+    test("rejects executable names that are unsafe to embed in a shell script", ({ expect }) => {
+      expect(() => buildSnapCommandLauncherScript({ execName: "app$evil", args: [] })).toThrow(/not safe in shell scripts/)
+      expect(() => buildSnapCommandLauncherScript({ execName: "app`id`", args: [] })).toThrow(/not safe in shell scripts/)
+      expect(() => buildSnapCommandLauncherScript({ execName: 'app"name', args: [] })).toThrow(/not safe in shell scripts/)
+    })
+  })
+
+  describe("shellQuote", () => {
+    test("wraps a simple arg in single quotes", ({ expect }) => {
+      expect(shellQuote("--no-sandbox")).toBe("'--no-sandbox'")
+    })
+
+    test("escapes embedded single quotes", ({ expect }) => {
+      expect(shellQuote("it's")).toBe("'it'\\''s'")
+    })
+
+    test("neutralizes shell metacharacters", ({ expect }) => {
+      expect(shellQuote("--flag=$(evil)")).toBe("'--flag=$(evil)'")
+      expect(shellQuote("`id`")).toBe("'`id`'")
+    })
+  })
+})

--- a/test/src/linux/snapcraftTest.ts
+++ b/test/src/linux/snapcraftTest.ts
@@ -259,7 +259,70 @@ describe.heavy.ifEnv(hasSnapInstalled())("snapcraft", { sequential: true, timeou
       effectiveOptionComputed: async ({ snap }) => {
         delete snap.platforms // arch-specific: varies by host; tested separately via armhf tests
         expect(snap).toMatchSnapshot()
-        expect(snap.apps?.[appName]?.command).toContain("--ozone-platform=x11")
+        // core24 always routes the command through the launcher script; forceX11's --ozone-platform=x11
+        // flag (which contains "=", forbidden inline by snapd) is passed through it.
+        expect(snap.apps?.[appName]?.command).toBe("command.sh")
+        return Promise.resolve(true)
+      },
+    })
+  })
+
+  test("core24 command always points at the launcher script and keeps it at the snap root", ({ expect }) => {
+    const appName = "sep"
+    return app(expect, {
+      targets: snapTarget,
+      config: {
+        extraMetadata: { name: appName },
+        productName: "Sep",
+        // --js-flags="..." contains both `=` and `"`, which snapd forbids inline — passed via the launcher.
+        snapcraft: { base: "core24", core24: { executableArgs: ['--js-flags="--max-old-space-size=4096"'] } },
+      },
+      effectiveOptionComputed: async ({ snap }) => {
+        delete snap.platforms
+        expect(snap.apps?.[appName]?.command).toBe("command.sh")
+        // the launcher must live at the snap root, never organized under app/
+        const organize = snap.parts?.[appName]?.organize as Record<string, string> | undefined
+        expect(organize?.["command.sh"]).toBeUndefined()
+        return Promise.resolve(true)
+      },
+    })
+  })
+
+  test("core24 removes chrome-sandbox when launching with --no-sandbox", ({ expect }) => {
+    const appName = "sep"
+    return app(expect, {
+      targets: snapTarget,
+      config: {
+        extraMetadata: { name: appName },
+        productName: "Sep",
+        // custom string plugs => no browser-support allow-sandbox => --no-sandbox is injected
+        snapcraft: { base: "core24", core24: { plugs: ["network"] } },
+      },
+      effectiveOptionComputed: async ({ snap }) => {
+        delete snap.platforms
+        expect(snap.apps?.[appName]?.command).toBe("command.sh")
+        const organize = snap.parts?.[appName]?.organize as Record<string, string> | undefined
+        expect(organize?.["chrome-sandbox"]).toBeUndefined()
+        return Promise.resolve(true)
+      },
+    })
+  })
+
+  test("core24 keeps chrome-sandbox when browser-support sandbox is allowed", ({ expect }) => {
+    const appName = "sep"
+    return app(expect, {
+      targets: snapTarget,
+      config: {
+        extraMetadata: { name: appName },
+        productName: "Sep",
+        // default config injects browser-support with allow-sandbox:true => no --no-sandbox
+        snapcraft: { base: "core24" },
+      },
+      effectiveOptionComputed: async ({ snap }) => {
+        delete snap.platforms
+        expect(snap.apps?.[appName]?.command).toBe("command.sh")
+        const organize = snap.parts?.[appName]?.organize as Record<string, string> | undefined
+        expect(organize?.["chrome-sandbox"]).toBe("app/chrome-sandbox")
         return Promise.resolve(true)
       },
     })
@@ -659,6 +722,22 @@ describe.heavy.ifEnv(hasSnapInstalled())("snapcraft", { sequential: true, timeou
           snapcraft: {
             base: "core24",
             core24: { useMultipass: true },
+          },
+        },
+      })
+    })
+
+    // End-to-end check that snapcraft accepts the generated launcher-script command and the
+    // chrome-sandbox removal: forceX11 produces a "=" arg (forbidden inline) and the custom
+    // string plugs force --no-sandbox (which strips chrome-sandbox).
+    test("core24 useMultipass full build with launcher script + no-sandbox", async ({ expect }) => {
+      await app(expect, {
+        targets: snapTarget,
+        config: {
+          productName: "Sep",
+          snapcraft: {
+            base: "core24",
+            core24: { useMultipass: true, forceX11: true, plugs: ["network"] },
           },
         },
       })


### PR DESCRIPTION
Allows `executableArgs`/`forceX11` flags containing `=` or quotes build correctly, and the unused `chrome-sandbox` helper is removed automatically when launching with `--no-sandbox`
