### PR TITLE
feat: promote Azure Trusted Signing and Snap Core24 out of Beta; update documentation

### DIFF
--- a/.changeset/tired-ants-wonder.md
+++ b/.changeset/tired-ants-wonder.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat: promote Azure Trusted Signing and Snap Core24 out of Beta

--- a/.changeset/win-codesign-docs.md
+++ b/.changeset/win-codesign-docs.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+docs(win): expand JSDoc for all Windows code signing options (regenerating scheme.json) and modernize the code-signing docs — correct osslsigncode vs Wine, HSM dual-signing, and the "latest" winCodeSign toolset model

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -6322,7 +6322,7 @@
     },
     "SnapOptions24": {
       "additionalProperties": false,
-      "description": "**[Beta]** Options for building a core24 snap. This interface does not extend the legacy\n`SnapBaseOptions` — it uses the snapcraft CLI directly.\n\nFields inherited from {@link CommonLinuxOptions} (`description`, `category`, `mimeTypes`,\n`executableArgs`, `desktop`, `synopsis`) are automatically populated from the root `linux.*`\nconfiguration. You do not need to duplicate them here; values set directly on this interface\ntake precedence over the cascaded `linux.*` values.",
+      "description": "Options for building a core24 snap. This interface does not extend the legacy\n`SnapBaseOptions` — it uses the snapcraft CLI directly.\n\nFields inherited from {@link CommonLinuxOptions} (`description`, `category`, `mimeTypes`,\n`executableArgs`, `desktop`, `synopsis`) are automatically populated from the root `linux.*`\nconfiguration. You do not need to duplicate them here; values set directly on this interface\ntake precedence over the cascaded `linux.*` values.",
       "properties": {
         "after": {
           "anyOf": [
@@ -7218,7 +7218,7 @@
               "type": "null"
             }
           ],
-          "description": "**[Beta]** Options for building a core24 snap. Uses the snapcraft CLI directly.\nInherits desktop-entry fields from `CommonLinuxOptions` and publish config from `TargetSpecificOptions`."
+          "description": "Options for building a core24 snap. Uses the snapcraft CLI directly.\nInherits desktop-entry fields from `CommonLinuxOptions` and publish config from `TargetSpecificOptions`."
         },
         "cscLink": {
           "description": "Snapcraft Store credentials — base64-encoded credentials string or file path.\nAccepts the same formats as `WIN_CSC_LINK` / `CSC_LINK`: base64 data,\nabsolute/relative/`~/` file paths, and `file://` URIs.\nRelative paths are resolved against the build resources directory.\n\nInjected as `SNAPCRAFT_STORE_CREDENTIALS` into every snapcraft subprocess\n(core18/core20/core22/core24 builds and `snapcraft upload`).\nNot applied for `base: \"custom\"` — inject credentials manually via environment variables.\n\nThe `SNAP_CSC_LINK` environment variable is the CI-friendly alternative.\nGenerate with: `snapcraft export-login - | base64 -w0`",
@@ -7233,7 +7233,7 @@
               "type": "null"
             }
           ],
-          "description": "**[Beta]** Pass-through custom snap configuration. electron-builder will read the\nsnapcraft.yaml at `yamlPath` and use it verbatim — no plugs, extensions,\norganize mappings, or desktop files are injected."
+          "description": "Pass-through custom snap configuration. electron-builder will read the\nsnapcraft.yaml at `yamlPath` and use it verbatim — no plugs, extensions,\norganize mappings, or desktop files are injected."
         },
         "publish": {
           "anyOf": [
@@ -7933,17 +7933,18 @@
     },
     "WindowsAzureSigningConfig": {
       "additionalProperties": false,
+      "description": "The `signtool /dlib` Azure Trusted Signing integration was introduced in `toolsets.winCodeSign: 1.3.0`.\nThe legacy PowerShell integration is deprecated, but leverages the same underlying Azure APIs, so both interfaces share the same config shape.",
       "properties": {
         "additionalMetadata": {
           "$ref": "#/definitions/Record<string,string>",
           "description": "Additional fields to include verbatim in the `metadata.json` file passed to\n`Azure.CodeSigning.Dlib.dll` via `signtool /dmdf`. Use this for DLib-specific options\nnot covered by the typed fields above (e.g. `ExcludeCredentials`, `CorrelationId`)."
         },
         "certificateProfileName": {
-          "description": "The Certificate Profile name. Translates to field: CertificateProfileName.",
+          "description": "The name of the Trusted Signing Certificate Profile to sign with, as created in your Azure\nCode Signing Account. Maps to the DLib metadata field `CertificateProfileName`.",
           "type": "string"
         },
         "codeSigningAccountName": {
-          "description": "The Code Signing Account name. Translates to field: CodeSigningAccountName.",
+          "description": "The name of the Azure Trusted Signing (Code Signing) Account that owns the certificate profile.\nMaps to the DLib metadata field `CodeSigningAccountName`.",
           "type": "string"
         },
         "endpoint": {
@@ -7952,11 +7953,11 @@
         },
         "fileDigest": {
           "default": "SHA256",
-          "description": "The file digest algorithm. Translates to field: FileDigest.",
+          "description": "The digest algorithm used to hash the files being signed. Maps to the DLib metadata field\n`FileDigest`.",
           "type": "string"
         },
         "publisherName": {
-          "description": "[The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.",
+          "description": "The publisher name to associate with the signature, exactly as it appears in the certificate\nissued by your Trusted Signing certificate profile. Required. Used for\n[update verification](#verifyUpdateCodeSignature) (embedded in `app-update.yml` and checked by\nelectron-updater) and must match the certificate subject.",
           "type": "string"
         },
         "timestampDigest": {
@@ -7971,6 +7972,7 @@
         },
         "type": {
           "const": "azure",
+          "description": "Discriminator selecting Azure Trusted Signing (cloud signing — no local certificate).",
           "type": "string"
         }
       },
@@ -8311,7 +8313,7 @@
               "type": "null"
             }
           ],
-          "description": "Code signing configuration. Set to `false` or `null` to disable Windows code signing\n(executable resources such as the icon and metadata are still edited). Leave unset to\nsign using credentials discovered from the environment (e.g. `WIN_CSC_LINK`). Otherwise\nprovide exactly one of the following signing modes:\n\n- `{ type: \"signtool\", ... }` — Sign with a local certificate file (.pfx/.p12) or a\n  certificate from the Windows certificate store.\n- `{ type: \"hsm\", ... }` — Sign using a Hardware Security Module (HSM) or FIPS-compliant\n  hardware token via signtool's `/csp` (cryptographic service provider) and `/kc` (key\n  container) flags. Requires `toolsets.winCodeSign: \"1.x\"`. Windows-only.\n- `{ type: \"pkcs11\", ... }` — Sign using a PKCS#11 hardware token via osslsigncode.\n  Available on macOS and Linux CI without a Windows VM.\n- `{ type: \"azure\", ... }` — Sign via Azure Trusted Signing (cloud service). Requires\n  Azure Entra ID environment variables for authentication."
+          "description": "Code signing configuration. Code signing stamps every installer and executable\nelectron-builder produces with an Authenticode signature, so that Windows (SmartScreen / UAC)\nand your auto-updater can verify the publisher and that the files were not tampered with.\n\nHow this option behaves:\n- Leave **unset** to sign using credentials discovered from the environment — primarily a\n  certificate supplied via `WIN_CSC_LINK` (or `CSC_LINK`) with its password in\n  `WIN_CSC_KEY_PASSWORD` (or `CSC_KEY_PASSWORD`). `WIN_CSC_LINK` accepts a file path, an\n  `https://` URL, or a base64-encoded certificate. This is the recommended setup for CI.\n- Set to `false` or `null` to **disable** code signing entirely (executable resources such as\n  the icon and metadata are still edited).\n- Set to an **object** to configure signing explicitly. The `type` field selects the signing\n  backend (`signtool` is the implicit default) and dispatches to a dedicated sign manager;\n  provide exactly one of the modes below. Each output artifact is signed individually, and by\n  default executables are dual-signed (see `signingHashAlgorithms`).\n\n- `{ type: \"signtool\", ... }` — Sign with a local certificate file (.pfx/.p12) or a\n  certificate from the Windows certificate store. Uses Microsoft `signtool.exe` on Windows and\n  `osslsigncode` on macOS/Linux.\n- `{ type: \"hsm\", ... }` — Sign using a Hardware Security Module (HSM) or FIPS-compliant\n  hardware token via signtool's `/csp` (cryptographic service provider) and `/kc` (key\n  container) flags. Requires a modern `winCodeSign` toolset (the default — only the legacy\n  `\"0.0.0\"` pin is unsupported). Windows-only.\n- `{ type: \"pkcs11\", ... }` — Sign using a PKCS#11 hardware token via osslsigncode.\n  Available on macOS and Linux CI without a Windows VM.\n- `{ type: \"azure\", ... }` — Sign via Azure Trusted Signing (cloud service). Requires\n  Azure Entra ID environment variables for authentication.\n\nSee [Code Signing](https://www.electron.build/code-signing)."
         },
         "signExts": {
           "anyOf": [
@@ -8326,7 +8328,7 @@
             }
           ],
           "default": null,
-          "description": "Explicit file name/extensions (`str.endsWith`) to also sign. Advanced option.\nSupports negative patterns, e.g. example that excludes `.appx` files: `[\"somefilename\", \".dll\", \"!.appx\"]`."
+          "description": "Additional file name suffixes to code sign, beyond the default. By default electron-builder\nonly signs `.exe` files; list extra suffixes here to also sign e.g. `.dll`, `.node`, or\nspecific file names. Advanced option — most apps do not need it.\n\nEach entry is matched with `String.endsWith`, so both bare extensions (`\".dll\"`) and full file\nnames (`\"mybinary.dll\"`) work. Prefix a pattern with `!` to *exclude* a suffix that would\notherwise be signed. Positive patterns are evaluated first, then negative ones. For example,\n`[\"somefilename\", \".dll\", \"!.appx\"]` signs `.dll` files (and anything ending in `somefilename`)\nbut never signs `.appx` files."
         },
         "target": {
           "anyOf": [
@@ -8358,7 +8360,7 @@
         },
         "verifyUpdateCodeSignature": {
           "default": true,
-          "description": "Whether to verify the signature of an available update before installation.\nThe [publisher name](#publisherName) will be used for the signature verification.",
+          "description": "Whether the NSIS auto-updater should verify the Authenticode signature of a downloaded update\nbefore installing it. This is a **runtime** check performed by your app via electron-updater,\nnot a build-time check.\n\nWhen enabled (the default), the resolved [publisher name](#publisherName) is embedded into\n`app-update.yml` at build time. At update time electron-updater inspects the certificate that\nsigned the downloaded installer and compares its subject (Distinguished Name / Common Name)\nagainst that publisher name, refusing to install on a mismatch. This prevents a tampered or\nmaliciously substituted update from being installed.\n\nSet to `false` to skip verification — in which case the publisher name is **not** embedded.\nDisable this only if your updates are not Authenticode-signed.",
           "type": "boolean"
         }
       },
@@ -8368,7 +8370,7 @@
       "additionalProperties": false,
       "properties": {
         "additionalCertificateFile": {
-          "description": "The path to an additional certificate file you want to add to the signature block.",
+          "description": "Path to an additional certificate file (typically an intermediate / cross-signing CA\ncertificate) whose contents are added to the signature block via signtool's `/ac` flag. Use\nthis when the signing certificate's full chain is not already present on target machines and\nyou want it embedded in the signature so the chain can be validated.",
           "type": [
             "null",
             "string"
@@ -8382,21 +8384,21 @@
           ]
         },
         "certificateSha1": {
-          "description": "The SHA1 thumbprint of the certificate in the Windows certificate store.",
+          "description": "Alternative to `certificateFile`: locate the public certificate in the Windows certificate\nstore by its SHA-1 thumbprint. The private key still comes from the HSM via\n`cryptoServiceProvider` / `keyContainer`; this only identifies which public certificate to sign\nwith.",
           "type": [
             "null",
             "string"
           ]
         },
         "certificateSubjectName": {
-          "description": "The subject name of the certificate in the Windows certificate store.",
+          "description": "Alternative to `certificateFile`: locate the public certificate in the Windows certificate\nstore by (a substring of) its subject name. The private key still comes from the HSM via\n`cryptoServiceProvider` / `keyContainer`; this only identifies which public certificate to sign\nwith.",
           "type": [
             "null",
             "string"
           ]
         },
         "cryptoServiceProvider": {
-          "description": "The name of the cryptographic service provider (CSP) that holds the private key.\nMaps to signtool's `/csp` flag. Examples:\n- Google Cloud KMS: `\"Google Cloud KMS Provider\"`\n- Smart card / FIPS token: `\"Microsoft Base Smart Card Crypto Provider\"`\n\nRequires `toolsets.winCodeSign: \"1.x\"`. Windows-only — use `type: \"pkcs11\"` on macOS/Linux.",
+          "description": "The name of the cryptographic service provider (CSP) that holds the private key.\nMaps to signtool's `/csp` flag. Examples:\n- Google Cloud KMS: `\"Google Cloud KMS Provider\"`\n- Smart card / FIPS token: `\"Microsoft Base Smart Card Crypto Provider\"`\n\nRequires a modern `winCodeSign` toolset (the default; only the legacy `\"0.0.0\"` pin is\nunsupported). Windows-only — use `type: \"pkcs11\"` on macOS/Linux.",
           "type": "string"
         },
         "keyContainer": {
@@ -8418,11 +8420,11 @@
               ]
             }
           ],
-          "description": "[The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.\nDefaults to common name from your code signing certificate."
+          "description": "The publisher name(s) to associate with the signature, written exactly as the subject appears\nin your code signing certificate. May be a single string or an array — an array is useful when\nrotating certificates, so updates signed by either the old or the new certificate still verify.\n\nThis value is not a `signtool` argument; it is consumed in two places:\n- **Update verification** — when [verifyUpdateCodeSignature](#verifyUpdateCodeSignature) is\n  enabled, it is written into `app-update.yml` and electron-updater checks it against the\n  certificate that signed each downloaded update.\n- **AppX / MSIX identity** — the package `Publisher` attribute must equal the certificate\n  subject, so electron-builder derives it from this value (or the certificate) to keep them\n  in sync; a mismatch makes packaging fail with `ERROR_BAD_FORMAT`.\n\nDefaults to the Common Name (CN) extracted from your code signing certificate. Set to `null`\nto opt out."
         },
         "rfc3161TimeStampServer": {
           "default": "http://timestamp.digicert.com",
-          "description": "The URL of the RFC 3161 time stamp server.",
+          "description": "The URL of the [RFC 3161](https://www.ietf.org/rfc/rfc3161.txt) timestamp server, used for\nSHA-256 and nested/appended signatures (signtool's `/tr` flag). Timestamping records *when*\nthe file was signed so the signature stays valid after the signing certificate expires.\nIgnored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.",
           "type": [
             "null",
             "string"
@@ -8440,7 +8442,7 @@
               ]
             }
           ],
-          "description": "The custom function (or path to file or module id) to sign Windows executables."
+          "description": "A custom signing hook that **replaces** electron-builder's built-in `signtool` /\n`osslsigncode` invocation. Provide a function, or the path / module id of a file that exports\na `sign` function (resolved relative to the project, then as a module).\n\nThe hook is invoked once per signing pass (i.e. once per entry in\n[signingHashAlgorithms](#signingHashAlgorithms)) and receives a configuration object describing\nthe file to sign (`path`), the resolved certificate info (`cscInfo`), the current `hash`, and\nwhether this pass is a nested signature (`isNest`), plus a `computeSignToolArgs(isWin)` helper\nthat returns the default arguments electron-builder would otherwise have used. Use this to\nintegrate an external or cloud signing service. See\n[Code Signing](https://www.electron.build/code-signing)."
         },
         "signingHashAlgorithms": {
           "anyOf": [
@@ -8459,11 +8461,11 @@
             }
           ],
           "default": "['sha1', 'sha256']",
-          "description": "Array of signing algorithms used. For AppX `sha256` is always used."
+          "description": "The digest (hash) algorithms to sign with, applied via signtool's `/fd` flag (or\nosslsigncode's `-h`). One signing pass runs per entry, in order; listing more than one\n**dual-signs** the file, with each additional signature appended as a nested signature\n(signtool `/as`). Signing with both `sha1` and `sha256` lets a single binary validate on\nlegacy (pre-SHA-2) Windows as well as modern Windows.\n\nSome targets override this: `.msi` cannot be dual-signed (a single hash is used) and AppX/MSIX\nis always `sha256` only."
         },
         "timeStampServer": {
           "default": "http://timestamp.digicert.com",
-          "description": "The URL of the time stamp server.",
+          "description": "The URL of the legacy Authenticode timestamp server, used for SHA-1 signatures (signtool's\n`/t` flag). This is also the timestamp server used by `osslsigncode` (`-t`) when signing on\nmacOS/Linux. See [rfc3161TimeStampServer](#rfc3161TimeStampServer) for SHA-256 / nested\nsignatures. Ignored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.",
           "type": [
             "null",
             "string"
@@ -8471,6 +8473,7 @@
         },
         "type": {
           "const": "hsm",
+          "description": "Discriminator selecting HSM / hardware-token signing via signtool's `/csp` and `/kc` flags.",
           "type": "string"
         }
       },
@@ -8483,9 +8486,10 @@
     },
     "WindowsPkcs11SigningConfig": {
       "additionalProperties": false,
+      "description": "Sign with a PKCS#11 hardware token (smart card, USB HSM, cloud KMS exposed via a PKCS#11\nprovider) using `osslsigncode`. Unlike `hsm`, this mode does **not** require Windows or a\nWindows VM, so it can sign Windows binaries directly from macOS/Linux CI. The token PIN is read\nfrom the `WIN_CSC_KEY_PASSWORD` (or `CSC_KEY_PASSWORD`) environment variable.",
       "properties": {
         "additionalCertificateFile": {
-          "description": "The path to an additional certificate file you want to add to the signature block.",
+          "description": "Path to an additional certificate file (typically an intermediate / cross-signing CA\ncertificate) whose contents are added to the signature block via signtool's `/ac` flag. Use\nthis when the signing certificate's full chain is not already present on target machines and\nyou want it embedded in the signature so the chain can be validated.",
           "type": [
             "null",
             "string"
@@ -8521,11 +8525,11 @@
               ]
             }
           ],
-          "description": "[The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.\nDefaults to common name from your code signing certificate."
+          "description": "The publisher name(s) to associate with the signature, written exactly as the subject appears\nin your code signing certificate. May be a single string or an array — an array is useful when\nrotating certificates, so updates signed by either the old or the new certificate still verify.\n\nThis value is not a `signtool` argument; it is consumed in two places:\n- **Update verification** — when [verifyUpdateCodeSignature](#verifyUpdateCodeSignature) is\n  enabled, it is written into `app-update.yml` and electron-updater checks it against the\n  certificate that signed each downloaded update.\n- **AppX / MSIX identity** — the package `Publisher` attribute must equal the certificate\n  subject, so electron-builder derives it from this value (or the certificate) to keep them\n  in sync; a mismatch makes packaging fail with `ERROR_BAD_FORMAT`.\n\nDefaults to the Common Name (CN) extracted from your code signing certificate. Set to `null`\nto opt out."
         },
         "rfc3161TimeStampServer": {
           "default": "http://timestamp.digicert.com",
-          "description": "The URL of the RFC 3161 time stamp server.",
+          "description": "The URL of the [RFC 3161](https://www.ietf.org/rfc/rfc3161.txt) timestamp server, used for\nSHA-256 and nested/appended signatures (signtool's `/tr` flag). Timestamping records *when*\nthe file was signed so the signature stays valid after the signing certificate expires.\nIgnored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.",
           "type": [
             "null",
             "string"
@@ -8543,7 +8547,7 @@
               ]
             }
           ],
-          "description": "The custom function (or path to file or module id) to sign Windows executables."
+          "description": "A custom signing hook that **replaces** electron-builder's built-in `signtool` /\n`osslsigncode` invocation. Provide a function, or the path / module id of a file that exports\na `sign` function (resolved relative to the project, then as a module).\n\nThe hook is invoked once per signing pass (i.e. once per entry in\n[signingHashAlgorithms](#signingHashAlgorithms)) and receives a configuration object describing\nthe file to sign (`path`), the resolved certificate info (`cscInfo`), the current `hash`, and\nwhether this pass is a nested signature (`isNest`), plus a `computeSignToolArgs(isWin)` helper\nthat returns the default arguments electron-builder would otherwise have used. Use this to\nintegrate an external or cloud signing service. See\n[Code Signing](https://www.electron.build/code-signing)."
         },
         "signingHashAlgorithms": {
           "anyOf": [
@@ -8562,11 +8566,11 @@
             }
           ],
           "default": "['sha1', 'sha256']",
-          "description": "Array of signing algorithms used. For AppX `sha256` is always used."
+          "description": "The digest (hash) algorithms to sign with, applied via signtool's `/fd` flag (or\nosslsigncode's `-h`). One signing pass runs per entry, in order; listing more than one\n**dual-signs** the file, with each additional signature appended as a nested signature\n(signtool `/as`). Signing with both `sha1` and `sha256` lets a single binary validate on\nlegacy (pre-SHA-2) Windows as well as modern Windows.\n\nSome targets override this: `.msi` cannot be dual-signed (a single hash is used) and AppX/MSIX\nis always `sha256` only."
         },
         "timeStampServer": {
           "default": "http://timestamp.digicert.com",
-          "description": "The URL of the time stamp server.",
+          "description": "The URL of the legacy Authenticode timestamp server, used for SHA-1 signatures (signtool's\n`/t` flag). This is also the timestamp server used by `osslsigncode` (`-t`) when signing on\nmacOS/Linux. See [rfc3161TimeStampServer](#rfc3161TimeStampServer) for SHA-256 / nested\nsignatures. Ignored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.",
           "type": [
             "null",
             "string"
@@ -8574,6 +8578,7 @@
         },
         "type": {
           "const": "pkcs11",
+          "description": "Discriminator selecting cross-platform PKCS#11 token signing via `osslsigncode`.",
           "type": "string"
         }
       },
@@ -8586,37 +8591,38 @@
     },
     "WindowsSigntoolSigningConfig": {
       "additionalProperties": false,
+      "description": "Sign with a certificate file (`.pfx` / `.p12`) or with a certificate from the Windows\ncertificate store, using Microsoft `signtool.exe` on Windows and `osslsigncode` on macOS/Linux.\nThis is the default mode when `win.sign` is unset. Supply the certificate one of four ways:\na file via `certificateFile` (or the `WIN_CSC_LINK` env var), or a store lookup via\n`certificateSubjectName` or `certificateSha1`.",
       "properties": {
         "additionalCertificateFile": {
-          "description": "The path to an additional certificate file you want to add to the signature block.",
+          "description": "Path to an additional certificate file (typically an intermediate / cross-signing CA\ncertificate) whose contents are added to the signature block via signtool's `/ac` flag. Use\nthis when the signing certificate's full chain is not already present on target machines and\nyou want it embedded in the signature so the chain can be validated.",
           "type": [
             "null",
             "string"
           ]
         },
         "certificateFile": {
-          "description": "The path to the *.pfx or *.p12 certificate file. Prefer the `WIN_CSC_LINK` environment\nvariable when possible. See [Code Signing](https://www.electron.build/code-signing).",
+          "description": "Path to the PKCS#12 certificate file (`.pfx` or `.p12`) holding both the signing certificate\nand its private key. Passed to signtool via `/f` (or osslsigncode via `-pkcs12`).\n\nPrefer supplying this out-of-band via the `WIN_CSC_LINK` (or `CSC_LINK`) environment variable\ninstead of hardcoding a path — that variable also accepts an `https://` URL or a base64-encoded\ncertificate, which is safer and more convenient on CI. See\n[Code Signing](https://www.electron.build/code-signing).",
           "type": [
             "null",
             "string"
           ]
         },
         "certificatePassword": {
-          "description": "The password to the certificate provided in `certificateFile`. Prefer the\n`WIN_CSC_KEY_PASSWORD` environment variable when possible.",
+          "description": "The password protecting the private key in `certificateFile`. Passed to signtool via `/p`\n(or osslsigncode via `-pass`).\n\nPrefer the `WIN_CSC_KEY_PASSWORD` (or `CSC_KEY_PASSWORD`) environment variable so the secret\nnever lands in your build configuration.",
           "type": [
             "null",
             "string"
           ]
         },
         "certificateSha1": {
-          "description": "The SHA1 hash of the signing certificate. Works only on Windows (or macOS with Parallels Desktop).",
+          "description": "Select the signing certificate from the Windows certificate store by its SHA-1 thumbprint,\ninstead of pointing at a `.pfx` file. electron-builder looks the certificate up in the store\nand signs with `/sha1 <thumbprint> /s <store>`. Like\n[certificateSubjectName](#certificateSubjectName), this suits EV certificates backed by a\nhardware token; if both are set, both must resolve to the same certificate.\n\nWorks only on Windows (or macOS with Parallels Desktop, via the bundled Windows VM).",
           "type": [
             "null",
             "string"
           ]
         },
         "certificateSubjectName": {
-          "description": "The name of the subject of the signing certificate. Required for EV Code Signing.\nWorks only on Windows (or macOS with Parallels Desktop).",
+          "description": "Select the signing certificate from the Windows certificate store by (a substring of) its\nsubject name, instead of pointing at a `.pfx` file. electron-builder enumerates the installed\ncode-signing certificates, picks the match, and signs by its thumbprint\n(`/sha1 <thumbprint> /s <store>`). **Required for EV (Extended Validation) certificates**,\nwhose private keys live on a hardware token and cannot be exported to a file.\n\nWorks only on Windows (or macOS with Parallels Desktop, via the bundled Windows VM).",
           "type": [
             "null",
             "string"
@@ -8637,11 +8643,11 @@
               ]
             }
           ],
-          "description": "[The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.\nDefaults to common name from your code signing certificate."
+          "description": "The publisher name(s) to associate with the signature, written exactly as the subject appears\nin your code signing certificate. May be a single string or an array — an array is useful when\nrotating certificates, so updates signed by either the old or the new certificate still verify.\n\nThis value is not a `signtool` argument; it is consumed in two places:\n- **Update verification** — when [verifyUpdateCodeSignature](#verifyUpdateCodeSignature) is\n  enabled, it is written into `app-update.yml` and electron-updater checks it against the\n  certificate that signed each downloaded update.\n- **AppX / MSIX identity** — the package `Publisher` attribute must equal the certificate\n  subject, so electron-builder derives it from this value (or the certificate) to keep them\n  in sync; a mismatch makes packaging fail with `ERROR_BAD_FORMAT`.\n\nDefaults to the Common Name (CN) extracted from your code signing certificate. Set to `null`\nto opt out."
         },
         "rfc3161TimeStampServer": {
           "default": "http://timestamp.digicert.com",
-          "description": "The URL of the RFC 3161 time stamp server.",
+          "description": "The URL of the [RFC 3161](https://www.ietf.org/rfc/rfc3161.txt) timestamp server, used for\nSHA-256 and nested/appended signatures (signtool's `/tr` flag). Timestamping records *when*\nthe file was signed so the signature stays valid after the signing certificate expires.\nIgnored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.",
           "type": [
             "null",
             "string"
@@ -8659,7 +8665,7 @@
               ]
             }
           ],
-          "description": "The custom function (or path to file or module id) to sign Windows executables."
+          "description": "A custom signing hook that **replaces** electron-builder's built-in `signtool` /\n`osslsigncode` invocation. Provide a function, or the path / module id of a file that exports\na `sign` function (resolved relative to the project, then as a module).\n\nThe hook is invoked once per signing pass (i.e. once per entry in\n[signingHashAlgorithms](#signingHashAlgorithms)) and receives a configuration object describing\nthe file to sign (`path`), the resolved certificate info (`cscInfo`), the current `hash`, and\nwhether this pass is a nested signature (`isNest`), plus a `computeSignToolArgs(isWin)` helper\nthat returns the default arguments electron-builder would otherwise have used. Use this to\nintegrate an external or cloud signing service. See\n[Code Signing](https://www.electron.build/code-signing)."
         },
         "signingHashAlgorithms": {
           "anyOf": [
@@ -8678,11 +8684,11 @@
             }
           ],
           "default": "['sha1', 'sha256']",
-          "description": "Array of signing algorithms used. For AppX `sha256` is always used."
+          "description": "The digest (hash) algorithms to sign with, applied via signtool's `/fd` flag (or\nosslsigncode's `-h`). One signing pass runs per entry, in order; listing more than one\n**dual-signs** the file, with each additional signature appended as a nested signature\n(signtool `/as`). Signing with both `sha1` and `sha256` lets a single binary validate on\nlegacy (pre-SHA-2) Windows as well as modern Windows.\n\nSome targets override this: `.msi` cannot be dual-signed (a single hash is used) and AppX/MSIX\nis always `sha256` only."
         },
         "timeStampServer": {
           "default": "http://timestamp.digicert.com",
-          "description": "The URL of the time stamp server.",
+          "description": "The URL of the legacy Authenticode timestamp server, used for SHA-1 signatures (signtool's\n`/t` flag). This is also the timestamp server used by `osslsigncode` (`-t`) when signing on\nmacOS/Linux. See [rfc3161TimeStampServer](#rfc3161TimeStampServer) for SHA-256 / nested\nsignatures. Ignored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.",
           "type": [
             "null",
             "string"
@@ -8690,6 +8696,7 @@
         },
         "type": {
           "const": "signtool",
+          "description": "Discriminator selecting the default file/store signing mode.",
           "type": "string"
         }
       },

--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -44,16 +44,14 @@ export interface SnapcraftOptions extends TargetSpecificOptions {
   readonly core22?: SnapOptionsLegacy | null
 
   /**
-   * **[Beta]** Options for building a core24 snap. Uses the snapcraft CLI directly.
+   * Options for building a core24 snap. Uses the snapcraft CLI directly.
    * Inherits desktop-entry fields from `CommonLinuxOptions` and publish config from `TargetSpecificOptions`.
-   * @beta
    */
   readonly core24?: SnapOptions24 | null
   /**
-   * **[Beta]** Pass-through custom snap configuration. electron-builder will read the
+   * Pass-through custom snap configuration. electron-builder will read the
    * snapcraft.yaml at `yamlPath` and use it verbatim — no plugs, extensions,
    * organize mappings, or desktop files are injected.
-   * @beta
    */
   readonly custom?: SnapOptionsCustom | null
 }
@@ -312,15 +310,13 @@ export interface RemoteBuildOptions {
 }
 
 /**
- * **[Beta]** Options for building a core24 snap. This interface does not extend the legacy
+ * Options for building a core24 snap. This interface does not extend the legacy
  * `SnapBaseOptions` — it uses the snapcraft CLI directly.
  *
  * Fields inherited from {@link CommonLinuxOptions} (`description`, `category`, `mimeTypes`,
  * `executableArgs`, `desktop`, `synopsis`) are automatically populated from the root `linux.*`
  * configuration. You do not need to duplicate them here; values set directly on this interface
  * take precedence over the cascaded `linux.*` values.
- *
- * @beta
  */
 export interface SnapOptions24 extends CommonLinuxOptions, TargetSpecificOptions {
   // ─── Build environment (mutually exclusive) ─────────────────────────────────

--- a/packages/app-builder-lib/src/options/winOptions.ts
+++ b/packages/app-builder-lib/src/options/winOptions.ts
@@ -25,26 +25,51 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   readonly legalTrademarks?: string | null
 
   /**
-   * Code signing configuration. Set to `false` or `null` to disable Windows code signing
-   * (executable resources such as the icon and metadata are still edited). Leave unset to
-   * sign using credentials discovered from the environment (e.g. `WIN_CSC_LINK`). Otherwise
-   * provide exactly one of the following signing modes:
+   * Code signing configuration. Code signing stamps every installer and executable
+   * electron-builder produces with an Authenticode signature, so that Windows (SmartScreen / UAC)
+   * and your auto-updater can verify the publisher and that the files were not tampered with.
+   *
+   * How this option behaves:
+   * - Leave **unset** to sign using credentials discovered from the environment — primarily a
+   *   certificate supplied via `WIN_CSC_LINK` (or `CSC_LINK`) with its password in
+   *   `WIN_CSC_KEY_PASSWORD` (or `CSC_KEY_PASSWORD`). `WIN_CSC_LINK` accepts a file path, an
+   *   `https://` URL, or a base64-encoded certificate. This is the recommended setup for CI.
+   * - Set to `false` or `null` to **disable** code signing entirely (executable resources such as
+   *   the icon and metadata are still edited).
+   * - Set to an **object** to configure signing explicitly. The `type` field selects the signing
+   *   backend (`signtool` is the implicit default) and dispatches to a dedicated sign manager;
+   *   provide exactly one of the modes below. Each output artifact is signed individually, and by
+   *   default executables are dual-signed (see `signingHashAlgorithms`).
    *
    * - `{ type: "signtool", ... }` — Sign with a local certificate file (.pfx/.p12) or a
-   *   certificate from the Windows certificate store.
+   *   certificate from the Windows certificate store. Uses Microsoft `signtool.exe` on Windows and
+   *   `osslsigncode` on macOS/Linux.
    * - `{ type: "hsm", ... }` — Sign using a Hardware Security Module (HSM) or FIPS-compliant
    *   hardware token via signtool's `/csp` (cryptographic service provider) and `/kc` (key
-   *   container) flags. Requires `toolsets.winCodeSign: "1.x"`. Windows-only.
+   *   container) flags. Requires a modern `winCodeSign` toolset (the default — only the legacy
+   *   `"0.0.0"` pin is unsupported). Windows-only.
    * - `{ type: "pkcs11", ... }` — Sign using a PKCS#11 hardware token via osslsigncode.
    *   Available on macOS and Linux CI without a Windows VM.
    * - `{ type: "azure", ... }` — Sign via Azure Trusted Signing (cloud service). Requires
    *   Azure Entra ID environment variables for authentication.
+   *
+   * See [Code Signing](https://www.electron.build/code-signing).
    */
   readonly sign?: WindowsSigningConfiguration | false | null
 
   /**
-   * Whether to verify the signature of an available update before installation.
-   * The [publisher name](#publisherName) will be used for the signature verification.
+   * Whether the NSIS auto-updater should verify the Authenticode signature of a downloaded update
+   * before installing it. This is a **runtime** check performed by your app via electron-updater,
+   * not a build-time check.
+   *
+   * When enabled (the default), the resolved [publisher name](#publisherName) is embedded into
+   * `app-update.yml` at build time. At update time electron-updater inspects the certificate that
+   * signed the downloaded installer and compares its subject (Distinguished Name / Common Name)
+   * against that publisher name, refusing to install on a mismatch. This prevents a tampered or
+   * maliciously substituted update from being installed.
+   *
+   * Set to `false` to skip verification — in which case the publisher name is **not** embedded.
+   * Disable this only if your updates are not Authenticode-signed.
    *
    * @default true
    */
@@ -58,8 +83,16 @@ export interface WindowsConfiguration extends PlatformSpecificBuildOptions {
   readonly requestedExecutionLevel?: RequestedExecutionLevel | null
 
   /**
-   * Explicit file name/extensions (`str.endsWith`) to also sign. Advanced option.
-   * Supports negative patterns, e.g. example that excludes `.appx` files: `["somefilename", ".dll", "!.appx"]`.
+   * Additional file name suffixes to code sign, beyond the default. By default electron-builder
+   * only signs `.exe` files; list extra suffixes here to also sign e.g. `.dll`, `.node`, or
+   * specific file names. Advanced option — most apps do not need it.
+   *
+   * Each entry is matched with `String.endsWith`, so both bare extensions (`".dll"`) and full file
+   * names (`"mybinary.dll"`) work. Prefix a pattern with `!` to *exclude* a suffix that would
+   * otherwise be signed. Positive patterns are evaluated first, then negative ones. For example,
+   * `["somefilename", ".dll", "!.appx"]` signs `.dll` files (and anything ending in `somefilename`)
+   * but never signs `.appx` files.
+   *
    * @see https://github.com/electron-userland/electron-builder/issues/7329
    * @default null
    */
@@ -70,67 +103,142 @@ export type RequestedExecutionLevel = "asInvoker" | "highestAvailable" | "requir
 
 // ─── Shared base for signtool-family signing modes ───────────────────────────
 
+/**
+ * Options shared by every certificate-based signing mode (`signtool`, `hsm`, `pkcs11`). These
+ * control the signature itself — publisher identity, digest algorithms, timestamping, and the
+ * extra certificates added to the signature block — independently of where the private key lives.
+ */
 interface WindowsSigningSharedOptions {
   /**
-   * [The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.
-   * Defaults to common name from your code signing certificate.
+   * The publisher name(s) to associate with the signature, written exactly as the subject appears
+   * in your code signing certificate. May be a single string or an array — an array is useful when
+   * rotating certificates, so updates signed by either the old or the new certificate still verify.
+   *
+   * This value is not a `signtool` argument; it is consumed in two places:
+   * - **Update verification** — when [verifyUpdateCodeSignature](#verifyUpdateCodeSignature) is
+   *   enabled, it is written into `app-update.yml` and electron-updater checks it against the
+   *   certificate that signed each downloaded update.
+   * - **AppX / MSIX identity** — the package `Publisher` attribute must equal the certificate
+   *   subject, so electron-builder derives it from this value (or the certificate) to keep them
+   *   in sync; a mismatch makes packaging fail with `ERROR_BAD_FORMAT`.
+   *
+   * Defaults to the Common Name (CN) extracted from your code signing certificate. Set to `null`
+   * to opt out.
+   *
+   * @see https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073
    */
   readonly publisherName?: string | Array<string> | null
 
   /**
-   * Array of signing algorithms used. For AppX `sha256` is always used.
+   * The digest (hash) algorithms to sign with, applied via signtool's `/fd` flag (or
+   * osslsigncode's `-h`). One signing pass runs per entry, in order; listing more than one
+   * **dual-signs** the file, with each additional signature appended as a nested signature
+   * (signtool `/as`). Signing with both `sha1` and `sha256` lets a single binary validate on
+   * legacy (pre-SHA-2) Windows as well as modern Windows.
+   *
+   * Some targets override this: `.msi` cannot be dual-signed (a single hash is used) and AppX/MSIX
+   * is always `sha256` only.
+   *
    * @default ['sha1', 'sha256']
    */
   readonly signingHashAlgorithms?: Array<"sha1" | "sha256"> | null
 
   /**
-   * The URL of the RFC 3161 time stamp server.
+   * The URL of the [RFC 3161](https://www.ietf.org/rfc/rfc3161.txt) timestamp server, used for
+   * SHA-256 and nested/appended signatures (signtool's `/tr` flag). Timestamping records *when*
+   * the file was signed so the signature stays valid after the signing certificate expires.
+   * Ignored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.
+   *
    * @default http://timestamp.digicert.com
    */
   readonly rfc3161TimeStampServer?: string | null
 
   /**
-   * The URL of the time stamp server.
+   * The URL of the legacy Authenticode timestamp server, used for SHA-1 signatures (signtool's
+   * `/t` flag). This is also the timestamp server used by `osslsigncode` (`-t`) when signing on
+   * macOS/Linux. See [rfc3161TimeStampServer](#rfc3161TimeStampServer) for SHA-256 / nested
+   * signatures. Ignored when the build runs with `ELECTRON_BUILDER_OFFLINE=true`.
+   *
    * @default http://timestamp.digicert.com
    */
   readonly timeStampServer?: string | null
 
   /**
-   * The path to an additional certificate file you want to add to the signature block.
+   * Path to an additional certificate file (typically an intermediate / cross-signing CA
+   * certificate) whose contents are added to the signature block via signtool's `/ac` flag. Use
+   * this when the signing certificate's full chain is not already present on target machines and
+   * you want it embedded in the signature so the chain can be validated.
    */
   readonly additionalCertificateFile?: string | null
 
   /**
-   * The custom function (or path to file or module id) to sign Windows executables.
+   * A custom signing hook that **replaces** electron-builder's built-in `signtool` /
+   * `osslsigncode` invocation. Provide a function, or the path / module id of a file that exports
+   * a `sign` function (resolved relative to the project, then as a module).
+   *
+   * The hook is invoked once per signing pass (i.e. once per entry in
+   * [signingHashAlgorithms](#signingHashAlgorithms)) and receives a configuration object describing
+   * the file to sign (`path`), the resolved certificate info (`cscInfo`), the current `hash`, and
+   * whether this pass is a nested signature (`isNest`), plus a `computeSignToolArgs(isWin)` helper
+   * that returns the default arguments electron-builder would otherwise have used. Use this to
+   * integrate an external or cloud signing service. See
+   * [Code Signing](https://www.electron.build/code-signing).
    */
   readonly sign?: CustomWindowsSign | string | null
 }
 
 // ─── Signing mode: signtool (file or Windows certificate store) ──────────────
 
+/**
+ * Sign with a certificate file (`.pfx` / `.p12`) or with a certificate from the Windows
+ * certificate store, using Microsoft `signtool.exe` on Windows and `osslsigncode` on macOS/Linux.
+ * This is the default mode when `win.sign` is unset. Supply the certificate one of four ways:
+ * a file via `certificateFile` (or the `WIN_CSC_LINK` env var), or a store lookup via
+ * `certificateSubjectName` or `certificateSha1`.
+ */
 export interface WindowsSigntoolSigningConfig extends WindowsSigningSharedOptions {
+  /** Discriminator selecting the default file/store signing mode. */
   readonly type: "signtool"
 
   /**
-   * The path to the *.pfx or *.p12 certificate file. Prefer the `WIN_CSC_LINK` environment
-   * variable when possible. See [Code Signing](https://www.electron.build/code-signing).
+   * Path to the PKCS#12 certificate file (`.pfx` or `.p12`) holding both the signing certificate
+   * and its private key. Passed to signtool via `/f` (or osslsigncode via `-pkcs12`).
+   *
+   * Prefer supplying this out-of-band via the `WIN_CSC_LINK` (or `CSC_LINK`) environment variable
+   * instead of hardcoding a path — that variable also accepts an `https://` URL or a base64-encoded
+   * certificate, which is safer and more convenient on CI. See
+   * [Code Signing](https://www.electron.build/code-signing).
    */
   readonly certificateFile?: string | null
 
   /**
-   * The password to the certificate provided in `certificateFile`. Prefer the
-   * `WIN_CSC_KEY_PASSWORD` environment variable when possible.
+   * The password protecting the private key in `certificateFile`. Passed to signtool via `/p`
+   * (or osslsigncode via `-pass`).
+   *
+   * Prefer the `WIN_CSC_KEY_PASSWORD` (or `CSC_KEY_PASSWORD`) environment variable so the secret
+   * never lands in your build configuration.
    */
   readonly certificatePassword?: string | null
 
   /**
-   * The name of the subject of the signing certificate. Required for EV Code Signing.
-   * Works only on Windows (or macOS with Parallels Desktop).
+   * Select the signing certificate from the Windows certificate store by (a substring of) its
+   * subject name, instead of pointing at a `.pfx` file. electron-builder enumerates the installed
+   * code-signing certificates, picks the match, and signs by its thumbprint
+   * (`/sha1 <thumbprint> /s <store>`). **Required for EV (Extended Validation) certificates**,
+   * whose private keys live on a hardware token and cannot be exported to a file.
+   *
+   * Works only on Windows (or macOS with Parallels Desktop, via the bundled Windows VM).
    */
   readonly certificateSubjectName?: string | null
 
   /**
-   * The SHA1 hash of the signing certificate. Works only on Windows (or macOS with Parallels Desktop).
+   * Select the signing certificate from the Windows certificate store by its SHA-1 thumbprint,
+   * instead of pointing at a `.pfx` file. electron-builder looks the certificate up in the store
+   * and signs with `/sha1 <thumbprint> /s <store>`. Like
+   * [certificateSubjectName](#certificateSubjectName), this suits EV certificates backed by a
+   * hardware token; if both are set, both must resolve to the same certificate.
+   *
+   * Works only on Windows (or macOS with Parallels Desktop, via the bundled Windows VM).
    */
   readonly certificateSha1?: string | null
 }
@@ -142,6 +250,7 @@ export interface WindowsSigntoolSigningConfig extends WindowsSigningSharedOption
  * real-hardware test coverage is limited.
  */
 export interface WindowsHsmSigningConfig extends WindowsSigningSharedOptions {
+  /** Discriminator selecting HSM / hardware-token signing via signtool's `/csp` and `/kc` flags. */
   readonly type: "hsm"
 
   /**
@@ -150,7 +259,8 @@ export interface WindowsHsmSigningConfig extends WindowsSigningSharedOptions {
    * - Google Cloud KMS: `"Google Cloud KMS Provider"`
    * - Smart card / FIPS token: `"Microsoft Base Smart Card Crypto Provider"`
    *
-   * Requires `toolsets.winCodeSign: "1.x"`. Windows-only — use `type: "pkcs11"` on macOS/Linux.
+   * Requires a modern `winCodeSign` toolset (the default; only the legacy `"0.0.0"` pin is
+   * unsupported). Windows-only — use `type: "pkcs11"` on macOS/Linux.
    */
   readonly cryptoServiceProvider: string
 
@@ -169,12 +279,18 @@ export interface WindowsHsmSigningConfig extends WindowsSigningSharedOptions {
   readonly certificateFile?: string | null
 
   /**
-   * The SHA1 thumbprint of the certificate in the Windows certificate store.
+   * Alternative to `certificateFile`: locate the public certificate in the Windows certificate
+   * store by its SHA-1 thumbprint. The private key still comes from the HSM via
+   * `cryptoServiceProvider` / `keyContainer`; this only identifies which public certificate to sign
+   * with.
    */
   readonly certificateSha1?: string | null
 
   /**
-   * The subject name of the certificate in the Windows certificate store.
+   * Alternative to `certificateFile`: locate the public certificate in the Windows certificate
+   * store by (a substring of) its subject name. The private key still comes from the HSM via
+   * `cryptoServiceProvider` / `keyContainer`; this only identifies which public certificate to sign
+   * with.
    */
   readonly certificateSubjectName?: string | null
 }
@@ -182,10 +298,16 @@ export interface WindowsHsmSigningConfig extends WindowsSigningSharedOptions {
 // ─── Signing mode: pkcs11 (cross-platform PKCS#11 via osslsigncode) ──────────
 
 /**
+ * Sign with a PKCS#11 hardware token (smart card, USB HSM, cloud KMS exposed via a PKCS#11
+ * provider) using `osslsigncode`. Unlike `hsm`, this mode does **not** require Windows or a
+ * Windows VM, so it can sign Windows binaries directly from macOS/Linux CI. The token PIN is read
+ * from the `WIN_CSC_KEY_PASSWORD` (or `CSC_KEY_PASSWORD`) environment variable.
+ *
  * @beta PKCS#11 signing is available in v27 as a beta feature. The interface is stable but
  * real-hardware test coverage is limited.
  */
 export interface WindowsPkcs11SigningConfig extends WindowsSigningSharedOptions {
+  /** Discriminator selecting cross-platform PKCS#11 token signing via `osslsigncode`. */
   readonly type: "pkcs11"
 
   /**
@@ -218,15 +340,20 @@ export interface WindowsPkcs11SigningConfig extends WindowsSigningSharedOptions 
 // ─── Signing mode: azure (Azure Trusted Signing) ──────────────────────────────
 
 /**
- * @beta The `signtool /dlib` Azure Trusted Signing integration introduced in v27 is a beta
- * feature. The legacy PowerShell fallback (triggered when `toolsets.winCodeSign` is unset or
- * `"0.0.0"`) remains supported for migration.
+ * The `signtool /dlib` Azure Trusted Signing integration was introduced in `toolsets.winCodeSign: 1.3.0`.
+ * The legacy PowerShell integration is deprecated, but leverages the same underlying Azure APIs, so both interfaces share the same config shape.
  */
 export interface WindowsAzureSigningConfig {
+  /** Discriminator selecting Azure Trusted Signing (cloud signing — no local certificate). */
   readonly type: "azure"
 
   /**
-   * [The publisher name](https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073), exactly as in your code signed certificate. Several names can be provided.
+   * The publisher name to associate with the signature, exactly as it appears in the certificate
+   * issued by your Trusted Signing certificate profile. Required. Used for
+   * [update verification](#verifyUpdateCodeSignature) (embedded in `app-update.yml` and checked by
+   * electron-updater) and must match the certificate subject.
+   *
+   * @see https://github.com/electron-userland/electron-builder/issues/1187#issuecomment-278972073
    */
   readonly publisherName: string
 
@@ -240,17 +367,20 @@ export interface WindowsAzureSigningConfig {
   readonly endpoint: string
 
   /**
-   * The Certificate Profile name. Translates to field: CertificateProfileName.
+   * The name of the Trusted Signing Certificate Profile to sign with, as created in your Azure
+   * Code Signing Account. Maps to the DLib metadata field `CertificateProfileName`.
    */
   readonly certificateProfileName: string
 
   /**
-   * The Code Signing Account name. Translates to field: CodeSigningAccountName.
+   * The name of the Azure Trusted Signing (Code Signing) Account that owns the certificate profile.
+   * Maps to the DLib metadata field `CodeSigningAccountName`.
    */
   readonly codeSigningAccountName: string
 
   /**
-   * The file digest algorithm. Translates to field: FileDigest.
+   * The digest algorithm used to hash the files being signed. Maps to the DLib metadata field
+   * `FileDigest`.
    * @default SHA256
    */
   readonly fileDigest?: string

--- a/website/docs/features/code-signing/code-signing-mac.md
+++ b/website/docs/features/code-signing/code-signing-mac.md
@@ -1,6 +1,6 @@
 # Code Signing for macOS
 
-macOS code signing is supported. If the configuration values are provided correctly in your package.json, then signing should be automatically executed.
+macOS code signing is supported and runs automatically once a valid signing identity is available — from your keychain or the `CSC_*` environment variables. electron-builder signs the app along with its nested frameworks, helpers, and any installer it produces, so Gatekeeper will allow it to run.
 
 On a macOS development machine, a valid and appropriate identity from your keychain will be automatically used. If no valid certificate is found, signing is skipped for all architectures — electron-builder does **not** apply an ad-hoc signature automatically. To opt in to ad-hoc signing explicitly, set `mac.identity` to `"-"` (see [Signing options](#signing-options) below).
 

--- a/website/docs/features/code-signing/code-signing-win.md
+++ b/website/docs/features/code-signing/code-signing-win.md
@@ -1,23 +1,32 @@
 # Code Signing for Windows
 
-Windows code signing is supported. If the configuration values are provided correctly in your package.json, then signing should be automatically executed.
+Windows code signing is supported and runs automatically once you configure a signing method — or simply provide signing credentials through environment variables. electron-builder signs every executable and installer it produces so that Windows SmartScreen and your auto-updater can verify your app's publisher and confirm it hasn't been tampered with.
 
-:::tip
-Windows is dual code-signed (SHA1 & SHA256 hashing algorithms).
+:::tip Dual signing
+By default each binary is dual-signed with both SHA-1 and SHA-256 (`signingHashAlgorithms: ["sha1", "sha256"]`) so it validates on legacy as well as modern Windows. A few targets are fixed: `.msi` is single-signed and AppX/MSIX is SHA-256 only.
 :::
 
-To sign an app on Windows, there are two types of certificates:
+## Choosing a signing method
 
-* EV Code Signing Certificate
-* Code Signing Certificate
+electron-builder offers several signing backends, selected by the `type` field of `win.sign` (detailed in the table below). Pick based on where your private key lives and which OS your build runs on:
 
-Both certificates work with auto-update. The regular (and often cheaper) Code Signing Certificate shows a warning during installation that goes away once enough users installed your application and you've built up trust. The EV Certificate has more trust and thus works immediately without any warnings. However, it is not possible to export the EV Certificate as it is bound to a physical USB dongle. Thus, you can't export the certificate for signing code on a CI, such as AppVeyor.
+- **Certificate file or Windows store** (`signtool`, the default) — a `.pfx`/`.p12` file or a certificate already in the Windows certificate store. Signs with Microsoft `signtool.exe` on Windows and `osslsigncode` on macOS/Linux.
+- **Hardware Security Module / FIPS token** (`hsm`) — the key stays in hardware, accessed through a Windows cryptographic service provider. Windows only.
+- **PKCS#11 hardware token** (`pkcs11`) — a smart card, USB HSM, or network token reached through a PKCS#11 module. Runs on macOS/Linux via `osslsigncode`.
+- **Azure Trusted Signing** (`azure`) — Microsoft's cloud signing service; no local key to manage. Works on any OS.
 
-If you are using an EV Certificate, you need to provide [`certificateSubjectName`](#certificatesubjectname) in your win configuration.
+### OV vs. EV certificates
 
-If you use Windows 7, please ensure that [PowerShell](https://blogs.technet.microsoft.com/heyscriptingguy/2013/06/02/weekend-scripter-install-powershell-3-0-on-windows-7/) is updated to version 3.0.
+For file- or store-based signing you need a Windows code signing certificate from a CA (DigiCert, Sectigo, SSL.com, …). They come in two grades:
 
-If you are on Linux or Mac and you want sign a Windows app using EV Code Signing Certificate, please use [the guide for Unix systems](../../tutorials/code-signing-windows-apps-on-unix.md).
+- **OV (Organization Validation)** — the common, lower-cost option. New publishers see a SmartScreen "unknown publisher" warning during install that fades as your download reputation grows. OV certificates export to a `.pfx`, so they work in CI with the `signtool` method.
+- **EV (Extended Validation)** — earns SmartScreen reputation immediately, but its private key is bound to a hardware token and **cannot** be exported to a file. Identify an EV certificate by `certificateSubjectName` or `certificateSha1` rather than a file path, and sign with the `hsm` (Windows) or `pkcs11` (macOS/Linux) method — or switch to `azure` to avoid managing hardware at all.
+
+Both grades work with auto-update.
+
+:::tip Signing without a Windows machine
+You don't need Windows to sign a Windows app. The default `signtool` method signs file-based certificates with `osslsigncode` on macOS/Linux, and the `pkcs11` and `azure` methods are designed for non-Windows CI. See also [Code Signing Windows Apps on Unix](../../tutorials/code-signing-windows-apps-on-unix.md).
+:::
 
 ---
 
@@ -25,14 +34,14 @@ If you are on Linux or Mac and you want sign a Windows app using EV Code Signing
 
 All Windows code signing is configured under a single `win.sign` key using a discriminated union with an explicit `type` field:
 
-| `win.sign` value | Behavior |
-|---|---|
-| unset | Sign using credentials discovered from the environment (`WIN_CSC_LINK` / `CSC_LINK`) |
-| `{ type: "signtool", ... }` | Sign with a local `.pfx`/`.p12` certificate file or Windows cert store |
-| `{ type: "hsm", ... }` | Sign via Hardware Security Module / FIPS token (Windows only) — **Beta** |
-| `{ type: "pkcs11", ... }` | Sign via PKCS#11 hardware token using osslsigncode (macOS/Linux CI) — **Beta** |
-| `{ type: "azure", ... }` | Sign via Azure Trusted Signing cloud service — **Beta** |
-| `false` or `null` | Disable signing (resedit resource editing still runs) |
+| `win.sign` value | Behavior | Platforms |
+|---|---|---|
+| unset | Sign using credentials discovered from the environment — `WIN_CSC_LINK` / `CSC_LINK` with `WIN_CSC_KEY_PASSWORD` / `CSC_KEY_PASSWORD` | all |
+| `{ type: "signtool", ... }` | Local `.pfx`/`.p12` certificate file or Windows certificate store | Windows (`signtool.exe`) · macOS/Linux (`osslsigncode`) |
+| `{ type: "hsm", ... }` | Hardware Security Module / FIPS token via a Windows CSP — **Beta** | Windows only |
+| `{ type: "pkcs11", ... }` | PKCS#11 hardware token via `osslsigncode` — **Beta** | macOS/Linux |
+| `{ type: "azure", ... }` | Azure Trusted Signing cloud service — **Beta** | all (`signtool /dlib`, Wine on macOS/Linux) |
+| `false` or `null` | Disable signing (resedit resource editing still runs) | all |
 
 Combining `win.sign: false` with `forceCodeSigning: true` is a configuration error and fails the build.
 
@@ -40,7 +49,7 @@ Combining `win.sign: false` with `forceCodeSigning: true` is a configuration err
 
 ## Signtool Signing (`type: "signtool"`)
 
-The standard signing mode. Signs executables with a local certificate file (`.pfx`/`.p12`) or a certificate from the Windows certificate store via `signtool.exe` (Wine on macOS/Linux).
+The standard signing mode, and the default when `win.sign` is unset. Signs with a local certificate file (`.pfx`/`.p12`) or a certificate from the Windows certificate store, using Microsoft `signtool.exe` on Windows and `osslsigncode` on macOS/Linux.
 
 ### Setup
 
@@ -81,9 +90,9 @@ For EV certificates (bound to a USB dongle), identify by subject name instead:
 
 ### Execution flow
 
-1. `cscInfo` resolves the certificate from `certificateFile`, `certificateSha1`, `certificateSubjectName`, or the `WIN_CSC_LINK` env var.
-2. For each file, `signtool.exe sign` is called twice in sequence: once for SHA1, once for SHA256 (`/as` nested signature).
-3. On macOS/Linux, `signtool.exe` runs inside Wine using the `winCodeSign` toolset bundle.
+1. The certificate is resolved from `certificateFile` (or the `WIN_CSC_LINK` / `CSC_LINK` env var), or looked up in the Windows certificate store by `certificateSubjectName` / `certificateSha1`.
+2. Each file is signed once per entry in `signingHashAlgorithms` — by default SHA-1, then SHA-256 with the second signature appended as a nested signature.
+3. On Windows the signer is Microsoft `signtool.exe`; on macOS/Linux it is `osslsigncode` from the `winCodeSign` toolset bundle — no Wine or Windows VM is involved. Note: certificate-store lookups (`certificateSubjectName` / `certificateSha1`) read the Windows store and therefore require Windows (or the bundled Windows VM), whereas file-based signing works on any platform.
 
 ### Configuration reference
 
@@ -101,7 +110,7 @@ Signs using a Hardware Security Module (HSM), FIPS-compliant token, or smart car
 
 **Platform:** Windows only. For macOS/Linux CI without a Windows VM, use [`type: "pkcs11"`](#pkcs11-signing-typepkcs11--beta) instead.
 
-**Requirement:** `toolsets.winCodeSign` must be `"1.0.0"` or `"1.1.0"`. The legacy `"0.0.0"` toolset does not include the required signtool version.
+**Requirement:** a modern `winCodeSign` toolset, which is the default — you do not need to pin a version. Only an explicit legacy pin (`toolsets.winCodeSign: "0.0.0"`) is unsupported, because it predates the required signtool version.
 
 ### Setup
 
@@ -120,19 +129,18 @@ Signs using a Hardware Security Module (HSM), FIPS-compliant token, or smart car
       "keyContainer": "projects/my-project/locations/us-east1/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
       "certificateFile": "chain.crt"
     }
-  },
-  "toolsets": {
-    "winCodeSign": "1.1.0"
   }
 }
 ```
+
+The default `winCodeSign` toolset already supports HSM signing, so no `toolsets` pin is needed.
 
 ### Execution flow
 
 1. `signtool.exe sign` is invoked with `/csp <cryptoServiceProvider>` and `/kc <keyContainer>`.
 2. The certificate is identified via `certificateFile`, `certificateSha1`, or `certificateSubjectName`.
 3. The HSM performs the private-key operation; the resulting signature is embedded by signtool.
-4. SHA256 signing only (no SHA1 dual-sign path for HSM).
+4. By default the file is dual-signed (SHA-1, then SHA-256), the same as the `signtool` mode — the HSM performs a key operation for each pass. Set `signingHashAlgorithms: ["sha256"]` to produce a single SHA-256 signature instead.
 
 ### Caveats
 
@@ -222,7 +230,7 @@ With an optional external certificate chain file (if the token does not carry th
 ## Azure Trusted Signing (`type: "azure"`) — Beta
 
 :::warning[Beta feature]
-The `signtool /dlib` Azure Trusted Signing integration introduced in v27 is a **beta** feature. The legacy PowerShell fallback (triggered when `toolsets.winCodeSign` is unset or `"0.0.0"`) remains available during the migration window. Please [report issues](https://github.com/electron-userland/electron-builder/issues) if you encounter problems.
+The `signtool /dlib` Azure Trusted Signing integration introduced in v27 is a **beta** feature. It is the default path on current toolsets; the legacy PowerShell fallback remains available only when you explicitly pin `toolsets.winCodeSign` below `"1.3.0"` (see [Legacy PowerShell fallback](#legacy-powershell-fallback) below). Please [report issues](https://github.com/electron-userland/electron-builder/issues) if you encounter problems.
 :::
 
 Microsoft's cloud-based code signing service. No certificate file or private key is managed locally — authentication is via Azure Entra ID environment variables and signing is performed by the Azure service.
@@ -250,7 +258,7 @@ Set the required environment variables (descriptions from [Azure.Identity — En
 If you use the minimal setup with an "App registration" as described above, only `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` are needed.
 :::
 
-Then configure `win.sign` and pin the `winCodeSign` toolset (required for the `/dlib` integration):
+Then configure `win.sign`. The default toolset already ships the `/dlib` integration, so **no `winCodeSign` pin is required**:
 
 ```jsonc
 {
@@ -262,9 +270,6 @@ Then configure `win.sign` and pin the `winCodeSign` toolset (required for the `/
       "codeSigningAccountName": "my-trusted-signing-account",
       "certificateProfileName": "my-cert-profile"
     }
-  },
-  "toolsets": {
-    "winCodeSign": "1.3.0"
   }
 }
 ```
@@ -299,11 +304,11 @@ Use `additionalMetadata` to pass extra fields verbatim into `metadata.json`. Thi
 
 ### Legacy PowerShell fallback
 
-If `toolsets.winCodeSign` is unset or below `"1.3.0"`, electron-builder automatically falls back to the v26 PowerShell `Invoke-TrustedSigning` integration and emits a deprecation warning. This fallback will be removed in a future release. To upgrade, add `"toolsets": { "winCodeSign": "1.3.0" }` to your config.
+The default toolset (`winCodeSign` unset, `null`, or `"latest"`) resolves to the newest bundle (`1.3.0`+) and uses the modern `signtool /dlib` path. Only if you **explicitly** pin `toolsets.winCodeSign` below `"1.3.0"` (for example `"1.2.1"`, or the legacy `"0.0.0"`) does electron-builder fall back to the v26 PowerShell `Invoke-TrustedSigning` integration and emit a deprecation warning. This fallback will be removed in a future release, so avoid pinning an older toolset unless you specifically need it.
 
 ### Caveats
 
-- The `ats-bundle` (containing `Azure.CodeSigning.Dlib.dll` and its native dependency closure) and the `dotnet-runtime` bundle ship separately starting from `winCodeSign "1.3.0"`. Setting `toolsets.winCodeSign: "1.3.0"` (or higher) is required for the new integration; they are downloaded automatically on first use.
+- The `ats-bundle` (containing `Azure.CodeSigning.Dlib.dll` and its native dependency closure) and the `dotnet-runtime` bundle ship with `winCodeSign "1.3.0"` and later — which is the default. They are downloaded automatically on first use; no manual setup or toolset pin is required.
 - The DLib is a mixed-mode .NET 8 assembly: electron-builder automatically downloads and provides the **.NET 8 runtime** via the separate `dotnet-runtime` bundle — no manual runtime installation is required.
 - The DLib authenticates using the Azure environment variables at signing time — credentials are not embedded in config.
 - Network connectivity to the Azure endpoint is required during the build. Rate limits or outages will fail the build.

--- a/website/docs/features/code-signing/code-signing.md
+++ b/website/docs/features/code-signing/code-signing.md
@@ -39,11 +39,13 @@ All Apple certificates require membership in the [Apple Developer Program](https
 
 | Certificate Type | Trust | CI/CD Compatible | Notes |
 |---|---|---|---|
-| Standard OV Certificate | After reputation builds (days-weeks) | Yes (exportable) | Most common choice |
-| EV (Extended Validation) Certificate | Immediate | No (hardware dongle) | Best for fast trust; cannot be used in most CI |
+| Standard OV Certificate | After reputation builds (days-weeks) | Yes (exportable `.pfx`) | Most common choice |
+| EV (Extended Validation) Certificate | Immediate | Yes, via a hardware-token method | Key bound to a hardware dongle/HSM; not exportable to a file |
 | Azure Trusted Signing | Immediate | Yes | Microsoft's cloud signing service; see [code-signing-win.md](code-signing-win.md) |
 
 For Windows, purchase from any major CA (DigiCert, Sectigo, SSL.com). See [Get a Code Signing Certificate](https://msdn.microsoft.com/windows/hardware/drivers/dashboard/get-a-code-signing-certificate) (select "Microsoft Authenticode" platform).
+
+electron-builder picks the signing backend from the `type` field of `win.sign`: a certificate file or the Windows store (`signtool`, the default), a hardware token (`hsm` on Windows, `pkcs11` on macOS/Linux), or cloud signing (`azure`). An EV or other non-exportable key works in CI through the `hsm`, `pkcs11`, or `azure` methods. See [Windows Code Signing](code-signing-win.md) for full configuration.
 
 :::note[Gatekeeper and Apple certificates]
 macOS Gatekeeper only recognizes [Apple-issued certificates](https://developer.apple.com/support/code-signing/). Third-party certificates cannot be used to sign macOS apps for Gatekeeper.


### PR DESCRIPTION
### Summary

- Windows signing options — expanded JSDoc (`packages/app-builder-lib/src/options/winOptions.ts`). Every Windows code signing option now documents what it is, what it is used for, and how it is used at runtime — the actual `signtool`/`osslsigncode` flag or behavior it maps to, environment-variable fallbacks, platform constraints, and defaults. Covers the top-level `sign`, `verifyUpdateCodeSignature`, and `signExts`; the shared `publisherName`, `signingHashAlgorithms`, `rfc3161TimeStampServer`, `timeStampServer`, `additionalCertificateFile`, and the custom `sign` hook; and all four signing modes (`signtool`, `hsm`, `pkcs11`, `azure`) including each `type` discriminator.
- Modernized the Windows code-signing guide (`website/docs/features/code-signing/code-signing-win.md`). Replaced the stale intro (which referenced Windows 7 / PowerShell 3.0 / AppVeyor and only two certificate types) with a current overview of the four signing methods plus OV-vs-EV guidance, and corrected technical inaccuracies in the body (see Design notes).
- Aligned the code-signing overview (`website/docs/features/code-signing/code-signing.md`). The Windows certificate-types section now reflects that EV / non-exportable keys can be used in CI via the `hsm`, `pkcs11`, or `azure` methods, and points at the four `win.sign` backends.
- Modernized the macOS guide opener (`website/docs/features/code-signing/code-signing-mac.md`). Replaced the same stale "if the configuration values are provided correctly in your package.json" sentence with a current description of automatic signing. The rest of the macOS and notarization guides were reviewed and are already accurate (no changes needed).
- Snap options beta-promotion (`packages/app-builder-lib/src/options/SnapOptions.ts`, pre-existing working-tree change). Removes the `[Beta]` markers and `@beta` tags from `core24`, `custom`, and the `SnapOptions24` interface, promoting core24 snap support out of beta. This is also reflected in the scheme.json regeneration.

### Design notes

The documentation corrections were verified against the current signing code:

- osslsigncode, not Wine, for the default `signtool` mode on macOS/Linux. The guide previously claimed `signtool.exe` runs under Wine on non-Windows; the `signtool` path actually uses `osslsigncode`, and Wine is used only for the Azure `signtool /dlib` path. Certificate-store lookups (`certificateSubjectName` / `certificateSha1`) still require Windows (or the bundled Windows VM), whereas file-based signing works on any platform.
- HSM dual-signs by default. The guide previously said HSM is "SHA256 only"; HSM — like `signtool` and `pkcs11` — inherits the default `signingHashAlgorithms: ["sha1", "sha256"]` and dual-signs unless that is overridden.
- `winCodeSign` "latest" toolset model. `winCodeSign` now defaults to `"latest"` (resolving to `1.3.0`), so users no longer need to pin a version: Azure Trusted Signing uses the modern `signtool /dlib` path by default, and HSM works on any modern bundle. Only an explicit legacy `"0.0.0"` pin is unsupported, and the Azure legacy PowerShell fallback is reached only by explicitly pinning below `1.3.0` (not by leaving it unset). Updated the HSM requirement note, the Azure setup/legacy-fallback/caveats, and removed the now-unnecessary `toolsets` pins from the HSM and Azure examples.