### PR TITLE
fix: bundle a workspace sub-package's production dependencies into app.asar when the package manager resolves to the workspace root

### DIFF
--- a/.changeset/yarn-workspace-prod-deps.md
+++ b/.changeset/yarn-workspace-prod-deps.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: bundle a workspace sub-package's production dependencies into app.asar when the package manager resolves to the workspace root

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -145,6 +145,10 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     return this.info.metadata
   }
 
+  get originalMetadata(): Metadata {
+    return this.info.originalMetadata
+  }
+
   get framework(): Framework {
     return this.info.framework
   }

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -201,10 +201,79 @@ export async function computeNodeModuleFileSets(
   return result
 }
 
+type CollectedNodeModules = { nodeModules: NodeModuleInfo[]; logSummary: ModuleManager["logSummary"] }
+
+/** Runs a single package-manager collector against a single directory. */
+type CollectorRunner = (pm: PM, dir: string) => Promise<CollectedNodeModules>
+
+// `workspace:`/`file:`/`link:`/`portal:` dependencies are symlinked into place rather than
+// installed as standalone, hoistable packages, so they may legitimately be absent from a
+// collected tree and cannot be used to validate it.
+const LOCAL_DEPENDENCY_SPEC = /^(?:workspace|file|link|portal):/
+
+/**
+ * Determines whether a collected module tree actually describes the package being built.
+ *
+ * A package-manager `list` invocation can resolve to the wrong project root — most notably when
+ * electron-builder is run from a workspace sub-package whose dependencies are hoisted to the
+ * workspace root. In that case the collector returns a non-empty but unrelated tree. Accepting it
+ * would suppress the manual-traversal fallback that resolves the correct modules, so we need to
+ * tell a matching collection from a mismatched one.
+ *
+ * A collection matches when at least one of the package's declared external (registry-installed,
+ * non-`workspace:`/`file:`/`link:`/`portal:`) production dependencies is present at the top level —
+ * those direct dependencies are always hoisted to the top level of a correct collection. When the
+ * package declares no external production dependencies there is nothing to validate against, so any
+ * non-empty collection is accepted.
+ */
+export function collectionMatchesAppDependencies(nodeModules: NodeModuleInfo[], dependencies: Record<string, string> | undefined): boolean {
+  const requiredExternalDeps = Object.entries(dependencies ?? {})
+    .filter(([, spec]) => !LOCAL_DEPENDENCY_SPEC.test(spec))
+    .map(([name]) => name)
+  if (requiredExternalDeps.length === 0) {
+    return true
+  }
+  const collected = new Set(nodeModules.map(it => it.name))
+  return requiredExternalDeps.some(name => collected.has(name))
+}
+
+/**
+ * Walks the candidate (package-manager, directory) combinations and returns the first collection
+ * that both contains modules and matches the package being built (see
+ * {@link collectionMatchesAppDependencies}). A non-empty collection that does NOT match — e.g. a
+ * workspace-root tree returned for a sub-package — is retained only as a last-resort fallback so a
+ * later approach (notably {@link PM.TRAVERSAL}) can supply the correct modules.
+ */
+export async function resolveFirstMatchingCollection(options: {
+  pmApproaches: PM[]
+  searchDirectories: string[]
+  dependencies: Record<string, string> | undefined
+  run: CollectorRunner
+}): Promise<CollectedNodeModules | undefined> {
+  const { pmApproaches, searchDirectories, dependencies, run } = options
+  let fallback: CollectedNodeModules | undefined
+
+  for (const pm of pmApproaches) {
+    for (const dir of searchDirectories) {
+      log.info({ pm, searchDir: dir }, "searching for node modules")
+      const deps = await run(pm, dir)
+      if (deps.nodeModules.length === 0) {
+        log.info({ pm, searchDir: dir }, "no node modules found in collection, trying next search directory")
+        continue
+      }
+      if (collectionMatchesAppDependencies(deps.nodeModules, dependencies)) {
+        log.debug({ pm, searchDir: dir, depCount: deps.nodeModules.length }, "collected node modules")
+        return deps
+      }
+      log.info({ pm, searchDir: dir }, "collected node modules do not match the target package, trying next search directory/approach")
+      fallback ??= deps
+    }
+  }
+  return fallback
+}
+
 async function collectNodeModulesWithLogging(platformPackager: PlatformPackager<any>, arch: Arch | null) {
   const { tempDirManager, appDir, projectDir } = platformPackager
-
-  let deps: { nodeModules: NodeModuleInfo[]; logSummary: ModuleManager["logSummary"] } | undefined = undefined
 
   // Drop packages whose `package.json` `cpu`/`os` is incompatible with the target arch/platform while
   // collecting (e.g. exclude `@esbuild/darwin-arm64` from the x64 slice). See NodeModulesCollector.
@@ -213,24 +282,16 @@ async function collectNodeModulesWithLogging(platformPackager: PlatformPackager<
 
   const searchDirectories = Array.from(new Set([appDir, projectDir, await platformPackager.getWorkspaceRoot()])).filter((it): it is string => isEmptyOrSpaces(it) === false)
   const pmApproaches = [await platformPackager.getPackageManager(), PM.TRAVERSAL]
-  for (const pm of pmApproaches) {
-    for (const dir of searchDirectories) {
-      log.info({ pm, searchDir: dir }, "searching for node modules")
-      const collector = getCollectorByPackageManager(pm, dir, tempDirManager)
-      deps = await collector.getNodeModules({ packageName: platformPackager.nodePackageName, archFilter })
-      if (deps.nodeModules.length > 0) {
-        break
-      }
-      const attempt = searchDirectories.indexOf(dir)
-      if (attempt < searchDirectories.length - 1) {
-        log.info({ searchDir: dir, attempt }, "no node modules found in collection, trying next search directory")
-      }
-    }
-    if (deps?.nodeModules?.length) {
-      log.debug({ pm, nodeModules: deps.nodeModules }, "collected node modules")
-      break
-    }
-  }
+
+  // Validate against the as-declared (pre-extraMetadata) production dependencies so a configured
+  // `extraMetadata.dependencies` entry that isn't installed cannot reject a correct collection.
+  const deps = await resolveFirstMatchingCollection({
+    pmApproaches,
+    searchDirectories,
+    dependencies: platformPackager.originalMetadata.dependencies,
+    run: (pm, dir) => getCollectorByPackageManager(pm, dir, tempDirManager).getNodeModules({ packageName: platformPackager.nodePackageName, archFilter }),
+  })
+
   if (!deps?.nodeModules?.length) {
     log.warn({ searchDirectories: searchDirectories.map(it => log.filePath(it)) }, "no node modules returned while searching directories")
     return []

--- a/test/src/node-module-collector/collectNodeModulesTest.ts
+++ b/test/src/node-module-collector/collectNodeModulesTest.ts
@@ -1,0 +1,164 @@
+import { describe, test } from "vitest"
+import { collectionMatchesAppDependencies, resolveFirstMatchingCollection } from "app-builder-lib/src/util/appFileCopier"
+import { PM } from "app-builder-lib/src/node-module-collector/packageManager"
+import type { NodeModuleInfo } from "app-builder-lib/src/node-module-collector/types"
+import type { ModuleManager } from "app-builder-lib/src/node-module-collector/moduleManager"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeModule = (name: string): NodeModuleInfo => ({ name, version: "1.0.0", dir: `/virtual/${name}` })
+
+const collection = (names: string[]) => ({
+  nodeModules: names.map(makeModule),
+  logSummary: {} as ModuleManager["logSummary"],
+})
+
+// The dependency tree npm reports when it resolves to the wrong project root from inside a Yarn
+// workspace sub-package: npm's own bundled internals rather than the app's production deps.
+const NPM_INTERNALS = ["cacache", "node-gyp", "@npmcli/fs", "minipass", "minipass-fetch"]
+
+// ---------------------------------------------------------------------------
+// collectionMatchesAppDependencies
+// ---------------------------------------------------------------------------
+
+describe("collectionMatchesAppDependencies", () => {
+  test("matches when a declared production dependency is present at the top level", ({ expect }) => {
+    const deps = { minimist: "^1.2.8", "fs-extra": "^11.0.0" }
+    expect(collectionMatchesAppDependencies([makeModule("minimist"), makeModule("transitive-dep")], deps)).toBe(true)
+  })
+
+  test("matches when every declared dependency is present", ({ expect }) => {
+    const deps = { minimist: "^1.2.8", "fs-extra": "^11.0.0" }
+    expect(collectionMatchesAppDependencies([makeModule("minimist"), makeModule("fs-extra")], deps)).toBe(true)
+  })
+
+  test("does not match when none of the declared dependencies are present (issue #9945)", ({ expect }) => {
+    // The app depends on `minimist` (and others) but the collected tree is npm's own internals.
+    const deps = { minimist: "^1.2.8", "fs-extra": "^11.0.0", chalk: "^5.0.0" }
+    expect(collectionMatchesAppDependencies(NPM_INTERNALS.map(makeModule), deps)).toBe(false)
+  })
+
+  test("accepts any non-empty collection when the package declares no production dependencies", ({ expect }) => {
+    expect(collectionMatchesAppDependencies([makeModule("anything")], undefined)).toBe(true)
+    expect(collectionMatchesAppDependencies([makeModule("anything")], {})).toBe(true)
+  })
+
+  describe("local-protocol dependency specs", () => {
+    for (const spec of ["workspace:*", "workspace:^1.0.0", "file:../shared", "link:../shared", "portal:../shared"]) {
+      test(`ignores ${spec} specs (cannot be used to validate a hoisted collection)`, ({ expect }) => {
+        // `@org/shared` is symlinked, not hoisted, so its absence must not reject the collection;
+        // the real external dep `minimist` is what makes this a match.
+        const deps = { "@org/shared": spec, minimist: "^1.2.8" }
+        expect(collectionMatchesAppDependencies([makeModule("minimist")], deps)).toBe(true)
+      })
+    }
+
+    test("accepts collection when only local-protocol dependencies are declared", ({ expect }) => {
+      // Nothing external to validate against -> any non-empty collection is acceptable.
+      const deps = { "@org/shared": "workspace:*", "@org/utils": "file:../utils" }
+      expect(collectionMatchesAppDependencies([makeModule("@org/shared")], deps)).toBe(true)
+    })
+
+    test("does not match when the only external dep is missing among local-protocol deps", ({ expect }) => {
+      const deps = { "@org/shared": "workspace:*", minimist: "^1.2.8" }
+      expect(collectionMatchesAppDependencies(NPM_INTERNALS.map(makeModule), deps)).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveFirstMatchingCollection
+// ---------------------------------------------------------------------------
+
+describe("resolveFirstMatchingCollection", () => {
+  const appDeps = { minimist: "^1.2.8", "fs-extra": "^11.0.0" }
+
+  test("returns the first matching collection from the active package manager", async ({ expect }) => {
+    const calls: Array<{ pm: PM; dir: string }> = []
+    const result = await resolveFirstMatchingCollection({
+      pmApproaches: [PM.YARN_BERRY, PM.TRAVERSAL],
+      searchDirectories: ["/app"],
+      dependencies: appDeps,
+      run: (pm, dir) => {
+        calls.push({ pm, dir })
+        return Promise.resolve(collection(["minimist", "fs-extra"]))
+      },
+    })
+    expect(result?.nodeModules.map(m => m.name)).toEqual(["minimist", "fs-extra"])
+    // TRAVERSAL must not run once the active package manager already produced a matching result.
+    expect(calls).toEqual([{ pm: PM.YARN_BERRY, dir: "/app" }])
+  })
+
+  test("falls through to TRAVERSAL when the active manager returns a mismatched tree (issue #9945)", async ({ expect }) => {
+    const calls: Array<{ pm: PM; dir: string }> = []
+    const result = await resolveFirstMatchingCollection({
+      pmApproaches: [PM.YARN_BERRY, PM.TRAVERSAL],
+      searchDirectories: ["/app"],
+      dependencies: appDeps,
+      run: (pm, dir) => {
+        calls.push({ pm, dir })
+        // Yarn Berry delegates to npm, which resolves to the workspace root and returns npm
+        // internals; only the manual traversal resolves the sub-package's real dependencies.
+        return Promise.resolve(pm === PM.TRAVERSAL ? collection(["minimist", "fs-extra"]) : collection(NPM_INTERNALS))
+      },
+    })
+    expect(result?.nodeModules.map(m => m.name)).toEqual(["minimist", "fs-extra"])
+    expect(calls).toEqual([
+      { pm: PM.YARN_BERRY, dir: "/app" },
+      { pm: PM.TRAVERSAL, dir: "/app" },
+    ])
+  })
+
+  test("skips empty collections and advances to the next search directory", async ({ expect }) => {
+    const calls: Array<{ pm: PM; dir: string }> = []
+    const result = await resolveFirstMatchingCollection({
+      pmApproaches: [PM.NPM, PM.TRAVERSAL],
+      searchDirectories: ["/app", "/workspace-root"],
+      dependencies: appDeps,
+      run: (pm, dir) => {
+        calls.push({ pm, dir })
+        return Promise.resolve(dir === "/workspace-root" ? collection(["minimist"]) : collection([]))
+      },
+    })
+    expect(result?.nodeModules.map(m => m.name)).toEqual(["minimist"])
+    expect(calls).toEqual([
+      { pm: PM.NPM, dir: "/app" },
+      { pm: PM.NPM, dir: "/workspace-root" },
+    ])
+  })
+
+  test("retains a mismatched collection as a last resort when nothing matches", async ({ expect }) => {
+    // If even TRAVERSAL cannot produce a matching tree we must not regress to an empty asar;
+    // the first non-empty (mismatched) collection is returned rather than undefined.
+    const result = await resolveFirstMatchingCollection({
+      pmApproaches: [PM.YARN_BERRY, PM.TRAVERSAL],
+      searchDirectories: ["/app"],
+      dependencies: appDeps,
+      run: () => Promise.resolve(collection(NPM_INTERNALS)),
+    })
+    expect(result?.nodeModules.map(m => m.name)).toEqual(NPM_INTERNALS)
+  })
+
+  test("returns undefined when every approach yields an empty collection", async ({ expect }) => {
+    const result = await resolveFirstMatchingCollection({
+      pmApproaches: [PM.NPM, PM.TRAVERSAL],
+      searchDirectories: ["/app"],
+      dependencies: appDeps,
+      run: () => Promise.resolve(collection([])),
+    })
+    expect(result).toBeUndefined()
+  })
+
+  test("prefers a matching collection over an earlier mismatched fallback across directories", async ({ expect }) => {
+    const result = await resolveFirstMatchingCollection({
+      pmApproaches: [PM.YARN_BERRY, PM.TRAVERSAL],
+      searchDirectories: ["/app", "/workspace-root"],
+      dependencies: appDeps,
+      run: pm => Promise.resolve(pm === PM.TRAVERSAL ? collection(["minimist", "fs-extra"]) : collection(NPM_INTERNALS)),
+    })
+    // The mismatched YARN_BERRY result (tried first across both dirs) must not win.
+    expect(result?.nodeModules.map(m => m.name)).toEqual(["minimist", "fs-extra"])
+  })
+})

--- a/test/src/node-module-collector/traversalCollectorTest.ts
+++ b/test/src/node-module-collector/traversalCollectorTest.ts
@@ -296,6 +296,46 @@ describe("TraversalNodeModulesCollector", { sequential: true }, () => {
     })
   })
 
+  describe("workspace sub-package with hoisted dependencies (issue #9945)", () => {
+    test("resolves a sub-package's production deps hoisted to the workspace root", async ({ expect }) => {
+      // Reproduces the Yarn-Berry `nmHoistingLimits: workspaces` layout: the Electron app is a
+      // workspace member at packages/app, and its production dependencies are hoisted up to the
+      // workspace-root node_modules rather than living under packages/app/node_modules.
+      root = await buildPackageTree({
+        "package.json": {
+          name: "workspace-root",
+          version: "1.0.0",
+          private: true,
+          workspaces: ["packages/*"],
+        },
+        "packages/app/package.json": {
+          name: "app",
+          version: "1.0.0",
+          dependencies: { minimist: "^1.2.8", "fs-extra": "^11.0.0" },
+        },
+        // Hoisted to the workspace root, not packages/app/node_modules.
+        "node_modules/minimist/package.json": { name: "minimist", version: "1.2.8" },
+        "node_modules/fs-extra/package.json": {
+          name: "fs-extra",
+          version: "11.2.0",
+          dependencies: { "graceful-fs": "^4.0.0" },
+        },
+        "node_modules/graceful-fs/package.json": { name: "graceful-fs", version: "4.2.11" },
+      })
+
+      const collector = new TraversalNodeModulesCollector(path.join(root, "packages", "app"), mockTmpDir)
+      const { nodeModules } = await collector.getNodeModules({ packageName: "app" })
+      const names = nodeModules.map(m => m.name)
+
+      expect(names).toContain("minimist")
+      expect(names).toContain("fs-extra")
+      // transitive dependency of fs-extra, also hoisted to the workspace root
+      expect(names).toContain("graceful-fs")
+      // the workspace root itself must not be collected as a dependency of the app
+      expect(names).not.toContain("workspace-root")
+    })
+  })
+
   describe("circular dependency and self-reference handling", () => {
     test("handles self-referential dependencies gracefully (does not loop)", async ({ expect }) => {
       root = await buildPackageTree({


### PR DESCRIPTION
ESM port of https://github.com/electron-userland/electron-builder/pull/9950 from v26 to v27
