### PR TITLE
feat: Allow including default-excluded files via `files` globs; remove `disableDefaultIgnoredFiles` (BREAKING)

### DIFF
--- a/.changeset/obj-files-reinclude.md
+++ b/.changeset/obj-files-reinclude.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": major
+---
+
+feat: allow including default-excluded files (e.g. Wavefront `.obj`) by adding an explicit `files` glob such as `**/*.obj` (fixes #6126). BREAKING: removed the `disableDefaultIgnoredFiles` option — `electron-builder migrate-schema` strips it automatically; re-include specific files via `files` globs instead.

--- a/.changeset/obj-files-reinclude.md
+++ b/.changeset/obj-files-reinclude.md
@@ -1,5 +1,6 @@
 ---
 "app-builder-lib": major
+"electron-builder": major
 ---
 
 feat: allow including default-excluded files (e.g. Wavefront `.obj`) by adding an explicit `files` glob such as `**/*.obj` (fixes #6126). BREAKING: removed the `disableDefaultIgnoredFiles` option — `electron-builder migrate-schema` strips it automatically; re-include specific files via `files` globs instead.

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -2173,14 +2173,6 @@
           "description": "Whether to infer update channel from application version pre-release components. e.g. if version `0.12.1-alpha.1`, channel will be set to `alpha`. Otherwise to `latest`.\nThis does *not* apply to github publishing, which will [never auto-detect the update channel](https://github.com/electron-userland/electron-builder/issues/8589).",
           "type": "boolean"
         },
-        "disableDefaultIgnoredFiles": {
-          "default": false,
-          "description": "Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.",
-          "type": [
-            "null",
-            "boolean"
-          ]
-        },
         "electronLanguages": {
           "anyOf": [
             {
@@ -2819,14 +2811,6 @@
           "description": "Whether to infer update channel from application version pre-release components. e.g. if version `0.12.1-alpha.1`, channel will be set to `alpha`. Otherwise to `latest`.\nThis does *not* apply to github publishing, which will [never auto-detect the update channel](https://github.com/electron-userland/electron-builder/issues/8589).",
           "type": "boolean"
         },
-        "disableDefaultIgnoredFiles": {
-          "default": false,
-          "description": "Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.",
-          "type": [
-            "null",
-            "boolean"
-          ]
-        },
         "electronLanguages": {
           "anyOf": [
             {
@@ -3304,14 +3288,6 @@
           "default": true,
           "description": "Whether to infer update channel from application version pre-release components. e.g. if version `0.12.1-alpha.1`, channel will be set to `alpha`. Otherwise to `latest`.\nThis does *not* apply to github publishing, which will [never auto-detect the update channel](https://github.com/electron-userland/electron-builder/issues/8589).",
           "type": "boolean"
-        },
-        "disableDefaultIgnoredFiles": {
-          "default": false,
-          "description": "Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.",
-          "type": [
-            "null",
-            "boolean"
-          ]
         },
         "electronLanguages": {
           "anyOf": [
@@ -8056,14 +8032,6 @@
           "description": "Whether to infer update channel from application version pre-release components. e.g. if version `0.12.1-alpha.1`, channel will be set to `alpha`. Otherwise to `latest`.\nThis does *not* apply to github publishing, which will [never auto-detect the update channel](https://github.com/electron-userland/electron-builder/issues/8589).",
           "type": "boolean"
         },
-        "disableDefaultIgnoredFiles": {
-          "default": false,
-          "description": "Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.",
-          "type": [
-            "null",
-            "boolean"
-          ]
-        },
         "electronLanguages": {
           "anyOf": [
             {
@@ -8989,14 +8957,6 @@
         }
       ],
       "description": "Overrides for input/output directory paths used during the build."
-    },
-    "disableDefaultIgnoredFiles": {
-      "default": false,
-      "description": "Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.",
-      "type": [
-        "null",
-        "boolean"
-      ]
     },
     "dmg": {
       "anyOf": [

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -206,6 +206,16 @@ export function getDefaultIgnoredPatterns(userPatterns: ReadonlyArray<string>, i
   return patterns
 }
 
+/**
+ * Returns the default-excluded names/extensions that the given `files` patterns opt back in, formatted
+ * for display (extensions as `*.<ext>`, names verbatim). Empty when nothing default-excluded is
+ * re-included. Used to warn that files normally kept out of the package will now be included.
+ */
+export function getReincludedDefaultExclusions(patterns: ReadonlyArray<string>): Array<string> {
+  const reincluded = collectExplicitReincludes(patterns)
+  return [...[...reincluded.extensions].map(ext => `*.${ext}`), ...reincluded.names]
+}
+
 function ensureNoEndSlash(file: string): string {
   if (path.sep !== "/") {
     file = file.replace(/\//g, path.sep)
@@ -381,6 +391,12 @@ export function getMainFileMatchers(
     }
   }
   patterns.splice(insertIndex, 0, ...customFirstPatterns)
+
+  const reincludedDefaults = getReincludedDefaultExclusions(userSpecifiedPatterns)
+  if (reincludedDefaults.length > 0) {
+    // These files are kept out of the package by default; a user `files` pattern is opting them back in.
+    log.warn({ files: reincludedDefaults.join(", ") }, "`files` configuration re-includes files that are excluded by default — verify this is intentional")
+  }
 
   patterns.push(...getDefaultIgnoredPatterns(userSpecifiedPatterns, platformPackager.config.includePdb === true))
 

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -13,17 +13,198 @@ import { createFilter, hasMagic } from "./util/filter.js"
 const minimatchOptions = { dot: true }
 
 // noinspection SpellCheckingInspection
-export const excludedNames =
-  ".git,.hg,.svn,CVS,RCS,SCCS," +
-  "__pycache__,.DS_Store,thumbs.db,.gitignore,.gitkeep,.gitattributes,.npmignore," +
-  ".idea,.vs,.flowconfig,.jshintrc,.eslintrc,.circleci," +
-  ".yarn-integrity,.yarn-metadata.json,yarn-error.log,yarn.lock,package-lock.json,npm-debug.log,pnpm-lock.yaml,bun.lock,bun.lockb," +
-  "appveyor.yml,.travis.yml,circle.yml,.nyc_output,.husky,.github,electron-builder.env"
+// File/dir names excluded by default from the packaged app. A `files` entry may opt any of these
+// back in (see collectExplicitReincludes / getDefaultIgnoredPatterns).
+export const DEFAULT_EXCLUDED_NAMES: ReadonlyArray<string> = [
+  ".git",
+  ".hg",
+  ".svn",
+  "CVS",
+  "RCS",
+  "SCCS",
+  "__pycache__",
+  ".DS_Store",
+  "thumbs.db",
+  ".gitignore",
+  ".gitkeep",
+  ".gitattributes",
+  ".npmignore",
+  ".idea",
+  ".vs",
+  ".flowconfig",
+  ".jshintrc",
+  ".eslintrc",
+  ".circleci",
+  ".yarn-integrity",
+  ".yarn-metadata.json",
+  "yarn-error.log",
+  "yarn.lock",
+  "package-lock.json",
+  "npm-debug.log",
+  "pnpm-lock.yaml",
+  "bun.lock",
+  "bun.lockb",
+  "appveyor.yml",
+  ".travis.yml",
+  "circle.yml",
+  ".nyc_output",
+  ".husky",
+  ".github",
+  "electron-builder.env",
+]
 
-export const excludedExts =
-  "iml,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,suo,xproj,cc,d.ts," +
+// File extensions (without leading dot) excluded by default from the packaged app.
+export const DEFAULT_EXCLUDED_EXTENSIONS: ReadonlyArray<string> = [
+  "iml",
+  "hprof",
+  "orig",
+  "pyc",
+  "pyo",
+  "rbc",
+  "swp",
+  "csproj",
+  "sln",
+  "suo",
+  "xproj",
+  "cc",
+  "d.ts",
   // https://github.com/electron-userland/electron-builder/issues/7512
-  "mk,a,o,obj,forge-meta"
+  "mk",
+  "a",
+  "o",
+  "obj",
+  "forge-meta",
+]
+
+// Hard cap on the number of strings a single pattern may expand to. Real opt-in patterns expand to a
+// handful (`{obj,gltf,glb}`); this bound makes the expansion provably finite so a pathological pattern
+// (e.g. nested or many large `{...}` groups whose product is huge) degrades to "treated literally"
+// rather than hanging/OOM-ing the build. minimatch performs the authoritative expansion downstream.
+const MAX_BRACE_EXPANSIONS = 64
+
+// Expands `{a,b,c}` brace alternations in a pattern, honoring nesting. Returns the value unchanged
+// when it has no braces or would expand beyond MAX_BRACE_EXPANSIONS. Used only to detect which
+// extensions/names a `files` entry references — not for matching.
+function expandBraces(value: string): Array<string> {
+  const open = value.indexOf("{")
+  if (open === -1) {
+    return [value]
+  }
+  // Find the `}` that closes the first `{`, accounting for nested braces.
+  let depth = 0
+  let close = -1
+  for (let i = open; i < value.length; i++) {
+    if (value[i] === "{") {
+      depth++
+    } else if (value[i] === "}" && --depth === 0) {
+      close = i
+      break
+    }
+  }
+  if (close === -1) {
+    return [value]
+  }
+
+  const prefix = value.slice(0, open)
+  const suffix = value.slice(close + 1)
+  const result: Array<string> = []
+  for (const alternative of splitTopLevel(value.slice(open + 1, close))) {
+    for (const expanded of expandBraces(`${prefix}${alternative}${suffix}`)) {
+      if (result.length >= MAX_BRACE_EXPANSIONS) {
+        return [value]
+      }
+      result.push(expanded)
+    }
+  }
+  return result
+}
+
+// Splits on commas that are not inside a nested brace group, so `a,{b,c}` yields ["a", "{b,c}"].
+function splitTopLevel(value: string): Array<string> {
+  const parts: Array<string> = []
+  let depth = 0
+  let start = 0
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i]
+    if (ch === "{") {
+      depth++
+    } else if (ch === "}") {
+      depth--
+    } else if (ch === "," && depth === 0) {
+      parts.push(value.slice(start, i))
+      start = i + 1
+    }
+  }
+  parts.push(value.slice(start))
+  return parts
+}
+
+/**
+ * Determines which default-excluded extensions and names a user has explicitly opted back in to via
+ * their `files` patterns, so the corresponding defaults are not re-applied.
+ *
+ * A default is treated as opted back in only when a non-negated pattern references it concretely:
+ * an extension when a pattern's basename ends with `.<ext>` (e.g. `**\/*.obj`, `assets/*.{obj,gltf}`,
+ * `**\/*.d.ts`); a name when any path segment equals it (e.g. `**\/.github/**`, `**\/yarn.lock`).
+ * Broad patterns such as `**\/*` reference nothing concrete and therefore opt nothing in.
+ */
+export function collectExplicitReincludes(patterns: ReadonlyArray<string>): { extensions: Set<string>; names: Set<string> } {
+  const segments = new Set<string>()
+  const basenames: Array<string> = []
+  for (const pattern of patterns) {
+    if (pattern.startsWith("!")) {
+      continue
+    }
+    for (const expanded of expandBraces(pattern)) {
+      const parts = expanded.split("/")
+      for (const part of parts) {
+        segments.add(part)
+      }
+      basenames.push(parts[parts.length - 1])
+    }
+  }
+
+  const extensions = new Set(DEFAULT_EXCLUDED_EXTENSIONS.filter(ext => basenames.some(name => name.endsWith(`.${ext}`))))
+  const names = new Set(DEFAULT_EXCLUDED_NAMES.filter(name => segments.has(name)))
+  return { extensions, names }
+}
+
+/**
+ * Builds the trailing list of default ignore globs appended to the main app file matcher. Extensions
+ * and names the user has explicitly re-included (see {@link collectExplicitReincludes}) are omitted,
+ * so a `files` entry like `**\/*.obj` overrides the matching built-in exclusion.
+ */
+export function getDefaultIgnoredPatterns(userPatterns: ReadonlyArray<string>, includePdb: boolean): Array<string> {
+  const reincluded = collectExplicitReincludes(userPatterns)
+
+  const extensions = DEFAULT_EXCLUDED_EXTENSIONS.filter(ext => !reincluded.extensions.has(ext))
+  if (!includePdb) {
+    extensions.push("pdb")
+  }
+  const names = DEFAULT_EXCLUDED_NAMES.filter(name => !reincluded.names.has(name))
+
+  const patterns: Array<string> = []
+  // minimatch does not expand a single-member brace (`{x}` is matched literally), so emit a bare
+  // glob when only one extension/name survives the opt-in filtering.
+  if (extensions.length === 1) {
+    patterns.push(`!**/*.${extensions[0]}`)
+  } else if (extensions.length > 1) {
+    patterns.push(`!**/*.{${extensions.join(",")}}`)
+  }
+  patterns.push("!**/._*")
+  patterns.push("!**/electron-builder.{yaml,yml,json,json5,toml,ts}")
+  if (names.length === 1) {
+    patterns.push(`!**/${names[0]}`)
+  } else if (names.length > 1) {
+    patterns.push(`!**/{${names.join(",")}}`)
+  }
+  patterns.push("!.yarn{,/**/*}")
+  // https://github.com/electron-userland/electron-builder/issues/1969
+  // exclude only for app root, use .yarnclean to clean node_modules
+  patterns.push("!.editorconfig")
+  patterns.push("!.yarnrc.yml")
+  return patterns
+}
 
 function ensureNoEndSlash(file: string): string {
   if (path.sep !== "/") {
@@ -154,6 +335,10 @@ export function getMainFileMatchers(
   // https://github.com/electron-userland/electron-builder/issues/1741#issuecomment-311111418 so, do not use inclusive patterns
   const patterns = matcher.patterns
 
+  // Snapshot the user-specified patterns before the default/auto patterns are injected so a `files`
+  // entry can opt back in to a default-excluded extension/name (see getDefaultIgnoredPatterns).
+  const userSpecifiedPatterns = patterns.slice()
+
   const customFirstPatterns: Array<string> = []
   // electron-webpack - we need to copy only package.json and node_modules from root dir (and these files are added by default), so, explicit empty array is specified
   if (!matcher.isSpecifiedAsEmptyArray && (matcher.isEmpty() || matcher.containsOnlyIgnore())) {
@@ -197,17 +382,7 @@ export function getMainFileMatchers(
   }
   patterns.splice(insertIndex, 0, ...customFirstPatterns)
 
-  patterns.push(`!**/*.{${excludedExts}${platformPackager.config.includePdb === true ? "" : ",pdb"}}`)
-  patterns.push("!**/._*")
-  patterns.push("!**/electron-builder.{yaml,yml,json,json5,toml,ts}")
-  patterns.push(`!**/{${excludedNames}}`)
-
-  patterns.push("!.yarn{,/**/*}")
-
-  // https://github.com/electron-userland/electron-builder/issues/1969
-  // exclude ony for app root, use .yarnclean to clean node_modules
-  patterns.push("!.editorconfig")
-  patterns.push("!.yarnrc.yml")
+  patterns.push(...getDefaultIgnoredPatterns(userSpecifiedPatterns, platformPackager.config.includePdb === true))
 
   const debugLogger = platformPackager.debugLogger
   if (debugLogger.isEnabled) {

--- a/packages/app-builder-lib/src/indexInternal.ts
+++ b/packages/app-builder-lib/src/indexInternal.ts
@@ -7,7 +7,16 @@ export { CustomWindowsSign, WindowsSignTaskConfiguration } from "./codeSign/win/
 export { Configuration, ToolsetConfig, ToolsetCustom } from "./configuration.js"
 export { Publish } from "./core.js"
 export { getElectronVersion } from "./electron/electronVersion.js"
-export { FileMatcher, getFileMatchers, GetFileMatchersOptions } from "./fileMatcher.js"
+export {
+  collectExplicitReincludes,
+  DEFAULT_EXCLUDED_EXTENSIONS,
+  DEFAULT_EXCLUDED_NAMES,
+  FileMatcher,
+  getDefaultIgnoredPatterns,
+  getFileMatchers,
+  GetFileMatchersOptions,
+  getMainFileMatchers,
+} from "./fileMatcher.js"
 export { hoist, HoisterDependencyKind, HoisterResult, HoisterTree } from "./node-module-collector/hoist.js"
 export {
   BunNodeModulesCollector,

--- a/packages/app-builder-lib/src/indexInternal.ts
+++ b/packages/app-builder-lib/src/indexInternal.ts
@@ -16,6 +16,7 @@ export {
   getFileMatchers,
   GetFileMatchersOptions,
   getMainFileMatchers,
+  getReincludedDefaultExclusions,
 } from "./fileMatcher.js"
 export { hoist, HoisterDependencyKind, HoisterResult, HoisterTree } from "./node-module-collector/hoist.js"
 export {

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -153,13 +153,6 @@ export interface PlatformSpecificBuildOptions extends TargetSpecificOptions, Fil
   readonly compression?: CompressionLevel | null
 
   /**
-   * Whether to exclude all default ignored files(https://www.electron.build/contents#files) and options. Defaults to `false`.
-   *
-   * @default false
-   */
-  disableDefaultIgnoredFiles?: boolean | null
-
-  /**
    * Whether to package the application's source code into an archive, using [Electron's archive format](http://electron.atom.io/docs/tutorial/application-packaging/).
    *
    * Node modules that must be unpacked will be detected automatically. Use {@link AsarOptions.unpack} to specify additional files to unpack.

--- a/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
+++ b/packages/app-builder-lib/src/util/NodeModuleCopyHelper.ts
@@ -3,7 +3,7 @@ import { realpathSync } from "fs"
 import fsExtra from "fs-extra"
 import * as path from "path"
 import asyncPool from "tiny-async-pool"
-import { excludedNames, FileMatcher } from "../fileMatcher.js"
+import { DEFAULT_EXCLUDED_NAMES, FileMatcher } from "../fileMatcher.js"
 import { PlatformPackager } from "../platformPackager.js"
 import { FileCopyHelper } from "./AppFileWalker.js"
 import { NodeModuleInfo } from "../node-module-collector/types.js"
@@ -21,7 +21,7 @@ const excludedFiles = new Set(
     "binding.gyp",
     ".npmignore",
     "node_gyp_bins",
-  ].concat(excludedNames.split(","))
+  ].concat(DEFAULT_EXCLUDED_NAMES)
 )
 
 const topLevelExcludedFiles = new Set([
@@ -86,7 +86,7 @@ export class NodeModuleCopyHelper extends FileCopyHelper {
 
         // check if filematcher matches the files array as more important than the default excluded files.
         const fileMatched = filter != null && filter(dirPath, fsExtra.lstatSync(dirPath))
-        if (!fileMatched || !forceIncluded || !!this.packager.config.disableDefaultIgnoredFiles) {
+        if (!fileMatched || !forceIncluded) {
           for (const ext of nodeModuleExcludedExts) {
             if (name.endsWith(ext)) {
               return null

--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -6,7 +6,7 @@ import * as path from "path"
 import asyncPool from "tiny-async-pool"
 import { isLibOrExe } from "../asar/unpackDetector.js"
 import { Platform } from "../core.js"
-import { excludedExts, FileMatcher } from "../fileMatcher.js"
+import { DEFAULT_EXCLUDED_EXTENSIONS, FileMatcher } from "../fileMatcher.js"
 import { getCollectorByPackageManager, PM } from "../node-module-collector/index.js"
 import { LogMessageByKey, logMessageLevelByKey, ModuleManager } from "../node-module-collector/moduleManager.js"
 import { Packager } from "../packager.js"
@@ -144,7 +144,7 @@ export async function computeFileSets(matchers: Array<FileMatcher>, transformer:
 
 function getNodeModuleExcludedExts(platformPackager: PlatformPackager<any>) {
   // do not exclude *.h files (https://github.com/electron-userland/electron-builder/issues/2852)
-  const result = [".o", ".obj"].concat(excludedExts.split(",").map(it => `.${it}`))
+  const result = DEFAULT_EXCLUDED_EXTENSIONS.map(it => `.${it}`)
   if (platformPackager.config.includePdb !== true) {
     result.push(".pdb")
   }

--- a/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
+++ b/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
@@ -320,6 +320,14 @@ class ConfigCodemod {
     this.indentUnit = this.detectIndentUnit(root)
     this.ruleRemoveKeys(root, ["electronCompile"], "removed electronCompile (unsupported since v27; migrate to electron-vite, esbuild, or webpack)")
     this.ruleRemoveKeys(root, ["framework", "nodeVersion", "launchUiVersion"], key => `removed ${key} (Electron is the only supported framework in v27)`)
+    const disableDefaultIgnoredFilesDesc = "removed disableDefaultIgnoredFiles (in v27, include a default-excluded file via an explicit `files` glob, e.g. `**/*.obj`)"
+    this.ruleRemoveKeys(root, ["disableDefaultIgnoredFiles"], disableDefaultIgnoredFilesDesc)
+    for (const platform of ["mac", "win", "linux"]) {
+      const p = this.getObjectProp(root, platform)
+      if (p != null) {
+        this.ruleRemoveKeys(p, ["disableDefaultIgnoredFiles"], disableDefaultIgnoredFilesDesc)
+      }
+    }
     this.ruleNativeModules(root)
     this.ruleAsar(root)
     this.ruleAppImageSystemIntegration(root)

--- a/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
+++ b/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
@@ -322,7 +322,8 @@ class ConfigCodemod {
     this.ruleRemoveKeys(root, ["framework", "nodeVersion", "launchUiVersion"], key => `removed ${key} (Electron is the only supported framework in v27)`)
     const disableDefaultIgnoredFilesDesc = "removed disableDefaultIgnoredFiles (in v27, include a default-excluded file via an explicit `files` glob, e.g. `**/*.obj`)"
     this.ruleRemoveKeys(root, ["disableDefaultIgnoredFiles"], disableDefaultIgnoredFilesDesc)
-    for (const platform of ["mac", "win", "linux"]) {
+    // mas/masDev are MacConfiguration-derived, so they accept the (now-removed) key too.
+    for (const platform of ["mac", "mas", "masDev", "win", "linux"]) {
       const p = this.getObjectProp(root, platform)
       if (p != null) {
         this.ruleRemoveKeys(p, ["disableDefaultIgnoredFiles"], disableDefaultIgnoredFilesDesc)

--- a/packages/electron-builder/src/cli/migrate-schema.ts
+++ b/packages/electron-builder/src/cli/migrate-schema.ts
@@ -82,6 +82,17 @@ export function migrateConfig(raw: Record<string, any>): MigrationResult {
     }
   }
 
+  // ── 2b. disableDefaultIgnoredFiles removed (root + platform configs) ──────
+  for (const obj of [c, c.mac, c.win, c.linux]) {
+    if (obj != null && typeof obj === "object" && "disableDefaultIgnoredFiles" in obj) {
+      delete obj.disableDefaultIgnoredFiles
+      changes.push({
+        key: "disableDefaultIgnoredFiles",
+        description: "removed disableDefaultIgnoredFiles (in v27, include a default-excluded file via an explicit `files` glob, e.g. `**/*.obj`)",
+      })
+    }
+  }
+
   // ── 3. npmSkipBuildFromSource → buildDependenciesFromSource ───────────────
   if ("npmSkipBuildFromSource" in c) {
     // will be picked up by the nativeModules step below

--- a/packages/electron-builder/src/cli/migrate-schema.ts
+++ b/packages/electron-builder/src/cli/migrate-schema.ts
@@ -83,7 +83,8 @@ export function migrateConfig(raw: Record<string, any>): MigrationResult {
   }
 
   // ── 2b. disableDefaultIgnoredFiles removed (root + platform configs) ──────
-  for (const obj of [c, c.mac, c.win, c.linux]) {
+  // mas/masDev are MacConfiguration-derived, so they accept the (now-removed) key too.
+  for (const obj of [c, c.mac, c.mas, c.masDev, c.win, c.linux]) {
     if (obj != null && typeof obj === "object" && "disableDefaultIgnoredFiles" in obj) {
       delete obj.disableDefaultIgnoredFiles
       changes.push({

--- a/test/snapshots/filesTest.js.snap
+++ b/test/snapshots/filesTest.js.snap
@@ -1,5 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`default-excluded extension stays excluded without a re-include glob 1`] = `
+{
+  "linux": [],
+}
+`;
+
 exports[`expand not defined env 1`] = `"ERR_ELECTRON_BUILDER_ENV_NOT_DEFINED"`;
 
 exports[`extraResources - two-package 1`] = `
@@ -111,6 +117,12 @@ exports[`files.from asar 1`] = `
 `;
 
 exports[`map resources 1`] = `
+{
+  "linux": [],
+}
+`;
+
+exports[`re-include default-excluded extension via files glob 1`] = `
 {
   "linux": [],
 }

--- a/test/src/filesTest.ts
+++ b/test/src/filesTest.ts
@@ -48,6 +48,51 @@ test.ifNotWindows("files", ({ expect }) =>
   )
 )
 
+// https://github.com/electron-userland/electron-builder/issues/6126
+// a default-excluded extension (.obj) is shipped when the user adds an explicit re-include glob
+test.ifNotWindows("re-include default-excluded extension via files glob", ({ expect }) =>
+  app(
+    expect,
+    {
+      targets: linuxDirTarget,
+      config: {
+        asar: false,
+        files: ["**/*", "**/*.obj"],
+      },
+    },
+    {
+      projectDirCreated: projectDir =>
+        Promise.all([fsExtra.outputFile(path.join(projectDir, "assets", "model.obj"), "obj-data"), fsExtra.outputFile(path.join(projectDir, "assets", "index.js"), "js")]),
+      packed: context => {
+        const appDir = path.join(context.getResources(Platform.LINUX), "app")
+        return Promise.all([assertThat(expect, path.join(appDir, "assets", "model.obj")).isFile(), assertThat(expect, path.join(appDir, "assets", "index.js")).isFile()])
+      },
+    }
+  )
+)
+
+// control for the test above: without an explicit re-include, the default exclusion still applies
+test.ifNotWindows("default-excluded extension stays excluded without a re-include glob", ({ expect }) =>
+  app(
+    expect,
+    {
+      targets: linuxDirTarget,
+      config: {
+        asar: false,
+        files: ["**/*"],
+      },
+    },
+    {
+      projectDirCreated: projectDir =>
+        Promise.all([fsExtra.outputFile(path.join(projectDir, "assets", "model.obj"), "obj-data"), fsExtra.outputFile(path.join(projectDir, "assets", "index.js"), "js")]),
+      packed: context => {
+        const appDir = path.join(context.getResources(Platform.LINUX), "app")
+        return Promise.all([assertThat(expect, path.join(appDir, "assets", "model.obj")).doesNotExist(), assertThat(expect, path.join(appDir, "assets", "index.js")).isFile()])
+      },
+    }
+  )
+)
+
 test.ifNotWindows("files.from asar", ({ expect }) =>
   app(
     expect,

--- a/test/src/filterTest.ts
+++ b/test/src/filterTest.ts
@@ -1,4 +1,4 @@
-import { FilterStats } from "builder-util"
+import { FilterStats, log } from "builder-util"
 import {
   collectExplicitReincludes,
   DEFAULT_EXCLUDED_EXTENSIONS,
@@ -8,8 +8,10 @@ import {
   getFileMatchers,
   GetFileMatchersOptions,
   getMainFileMatchers,
+  getReincludedDefaultExclusions,
 } from "app-builder-lib/internal"
 import * as path from "path"
+import { vi } from "vitest"
 
 // ---------------------------------------------------------------------------
 // Stat mocks
@@ -499,5 +501,50 @@ describe("getMainFileMatchers – default exclusions respect `files` re-includes
   test("with **/*.obj, the obj exclusion is dropped (issue #6126)", ({ expect }) => {
     const extPattern = buildMatcherPatterns(["**/*", "**/*.obj"]).find(p => p.startsWith("!**/*.{"))!
     expect(extPattern.split(/[{,}]/)).not.toContain("obj")
+  })
+
+  test("warns once when a default-excluded file is re-included", ({ expect }) => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => log)
+    try {
+      buildMatcherPatterns(["**/*", "**/*.obj", "**/.github/**"])
+      expect(warn).toHaveBeenCalledTimes(1)
+      const [data, message] = warn.mock.calls[0]
+      expect((data as any).files).toContain("*.obj")
+      expect((data as any).files).toContain(".github")
+      expect(message).toMatch(/excluded by default/)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  test("does not warn when no default-excluded file is re-included", ({ expect }) => {
+    const warn = vi.spyOn(log, "warn").mockImplementation(() => log)
+    try {
+      buildMatcherPatterns(["**/*", "src/**/*.js"])
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getReincludedDefaultExclusions – which default exclusions a config opts back in
+// ---------------------------------------------------------------------------
+
+describe("getReincludedDefaultExclusions", () => {
+  test("formats re-included extensions as *.ext and names verbatim", ({ expect }) => {
+    const result = getReincludedDefaultExclusions(["**/*", "**/*.obj", "**/.github/**", "**/yarn.lock"])
+    expect(result).toContain("*.obj")
+    expect(result).toContain(".github")
+    expect(result).toContain("yarn.lock")
+  })
+
+  test("is empty when nothing default-excluded is re-included", ({ expect }) => {
+    expect(getReincludedDefaultExclusions(["**/*", "src/**", "assets/*.png"])).toEqual([])
+  })
+
+  test("ignores negated patterns", ({ expect }) => {
+    expect(getReincludedDefaultExclusions(["!**/*.obj", "!**/.github/**"])).toEqual([])
   })
 })

--- a/test/src/filterTest.ts
+++ b/test/src/filterTest.ts
@@ -1,5 +1,14 @@
 import { FilterStats } from "builder-util"
-import { FileMatcher, getFileMatchers, GetFileMatchersOptions } from "app-builder-lib/internal"
+import {
+  collectExplicitReincludes,
+  DEFAULT_EXCLUDED_EXTENSIONS,
+  DEFAULT_EXCLUDED_NAMES,
+  FileMatcher,
+  getDefaultIgnoredPatterns,
+  getFileMatchers,
+  GetFileMatchersOptions,
+  getMainFileMatchers,
+} from "app-builder-lib/internal"
 import * as path from "path"
 
 // ---------------------------------------------------------------------------
@@ -318,5 +327,177 @@ describe("getFileMatchers – string patterns in config.files", () => {
     expect(result).not.toBeNull()
     expect(result![0].patterns).toContain("installer.nsis")
     expect(result![0].patterns).not.toContain("should-be-ignored.txt")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// collectExplicitReincludes – which default exclusions the user opted back in
+// ---------------------------------------------------------------------------
+
+describe("collectExplicitReincludes", () => {
+  test("broad patterns opt nothing in", ({ expect }) => {
+    const { extensions, names } = collectExplicitReincludes(["**/*", "package.json", "dist/**/*"])
+    expect(extensions.size).toBe(0)
+    expect(names.size).toBe(0)
+  })
+
+  test("a basename ending in a default ext opts that ext in", ({ expect }) => {
+    const { extensions } = collectExplicitReincludes(["**/*", "**/*.obj"])
+    expect([...extensions]).toEqual(["obj"])
+  })
+
+  test("brace alternations opt each listed ext in", ({ expect }) => {
+    const { extensions } = collectExplicitReincludes(["**/*", "assets/*.{obj,o}"])
+    expect(extensions.has("obj")).toBe(true)
+    expect(extensions.has("o")).toBe(true)
+  })
+
+  test("multi-dot extensions like d.ts are matched", ({ expect }) => {
+    const { extensions } = collectExplicitReincludes(["**/*.d.ts"])
+    expect(extensions.has("d.ts")).toBe(true)
+  })
+
+  test("a path segment equal to a default name opts that name in", ({ expect }) => {
+    const { names } = collectExplicitReincludes(["**/*", "**/.github/**"])
+    expect(names.has(".github")).toBe(true)
+  })
+
+  test("names with dots (lockfiles) are matched as whole segments", ({ expect }) => {
+    const { names } = collectExplicitReincludes(["**/*", "**/yarn.lock"])
+    expect(names.has("yarn.lock")).toBe(true)
+  })
+
+  test("negated patterns never opt anything in", ({ expect }) => {
+    const { extensions, names } = collectExplicitReincludes(["!**/*.obj", "!**/.github/**"])
+    expect(extensions.size).toBe(0)
+    expect(names.size).toBe(0)
+  })
+
+  test("nested braces are expanded for opt-in detection", ({ expect }) => {
+    const { extensions } = collectExplicitReincludes(["**/*.{obj,{a,o}}"])
+    expect(extensions.has("obj")).toBe(true)
+    expect(extensions.has("a")).toBe(true)
+    expect(extensions.has("o")).toBe(true)
+
+    const { names } = collectExplicitReincludes(["**/{.github,{.husky,.idea}}/**"])
+    expect(names.has(".github")).toBe(true)
+    expect(names.has(".husky")).toBe(true)
+    expect(names.has(".idea")).toBe(true)
+  })
+
+  test("does not blow up on a pathological brace pattern (bounded expansion)", ({ expect }) => {
+    // product of alternatives across these groups is 2**20; expansion must bail to a literal, not OOM
+    const bomb = "**/" + "{a,b}".repeat(20) + ".js"
+    const { extensions, names } = collectExplicitReincludes([bomb])
+    expect(extensions.size).toBe(0)
+    expect(names.size).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDefaultIgnoredPatterns – trailing default ignore globs appended to the matcher
+// ---------------------------------------------------------------------------
+
+describe("getDefaultIgnoredPatterns", () => {
+  const extPatternOf = (patterns: Array<string>) => patterns.find(p => p.startsWith("!**/*.{"))!
+  const namePatternOf = (patterns: Array<string>) => patterns.find(p => p.startsWith("!**/{"))!
+
+  test("by default excludes obj and electron-builder.env, and appends pdb when includePdb is false", ({ expect }) => {
+    const patterns = getDefaultIgnoredPatterns([], false)
+    const extPattern = extPatternOf(patterns)
+    expect(extPattern).toContain("obj")
+    expect(extPattern).toContain("pdb")
+    expect(namePatternOf(patterns)).toContain("electron-builder.env")
+  })
+
+  test("includePdb=true omits pdb from the extension glob", ({ expect }) => {
+    expect(extPatternOf(getDefaultIgnoredPatterns([], true))).not.toContain("pdb")
+  })
+
+  test("an explicit **/*.obj re-include drops obj from the exclusion glob but keeps the others", ({ expect }) => {
+    const extPattern = extPatternOf(getDefaultIgnoredPatterns(["**/*", "**/*.obj"], false))
+    // obj as a {…} list member is gone, but `o` and `forge-meta` remain
+    expect(extPattern.split(/[{,}]/)).not.toContain("obj")
+    expect(extPattern).toContain("forge-meta")
+    expect(extPattern).toContain("o,")
+  })
+
+  test("re-including .d.ts drops only d.ts", ({ expect }) => {
+    const extPattern = extPatternOf(getDefaultIgnoredPatterns(["**/*.d.ts"], false))
+    expect(extPattern.split(/[{,}]/)).not.toContain("d.ts")
+    expect(extPattern).toContain("iml")
+  })
+
+  test("re-including a name drops it from the name glob but keeps the rest", ({ expect }) => {
+    const namePattern = namePatternOf(getDefaultIgnoredPatterns(["**/.github/**"], false))
+    expect(namePattern.split(/[{,}]/)).not.toContain(".github")
+    expect(namePattern).toContain("electron-builder.env")
+  })
+
+  test("broad **/* alone keeps every default exclusion intact", ({ expect }) => {
+    const patterns = getDefaultIgnoredPatterns(["**/*"], false)
+    expect(extPatternOf(patterns)).toContain("obj")
+    expect(namePatternOf(patterns)).toContain("electron-builder.env")
+  })
+
+  test("always appends the fixed config/editor ignores", ({ expect }) => {
+    const patterns = getDefaultIgnoredPatterns(["**/*"], false)
+    expect(patterns).toContain("!**/._*")
+    expect(patterns).toContain("!**/electron-builder.{yaml,yml,json,json5,toml,ts}")
+    expect(patterns).toContain("!.yarn{,/**/*}")
+    expect(patterns).toContain("!.editorconfig")
+    expect(patterns).toContain("!.yarnrc.yml")
+  })
+
+  test("the default (no opt-in) extension glob matches the historical hardcoded list", ({ expect }) => {
+    const expected = `!**/*.{${[...DEFAULT_EXCLUDED_EXTENSIONS, "pdb"].join(",")}}`
+    expect(extPatternOf(getDefaultIgnoredPatterns([], false))).toBe(expected)
+  })
+
+  test("the default (no opt-in) name glob matches the historical hardcoded list", ({ expect }) => {
+    expect(namePatternOf(getDefaultIgnoredPatterns([], false))).toBe(`!**/{${DEFAULT_EXCLUDED_NAMES.join(",")}}`)
+  })
+
+  test("a lone surviving extension is emitted as a literal (single-member braces don't match in minimatch)", ({ expect }) => {
+    // opt back in every default extension; only the implicit pdb should remain
+    const optInAll = DEFAULT_EXCLUDED_EXTENSIONS.map(ext => `**/*.${ext}`)
+    const patterns = getDefaultIgnoredPatterns(optInAll, false)
+    expect(patterns).toContain("!**/*.pdb")
+    expect(patterns.some(p => p.startsWith("!**/*.{"))).toBe(false)
+  })
+
+  test("a lone surviving name is emitted as a literal", ({ expect }) => {
+    const optInAllButEnv = DEFAULT_EXCLUDED_NAMES.filter(n => n !== "electron-builder.env").map(n => `**/${n}`)
+    const patterns = getDefaultIgnoredPatterns(optInAllButEnv, true)
+    expect(patterns).toContain("!**/electron-builder.env")
+    expect(patterns.some(p => p.startsWith("!**/{"))).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getMainFileMatchers – end-to-end pattern assembly (issue #6126)
+// ---------------------------------------------------------------------------
+
+describe("getMainFileMatchers – default exclusions respect `files` re-includes", () => {
+  function buildMatcherPatterns(files: Array<string>): Array<string> {
+    const platformPackager = {
+      projectDir: "/app",
+      buildResourcesDir: "build",
+      isPrepackedAppAsar: false,
+      config: { files, includePdb: false },
+      debugLogger: { isEnabled: false },
+    } as any
+    const matchers = getMainFileMatchers("/app", "/out", noMacro, {} as any, platformPackager, "/app/dist")
+    return matchers[0].patterns
+  }
+
+  test("without an explicit include, .obj stays excluded", ({ expect }) => {
+    const extPattern = buildMatcherPatterns(["**/*"]).find(p => p.startsWith("!**/*.{"))!
+    expect(extPattern).toContain("obj")
+  })
+
+  test("with **/*.obj, the obj exclusion is dropped (issue #6126)", ({ expect }) => {
+    const extPattern = buildMatcherPatterns(["**/*", "**/*.obj"]).find(p => p.startsWith("!**/*.{"))!
+    expect(extPattern.split(/[{,}]/)).not.toContain("obj")
   })
 })

--- a/test/src/filterTest.ts
+++ b/test/src/filterTest.ts
@@ -481,15 +481,19 @@ describe("getDefaultIgnoredPatterns", () => {
 // ---------------------------------------------------------------------------
 
 describe("getMainFileMatchers – default exclusions respect `files` re-includes", () => {
+  // Use path.resolve so appDir matches FileMatcher.from after the constructor normalizes path
+  // separators (on Windows a literal "/app" becomes "\app", and getMainFileMatchers early-returns
+  // unless matcher.from === appDir).
+  const appDir = path.resolve("/app")
   function buildMatcherPatterns(files: Array<string>): Array<string> {
     const platformPackager = {
-      projectDir: "/app",
+      projectDir: appDir,
       buildResourcesDir: "build",
       isPrepackedAppAsar: false,
       config: { files, includePdb: false },
       debugLogger: { isEnabled: false },
     } as any
-    const matchers = getMainFileMatchers("/app", "/out", noMacro, {} as any, platformPackager, "/app/dist")
+    const matchers = getMainFileMatchers(appDir, path.resolve("/out"), noMacro, {} as any, platformPackager, path.join(appDir, "dist"))
     return matchers[0].patterns
   }
 

--- a/test/src/migrateProgrammaticSchemaTest.ts
+++ b/test/src/migrateProgrammaticSchemaTest.ts
@@ -89,6 +89,24 @@ describe("migrateProgrammaticSource — locate shapes", () => {
   }
 })
 
+describe("migrateProgrammaticSource — disableDefaultIgnoredFiles", () => {
+  test("strips the root-level key, preserving surrounding properties", () => {
+    const result = run(`export default {\n  appId: "com.a.b",\n  disableDefaultIgnoredFiles: true,\n  files: ["dist/**/*"],\n}\n`)
+    expect(result.status).toBe("migrated")
+    expect(result.code).not.toContain("disableDefaultIgnoredFiles")
+    expect(result.code).toContain(`appId: "com.a.b"`)
+    expect(result.code).toContain(`files: ["dist/**/*"]`)
+    expect(result.changes.some(c => c.key === "disableDefaultIgnoredFiles")).toBe(true)
+  })
+
+  test("strips the key from a platform config object too", () => {
+    const result = run(`export default {\n  win: {\n    target: "nsis",\n    disableDefaultIgnoredFiles: true,\n  },\n}\n`)
+    expect(result.status).toBe("migrated")
+    expect(result.code).not.toContain("disableDefaultIgnoredFiles")
+    expect(result.code).toContain(`target: "nsis"`)
+  })
+})
+
 describe("migrateProgrammaticSource — unsupported shapes (bail with reason)", () => {
   test("spread is unsupported", () => {
     const result = run(`const base = {}\nexport default {\n  ...base,\n  npmRebuild: true,\n}\n`)

--- a/test/src/migrateProgrammaticSchemaTest.ts
+++ b/test/src/migrateProgrammaticSchemaTest.ts
@@ -99,8 +99,10 @@ describe("migrateProgrammaticSource — disableDefaultIgnoredFiles", () => {
     expect(result.changes.some(c => c.key === "disableDefaultIgnoredFiles")).toBe(true)
   })
 
-  test("strips the key from a platform config object too", () => {
-    const result = run(`export default {\n  win: {\n    target: "nsis",\n    disableDefaultIgnoredFiles: true,\n  },\n}\n`)
+  test("strips the key from platform config objects too (win/mas/masDev)", () => {
+    const result = run(
+      `export default {\n  win: {\n    target: "nsis",\n    disableDefaultIgnoredFiles: true,\n  },\n  mas: {\n    disableDefaultIgnoredFiles: true,\n  },\n  masDev: {\n    disableDefaultIgnoredFiles: true,\n  },\n}\n`
+    )
     expect(result.status).toBe("migrated")
     expect(result.code).not.toContain("disableDefaultIgnoredFiles")
     expect(result.code).toContain(`target: "nsis"`)

--- a/test/src/migrateSchemaTest.ts
+++ b/test/src/migrateSchemaTest.ts
@@ -63,12 +63,22 @@ describe("migrateConfig — disableDefaultIgnoredFiles", () => {
     expect(result.changes[0].key).toBe("disableDefaultIgnoredFiles")
   })
 
-  test("removes the key from platform configs as well", () => {
-    const result = migrateConfig({ disableDefaultIgnoredFiles: false, win: { disableDefaultIgnoredFiles: true, target: "nsis" }, mac: {} })
+  test("removes the key from every platform config (mac/mas/masDev/win/linux)", () => {
+    const result = migrateConfig({
+      disableDefaultIgnoredFiles: false,
+      mac: { disableDefaultIgnoredFiles: true },
+      mas: { disableDefaultIgnoredFiles: true },
+      masDev: { disableDefaultIgnoredFiles: true },
+      win: { disableDefaultIgnoredFiles: true, target: "nsis" },
+      linux: { disableDefaultIgnoredFiles: true },
+    })
     expect("disableDefaultIgnoredFiles" in result.migrated).toBe(false)
-    expect("disableDefaultIgnoredFiles" in result.migrated.win).toBe(false)
+    for (const platform of ["mac", "mas", "masDev", "win", "linux"]) {
+      expect("disableDefaultIgnoredFiles" in result.migrated[platform]).toBe(false)
+    }
     expect(result.migrated.win.target).toBe("nsis")
-    expect(result.changes.filter(c => c.key === "disableDefaultIgnoredFiles")).toHaveLength(2)
+    // root + 5 platforms
+    expect(result.changes.filter(c => c.key === "disableDefaultIgnoredFiles")).toHaveLength(6)
   })
 })
 

--- a/test/src/migrateSchemaTest.ts
+++ b/test/src/migrateSchemaTest.ts
@@ -54,6 +54,24 @@ describe("migrateConfig — framework / nodeVersion / launchUiVersion", () => {
   })
 })
 
+describe("migrateConfig — disableDefaultIgnoredFiles", () => {
+  test("removes the root-level key", () => {
+    const result = migrateConfig({ disableDefaultIgnoredFiles: true, appId: "com.a.b" })
+    expect("disableDefaultIgnoredFiles" in result.migrated).toBe(false)
+    expect(result.migrated.appId).toBe("com.a.b")
+    expect(result.changes).toHaveLength(1)
+    expect(result.changes[0].key).toBe("disableDefaultIgnoredFiles")
+  })
+
+  test("removes the key from platform configs as well", () => {
+    const result = migrateConfig({ disableDefaultIgnoredFiles: false, win: { disableDefaultIgnoredFiles: true, target: "nsis" }, mac: {} })
+    expect("disableDefaultIgnoredFiles" in result.migrated).toBe(false)
+    expect("disableDefaultIgnoredFiles" in result.migrated.win).toBe(false)
+    expect(result.migrated.win.target).toBe("nsis")
+    expect(result.changes.filter(c => c.key === "disableDefaultIgnoredFiles")).toHaveLength(2)
+  })
+})
+
 describe("migrateConfig — nativeModules grouping", () => {
   test("moves buildDependenciesFromSource under nativeModules", () => {
     const result = migrateConfig({ buildDependenciesFromSource: true })

--- a/website/docs/contents.md
+++ b/website/docs/contents.md
@@ -242,13 +242,31 @@ files:
 
 See [Two package.json Structure](tutorials/two-package-structure.md) for the full monorepo setup.
 
-## Disabling Default Ignored Files
+## Including Default-Excluded Files
+
+electron-builder excludes a set of development-only file extensions and names by default — for example
+build artifacts such as `.obj`, `.o`, `.a`, and `.d.ts`, lockfiles such as `yarn.lock` and
+`package-lock.json`, and VCS/tooling metadata such as `.git`, `.idea`, and `.github`.
+
+To ship a file that would otherwise be excluded, add an explicit `files` glob that targets it. An
+explicit include overrides the matching default exclusion:
 
 ```yaml
-disableDefaultIgnoredFiles: false    # Default: false
+files:
+  - "**/*"
+  - "**/*.obj"        # keep Wavefront .obj 3D models that are excluded by default
 ```
 
-Set to `true` to opt out of all default exclusion patterns. This includes every file in the app directory — including test files, source maps, and hidden files. Not recommended for production.
+The same applies to default-excluded names — reference the name in a pattern segment, e.g.:
+
+```yaml
+files:
+  - "**/*"
+  - "**/.github/**"   # keep the .github directory that is excluded by default
+```
+
+Only patterns that name an extension or directory concretely opt it back in; broad patterns such as
+`**/*` continue to honor the defaults.
 
 ## Troubleshooting
 

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -67,6 +67,7 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | Config change | Before | After |
 |---|---|---|
 | `electronCompile` removed | `"electronCompile": true` | *(deleted)* |
+| `disableDefaultIgnoredFiles` removed | `"disableDefaultIgnoredFiles": true` | *(deleted)* |
 | `framework` / `nodeVersion` / `launchUiVersion` removed | `"framework": "electron"` | *(deleted)* |
 | `npmSkipBuildFromSource` removed | `"npmSkipBuildFromSource": true` | `"nativeModules": { "buildDependenciesFromSource": false }` |
 | Native-module options grouped | `"npmRebuild": true` | `"nativeModules": { "npmRebuild": true }` |
@@ -107,6 +108,7 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | Node.js >=22.12.0 required | — | Update your runtime and CI node version |
 | All packages are native ESM | — | None — `require()` still works on Node >=22.12 |
 | `electronCompile` config option removed | ✓ | Remove from build config; migrate off `electron-compile` |
+| `disableDefaultIgnoredFiles` removed | ✓ | Removed automatically; re-include specific files via a `files` glob (e.g. `**/*.obj`) |
 | `electron-forge-maker-*` are now ESM | — | None — same API, same export shape |
 | Implicit `--publish` removed | — | Pass `--publish` explicitly |
 | `snap` config key removed | ✓ | Restructured to `snapcraft` with an explicit `base` |
@@ -272,6 +274,24 @@ Quick start with electron-vite:
 ```bash
 npm create electron-vite@latest my-app
 ```
+
+### `disableDefaultIgnoredFiles`
+
+The `disableDefaultIgnoredFiles` option has been **removed**. To include a file that is excluded by default (for example a Wavefront `.obj` 3D model, or any other default-excluded extension/name), add an explicit `files` glob that targets it — an explicit include now overrides the matching default exclusion:
+
+```json5
+{
+  "build": {
+    "disableDefaultIgnoredFiles": true,  // ← delete this line
+    "files": [
+      "**/*",
+      "**/*.obj"  // ← add a glob for the default-excluded files you want to keep
+    ]
+  }
+}
+```
+
+Broad patterns such as `**/*` still honor the defaults; only a pattern that names the extension or directory concretely opts it back in.
 
 ### `framework`, `nodeVersion`, `launchUiVersion`
 


### PR DESCRIPTION
Fixes #6126

### Summary

- **Include default-excluded files via `files` globs.** electron-builder excludes a set of development-only file extensions and names by default (e.g. `.obj`, `.o`, `.a`, `.d.ts`, lockfiles, VCS/tooling metadata). Previously these were appended as unconditional negative globs at the end of the app-file matcher, so there was no way to ship a legitimately-needed file with one of those extensions (e.g. Wavefront `.obj` 3D models). Now an explicit `files` glob that names the extension/directory overrides the matching default exclusion:

  ```yaml
  files:
    - "**/*"
    - "**/*.obj"        # kept; was excluded by default
    - "**/.github/**"   # kept; was excluded by default
  ```

  Broad patterns such as `**/*` continue to honor the defaults — only a pattern that names the extension or directory concretely opts it back in.

- **Removed the `disableDefaultIgnoredFiles` config option.** It only ever affected `node_modules` (not app files) and was an all-or-nothing switch that required redefining the entire default list. It is replaced by the per-file `files`-glob mechanism above. `electron-builder migrate-schema` strips it automatically (root and `mac`/`win`/`linux`) for both static (JSON/YAML) and programmatic (JS/TS) configs, so existing configs migrate cleanly instead of failing schema validation.

- **Refactored `excludedExts`/`excludedNames` into a single source of truth.** The two comma-joined string constants in `fileMatcher.ts` are now `DEFAULT_EXCLUDED_EXTENSIONS` / `DEFAULT_EXCLUDED_NAMES` arrays, consumed directly by all three call sites (`getMainFileMatchers`, `NodeModuleCopyHelper`, `appFileCopier`) instead of being re-split per use. The default (no opt-in) output is byte-for-byte identical to the previous hardcoded patterns.

- **Extracted small, unit-testable helpers** to reduce the size/complexity of `getMainFileMatchers`:
  - `collectExplicitReincludes(patterns)` — returns the default extensions/names a user's non-negated `files` patterns reference concretely (basename ends with `.<ext>`, or a path segment equals a name). Negated patterns and broad globs opt nothing in.
  - `getDefaultIgnoredPatterns(userPatterns, includePdb)` — builds the trailing default-ignore globs, omitting anything re-included. Emits a bare glob (`!**/*.pdb`) when a single extension/name survives, since minimatch treats a single-member `{x}` brace literally.
  - `expandBraces(value)` — nesting-aware brace expansion bounded to `MAX_BRACE_EXPANSIONS` so a pathological pattern degrades to "treated literally" rather than expanding multiplicatively.

### Design notes

- **Precedence.** The default exclusions are appended after the user's `files` patterns, so they normally win. Rather than reordering (which would let a broad `dist/**/*` silently re-include everything), the opt-in is targeted: an extension/name is removed from the default exclusion list only when the user names it concretely. This keeps the defaults intact for everyone who doesn't explicitly opt in.
- **`node_modules`.** The default exclusion set there is unchanged; `onNodeModuleFile` remains the hook for forcing inclusion of files inside dependencies. The redundant `disableDefaultIgnoredFiles` branch (which had no effect at its default) was removed.
- **Schema.** `scheme.json` was regenerated via `pnpm generate:schema` (drops the 5 `disableDefaultIgnoredFiles` entries; no other changes).

### Tests

- `filterTest.ts` — unit coverage for `collectExplicitReincludes`, `getDefaultIgnoredPatterns`, and `getMainFileMatchers`: default exclusions, single/brace/multi-dot/nested opt-ins, negated/broad-pattern safety, single-survivor literal emission, bounded brace expansion, and a check that the default output matches the historical hardcoded lists.
- `filesTest.ts` — e2e: a `.obj` under the app dir is packaged when `files` includes `**/*.obj`, and stays excluded without it (control).
- `migrateSchemaTest.ts` / `migrateProgrammaticSchemaTest.ts` — `disableDefaultIgnoredFiles` is stripped at the root and within platform configs for both config forms.

### Docs

- `website/docs/contents.md` — replaced the "Disabling Default Ignored Files" section with "Including Default-Excluded Files".
- `website/docs/migration/v26-to-v27.md` — documented the removal in all three places used for codemod-handled removals.
