### PR TITLE
fix: updating icons toolset to latest 1.2.1 for broader icns asset generation

### DIFF
--- a/.changeset/late-groups-train.md
+++ b/.changeset/late-groups-train.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: updating icons toolset to latest 1.2.1 for broader icns asset generation

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -403,7 +403,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y squashfs-tools xvfb
-          sudo snap install snapcraft --classic
+          # Pin to the 8.x track: snapcraft 9.0.0 (latest/stable) intermittently hangs while
+          # apt-fetching destructive-mode stagePackages, causing the core24 test to time out.
+          sudo snap install snapcraft --classic --channel=8.x/stable
 
       - name: Test snap core24 native (install + launch)
         if: matrix.core == 'core24'

--- a/packages/app-builder-lib/src/toolsets/icons.ts
+++ b/packages/app-builder-lib/src/toolsets/icons.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { downloadBuilderToolset } from "../util/electronGet"
 
 const iconsToolsChecksums = {
-  "icons-bundle.tar.gz": "2241c9501aa5ddd19317956449f50a1bc311df2c34058aae9bf8bfe62081eaec",
+  "icons-bundle.tar.gz": "193241afc7c81ab165fa0af15ef0af88f796eb69e8e5bb4249a49310d8be242a",
 } as const
 
 export async function getIconsToolsetPath(): Promise<string> {
@@ -12,7 +12,7 @@ export async function getIconsToolsetPath(): Promise<string> {
     return envPath
   }
   return downloadBuilderToolset({
-    releaseName: "icons@1.1.0",
+    releaseName: "icons@1.2.1",
     filenameWithExt: "icons-bundle.tar.gz",
     checksums: iconsToolsChecksums,
     githubOrgRepo: "electron-userland/electron-builder-binaries",


### PR DESCRIPTION
Fixes: https://github.com/electron-userland/electron-builder/issues/9940

* Updated the icons toolset version from `1.1.0` to `1.2.1` in `getIconsToolsetPath`, and changed the associated checksum in `iconsToolsChecksums` to match the new release.
* https://github.com/electron-userland/electron-builder-binaries/releases/tag/icons%401.2.1