### PR TITLE
chore(test): resolve flakiness in snap core24  unit test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -401,7 +401,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y squashfs-tools xvfb
-          sudo snap install snapcraft --classic
+          # Pin to the 8.x track: snapcraft 9.0.0 (latest/stable) intermittently hangs while
+          # apt-fetching destructive-mode stagePackages, causing the core24 test to time out.
+          sudo snap install snapcraft --classic --channel=8.x/stable
 
       - name: Test snap core24 native (install + launch)
         if: matrix.core == 'core24'

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -89,7 +89,7 @@ function getLockfileFixtureNameCandidates(currentTestName: string): Array<string
   return [...new Set(names.filter(Boolean))]
 }
 
-export const EXTENDED_TIMEOUT = 14 * 60 * 1000
+export const EXTENDED_TIMEOUT = 20 * 60 * 1000
 export const linuxDirTarget = Platform.LINUX.createTarget(DIR_TARGET, Arch.x64)
 export const snapTarget = Platform.LINUX.createTarget("snap", Arch.x64)
 

--- a/test/src/linux/snapHeavyTest.ts
+++ b/test/src/linux/snapHeavyTest.ts
@@ -10,7 +10,7 @@ import { app, assertPack, EXTENDED_TIMEOUT, snapTarget } from "../helpers/packTe
 import { launchSnapBinary } from "../helpers/launchAppCrossPlatform"
 
 // very slow
-const options = { sequential: true, timeout: EXTENDED_TIMEOUT }
+const options = { sequential: true, timeout: 3 * EXTENDED_TIMEOUT }
 
 // Guard: tests run when RUN_SNAP_TESTS=true AND snapcraft is found in PATH.
 // test-snap.sh sets RUN_SNAP_TESTS=true and runs inside Docker images that
@@ -179,7 +179,7 @@ describe.heavy.ifEnv(hasSnapInstalled())("snap heavy", options, () => {
     const core = _core as any
 
     // ── build-only test (always runs when snap tooling is present) ───────────
-    test(`snap full (${core})`, ({ expect }) =>
+    test(`snap full (${core})`, options, ({ expect }) =>
       app(expect, {
         targets: snapTarget,
         config: {
@@ -205,12 +205,12 @@ describe.heavy.ifEnv(hasSnapInstalled())("snap heavy", options, () => {
       }))
 
     // ── install+launch integration (requires unsquashfs) ────────────────────
-    test.ifEnv(canRunInstallTests())(`snap install+launch (${core})`, async ({ expect }) => {
+    test.ifEnv(canRunInstallTests())(`snap install+launch (${core})`, options, async ({ expect }) => {
       await runInstallLaunchTest(expect, core as "core18" | "core20" | "core22" | "core24", snapYamlCallback(expect))
     })
 
     // armhf cross-compilation is not supported for core24 in host/destructive-mode
-    test.ifEnv(core !== "core24")(`snap full (${core} armhf)`, ({ expect }) =>
+    test.ifEnv(core !== "core24")(`snap full (${core} armhf)`, options, ({ expect }) =>
       app(expect, {
         targets: Platform.LINUX.createTarget("snap", Arch.armv7l),
         config: {
@@ -234,11 +234,11 @@ describe.heavy.ifEnv(hasSnapInstalled())("snap heavy", options, () => {
 // native Linux CI runners.
 
 describe.heavy.ifLinux.ifEnv(hasSnapInstalled() && canRunInstallTests())("snap core24 native", options, () => {
-  test("core24 build + install + launch", async ({ expect }) => {
+  test("core24 build + install + launch", options, async ({ expect }) => {
     await runInstallLaunchTest(expect, "core24", snapYamlCallback(expect))
   })
 
-  test("core24 destructive-mode (no gnome extension)", async ({ expect }) => {
+  test("core24 destructive-mode (no gnome extension)", options, async ({ expect }) => {
     await assertPack(
       expect,
       "test-app-one",
@@ -283,7 +283,7 @@ describe.heavy.ifLinux.ifEnv(hasSnapInstalled() && canRunInstallTests())("snap c
     )
   })
 
-  test("core24 with custom stagePackages", async ({ expect }) => {
+  test("core24 with custom stagePackages", options, async ({ expect }) => {
     await assertPack(
       expect,
       "test-app-one",

--- a/test/src/updater/differentialUpdateTest.ts
+++ b/test/src/updater/differentialUpdateTest.ts
@@ -33,9 +33,9 @@ async function testMac(expect: ExpectStatic, arch: Arch) {
   }
 }
 
-test.ifMac("Mac Intel", ({ expect }) => testMac(expect, Arch.x64))
+test.ifMac("Mac Intel", { timeout: EXTENDED_TIMEOUT }, ({ expect }) => testMac(expect, Arch.x64))
 // builds 2 archs, so double the timeout?
 test.ifMac("Mac universal", { timeout: 2 * EXTENDED_TIMEOUT }, ({ expect }) => testMac(expect, Arch.universal))
 
 // only run on arm64 macs, otherwise of course no files can be found to be updated to (due to arch mismatch)
-test.ifMac.ifEnv(process.arch === "arm64")("Mac arm64", ({ expect }) => testMac(expect, Arch.arm64))
+test.ifMac.ifEnv(process.arch === "arm64")("Mac arm64", { timeout: EXTENDED_TIMEOUT }, ({ expect }) => testMac(expect, Arch.arm64))

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -109,12 +109,13 @@ async function main() {
       runner: __dirname + "/vitest-config/vitest-network-retry-runner.ts",
       reporters: ["default", __dirname + "/vitest-config/vitest-smart-reporter.ts"],
 
-      maxWorkers: "40%",
-
-      fileParallelism: true,
+      // Disable Vitest's default file-based parallelism and use our custom shard-based sequencing instead.  This ensures that tests are grouped into shards according to our custom logic (e.g. platform-specific weighting) rather than Vitest's default file-based distribution.
+      // It's either disabling here or increasing test timeout to be generous due to the I/O-heavy nature of our tests and the fact that running many in parallel can exhaust memory (e.g. due to multiple icon-tool spawns across workers).
+      // Disabling file-based parallelism is more efficient than increasing timeouts, as it allows us to run tests in parallel at the shard level while keeping individual test files running sequentially within each shard.
+      fileParallelism: false,
       sequence: {
         sequencer: SmartSequencer,
-        concurrent: true,
+        concurrent: false,
       },
 
       slowTestThreshold: 2 * 60 * 1000,

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -118,8 +118,8 @@ async function main() {
         concurrent: false,
       },
 
-      slowTestThreshold: 2 * 60 * 1000,
-      testTimeout: 10 * 60 * 1000, // disk operations can be slow. We're generous with the timeout here to account for less-performant hardware
+      slowTestThreshold: 3 * 60 * 1000,
+      testTimeout: 15 * 60 * 1000, // disk operations can be slow. We're generous with the timeout here to account for less-performant hardware
 
       snapshotFormat: {
         printBasicPrototype: false,


### PR DESCRIPTION
* [`.github/workflows/test.yaml`] Pins Snapcraft to the `8.x/stable` channel in CI to avoid intermittent hangs with Snapcraft 9.x during core24 tests.
* [`test/src/helpers/packTester.ts`] Increases `EXTENDED_TIMEOUT` from 14 to 20 minutes to accommodate slower tests.
* `test/src/linux/snapHeavyTest.ts`, `test/src/updater/differentialUpdateTest.ts`: Increases timeouts for heavy Snap and Mac tests by applying the new `EXTENDED_TIMEOUT` and multiplying for even longer-running tests. 
* [`test/vitest-scripts/run-vitest.ts`] Disables Vitest's default file-based parallelism in favor of custom shard-based sequencing, sets `fileParallelism` to `false`, disables test concurrency, increases the slow test threshold, and raises the global test timeout to 15 minutes. This helps prevent resource exhaustion and improves reliability on less-performant hardware.