### PR TITLE
docs: extract v27 breaking changes into a dedicated, prominent page (IA restructure)

### DIFF
--- a/.changeset/v27-breaking-changes-doc-page.md
+++ b/.changeset/v27-breaking-changes-doc-page.md
@@ -1,0 +1,6 @@
+---
+"app-builder-lib": patch
+"electron-builder": patch
+---
+
+docs: add a dedicated v27 breaking-changes reference page and point the invalid-config error (`schemaValidator`) and `migrate-schema` CLI output at it

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,7 +6,9 @@ v27 migrates the entire electron-builder package ecosystem to **native ES module
 
 **Most projects need only a Node.js version bump.** The `build()` API and all exported types are unchanged, and CJS `require()` continues to work on Node >=22.12 — no code changes needed unless you used `electronCompile` or one of the removed config options below.
 
-Full guide: **[https://www.electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)**
+> **⚠️ Read the breaking changes before upgrading:** **[electron.build/docs/migration/v27-breaking-changes](https://www.electron.build/docs/migration/v27-breaking-changes)** — the authoritative catalogue of everything that changed.
+
+Step-by-step walkthrough: **[electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)**
 
 > **Toolsets now default to `"latest"`.** In v27 every `toolsets.*` property defaults to the **newest published bundle**: an unset property, `null`, and the literal `"latest"` all resolve to the latest version for that toolset. No config change is required, but the effective defaults moved — `wine` → `1.0.1` (Wine 11.0; was 4.0.1), `winCodeSign` → `1.3.0` (was 1.1.0; adds Azure Trusted Signing `dlib` + .NET 8), `appimage` → `1.1.0` (was 1.0.3; adds `unsquashfs`); `nsis` (1.2.1), `fpm` (2.2.1), `icons` (1.2.1), `linuxToolsMac` (1.0.0), `sevenZip` (1.0.0) are unchanged. Pin a toolset to `"0.0.0"` to restore its legacy bundle. Because `winCodeSign` now defaults to `1.3.0`, Azure Trusted Signing uses the faster `signtool /dlib` path automatically — pin `winCodeSign` below `1.3.0` only to force the legacy PowerShell path. The `null` value was dropped from the `ToolsetConfig` type (still works at runtime); TypeScript configs should switch `null` → `"latest"`.
 
@@ -44,7 +46,7 @@ It handles **every config-level breaking change** automatically: `electronCompil
 | Implicit `--publish` removed | — | Pass `--publish` explicitly |
 | `--em.build` / `--em.directories` CLI flags removed | — | Use `-c` / `-c.directories` |
 | `PackagerOptions.devMetadata` / `extraMetadata` removed | — | Use `config` / `config.extraMetadata` |
-| Toolset env-var overrides removed | — | Use `toolsets.X: { url, checksum }` (`ToolsetCustom`) |
+| Toolset env-var overrides removed | — | `APPIMAGE_TOOLS_PATH`, `ELECTRON_BUILDER_NSIS_DIR`, `USE_SYSTEM_WINE`, etc. → `toolsets.X: { url, checksum }` (`ToolsetCustom`) |
 | Toolset defaults now resolve to `"latest"` (newest bundle) | — | No action; pin to `"0.0.0"` to restore a legacy bundle. Effective bumps: `wine` 4.0.1→11.0, `winCodeSign`→1.3.0, `appimage`→1.1.0 |
 | `electron-forge-maker-*` are now ESM | — | None — same API, same `export default` shape |
 
@@ -89,4 +91,4 @@ Migrate to [electron-vite](https://electron-vite.org/), [esbuild](https://esbuil
 
 ### Full migration details
 
-See the complete, sectioned guide at [https://www.electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27).
+See the full **[breaking changes reference](https://www.electron.build/docs/migration/v27-breaking-changes)** and the step-by-step **[migration walkthrough](https://www.electron.build/docs/migration/v26-to-v27)**.

--- a/README.md
+++ b/README.md
@@ -97,11 +97,13 @@ See the full documentation on [electron.build](https://www.electron.build).
 
 **Node.js >=22.12.0** is required for v27.
 
-> **Upgrading from v26?** Run the automated migration command first — it rewrites your static config in place:
+> **⚠️ Upgrading from v26?** v27 is a major release with breaking changes (native ESM, Node >=22.12, and removed deprecated APIs). **Read the breaking changes before upgrading:** [electron.build/docs/migration/v27-breaking-changes](https://www.electron.build/docs/migration/v27-breaking-changes)
+>
+> Then run the automated migration command — it rewrites your config in place:
 > ```bash
 > electron-builder migrate-schema
 > ```
-> Full details: **[v26 → v27 migration guide](./MIGRATION.md)** · [electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)
+> Step-by-step walkthrough: **[v26 → v27 migration guide](./MIGRATION.md)** · [electron.build/docs/migration/v26-to-v27](https://www.electron.build/docs/migration/v26-to-v27)
 
 ## Installation
 ```

--- a/packages/app-builder-lib/src/util/config/schemaValidator.ts
+++ b/packages/app-builder-lib/src/util/config/schemaValidator.ts
@@ -45,7 +45,7 @@ export function validateSchema(schema: unknown, data: unknown, config: Validatio
   const guidance = [
     `Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration`,
     `If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.`,
-    `Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27`,
+    `Check the release notes for breaking changes: https://www.electron.build/docs/migration/v27-breaking-changes`,
   ]
   throw new Error(`${header}\n${formatted.join("\n")}\n${guidance.join("\n")}`)
 }

--- a/packages/electron-builder/src/cli/migrate-schema.ts
+++ b/packages/electron-builder/src/cli/migrate-schema.ts
@@ -767,7 +767,8 @@ function printManualSteps() {
     "• Move root-level package.json directories → build.directories",
     "",
     "• For programmatic configs (JS/TS/MJS/CJS), apply the above changes manually to your config object",
-    "• For additional guidance, check the migration guide: https://www.electron.build/docs/migration/v26-to-v27",
+    "• For additional guidance, check the migration walkthrough: https://www.electron.build/docs/migration/v26-to-v27",
+    "• Full list of breaking changes: https://www.electron.build/docs/migration/v27-breaking-changes",
   ]
   for (const step of steps) {
     process.stdout.write(`  ${step}\n`)

--- a/test/snapshots/configurationValidationTest.js.snap
+++ b/test/snapshots/configurationValidationTest.js.snap
@@ -21,7 +21,7 @@ exports[`appId as object 1`] = `
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
 If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
-Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v27-breaking-changes"
 `;
 
 exports[`extraFiles 1`] = `

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-0.0.0__Test.js.snap
@@ -51,7 +51,7 @@ exports[`LinuxPackager > AppImage - deprecated systemIntegration 1`] = `
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
 If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
-Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v27-breaking-changes"
 `;
 
 exports[`LinuxPackager > AppImage - desktopName drives installed filename (reverse-DNS) 1`] = `

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.0.3__Test.js.snap
@@ -51,7 +51,7 @@ exports[`LinuxPackager > AppImage - deprecated systemIntegration 1`] = `
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
 If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
-Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v27-breaking-changes"
 `;
 
 exports[`LinuxPackager > AppImage - desktopName drives installed filename (reverse-DNS) 1`] = `

--- a/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.1.0__Test.js.snap
+++ b/test/snapshots/generated/linuxPackager/linuxPackager__appimage-1.1.0__Test.js.snap
@@ -51,7 +51,7 @@ exports[`LinuxPackager > AppImage - deprecated systemIntegration 1`] = `
 
 Please check the documentation to ensure that your configuration matches the expected schema: https://www.electron.build/configuration
 If you recently upgraded electron-builder to v27, please run \`electron-builder migrate-schema\` to automatically update your configuration.
-Check the release notes for breaking changes: https://www.electron.build/docs/migration/v26-to-v27"
+Check the release notes for breaking changes: https://www.electron.build/docs/migration/v27-breaking-changes"
 `;
 
 exports[`LinuxPackager > AppImage - desktopName drives installed filename (reverse-DNS) 1`] = `

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -71,7 +71,7 @@ For other commands please see help using `--help` arg, e.g. `./node_modules/.bin
 :::
 
 :::note[Requirements]
-electron-builder v27 requires **Node.js >=22.12.0**. See the [migration guide](./migration/v26-to-v27) if upgrading from v26.
+electron-builder v27 requires **Node.js >=22.12.0**. Upgrading from v26? Review the [v27 breaking changes](./migration/v27-breaking-changes), then follow the [migration walkthrough](./migration/v26-to-v27).
 :::
 
 Prepend `npx` to sample commands below if you run them from Terminal and not from `package.json` scripts.

--- a/website/docs/linux.md
+++ b/website/docs/linux.md
@@ -88,7 +88,7 @@ To fix this, set `desktopName` in `package.json`:
 electron-builder installs the `.desktop` file as `${desktopName}.desktop` (here `com.example.MyApp.desktop`) and sets `StartupWMClass=com.example.MyApp`, both matching Electron's `app_id`. A trailing `.desktop` in `desktopName` is tolerated (stripped before the filename is composed), so configs written for earlier versions keep working. When `desktopName` is absent, the filename falls back to `executableName`.
 
 :::note[Changed in v27]
-The installed `.desktop` filename is now always derived from `desktopName`. The `linux.syncDesktopName` flag that previously gated this behaviour has been removed — see the [v26 → v27 migration guide](./migration/v26-to-v27.md#linuxsyncdesktopname-removed-always-synced).
+The installed `.desktop` filename is now always derived from `desktopName`. The `linux.syncDesktopName` flag that previously gated this behaviour has been removed — see the [v27 breaking changes](./migration/v27-breaking-changes.md#linuxsyncdesktopname-always-synced).
 :::
 
 :::warning[`desktopName` is required for reliable window association]

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -4,61 +4,36 @@ title: "Migrating from v26 to v27"
 
 # Migrating from v26 to v27
 
-v27 migrates the entire electron-builder package ecosystem to native ES modules (ESM), raises the minimum Node.js version to **22.12.0**, and hard-deletes the deprecated APIs that accumulated since v22.
+This is the **step-by-step walkthrough** for upgrading a project from v26 to v27. For the authoritative catalogue of **everything that changed**, see **[v27 Breaking Changes →](./v27-breaking-changes)**.
 
-**Most projects need only a Node.js version bump.** The `build()` API, all runtime configuration options, and all exported types are unchanged. CJS `require()` continues to work without any code changes on supported Node.js versions.
+v27 migrates the entire electron-builder ecosystem to native ES modules, raises the minimum Node.js version to **22.12.0**, and hard-deletes the deprecated APIs that accumulated since v22.
 
-:::tip[Run the automated migrator first]
-Before reading further, run the built-in command to automatically rewrite your config:
-
-```bash
-electron-builder migrate-schema
-```
-
-Use `--dry-run` to preview changes without writing. This handles every config-level breaking change automatically — see [what it migrates](#automated-migration-tool) for the full list.
+:::danger[Don't upgrade without reading the breaking changes]
+Every breaking change — what's removed, renamed, restructured, and what action each requires — is catalogued on the **[v27 Breaking Changes](./v27-breaking-changes)** page. Skim it before you start so nothing surprises you.
 :::
 
-:::info[Toolsets now default to the newest bundle (`"latest"`)]
-In v27 every `toolsets.*` property defaults to **`"latest"`** — an **unset** property, `null`, and the literal `"latest"` all resolve to the **newest published bundle** for that toolset (previously each property defaulted to a fixed pinned version). No config change is required, but the effective defaults moved:
+**Most projects need only a Node.js version bump plus one command.** The `build()` API, all runtime configuration options, and all exported types are unchanged. CJS `require()` continues to work without any code changes on supported Node.js versions.
 
-- **`wine` → `1.0.1`** — Wine 11.0 (was Wine 4.0.1); macOS arm64 via Rosetta. Linux still uses host-installed `wine`.
-- **`winCodeSign` → `1.3.0`** — Windows Kits 10.0.26100.0, `osslsigncode` 2.11 (native arm64), and the Azure Trusted Signing `dlib` + .NET 8 payload.
-- **`appimage` → `1.1.0`** — static FUSE3-compatible runtime; adds `unsquashfs` support.
-- `nsis` (`1.2.1`), `fpm` (`2.2.1`), `icons` (`1.2.1`), `linuxToolsMac` (`1.0.0`), and `sevenZip` (`1.0.0`) are unchanged.
+The upgrade is three steps:
 
-To stay on a legacy bundle, pin the toolset to `"0.0.0"`. Because `winCodeSign` now defaults to `1.3.0`, **Azure Trusted Signing uses the faster `signtool /dlib` path out of the box** — no explicit pin needed (pin `winCodeSign` *below* `1.3.0` to force the legacy PowerShell path). Full breakdown in [Toolsets](#toolsets).
-:::
+1. [Run the automated migrator](#step-1-run-the-automated-migrator) — rewrites your config to v27 form
+2. [Update Node.js](#step-2-update-nodejs) — to >=22.12.0
+3. [Apply the manual steps](#step-3-apply-the-manual-steps) — the few things the migrator can't do
 
-This guide is organized by purpose:
-
-- [Automated migration tool](#automated-migration-tool) — run this first
-- [Breaking changes at a glance](#breaking-changes-at-a-glance) — the full table
-- [Runtime changes](#runtime-changes) — Node.js and ESM
-- [Removed configuration options](#removed-configuration-options)
-- [Restructured configuration](#restructured-configuration)
-- [NSIS file associations](#nsis-file-associations) — ProgID format change
-- [CLI changes](#cli-changes)
-- [Toolsets](#toolsets)
-- [Programmatic and plugin-author API changes](#programmatic-and-plugin-author-api-changes)
-- [Summary checklist](#summary-checklist)
-- [Internal changes (non-user-facing)](#internal-changes-non-user-facing) — for transparency
-- [Design notes](#design-notes) — rationale behind the breaking changes
+Then walk the [summary checklist](#summary-checklist).
 
 ---
 
-## Automated migration tool
+## Step 1: Run the automated migrator
 
-Run the built-in command to automatically apply the config-level breaking changes to your project:
-
-```bash
-electron-builder migrate-schema
-```
-
-This rewrites your `electron-builder.json`, `electron-builder.yml`, `package.json` (build key), or any other static config format in place. Use `--dry-run` (`-n`) to preview changes without writing:
+Run the built-in command to apply every **config-level** breaking change to your project automatically:
 
 ```bash
-electron-builder migrate-schema --dry-run
+electron-builder migrate-schema            # apply changes in place
+electron-builder migrate-schema --dry-run  # preview without writing (alias: -n)
 ```
+
+This rewrites your `electron-builder.json`, `electron-builder.yml`, `package.json` (build key), or any other static config format in place. It also rewrites **programmatic** configs (`.js`/`.ts`/`.cjs`/`.mjs`) via an AST-located codemod that preserves comments, imports, functions, and formatting.
 
 Pass `--config <path>` to point at a non-default config file, or `--project-dir <dir>` to specify the project root (default: current directory).
 
@@ -82,8 +57,8 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | `mac.universal` fields → `universal` | `"mac": { "mergeASARs": true }` | `"mac": { "universal": { "mergeASARs": true } }` |
 | `electronDownload` → `electronGet` | `"electronDownload": { "mirror": "https://m/" }` | `"electronGet": { "mirrorOptions": { "mirror": "https://m/" } }` |
 | `GithubOptions.vPrefixedTagName` | `"vPrefixedTagName": false` | `"tagNamePrefix": ""` |
-| `GitlabOptions.vPrefixedTagName` | `"vPrefixedTagName": true` | *(deleted)* |
-| `win.azureSignOptions` → `win.sign` | `"win": { "azureSignOptions": { "endpoint": "…", … } }` | `"win": { "sign": { "type": "azure", "endpoint": "…", … } }` |
+| `GitlabOptions.vPrefixedTagName` | `"vPrefixedTagName": false` | *(stripped — ⚠️ may flip GitLab tags `1.2.3`→`v1.2.3`; the field still works at runtime, [see note](./v27-breaking-changes#githuboptions--gitlaboptions-vprefixedtagname))* |
+| `win.azureSignOptions` → `win.sign` | `"win": { "azureSignOptions": { "endpoint": "…" } }` | `"win": { "sign": { "type": "azure", "endpoint": "…" } }` |
 | `win.signtoolOptions` → `win.sign` | `"win": { "signtoolOptions": { "certificateFile": "…" } }` | `"win": { "sign": { "type": "signtool", "certificateFile": "…" } }` |
 | Azure extra sign keys | `"win": { "azureSignOptions": { "ExcludeCredentials": "X" } }` | `"win": { "sign": { "type": "azure", "additionalMetadata": { "ExcludeCredentials": "X" } } }` |
 | `win.signExecutable: false` | `"win": { "signExecutable": false }` | `"win": { "sign": false }` |
@@ -94,68 +69,24 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | `squirrelWindows.noMsi` inverted | `"squirrelWindows": { "noMsi": true }` | `"squirrelWindows": { "msi": false }` |
 | Root-level `directories` moved | `{ "directories": { "output": "dist" } }` (package.json root) | `{ "build": { "directories": { "output": "dist" } } }` |
 
-> **Note:** Programmatic configs (`.js`, `.ts`, `.cjs`, `.mjs`) and TOML configs cannot be auto-rewritten. The command prints the required manual steps instead. See [serialization caveats](#migrate-schema-serialization-caveats).
+> Each row links to its full explanation on the [v27 Breaking Changes](./v27-breaking-changes#breaking-changes-at-a-glance) page.
 
-> **`snap` base defaulting:** When your old `snap` config has no `base` field, the tool assumes `"core20"` (v27's 1-to-1 migration target) and prints a warning so you can confirm or change it. A `base: "custom"` config is moved verbatim without per-base nesting.
+### Serialization caveats
 
----
-
-## Breaking changes at a glance
-
-| Change | Auto-migrated | Action required |
-|--------|:---:|----------------|
-| Node.js >=22.12.0 required | — | Update your runtime and CI node version |
-| All packages are native ESM | — | None — `require()` still works on Node >=22.12 |
-| `electronCompile` config option removed | ✓ | Remove from build config; migrate off `electron-compile` |
-| `electron-forge-maker-*` are now ESM | — | None — same API, same export shape |
-| Implicit `--publish` removed | — | Pass `--publish` explicitly |
-| `snap` config key removed | ✓ | Restructured to `snapcraft` with an explicit `base` |
-| `GithubOptions.vPrefixedTagName` removed | ✓ | Use `tagNamePrefix` instead |
-| `GitlabOptions.vPrefixedTagName` removed | ✓ | Removed automatically |
-| `framework`, `nodeVersion`, `launchUiVersion` removed | ✓ | Removed automatically |
-| ProtonFramework and LibUiFramework removed | — | Migrate to an Electron-based build setup |
-| `devMetadata`, `extraMetadata` in `PackagerOptions` removed | — | Use `config` / `config.extraMetadata` instead |
-| `--em.build`, `--em.directories` CLI flags removed | — | Use `-c` / `-c.directories` instead |
-| `npmSkipBuildFromSource` removed | ✓ | Replaced by `nativeModules.buildDependenciesFromSource` |
-| `buildDependenciesFromSource`, `nodeGypRebuild`, `npmRebuild`, `nativeRebuilder` moved | ✓ | Grouped under `nativeModules`; `nativeRebuilder` → `rebuildMode` |
-| `appImage.systemIntegration` removed | ✓ | Removed automatically |
-| Legacy asar keys removed | ✓ | `asar-unpack`, `asar-unpack-dir`, `asar.unpackDir` replaced by `asar.unpack` |
-| `asarUnpack` moved into `asar` object | ✓ | Use `asar.unpack` |
-| `disableSanityCheckAsar` moved | ✓ | Use `asar.disableSanityCheck` |
-| `disableAsarIntegrity` moved | ✓ | Use `asar.disableIntegrity` |
-| `asar: true` removed | ✓ | Removed automatically (absence means enabled) |
-| macOS signing options consolidated under `mac.sign` | ✓ | `identity` / `entitlements` / `hardenedRuntime` / `type` / etc. → `mac.sign.*`; `signIgnore` → `sign.ignore` |
-| `mac.universal` options consolidated | ✓ | `mergeASARs` / `singleArchFiles` / `x64ArchFiles` → `mac.universal.*` |
-| `electronDownload` renamed to `electronGet` | ✓ | Reshaped to `@electron/get` options; some legacy fields dropped (warned) |
-| `directories` at package.json root removed | ✓ | Specify under `build.directories` |
-| `build.helper-bundle-id` removed | ✓ | Moved to `mac.helperBundleId` |
-| `squirrelWindows.noMsi` removed | ✓ | Replaced by `msi` (inverted) |
-| `<%= var %>` EJS template syntax in Linux scripts removed | — | Use `${var}` |
-| `CI_BUILD_TAG` environment variable removed | — | Use `CI_COMMIT_TAG` |
-| `linux.syncDesktopName` removed | — | Behaviour is now always on; remove the flag, set `desktopName` to control the filename |
-| NSIS file-association ProgID format changed | — | Update custom NSIS scripts that reference the old ProgID (the association `name`/`ext`) |
-| `win.azureSignOptions` removed | ✓ | Replaced by `win.sign: { type: "azure", … }` |
-| `win.signtoolOptions` removed | ✓ | Replaced by `win.sign: { type: "signtool", … }` |
-| `win.sign` is now the unified signing entry point | — | Use a discriminated union with `type: "signtool" \| "hsm" \| "pkcs11" \| "azure"` |
-| `win.signExecutable` removed | ✓ | `false` maps to `win.sign: false`; `true` is removed (default) |
-| `win.signAndEditExecutable` removed | ✓ | Resource editing always runs; no direct replacement for `false` (see docs) |
-| Azure extra index-signature keys moved | ✓ | Extra keys moved into `win.sign.additionalMetadata` |
-| New: `win.sign: { type: "hsm", … }` | — | Beta: HSM/FIPS token signing via signtool `/csp /kc`; requires `toolsets.winCodeSign: "1.x"` |
-| New: `win.sign: { type: "pkcs11", … }` | — | Beta: cross-platform PKCS#11 signing via osslsigncode (macOS/Linux CI) |
-| Azure Trusted Signing `signtool /dlib` is the default | — | Default `winCodeSign` (`"latest"` → `1.3.0`) enables it automatically; pin `winCodeSign` below `1.3.0` to force the legacy PowerShell path |
-| Toolset env-var overrides removed | — | Replace `APPIMAGE_TOOLS_PATH`, `ELECTRON_BUILDER_NSIS_DIR`, etc. with `toolsets.X: { url, checksum }` |
-| Toolset defaults now resolve to `"latest"` (newest bundle) | — | No action; pin to `"0.0.0"` to restore a legacy bundle if needed |
-| `PlatformPackager.info` deprecated; `platformSpecificBuildOptions` protected | — | Plugin authors: use the new pass-through getters |
+- **JSON5 → JSON**: when `migrate-schema` rewrites a `.json5` file it produces valid JSON (no comments, standard quoting) and prints a warning. If preserving comments matters, apply the changes manually.
+- **TOML**: the `toml` npm package is read-only. `migrate-schema` detects TOML configs, prints the required changes, and exits without writing.
+- **YAML**: `js-yaml` preserves key order when round-tripping but does not preserve comments.
+- **Programmatic configs** (`.js`/`.ts`/`.cjs`/`.mjs`): rewritten in place when reducible to a single object literal; falls back to printing manual steps for dynamic function bodies, spreads, or computed keys, or when `typescript` is not installed.
+- **`snap` base defaulting**: when your old `snap` config has no `base` field, the tool assumes `"core20"` (v27's 1-to-1 migration target) and prints a warning so you can confirm or change it.
 
 ---
 
-## Runtime changes
+## Step 2: Update Node.js
 
-### Update Node.js to >=22.12.0
-
-v27 requires **Node.js 22.12.0 or later**. This is the version where Node's [`require(esm)`](https://nodejs.org/en/blog/release/v22.12.0) support was stabilized (no flags needed), which allows both CJS and ESM consumers to use these packages without any code changes.
+v27 requires **Node.js 22.12.0 or later** — the version where Node's [`require(esm)`](https://nodejs.org/en/blog/release/v22.12.0) support was stabilized, allowing both CJS and ESM consumers to use these packages without code changes.
 
 Update your local environment:
+
 ```bash
 # nvm
 nvm install 22 && nvm use 22
@@ -165,6 +96,7 @@ fnm install 22 && fnm use 22
 ```
 
 Update CI (GitHub Actions):
+
 ```yaml
 - uses: actions/setup-node@v4
   with:
@@ -172,818 +104,48 @@ Update CI (GitHub Actions):
 ```
 
 Update your `package.json` engines field if you declare one:
+
 ```json
-{
-  "engines": {
-    "node": ">=22.12.0"
-  }
-}
+{ "engines": { "node": ">=22.12.0" } }
 ```
 
-### ESM output — what changes for your project
-
-electron-builder packages now ship as native ES modules. On **Node >=22.12.0** both styles continue to work:
-
-**CJS `require()` — still works**
-```js
-const { build, Platform } = require("electron-builder")
-```
-
-**ESM `import` — now the preferred style**
-```js
-import { build, Platform } from "electron-builder"
-```
-
-**TypeScript**
-```ts
-import { build, Configuration, Platform } from "electron-builder"
-
-const config: Configuration = {
-  appId: "com.example.myapp",
-  mac: { target: "dmg" },
-}
-
-await build({ targets: Platform.MAC.createTarget(), config })
-```
-
-If your project uses `"type": "module"` or ESM imports, no changes are needed. If it uses CJS on Node >=22.12, `require()` continues to work as before.
-
-The `build()` function signature, all configuration options, and all exported types are otherwise unchanged.
-
-### `electron-forge-maker-*` plugins
-
-The four Forge maker plugins (`electron-forge-maker-appimage`, `electron-forge-maker-nsis`, `electron-forge-maker-nsis-web`, `electron-forge-maker-snap`) are now native ES modules. The public API is identical — Electron Forge loads them via dynamic `import()` internally, so no config changes are required.
-
-### TypeScript `moduleResolution` settings
-
-v27 packages include `exports` maps and full TypeScript declarations. The following `tsconfig.json` settings all work:
-
-| `moduleResolution` | Works |
-|---|---|
-| `"node"` (legacy) | ✓ |
-| `"node16"` / `"nodenext"` | ✓ |
-| `"bundler"` | ✓ (recommended) |
-
-### CI and Docker environments
-
-Confirm your CI and Docker images run Node.js 22.12 or later.
-
-```yaml
-# GitHub Actions
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-```
+Confirm your CI and Docker images run Node.js 22.12 or later:
 
 ```dockerfile
-# Docker
 FROM node:22-bookworm-slim
 ```
 
-electron-builder's own Docker images for Linux builds have been updated as well and are available in both node 22 and 24 flavors. https://hub.docker.com/r/electronuserland/builder/tags
+electron-builder's own Docker images for Linux builds have been updated and are available in both node 22 and 24 flavors: https://hub.docker.com/r/electronuserland/builder/tags
+
+### ESM/CJS — no code changes needed on Node >=22.12
+
+```js
+// CJS require() — still works
+const { build } = require("electron-builder")
+
+// ESM import — now the preferred style
+import { build } from "electron-builder"
+```
+
+`moduleResolution` settings `"node"`, `"node16"`/`"nodenext"`, and `"bundler"` (recommended) all work. See [Native ESM output](./v27-breaking-changes#native-esm-output) for details.
 
 ---
 
-## Removed configuration options
-
-### `electronCompile`
-
-The `electronCompile` configuration option has been **removed**. `electron-compile` is an unmaintained library with no releases since 2019.
-
-```json5
-{
-  "build": {
-    "electronCompile": true  // ← delete this line
-  }
-}
-```
-
-If your project relies on `electron-compile` for source compilation, migrate to a modern build tool before upgrading to v27:
-
-- **[electron-vite](https://electron-vite.org/)** — recommended; fast, first-class ESM and Electron integration
-- **[esbuild](https://esbuild.github.io/)** — extremely fast, minimal configuration
-- **[webpack](https://webpack.electron.build/)** — mature, widely used; `electron-webpack` for Electron-specific setup
-
-Quick start with electron-vite:
-```bash
-npm create electron-vite@latest my-app
-```
-
-### `framework`, `nodeVersion`, `launchUiVersion`
-
-These three fields are removed. Only Electron is supported as a target framework — `proton`/`proton-native` and `libui` support has been removed.
-
-```json5
-{
-  "build": {
-    "framework": "electron",     // ← delete; "electron" was and remains the default
-    "nodeVersion": "current",    // ← delete; no effect
-    "launchUiVersion": "0.1.0"  // ← delete; no effect
-  }
-}
-```
-
-### `appImage.systemIntegration`
-
-Removed. Desktop integration is handled automatically by [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher).
-
-### `npmSkipBuildFromSource`
-
-Removed. Use `buildDependenciesFromSource` (now under `nativeModules` — see [Restructured configuration](#native-module-options-grouped-under-nativemodules)). It is the logical inverse:
-
-```json5
-// v26
-{ "npmSkipBuildFromSource": true }
-
-// v27 equivalent
-{ "nativeModules": { "buildDependenciesFromSource": false } }
-```
-
-### ASAR options consolidated under `asar`
-
-All ASAR-related configuration is now nested under a single `asar` key. Flat root-level properties are removed.
-
-**Unpack patterns** (`asarUnpack` and the older hyphenated aliases):
-
-| Removed key | Replacement |
-|---|---|
-| `asar-unpack` | `asar.unpack` |
-| `asar-unpack-dir` | `asar.unpack` |
-| `asar.unpackDir` | `asar.unpack` |
-| `asarUnpack` | `asar.unpack` |
-
-```json5
-// Before
-{
-  "build": {
-    "asarUnpack": ["**/*.node", "resources/**"]
-  }
-}
-
-// After
-{
-  "build": {
-    "asar": {
-      "unpack": ["**/*.node", "resources/**"]
-    }
-  }
-}
-```
-
-**Integrity and sanity-check flags** (`disableSanityCheckAsar`, `disableAsarIntegrity`):
-
-| Removed key | Replacement |
-|---|---|
-| `disableSanityCheckAsar` | `asar.disableSanityCheck` |
-| `disableAsarIntegrity` | `asar.disableIntegrity` |
-
-```json5
-// Before
-{
-  "build": {
-    "disableSanityCheckAsar": true,
-    "disableAsarIntegrity": true
-  }
-}
-
-// After
-{
-  "build": {
-    "asar": {
-      "disableSanityCheck": true,
-      "disableIntegrity": true
-    }
-  }
-}
-```
-
-**`asar: true` is no longer valid.** Simply omit the `asar` key entirely to enable ASAR with defaults, or specify an object:
-
-```json5
-// Before — enabling ASAR with defaults
-{ "build": { "asar": true } }
-
-// After — omit entirely (ASAR is enabled by default) or use an object
-{ "build": { "asar": {} } }
-```
-
-When `asar: false` all the sub-options are irrelevant and the migrator skips them.
-
-The `asar` type is now `AsarOptions | false | null`. All options combined:
-
-```json5
-{
-  "build": {
-    "asar": {
-      "unpack": ["**/*.node"],
-      "smartUnpack": true,
-      "ordering": "packing-order.txt",
-      "disableSanityCheck": false,
-      "disableIntegrity": false
-    }
-  }
-}
-```
-
-### Root-level `directories` in `package.json`
-
-Specifying `directories` at the root of `package.json` is removed. Move it under the `build` key.
-
-```json
-// Before
-{
-  "name": "my-app",
-  "directories": { "output": "dist" }
-}
-
-// After
-{
-  "name": "my-app",
-  "build": {
-    "directories": { "output": "dist" }
-  }
-}
-```
-
-### `build.helper-bundle-id`
-
-The hyphenated root-level `helper-bundle-id` is removed. Use `mac.helperBundleId`.
-
-```json5
-// Before
-{ "build": { "helper-bundle-id": "com.example.helper" } }
-
-// After
-{ "build": { "mac": { "helperBundleId": "com.example.helper" } } }
-```
-
-### `squirrelWindows.noMsi`
-
-The `noMsi` boolean is removed in favor of its inverse, `msi`.
-
-```json5
-// Before
-{ "build": { "squirrelWindows": { "noMsi": true } } }
-
-// After
-{ "build": { "squirrelWindows": { "msi": false } } }
-```
-
-### `GithubOptions.vPrefixedTagName` → `tagNamePrefix`
-
-The `vPrefixedTagName` boolean on `GithubOptions` is removed. Use `tagNamePrefix` to control the tag prefix.
-
-```json5
-// Before
-{ "publish": { "provider": "github", "vPrefixedTagName": false } }
-
-// After
-{ "publish": { "provider": "github", "tagNamePrefix": "" } }  // empty string = no prefix
-```
-
-To keep the default `v` prefix, simply remove `vPrefixedTagName` — `tagNamePrefix` defaults to `"v"`.
-
-`vPrefixedTagName` on `GitlabOptions` is also removed. GitLab releases now always use the `v`-prefixed tag (e.g. `v1.2.3`). There is no replacement option; update your release pipeline if your GitLab tags do not follow this convention.
-
-### `devMetadata`, `extraMetadata` (programmatic `PackagerOptions`)
-
-These fields in the programmatic `PackagerOptions` API are removed (they have thrown `InvalidConfigurationError` since v22).
-
-```ts
-// Before
-await build({
-  targets: Platform.MAC.createTarget(),
-  devMetadata: { ... },    // ← removed
-  extraMetadata: { ... },  // ← removed
-})
-
-// After
-await build({
-  targets: Platform.MAC.createTarget(),
-  config: {
-    extraMetadata: { ... },
-  },
-})
-```
-
-### Linux script EJS template syntax
-
-The legacy `<%= varName %>` EJS interpolation in Linux maintainer scripts (e.g. FPM `after-install`/`after-remove`) is removed. Use shell-style `${varName}` instead.
-
-### `CI_BUILD_TAG` environment variable
-
-Removed. Use `CI_COMMIT_TAG` (the standard GitLab CI variable) to provide the release tag.
-
-### `linux.syncDesktopName` removed (always synced)
-
-The `linux.syncDesktopName` flag is removed. The behaviour it gated is now **always on**: the installed `.desktop` filename is always derived from the `desktopName` field in `package.json` — installed as `${desktopName}.desktop`, with any trailing `.desktop` in the value stripped first — falling back to `executableName` only when `desktopName` is absent.
-
-```json5
-// Before (v26) — opt-in
-{
-  "build": {
-    "linux": {
-      "syncDesktopName": true  // ← delete this line; the behaviour is now the default
-    }
-  }
-}
-```
-
-No replacement is needed — simply remove the flag. To control the installed filename, set (or omit) `desktopName` in your root `package.json`:
-
-```json title="package.json"
-{
-  "desktopName": "com.example.MyApp"
-}
-```
-
-**Why this changed:** Electron derives its `app_id` / `WM_CLASS` from `desktopName`, and desktop environments match a running window to its launcher entry by comparing `WM_CLASS` against the installed `.desktop` filename. When the two diverged — which is exactly what happened with `syncDesktopName: false` (the v26 default) whenever a `desktopName` was set — GNOME, KDE, and others failed to associate the window with its launcher, breaking taskbar grouping, dock icons, and launcher highlighting (see [#9103](https://github.com/electron-userland/electron-builder/issues/9103)). Making the sync opt-in meant the default produced broken window association for any app that set a reverse-DNS `desktopName`, which is the recommended convention. The flag had no legitimate use case where leaving it `false` was correct: if `desktopName` is set you want the filename to match it, and if it is unset the behaviour is identical with or without the flag. Removing it eliminates a footgun rather than removing functionality. Path-traversal/NUL validation on the resulting filename is unchanged.
-
----
-
-## Restructured configuration
-
-### Native-module options grouped under `nativeModules`
-
-Four root-level configuration properties are moved into a new `nativeModules` sub-key, and `nativeRebuilder` is renamed to `rebuildMode`.
-
-```json5
-// Before (v26)
-{
-  "build": {
-    "buildDependenciesFromSource": true,
-    "nodeGypRebuild": false,
-    "npmRebuild": true,
-    "nativeRebuilder": "parallel"
-  }
-}
-
-// After (v27)
-{
-  "build": {
-    "nativeModules": {
-      "buildDependenciesFromSource": true,
-      "nodeGypRebuild": false,
-      "npmRebuild": true,
-      "rebuildMode": "parallel"
-    }
-  }
-}
-```
-
-`npmArgs` is **not** affected — it controls the package-manager install phase and remains at the root level.
-
-`npmSkipBuildFromSource` (deprecated in v26) is removed; the `migrate-schema` command converts it to its inverse, `nativeModules.buildDependenciesFromSource`.
-
-### `snap` → `snapcraft`
-
-The top-level `snap` configuration key is removed. Use `snapcraft` with an explicit `base` field and per-base options nested under a sub-key named after the base.
-
-```json5
-// Before
-{
-  "build": {
-    "snap": {
-      "confinement": "strict",
-      "stagePackages": ["libfoo"],
-      "base": "core22"
-    }
-  }
-}
-
-// After
-{
-  "build": {
-    "snapcraft": {
-      "base": "core22",
-      "core22": {
-        "confinement": "strict",
-        "stagePackages": ["libfoo"]
-      }
-    }
-  }
-}
-```
-
-Supported `base` values: `"core18"`, `"core20"`, `"core22"`, `"core24"`, and `"custom"`. The `migrate-schema` command performs this restructuring; when the old config has no `base`, it assumes `"core20"` and warns so you can confirm. A `base: "custom"` config (inline/path `snapcraft.yaml`) is moved verbatim.
-
-### Windows code signing unified under `win.sign`
-
-In v26, Windows signing used two separate root-level keys (`signtoolOptions` and `azureSignOptions`). In v27, all Windows signing modes are expressed through a single `win.sign` key typed as a discriminated union:
-
-```typescript
-win.sign: { type: "signtool" | "hsm" | "pkcs11" | "azure", … } | false | null
-```
-
-`false` / `null` disables signing entirely. Unset means electron-builder discovers credentials from the environment (e.g. `WIN_CSC_LINK`).
-
-#### `win.signtoolOptions` → `win.sign: { type: "signtool", … }`
-
-All fields move verbatim into `win.sign`; add `type: "signtool"`:
-
-```json5
-// Before
-{
-  "win": {
-    "signtoolOptions": {
-      "certificateFile": "cert.pfx",
-      "certificatePassword": "secret",
-      "publisherName": "CN=ACME Inc",
-      "signingHashAlgorithms": ["sha256"]
-    }
-  }
-}
-
-// After
-{
-  "win": {
-    "sign": {
-      "type": "signtool",
-      "certificateFile": "cert.pfx",
-      "certificatePassword": "secret",
-      "publisherName": "CN=ACME Inc",
-      "signingHashAlgorithms": ["sha256"]
-    }
-  }
-}
-```
-
-#### `win.azureSignOptions` → `win.sign: { type: "azure", … }`
-
-Fields move into `win.sign` with `type: "azure"`. The old index signature (`[k: string]: string`) that allowed arbitrary extra keys is replaced by an explicit `additionalMetadata` object. The `migrate-schema` command both restructures the key and moves any unrecognized extra keys into `additionalMetadata`.
-
-The default `winCodeSign` (`"latest"` → `1.3.0`) uses the faster `signtool /dlib` path, which reads a `metadata.json` file — that is what `additionalMetadata` feeds into. The PowerShell `Invoke-TrustedSigning` path is now the **legacy fallback**, triggered only when `toolsets.winCodeSign` is pinned *below* `"1.3.0"` (e.g. `"1.2.1"` or `"0.0.0"`).
-
-```json5
-// Before
-{
-  "win": {
-    "azureSignOptions": {
-      "endpoint": "https://weu.codesigning.azure.net/",
-      "codeSigningAccountName": "my-account",
-      "certificateProfileName": "my-profile",
-      "publisherName": "CN=My Company",
-      "ExcludeCredentials": "ManagedIdentityCredential"
-    }
-  }
-}
-
-// After
-{
-  "win": {
-    "sign": {
-      "type": "azure",
-      "endpoint": "https://weu.codesigning.azure.net/",
-      "codeSigningAccountName": "my-account",
-      "certificateProfileName": "my-profile",
-      "publisherName": "CN=My Company",
-      "additionalMetadata": {
-        "ExcludeCredentials": "ManagedIdentityCredential"
-      }
-    },
-  },
-  "toolsets": {
-    // signtool /dlib is already the default (winCodeSign "latest" → 1.3.0); this explicit pin is optional
-    "winCodeSign": "1.3.0"
-  }
-}
-```
-
-#### New signing modes (beta): `hsm` and `pkcs11`
-
-v27 introduces two new signing modes in `win.sign`:
-
-**`type: "hsm"` — Hardware Security Module via signtool `/csp /kc`** (Windows-only; requires `toolsets.winCodeSign: "1.x"`):
-
-```json5
-{
-  "win": {
-    "sign": {
-      "type": "hsm",
-      "cryptoServiceProvider": "Google Cloud KMS Provider",
-      "keyContainer": "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
-      "certificateFile": "cert.crt"
-    }
-  },
-  "toolsets": { "winCodeSign": "1.3.0" }
-}
-```
-
-**`type: "pkcs11"` — PKCS#11 token via osslsigncode** (cross-platform; runs on macOS/Linux CI without a Windows VM):
-
-```json5
-{
-  "win": {
-    "sign": {
-      "type": "pkcs11",
-      "pkcs11Module": "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so",
-      "pkcs11KeyUri": "pkcs11:token=MyToken;object=MyKey;type=private",
-      "certificateFile": "cert.pem"
-    }
-  },
-  "toolsets": { "winCodeSign": "1.3.0" }
-}
-```
-
-Both HSM and PKCS#11 are **beta** — the interfaces are stable but real-hardware test coverage is limited.
-
-#### `win.signExecutable` and `win.signAndEditExecutable` removed
-
-These two flags are removed in v27:
-
-| Removed | Replacement |
-|---------|-------------|
-| `win.signExecutable: false` | `win.sign: false` (disables signing; resource editing still runs) |
-| `win.signExecutable: true` | *(deleted — signing is enabled by default when credentials are available)* |
-| `win.signAndEditExecutable: true` | *(deleted — resource editing always runs)* |
-| `win.signAndEditExecutable: false` | No direct equivalent — see note below |
-
-:::warning
-`win.signAndEditExecutable: false` formerly skipped both resource editing (icon, metadata) and signing. In v27 resource editing always runs. To skip only signing, use `win.sign: false`. If you need to skip resource editing for a specific artifact, apply resources manually after building.
-:::
-
-### macOS signing options consolidated under `mac.sign`
-
-All macOS code-signing options now live inside a single `sign` object on `mac` (and `mas` / `masDev`), mirroring the Windows `win.sign` grouping. The scattered root-level fields are removed. `mac.sign` is typed as `CustomMacSign | ElectronSignOptions | string | null`, where `ElectronSignOptions` is a typed pass-through to [`@electron/osx-sign`](https://github.com/electron/osx-sign).
-
-| Removed (`mac.*`) | Replacement (`mac.sign.*`) |
-|---|---|
-| `identity` | `sign.identity` |
-| `entitlements` | `sign.entitlements` |
-| `entitlementsInherit` | `sign.entitlementsInherit` |
-| `entitlementsLoginHelper` | `sign.entitlementsLoginHelper` |
-| `provisioningProfile` | `sign.provisioningProfile` |
-| `type` | `sign.type` |
-| `binaries` | `sign.binaries` |
-| `requirements` | `sign.requirements` |
-| `hardenedRuntime` | `sign.hardenedRuntime` |
-| `gatekeeperAssess` | `sign.gatekeeperAssess` |
-| `strictVerify` | `sign.strictVerify` |
-| `preAutoEntitlements` | `sign.preAutoEntitlements` |
-| `timestamp` | `sign.timestamp` |
-| `additionalArguments` | `sign.additionalArguments` |
-| `signIgnore` | `sign.ignore` *(renamed to the `@electron/osx-sign` canonical name)* |
-
-```json5
-// Before
-{
-  "mac": {
-    "identity": "Developer ID Application: My Company (TEAMID)",
-    "entitlements": "build/entitlements.mac.plist",
-    "hardenedRuntime": true,
-    "gatekeeperAssess": false,
-    "signIgnore": ["**/*.txt"]
-  }
-}
-
-// After
-{
-  "mac": {
-    "sign": {
-      "identity": "Developer ID Application: My Company (TEAMID)",
-      "entitlements": "build/entitlements.mac.plist",
-      "hardenedRuntime": true,
-      "gatekeeperAssess": false,
-      "ignore": ["**/*.txt"]
-    }
-  }
-}
-```
-
-To skip signing, use `mac.sign.identity: null` (or `mac.sign: null`). The same structure applies to `mas` and `masDev`.
-
-:::warning[Custom signing functions]
-If you used `mac.sign` as a **custom signing function or module path** (`sign: "./customSign.js"`) together with sibling fields like `identity`, the two can no longer coexist — `sign` is now a single union. `migrate-schema` leaves your custom signer untouched and prints a warning so you can decide whether to keep the custom function or switch to an `ElectronSignOptions` object.
-:::
-
-### `mac.universal` options consolidated
-
-The universal-build options move from `mac` root into a `universal` object (typed as `ElectronUniversalOptions`, a pass-through to [`@electron/universal`](https://github.com/electron/universal)). They have no effect unless the target arch is `universal`.
-
-| Removed (`mac.*`) | Replacement (`mac.universal.*`) |
-|---|---|
-| `mergeASARs` | `universal.mergeASARs` |
-| `singleArchFiles` | `universal.singleArchFiles` |
-| `x64ArchFiles` | `universal.x64ArchFiles` |
-
-```json5
-// Before
-{ "mac": { "mergeASARs": true, "singleArchFiles": "*.node" } }
-
-// After
-{ "mac": { "universal": { "mergeASARs": true, "singleArchFiles": "*.node" } } }
-```
-
-### `electronDownload` → `electronGet`
-
-The `electronDownload` configuration key is renamed to `electronGet` and reshaped to match [`@electron/get`](https://github.com/electron/get)'s options directly (v27 upgrades to `@electron/get` v5, which downloads via `fetch`).
-
-| Old `electronDownload.*` | New `electronGet.*` |
-|---|---|
-| `mirror` | `mirrorOptions.mirror` |
-| `isVerifyChecksum: false` | `unsafelyDisableChecksums: true` |
-| `cache`, `customDir`, `customFilename`, `strictSSL` | *(no equivalent — dropped by `migrate-schema` with a warning)* |
-
-```json5
-// Before
-{ "electronDownload": { "mirror": "https://my-mirror/" } }
-
-// After
-{ "electronGet": { "mirrorOptions": { "mirror": "https://my-mirror/" } } }
-```
-
----
-
-## NSIS file associations
-
-### File-association ProgID format changed
-
-NSIS installers that declare `fileAssociations` now register each association under a unique, Microsoft-recommendation-compliant **ProgID** instead of using the association `name` (or extension) verbatim. The previous value could collide with unrelated applications — most easily when forking a project without changing `fileAssociations[].name`.
-
-The generated ProgID has the form `<program>.<component>`: `<program>` is derived from your `productName` (so it stays readable in the registry) and `<component>` mixes a short readable prefix with a value derived from the app GUID. It is at most 39 characters, contains only letters, digits, and a single period, and never starts with a digit.
-
-**No config change is required, and there is nothing to auto-migrate.** `fileAssociations` and its `name` / `ext` / `description` fields are unchanged; the new ProgID is produced automatically, and `migrate-schema` does not touch it because there is no config key involved. The installer and uninstaller derive the same ProgID, so registration and removal stay in sync.
-
-**Action is required only if** you ship a custom NSIS script (`nsis.include` / `nsis.script`) or external tooling that hard-codes the old ProgID — the association `name` or extension — for example to add extra shell verbs or registry entries under that key. Update those references to the new generated value.
-
-> On upgrade, an installer built with v27 registers the new ProgID. One-click installers run the previous version's uninstaller during the upgrade, which removes the old-format entry; with assisted installers that do not uninstall the prior version first, the old ProgID may remain in the registry until that version is removed.
-
----
-
-## CLI changes
-
-### `--publish` is no longer implicit
-
-v27 no longer auto-publishes based on the presence of CI tag environment variables. Pass `--publish <always|onTag|onTagOrDraft|never>` explicitly in your release scripts.
-
-### Removed flags: `--em.build`, `--em.directories`
-
-These flags are removed (they have thrown since v22).
-
-| Removed flag | Replacement |
-|---|---|
-| `--em.build` | `-c` (pass build config inline) |
-| `--em.directories` | `-c.directories` |
-
-### New command: `migrate-schema`
-
-See [Automated migration tool](#automated-migration-tool).
-
----
-
-## Toolsets
-
-### Toolset defaults updated
-
-In v27 every `toolsets.*` property defaults to **`"latest"`** — an unset property, `null`, or the literal `"latest"` all resolve to the **newest published bundle** for that toolset. (Earlier v27 prereleases pinned a fixed default per toolset; those fixed defaults are gone in favor of always selecting the newest bundle.) The `null` value is no longer part of the `ToolsetConfig` type — it still works at runtime, but TypeScript/programmatic configs typed against `Configuration` should switch `null` → `"latest"` or omit the key. `migrate-schema` does not rewrite this.
-
-| Toolset | v26 default | v27 `"latest"` resolves to | What the upgrade entails |
-|---------|-------------|----------------------------|--------------------------|
-| `wine` | `0.0.0` (Wine 4.0.1, macOS only) | `1.0.1` | Wine 11.0; macOS arm64 via Rosetta. Linux uses host-installed `wine` (no bundle shipped) |
-| `winCodeSign` | `0.0.0` (winCodeSign 2.6.0) | `1.3.0` | Windows Kits 10.0.26100.0; `osslsigncode` 2.11 + native arm64; bundles the Azure Trusted Signing `dlib` + .NET 8 runtime |
-| `appimage` | `0.0.0` (FUSE2 runtime) | `1.1.0` | Static FUSE3-compatible runtime (runs without a host FUSE install); adds `unsquashfs` support |
-| `nsis` | `0.0.0` (NSIS 3.0.4.1, split bundle) | `1.2.1` | NSIS 3.12; unified single-archive bundle; entrypoint scripts auto-set `NSISDIR` |
-| `fpm` | `2.2.1` | `2.2.1` | Unchanged — FPM 1.17.0 / Ruby 3.4.3 |
-| `icons` | `1.2.1` | `1.2.1` | Unchanged — `wasm-vips` + `@resvg/resvg-wasm` |
-| `linuxToolsMac` | `1.0.0` | `1.0.0` | Unchanged — gnu-tar, lzip, binutils, etc. (macOS → Linux archives) |
-| `sevenZip` | `1.0.0` | `1.0.0` | Unchanged — only published version |
-
-**No action required** for most projects — the new bundles are drop-in replacements and produce identical output. If you hit a regression introduced by a newer bundle, pin back to the legacy bundle by setting the toolset version to `"0.0.0"`:
-
-```json5
-{
-  "build": {
-    "toolsets": {
-      "winCodeSign": "0.0.0",   // restore winCodeSign 2.6.0
-      "nsis": "0.0.0",          // restore NSIS 3.0.4.1
-      "appimage": "0.0.0",      // restore FUSE2 AppImage runtime
-      "wine": "0.0.0"           // restore Wine 4.0.1 (macOS only)
-    }
-  }
-}
-```
-
-Azure Trusted Signing (`win.sign: { type: "azure" }`) uses the faster `signtool /dlib` path automatically: the default `winCodeSign` (`"latest"` → `1.3.0`) ships the ATS `dlib` + .NET 8 payload, so no pin is required. To **force the legacy** PowerShell `Invoke-TrustedSigning` path instead (which requires the `TrustedSigning` PS module in the signing environment), pin `winCodeSign` below `1.3.0`:
-
-```json5
-{
-  "build": {
-    "toolsets": {
-      "winCodeSign": "1.2.1" // or "0.0.0" — forces the legacy PowerShell signing path
-    }
-  }
-}
-```
-
-The signer resolves the path from the `winCodeSign` value: unset / `null` / `"latest"` and any explicit version `>= 1.3.0` use `signtool /dlib`; a version below `1.3.0` (no `dlib` in the bundle) uses PowerShell. A `ToolsetCustom` object uses `dlib` from your supplied bundle.
-
-This escape hatch is intended as a short-term workaround. The `"0.0.0"` alias may be removed in a future major release.
-
-### Toolset env-var overrides replaced by `ToolsetCustom`
-
-**This is a breaking change if you used env-var toolset overrides.** The following environment variables are **removed**:
-
-| Removed env var | Toolset it controlled |
-|---|---|
-| `APPIMAGE_TOOLS_PATH` | AppImage build tools (`mksquashfs`, runtime) |
-| `LINUX_TOOLS_MAC_PATH` | Linux-tools-mac bundle (`ar`, `lzip`, `gtar`) |
-| `CUSTOM_FPM_PATH` | FPM executable |
-| `ELECTRON_BUILDER_NSIS_DIR` | NSIS compiler bundle directory |
-| `ELECTRON_BUILDER_NSIS_RESOURCES_DIR` | NSIS resources/plugins directory |
-| `CUSTOM_NSIS_RESOURCES` | Alternate NSIS resources bundle |
-| `ELECTRON_BUILDER_WINE_TOOLSET_DIR` | Wine bundle directory |
-
-Replace env-var overrides with the new `ToolsetCustom` config object on the relevant `toolsets` key. The `url` accepts an `https://` URL (downloaded and cached automatically) or a `file://` path (used as-is).
-
-```json5
-// Remote bundle (URL)
-{
-  "build": {
-    "toolsets": {
-      "nsis": {
-        "url": "https://example.com/my-nsis-bundle-1.0.tar.gz",
-        "checksum": "sha256:abc123...",
-        "version": "my-custom-1.0"
-      }
-    }
-  }
-}
-```
-
-```json5
-// Local directory (no checksum required)
-{
-  "build": {
-    "toolsets": {
-      "appimage": {
-        "url": "file:///path/to/my-appimage-tools-dir"
-      }
-    }
-  }
-}
-```
-
-The bundle must mirror the directory layout of the corresponding built-in bundle. See [electron-builder-binaries/packages](https://github.com/electron-userland/electron-builder-binaries/tree/master/packages) for the expected structure.
-
-Supported archive formats: `.zip`, `.7z`, `.tar.gz`, `.tar.xz`. **Exception for `sevenZip`**: because 7-Zip is used to extract `.7z` and `.tar.xz` archives, a custom `sevenZip` bundle can only be supplied as a `.tar.gz`, `.zip`, or bare `file://` directory.
-
----
-
-## Programmatic and plugin-author API changes
-
-> **This section only affects you if you import from `app-builder-lib` and access the `packager` or `platformPackager` objects directly.** Standard project configurations are unaffected.
-
-### `info: Packager` is now `@deprecated`
-
-`PlatformPackager` has always exposed a public `info: Packager` field giving access to the whole-build orchestrator. In v27 this field is **deprecated** and will become `protected` in a future major release. TypeScript emits a `TS6385` hint anywhere your code chains through `.info.`:
-
-```ts
-// deprecated — produces a TS6385 hint
-const tmpDir = packager.info.tempDirManager
-await packager.info.emitArtifactCreated(event)
-```
-
-All commonly-needed properties are now directly accessible on `PlatformPackager`. Migrate by dropping the `.info.` chain:
-
-| Before (deprecated) | After |
-|---|---|
-| `packager.info.tempDirManager` | `packager.tempDirManager` |
-| `packager.info.metadata` | `packager.metadata` |
-| `packager.info.framework` | `packager.framework` |
-| `packager.info.cancellationToken` | `packager.cancellationToken` |
-| `packager.info.repositoryInfo` | `packager.repositoryInfo` |
-| `packager.info.relativeBuildResourcesDirname` | `packager.relativeBuildResourcesDirname` |
-| `packager.info.stageDirPathCustomizer` | `packager.stageDirPathCustomizer` |
-| `packager.info.areNodeModulesHandledExternally` | `packager.areNodeModulesHandledExternally` |
-| `packager.info.isPrepackedAppAsar` | `packager.isPrepackedAppAsar` |
-| `packager.info.appDir` | `packager.appDir` |
-| `packager.info.getWorkspaceRoot()` | `packager.getWorkspaceRoot()` |
-| `packager.info.emitArtifactBuildStarted(e)` | `packager.emitArtifactBuildStarted(e)` |
-| `packager.info.emitArtifactBuildCompleted(e)` | `packager.emitArtifactBuildCompleted(e)` |
-| `packager.info.emitArtifactCreated(e)` | `packager.emitArtifactCreated(e)` |
-| `packager.info.emitMsiProjectCreated(p)` | `packager.emitMsiProjectCreated(p)` |
-| `packager.info.emitAppxManifestCreated(p)` | `packager.emitAppxManifestCreated(p)` |
-
-The getters already on `PlatformPackager` in v26 are unchanged (`config`, `projectDir`, `buildResourcesDir`, `packagerOptions`, `appInfo`, `debugLogger`).
-
-### `platformSpecificBuildOptions` is now `protected`
-
-External consumers should use the two new public helpers instead:
-
-| Access pattern | v27 replacement |
-|---|---|
-| `packager.platformSpecificBuildOptions` (direct read) | `packager.platformOptions` |
-| `deepAssign({}, packager.platformSpecificBuildOptions, config.X)` | `packager.getOptionsForTarget<T>("X")` |
-
-`platformOptions` is a typed getter returning the same platform-level config object. `getOptionsForTarget<T>(key)` performs the standard merge of platform options with the named per-target key (e.g. `"appx"`, `"msi"`) and returns the result as `T`. All built-in targets (AppImage, Flatpak, Fpm, Snap, Appx, Msi, MsiWrapped, SquirrelWindows, DMG, NSIS, Archive) have been migrated; custom targets extending `PlatformPackager` must update any direct `.platformSpecificBuildOptions` access.
-
-### Removed exports
-
-`ProtonFramework`, `LibUiFramework`, and `SnapOptions` are removed from the public exports of `app-builder-lib` and `electron-builder`. Use the Electron framework and the `snapcraft` config shape respectively.
+## Step 3: Apply the manual steps
+
+`migrate-schema` handles every config-level change. The following require manual action — each links to its full explanation:
+
+- [ ] [Migrate off `electron-compile`](./v27-breaking-changes#electroncompile) to a modern bundler (electron-vite / esbuild / webpack), if you used `electronCompile`.
+- [ ] [Add `--publish` explicitly](./v27-breaking-changes#implicit---publish-removed) to your release scripts — auto-publish is gone.
+- [ ] [Replace `devMetadata` / `extraMetadata`](./v27-breaking-changes#devmetadata--extrametadata-programmatic-packageroptions) in the programmatic API with `config.extraMetadata`.
+- [ ] [Replace `--em.build` / `--em.directories`](./v27-breaking-changes#removed-flags---embuild---emdirectories) CLI flags with `-c` / `-c.directories`.
+- [ ] [Remove `linux.syncDesktopName`](./v27-breaking-changes#linuxsyncdesktopname-always-synced) — the behaviour is now always on; set `desktopName` to control the installed `.desktop` filename.
+- [ ] [Switch `<%= var %>` → `${var}`](./v27-breaking-changes#linux-maintainer-script-ejs-template-syntax) in Linux maintainer scripts.
+- [ ] [Update custom NSIS scripts](./v27-breaking-changes#nsis-file-association-progid-format-changed) that hard-code the old file-association ProgID.
+- [ ] [Replace `CI_BUILD_TAG`](./v27-breaking-changes#ci_build_tag-environment-variable) with `CI_COMMIT_TAG`.
+- [ ] [Replace toolset env-var overrides](./v27-breaking-changes#toolset-env-var-overrides-removed) (`APPIMAGE_TOOLS_PATH`, `ELECTRON_BUILDER_NSIS_DIR`, `USE_SYSTEM_WINE`, …) with `toolsets.X: { url, checksum }`.
+- [ ] [Validate toolset pins](./v27-breaking-changes#toolset-defaults-resolve-to-latest-newest-bundle) — defaults now resolve to `"latest"` (newest bundle); pin to `"0.0.0"` only if a legacy bundle is needed.
+- [ ] **Plugin/custom-target authors:** [replace `packager.info.X` and `platformSpecificBuildOptions`](./v27-breaking-changes#programmatic--plugin-author-api-changes) with the new pass-through getters.
 
 ---
 
@@ -1000,104 +162,23 @@ Run `electron-builder migrate-schema` first — it handles the items marked ✓ 
 - [ ] ✓ `electronCompile` removed (if present)
 - [ ] ✓ `framework`, `nodeVersion`, `launchUiVersion` removed (if present)
 - [ ] ✓ `npmSkipBuildFromSource` → `nativeModules.buildDependenciesFromSource` (if present)
-- [ ] ✓ `buildDependenciesFromSource`, `nodeGypRebuild`, `npmRebuild` moved into `nativeModules` (if present)
-- [ ] ✓ `nativeRebuilder` → `nativeModules.rebuildMode` (if present)
-- [ ] ✓ Legacy asar keys (`asar-unpack`, `asar-unpack-dir`, `asar.unpackDir`) → `asar.unpack` (if present)
-- [ ] ✓ `asarUnpack` → `asar.unpack` (if present)
-- [ ] ✓ `disableSanityCheckAsar` → `asar.disableSanityCheck` (if present)
-- [ ] ✓ `disableAsarIntegrity` → `asar.disableIntegrity` (if present)
-- [ ] ✓ `asar: true` → removed (absence means enabled) (if present)
-- [ ] ✓ macOS signing fields (`identity`, `entitlements`, `hardenedRuntime`, `type`, …) → `mac.sign.*`; `signIgnore` → `sign.ignore` (also `mas`/`masDev`)
-- [ ] ✓ `mac.universal` fields (`mergeASARs`, `singleArchFiles`, `x64ArchFiles`) → `mac.universal.*`
-- [ ] ✓ `electronDownload` → `electronGet` (verify dropped fields if you used `cache`/`customDir`/`customFilename`/`strictSSL`)
+- [ ] ✓ `buildDependenciesFromSource`, `nodeGypRebuild`, `npmRebuild` moved into `nativeModules`; `nativeRebuilder` → `rebuildMode`
+- [ ] ✓ Legacy asar keys + `asarUnpack` → `asar.unpack`; `disableSanityCheckAsar` → `asar.disableSanityCheck`; `disableAsarIntegrity` → `asar.disableIntegrity`; `asar: true` removed
+- [ ] ✓ macOS signing fields → `mac.sign.*`; `signIgnore` → `sign.ignore` (also `mas`/`masDev`)
+- [ ] ✓ `mac.universal` fields → `mac.universal.*`
+- [ ] ✓ `electronDownload` → `electronGet` (verify dropped `cache`/`customDir`/`customFilename`/`strictSSL`)
 - [ ] ✓ `appImage.systemIntegration` removed (if present)
 - [ ] ✓ `GithubOptions.vPrefixedTagName` → `tagNamePrefix` (if present)
-- [ ] ✓ `win.azureSignOptions` → `win.sign: { type: "azure", … }` (extra keys → `additionalMetadata`) (if present)
-- [ ] ✓ `win.signtoolOptions` → `win.sign: { type: "signtool", … }` (if present)
-- [ ] ✓ `win.signExecutable: false` → `win.sign: false`; `win.signExecutable: true` / `win.signAndEditExecutable: true` → removed (if present)
+- [ ] ✓ `win.azureSignOptions` / `win.signtoolOptions` → `win.sign`; `win.signExecutable` / `win.signAndEditExecutable` handled
 - [ ] ✓ `snap` restructured to `snapcraft` (verify the assumed `base` if none was set)
-- [ ] ✓ `helper-bundle-id` → `mac.helperBundleId` (if present)
-- [ ] ✓ `squirrelWindows.noMsi` → `msi` (if present)
-- [ ] ✓ Root-level `directories` → `build.directories` (package.json only)
+- [ ] ✓ `helper-bundle-id` → `mac.helperBundleId`; `squirrelWindows.noMsi` → `msi`; root-level `directories` → `build.directories`
 
-**Build config / scripts — manual steps required**
-- [ ] Migrated off `electron-compile` to a modern bundler (if you used `electronCompile`)
-- [ ] `--publish` flag added explicitly to release scripts (no more auto-publish)
-- [ ] `devMetadata` / `extraMetadata` in programmatic API → `config.extraMetadata` (if applicable)
-- [ ] `--em.build` / `--em.directories` CLI flags → `-c` / `-c.directories` (if applicable)
-- [ ] `<%= var %>` Linux script syntax → `${var}` (if applicable)
-- [ ] `linux.syncDesktopName` removed — delete the flag; set `desktopName` to control the installed `.desktop` filename (if applicable)
-- [ ] Custom NSIS scripts that reference the old file-association ProgID updated to the new generated value (only if you use `fileAssociations` with a custom NSIS script)
-- [ ] `CI_BUILD_TAG` → `CI_COMMIT_TAG` (if applicable)
-- [ ] Toolset env-var overrides → `toolsets.X: { url, checksum }` (if applicable)
-- [ ] Toolset version pins validated — defaults now resolve to `"latest"` (newest bundle): `winCodeSign: "1.3.0"`, `appimage: "1.1.0"`, `nsis: "1.2.1"`, `wine: "1.0.1"`; pin to `"0.0.0"` only if a legacy bundle is needed. Azure Trusted Signing `signtool /dlib` is now the default — pin `winCodeSign` below `1.3.0` only to force the legacy PowerShell path
+**Manual steps** — see [Step 3](#step-3-apply-the-manual-steps) above.
 
-**Plugin and custom-target authors**
-- [ ] Replace `packager.info.X` chains with direct `packager.X` getters (if applicable)
-- [ ] Replace `packager.platformSpecificBuildOptions` with `platformOptions` / `getOptionsForTarget` (if applicable)
+**Plugin and custom-target authors** — see the [programmatic API changes](./v27-breaking-changes#programmatic--plugin-author-api-changes).
 
 ---
 
-## Internal changes (non-user-facing)
+## Full breaking-changes reference
 
-These changes have no impact on your build configuration or the public API. They are listed here for transparency about what shipped in v27.
-
-- **Native ESM build pipeline.** Babel was removed entirely; packages are compiled by `tsc` to native ESM with `exports` maps and full type declarations.
-- **Code-quality modernization.** Production code paths adopt native Node.js APIs and modern TypeScript patterns: `sleep()` from `timers/promises` replaces hand-rolled `setTimeout` promise wrappers; native process signal handlers replace `async-exit-hook`; `Error.cause` preserves full stack traces in `ExecError`; `Reflect.get`/`Reflect.set` replace `as any` Proxy traps; the WHATWG `URL` API replaces legacy `url.format()`; SHA-256 replaces MD5 for WiX directory-ID generation; `console.*` calls were eliminated from production code paths.
-- **Dead-code removal.** `ProtonFramework`, `LibUiFramework`, and `binDownload.ts` were deleted; all binary downloads were consolidated into a single `downloadBuilderToolset` path.
-- **Flags consolidation.** All boolean `process.env` flags were consolidated into a single `flags.ts`, and `validateShellEmbeddable` moved to `builder-util/envUtil`.
-- **Source reorganization.** Platform-specific files were split into per-platform subdirectories (`targets/mac|win|linux/`, `vm/mac|win/`, `codeSign/mac|win/`, `electron/mac|win/`, `util/mac|win/`, `toolsets/win|linux/`). Import paths in `app-builder-lib` internals changed accordingly; the public API surface is unchanged.
-- **Toolset module split.** Toolset getters were split into single-purpose files alongside the new `ToolsetCustom` support.
-- **NSIS internals.** Arch package-file resolution and async resource loaders were extracted from `buildInstaller`/`configureDefines` for clarity (no behavioral change).
-- **Test suite.** Duplicated test files were replaced by runtime-generated tests (via `TestSuite`) that fan out across toolset version combinations.
-
----
-
-## Design notes
-
-Rationale behind the user-facing breaking changes, for those who want full transparency.
-
-### Why native ESM?
-
-`electron-builder` historically shipped CommonJS. The move to native ESM was driven by the ecosystem: major dependencies (`chalk`, `figures`, `ora`, etc.) have dropped CJS support, and Node.js 22.12's stabilized `require(esm)` makes it safe to ship ESM without breaking CJS consumers. The minimum was set to 22.12.0 specifically because earlier Node.js versions require `--experimental-require-module` to `require()` an ESM package.
-
-### Why move native-module options under `nativeModules`?
-
-In v26, options like `buildDependenciesFromSource`, `nodeGypRebuild`, `npmRebuild`, and `nativeRebuilder` were scattered at the root of `Configuration` alongside unrelated properties. They were grouped under `nativeModules` for the same reason `directories` and `toolsets` are sub-keys: related options should be co-located. The rename `nativeRebuilder → rebuildMode` makes the field name consistent with other enum-style selectors (`"sequential" | "parallel"` is a "mode").
-
-### Why unify all Windows signing under `win.sign`?
-
-In v26, Windows signing was split across two sibling root-level keys — `signtoolOptions` and `azureSignOptions` — with precedence rules that were easy to misconfigure (both present → Azure wins, silently). v27 replaces them with a single `win.sign` key typed as a discriminated union (`type: "signtool" | "hsm" | "pkcs11" | "azure"`). This makes the active signing mode explicit, makes the union self-documenting in IntelliSense, and mirrors the macOS `mac.sign` shape so both platforms have the same mental model. The `win.sign: false` sentinel explicitly disables signing, distinguishing it from "not configured" (env-based discovery) in a way that the old two-key setup could not cleanly express.
-
-### Why replace `[k: string]` in `WindowsAzureSigningConfiguration`?
-
-The v27 Azure integration switches from PowerShell `Invoke-TrustedSigning` to `signtool.exe /dlib /dmdf`, which reads a `metadata.json` file. An explicit `additionalMetadata: Record<string, string>` field is cleaner than an index signature because it makes intent visible in IntelliSense and prevents accidental shadowing of the typed fields. The legacy PowerShell path remains available (triggered when `toolsets.winCodeSign` is pinned *below* `"1.3.0"`, e.g. `"1.2.1"` or `"0.0.0"`; the default — unset / `null` / `"latest"` → newest bundle ≥ 1.3.0 — uses the `signtool /dlib` path) for projects that cannot yet upgrade to the `signtool /dlib` path.
-
-### Why restructure `snap` into `snapcraft`?
-
-The `snapcraft` shape makes the `base` explicit and nests per-base options under a base-named sub-key, so a single config can describe multiple bases unambiguously and core24 (which uses the snapcraft CLI directly) can coexist with legacy bases. `migrate-schema` automates the move but assumes `core20` when no base is present, because that is the v27 1-to-1 migration target — verify the assumption for your project.
-
-### Why consolidate macOS signing under `mac.sign`?
-
-In v26, ~15 signing options were scattered across the root of `MacConfiguration` (`identity`, `entitlements`, `hardenedRuntime`, `type`, `requirements`, `timestamp`, `signIgnore`, …) intermixed with unrelated packaging options. Grouping them under a single `sign` object makes the signing surface self-documenting and matches the Windows `win.sign` grouping, so both platforms read the same way. `sign` is now a typed pass-through (`ElectronSignOptions`) to `@electron/osx-sign`, so upstream options are forwarded directly and new osx-sign fields are picked up automatically instead of needing a bespoke mapping. `signIgnore` was renamed to `sign.ignore` to match the osx-sign canonical name. The same grouping rationale produced `mac.universal` (a pass-through to `@electron/universal`), which also keeps universal-only options out of the way for the common single-arch build.
-
-### Why rename `electronDownload` to `electronGet`?
-
-v27 upgrades to `@electron/get` v5, which downloads via `fetch` (replacing the `got`-based path) and exposes a `mirrorOptions` object rather than the old flat `mirror`/`customDir` fields. Renaming the config key to `electronGet` and typing it directly as the library's own options removes electron-builder's hand-maintained translation layer — what you set is what `@electron/get` receives. A few legacy fields (`cache`, `customDir`, `customFilename`, `strictSSL`) have no v5 equivalent; `migrate-schema` drops them with a warning.
-
-### migrate-schema serialization caveats
-
-- **JSON5 → JSON**: JSON5 supports comments and trailing commas. When `migrate-schema` rewrites a `.json5` file it produces valid JSON (no comments, standard quoting) and prints a warning. If preserving comments matters, apply the changes manually.
-- **TOML**: The `toml` npm package is read-only (parse only). `migrate-schema` detects TOML configs, prints the required changes, and exits without writing.
-- **YAML**: `js-yaml` preserves key order when round-tripping but does not preserve comments.
-- **Programmatic configs** (`.js`, `.ts`, `.cjs`, `.mjs`): Cannot be safely transformed — the command prints manual steps instead.
-
-### Why consolidate ASAR options under `asar`?
-
-In v26, `asarUnpack` lived alongside `asar` on `PlatformSpecificBuildOptions`, and `disableSanityCheckAsar` / `disableAsarIntegrity` lived at the root of `Configuration`. This was confusing: `asarUnpack` is meaningless when `asar: false`, yet nothing in the type system expressed that relationship. Moving all options under a single `asar` key makes the dependency explicit — if `asar` is absent or `false`, none of the sub-options apply. It also brings per-platform asar control in line with other per-platform sub-objects (`nativeModules`, `toolsets`, `directories`).
-
-The `asar: true` sentinel was removed because having both `true` (enable with defaults) and `{}` (same meaning, but object) was redundant. Absent `asar` key means enabled; `asar: false` means disabled. `migrate-schema` removes bare `asar: true` automatically.
-
-### `PlatformPackager.info` deprecation strategy
-
-The public `info: Packager` field created a hard coupling: any internal `Packager` refactor became a breaking change for all plugins. In v27, direct pass-through getters and methods were added for the properties plugin authors actually need, and `info` was marked `@deprecated` (a soft deprecation — it still works in v27 but emits a `TS6385` hint). It will become `protected` in a future major release.
+Every change above is documented in detail — with rationale (design notes) and before/after for each — on the **[v27 Breaking Changes](./v27-breaking-changes)** page.

--- a/website/docs/migration/v27-breaking-changes.md
+++ b/website/docs/migration/v27-breaking-changes.md
@@ -1,0 +1,684 @@
+---
+title: "v27 Breaking Changes"
+---
+
+# v27 Breaking Changes
+
+:::danger[Read this before upgrading to v27]
+v27 moves the entire electron-builder ecosystem to **native ES modules**, raises the minimum runtime to **Node.js 22.12.0**, and **hard-deletes the deprecated APIs** that accumulated since v22. Every breaking change in the release is catalogued on this page.
+
+**Most projects need only a Node.js bump plus one command.** Run the automated migrator and follow the step-by-step **[migration walkthrough →](./v26-to-v27)**.
+:::
+
+This page is the **canonical reference for _what_ changed** in v27. For the **_how_ — the ordered upgrade steps, the automated migrator, and the checklist** — see the [v26 → v27 migration walkthrough](./v26-to-v27).
+
+- The `build()` API, all runtime configuration options, and all exported types that survive are **unchanged**.
+- CJS `require()` continues to work without code changes on supported Node.js versions.
+- Every **config-level** breaking change below is rewritten automatically by `electron-builder migrate-schema` (look for the **Auto** ✓ marker). Runtime, CLI, env-var, and behavior changes require manual action.
+
+:::tip[Run the automated migrator first]
+```bash
+electron-builder migrate-schema            # apply changes in place
+electron-builder migrate-schema --dry-run  # preview only
+```
+This handles every change marked **Auto ✓** below. See the [walkthrough](./v26-to-v27#step-1-run-the-automated-migrator) for flags and serialization caveats.
+:::
+
+:::info[Toolsets now default to the newest bundle (`"latest"`)]
+In v27 every `toolsets.*` property defaults to **`"latest"`** — an **unset** property, `null`, and the literal `"latest"` all resolve to the **newest published bundle** for that toolset (previously each property defaulted to a fixed pinned version). No config change is required, but the effective defaults moved:
+
+- **`wine` → `1.0.1`** — Wine 11.0 (was Wine 4.0.1); macOS arm64 via Rosetta. Linux still uses host-installed `wine`.
+- **`winCodeSign` → `1.3.0`** — Windows Kits 10.0.26100.0, `osslsigncode` 2.11 (native arm64), and the Azure Trusted Signing `dlib` + .NET 8 payload.
+- **`appimage` → `1.1.0`** — static FUSE3-compatible runtime; adds `unsquashfs` support.
+- `nsis` (`1.2.1`), `fpm` (`2.2.1`), `icons` (`1.2.1`), `linuxToolsMac` (`1.0.0`), and `sevenZip` (`1.0.0`) are unchanged.
+
+To stay on a legacy bundle, pin the toolset to `"0.0.0"`. Because `winCodeSign` now defaults to `1.3.0`, **Azure Trusted Signing uses the faster `signtool /dlib` path out of the box**. Full breakdown in [Toolsets & environment variables](#toolsets--environment-variables).
+:::
+
+---
+
+## Breaking changes at a glance
+
+| Change | Auto | Action required |
+|--------|:---:|----------------|
+| [Node.js >=22.12.0 required](#nodejs-22120-required) | — | Update your runtime and CI Node version |
+| [All packages are native ESM](#native-esm-output) | — | None — `require()` still works on Node >=22.12 |
+| [`electron-forge-maker-*` are now ESM](#electron-forge-maker--plugins) | — | None — same API, same export shape |
+| [`electronCompile` removed](#electroncompile) | ✓ | Remove from config; migrate off `electron-compile` |
+| [`framework` / `nodeVersion` / `launchUiVersion` removed](#framework--nodeversion--launchuiversion) | ✓ | Removed automatically (Electron is the only framework) |
+| [ProtonFramework & LibUiFramework removed](#removed-exports) | — | Migrate to an Electron-based build setup |
+| [`appImage.systemIntegration` removed](#appimagesystemintegration) | ✓ | Removed automatically |
+| [`npmSkipBuildFromSource` removed](#npmskipbuildfromsource) | ✓ | Replaced by `nativeModules.buildDependenciesFromSource` |
+| [Native-module options grouped under `nativeModules`](#native-module-options--nativemodules) | ✓ | `nativeRebuilder` → `rebuildMode` |
+| [ASAR options consolidated under `asar`](#asar-options--asar) | ✓ | `asarUnpack` → `asar.unpack`, etc.; `asar: true` removed |
+| [macOS signing consolidated under `mac.sign`](#macos-signing--macsign) | ✓ | `identity`/`entitlements`/`hardenedRuntime`/… → `mac.sign.*`; `signIgnore` → `sign.ignore` |
+| [`mac.universal` options consolidated](#macuniversal) | ✓ | `mergeASARs`/`singleArchFiles`/`x64ArchFiles` → `mac.universal.*` |
+| [Windows signing unified under `win.sign`](#windows-signing--winsign) | ✓ | Discriminated union `type: "signtool" \| "hsm" \| "pkcs11" \| "azure"` |
+| [`win.signExecutable` / `win.signAndEditExecutable` removed](#winsignexecutable--winsignandeditexecutable-removed) | ✓ | `false` → `win.sign: false`; resource editing always runs |
+| [`electronDownload` → `electronGet`](#electrondownload--electronget) | ✓ | Reshaped to `@electron/get` options; some legacy fields dropped (warned) |
+| [`snap` config key removed](#snap--snapcraft) | ✓ | Restructured to `snapcraft` with an explicit `base` |
+| [Root-level `directories` removed](#root-level-directories-in-packagejson) | ✓ | Move under `build.directories` |
+| [`build.helper-bundle-id` removed](#buildhelper-bundle-id) | ✓ | Moved to `mac.helperBundleId` |
+| [`squirrelWindows.noMsi` removed](#squirrelwindowsnomsi) | ✓ | Replaced by `msi` (inverted) |
+| [`GithubOptions.vPrefixedTagName` removed](#githuboptions--gitlaboptions-vprefixedtagname) | ✓ | Use `tagNamePrefix` |
+| [`GitlabOptions.vPrefixedTagName` still works, but `migrate-schema` strips it](#githuboptions--gitlaboptions-vprefixedtagname) | ⚠️ | Re-add it after migrating if you rely on unprefixed GitLab tags |
+| [`devMetadata` / `extraMetadata` in `PackagerOptions` removed](#devmetadata--extrametadata-programmatic-packageroptions) | — | Use `config` / `config.extraMetadata` |
+| [Implicit `--publish` removed](#implicit---publish-removed) | — | Pass `--publish` explicitly |
+| [`--em.build` / `--em.directories` CLI flags removed](#removed-flags---embuild---emdirectories) | — | Use `-c` / `-c.directories` |
+| [`linux.syncDesktopName` removed](#linuxsyncdesktopname-always-synced) | — | Behaviour is always on; set `desktopName` to control the filename |
+| [Linux maintainer-script EJS syntax removed](#linux-maintainer-script-ejs-template-syntax) | — | Use `${var}` instead of `<%= var %>` |
+| [NSIS file-association ProgID format changed](#nsis-file-association-progid-format-changed) | — | Update custom NSIS scripts that hard-code the old ProgID |
+| [Toolset defaults resolve to `"latest"`](#toolset-defaults-resolve-to-latest-newest-bundle) | — | No action; pin to `"0.0.0"` to restore a legacy bundle |
+| [Toolset env-var overrides removed](#toolset-env-var-overrides-removed) | — | Replace `APPIMAGE_TOOLS_PATH`, `ELECTRON_BUILDER_NSIS_DIR`, `USE_SYSTEM_WINE`, … with `toolsets.X: { url, checksum }` |
+| [`CI_BUILD_TAG` env var removed](#ci_build_tag-environment-variable) | — | Use `CI_COMMIT_TAG` |
+| [Azure Trusted Signing `/dlib` is the default](#azure-trusted-signing-signtool-dlib-is-the-default) | — | Pin `winCodeSign` below `1.3.0` only to force the legacy PowerShell path |
+| [`PlatformPackager.info` & `platformSpecificBuildOptions` now `protected`](#programmatic--plugin-author-api-changes) | — | Plugin authors: hard break — `.info` no longer compiles externally; use the new pass-through getters |
+| [Linux `.desktop` `Exec` now runs a generated `*-launcher` script](#linux-launcher-entrypoint) | — | Update custom `.desktop`/AppArmor/MIME tooling that hard-codes the `Exec` command |
+| [`node_modules` arch/os-filtered on every build](#node_modules-are-now-archos-filtered-on-every-build) | — | Awareness — packages whose `cpu`/`os` mismatch the target are now excluded |
+| [Renamed type exports (`ElectronDownloadOptions`, `WindowsAzureSigningConfiguration`, …)](#removed-exports) | — | Import the new names — no compat aliases |
+| [`SnapOptions`, `ProtonFramework`, `LibUiFramework` exports removed](#removed-exports) | — | Use the `snapcraft` config shape / Electron framework |
+
+---
+
+## Runtime & ESM
+
+### Node.js >=22.12.0 required
+
+v27 requires **Node.js 22.12.0 or later**. This is the version where Node's [`require(esm)`](https://nodejs.org/en/blog/release/v22.12.0) support was stabilized (no flags needed), which allows both CJS and ESM consumers to use these packages without any code changes.
+
+```json
+{
+  "engines": {
+    "node": ">=22.12.0"
+  }
+}
+```
+
+See the walkthrough for [updating your runtime, CI, and Docker images](./v26-to-v27#step-2-update-nodejs).
+
+### Native ESM output
+
+electron-builder packages now ship as native ES modules. On **Node >=22.12.0** both styles continue to work:
+
+```js
+// CJS require() — still works
+const { build, Platform } = require("electron-builder")
+
+// ESM import — now the preferred style
+import { build, Platform } from "electron-builder"
+```
+
+If your project uses `"type": "module"` or ESM imports, no changes are needed. If it uses CJS on Node >=22.12, `require()` continues to work as before. The `build()` function signature, all configuration options, and all exported types are otherwise unchanged.
+
+**`moduleResolution`** — v27 packages include `exports` maps and full TypeScript declarations. `"node"` (legacy), `"node16"`/`"nodenext"`, and `"bundler"` (recommended) all work.
+
+### `electron-forge-maker-*` plugins
+
+The four Forge maker plugins (`electron-forge-maker-appimage`, `electron-forge-maker-nsis`, `electron-forge-maker-nsis-web`, `electron-forge-maker-snap`) are now native ES modules. The public API is identical — Electron Forge loads them via dynamic `import()` internally, so no config changes are required.
+
+---
+
+## Removed configuration options
+
+### `electronCompile`
+
+The `electronCompile` configuration option has been **removed**. `electron-compile` is an unmaintained library with no releases since 2019.
+
+```json5
+{ "build": { "electronCompile": true } }  // ← delete this line
+```
+
+If your project relies on `electron-compile` for source compilation, migrate to a modern build tool before upgrading:
+
+- **[electron-vite](https://electron-vite.org/)** — recommended; fast, first-class ESM and Electron integration
+- **[esbuild](https://esbuild.github.io/)** — extremely fast, minimal configuration
+- **[webpack](https://webpack.electron.build/)** — mature, widely used
+
+### `framework` / `nodeVersion` / `launchUiVersion`
+
+These three fields are removed. Only Electron is supported as a target framework — `proton`/`proton-native` and `libui` support has been removed (see [Removed exports](#removed-exports)).
+
+```json5
+{
+  "build": {
+    "framework": "electron",    // ← delete; "electron" was and remains the default
+    "nodeVersion": "current",   // ← delete; no effect
+    "launchUiVersion": "0.1.0"  // ← delete; no effect
+  }
+}
+```
+
+### `appImage.systemIntegration`
+
+Removed. Desktop integration is handled automatically by [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher).
+
+### `npmSkipBuildFromSource`
+
+Removed. Use `buildDependenciesFromSource` (now under [`nativeModules`](#native-module-options--nativemodules)). It is the logical inverse:
+
+```json5
+// v26
+{ "npmSkipBuildFromSource": true }
+// v27 equivalent
+{ "nativeModules": { "buildDependenciesFromSource": false } }
+```
+
+### `asar: true` sentinel
+
+**`asar: true` is no longer valid.** Omit the `asar` key entirely to enable ASAR with defaults, or specify an object. The full ASAR restructuring is documented under [ASAR options → `asar`](#asar-options--asar).
+
+```json5
+{ "build": { "asar": true } }  // Before — enable with defaults
+{ "build": { "asar": {} } }    // After — omit entirely (enabled by default) or use an object
+```
+
+### Root-level `directories` in `package.json`
+
+Specifying `directories` at the root of `package.json` is removed. Move it under the `build` key.
+
+```json
+{ "name": "my-app", "directories": { "output": "dist" } }              // Before
+{ "name": "my-app", "build": { "directories": { "output": "dist" } } } // After
+```
+
+### `build.helper-bundle-id`
+
+The hyphenated root-level `helper-bundle-id` is removed. Use `mac.helperBundleId`.
+
+```json5
+{ "build": { "helper-bundle-id": "com.example.helper" } }            // Before
+{ "build": { "mac": { "helperBundleId": "com.example.helper" } } }   // After
+```
+
+### `squirrelWindows.noMsi`
+
+The `noMsi` boolean is removed in favor of its inverse, `msi`.
+
+```json5
+{ "build": { "squirrelWindows": { "noMsi": true } } }   // Before
+{ "build": { "squirrelWindows": { "msi": false } } }    // After
+```
+
+### `GithubOptions` / `GitlabOptions` `vPrefixedTagName`
+
+The `vPrefixedTagName` boolean on `GithubOptions` is removed. Use `tagNamePrefix` to control the tag prefix.
+
+```json5
+{ "publish": { "provider": "github", "vPrefixedTagName": false } }   // Before
+{ "publish": { "provider": "github", "tagNamePrefix": "" } }         // After (empty string = no prefix)
+```
+
+To keep the default `v` prefix, simply remove `vPrefixedTagName` — `tagNamePrefix` defaults to `"v"`.
+
+:::warning[`GitlabOptions.vPrefixedTagName` — read before running the migrator]
+Only the **GitHub** field was actually removed. On **GitLab**, `vPrefixedTagName` still exists in the type, the schema, and the runtime, and continues to control the tag prefix (`vPrefixedTagName: false` → `1.2.3`; omit it → `v1.2.3`).
+
+However, `electron-builder migrate-schema` **deletes `vPrefixedTagName` from GitLab publish entries** — with no `tagNamePrefix` replacement, because GitLab has no such field. If you had `vPrefixedTagName: false`, running the migrator silently switches your GitLab tags from `1.2.3` to `v1.2.3`. **If you rely on unprefixed GitLab tags, re-add `vPrefixedTagName: false` after running `migrate-schema`** (or leave that publish entry untouched).
+:::
+
+### `linux.syncDesktopName` (always synced)
+
+The `linux.syncDesktopName` flag is removed. The behaviour it gated is now **always on**: the installed `.desktop` filename is always derived from the `desktopName` field in `package.json` — installed as `${desktopName}.desktop`, with any trailing `.desktop` in the value stripped first — falling back to `executableName` only when `desktopName` is absent.
+
+```json5
+// Before (v26) — opt-in
+{ "build": { "linux": { "syncDesktopName": true } } }  // ← delete this line
+```
+
+No replacement is needed — simply remove the flag. To control the installed filename, set (or omit) `desktopName` in your root `package.json`.
+
+**Why this changed:** Electron derives its `app_id` / `WM_CLASS` from `desktopName`, and desktop environments match a running window to its launcher entry by comparing `WM_CLASS` against the installed `.desktop` filename. When the two diverged — which is exactly what happened with `syncDesktopName: false` (the v26 default) whenever a `desktopName` was set — GNOME, KDE, and others failed to associate the window with its launcher, breaking taskbar grouping, dock icons, and launcher highlighting (see [#9103](https://github.com/electron-userland/electron-builder/issues/9103)). Removing the flag eliminates a footgun rather than removing functionality. Path-traversal/NUL validation on the resulting filename is unchanged.
+
+### Linux maintainer-script EJS template syntax
+
+The legacy `<%= varName %>` EJS interpolation in Linux maintainer scripts (e.g. FPM `after-install`/`after-remove`) is removed. Use shell-style `${varName}` instead.
+
+### `devMetadata` / `extraMetadata` (programmatic `PackagerOptions`)
+
+These fields in the programmatic `PackagerOptions` API are removed (they have thrown `InvalidConfigurationError` since v22).
+
+```ts
+// Before
+await build({ targets: Platform.MAC.createTarget(), devMetadata: { … }, extraMetadata: { … } })
+// After
+await build({ targets: Platform.MAC.createTarget(), config: { extraMetadata: { … } } })
+```
+
+---
+
+## Restructured configuration
+
+### Native-module options → `nativeModules`
+
+Four root-level configuration properties are moved into a new `nativeModules` sub-key, and `nativeRebuilder` is renamed to `rebuildMode`.
+
+```json5
+// Before (v26)
+{ "build": { "buildDependenciesFromSource": true, "nodeGypRebuild": false, "npmRebuild": true, "nativeRebuilder": "parallel" } }
+
+// After (v27)
+{ "build": { "nativeModules": { "buildDependenciesFromSource": true, "nodeGypRebuild": false, "npmRebuild": true, "rebuildMode": "parallel" } } }
+```
+
+`npmArgs` is **not** affected — it controls the package-manager install phase and remains at the root level. `npmSkipBuildFromSource` (deprecated in v26) is removed; `migrate-schema` converts it to its inverse, `nativeModules.buildDependenciesFromSource`.
+
+### ASAR options → `asar`
+
+All ASAR-related configuration is now nested under a single `asar` key. Flat root-level properties are removed. The `asar` type is now `AsarOptions | false | null`.
+
+| Removed key | Replacement |
+|---|---|
+| `asar-unpack` | `asar.unpack` |
+| `asar-unpack-dir` | `asar.unpack` |
+| `asar.unpackDir` | `asar.unpack` |
+| `asarUnpack` | `asar.unpack` |
+| `disableSanityCheckAsar` | `asar.disableSanityCheck` |
+| `disableAsarIntegrity` | `asar.disableIntegrity` |
+| `asar: true` | *(removed — absence means enabled)* |
+
+```json5
+// Before
+{ "build": { "asarUnpack": ["**/*.node"], "disableSanityCheckAsar": true, "disableAsarIntegrity": true } }
+
+// After
+{
+  "build": {
+    "asar": {
+      "unpack": ["**/*.node"],
+      "disableSanityCheck": true,
+      "disableIntegrity": true
+    }
+  }
+}
+```
+
+When `asar: false`, all the sub-options are irrelevant and the migrator skips them.
+
+### macOS signing → `mac.sign`
+
+All macOS code-signing options now live inside a single `sign` object on `mac` (and `mas` / `masDev`), mirroring the Windows `win.sign` grouping. `mac.sign` is typed as `CustomMacSign | ElectronSignOptions | string | null`, where `ElectronSignOptions` is a typed pass-through to [`@electron/osx-sign`](https://github.com/electron/osx-sign).
+
+| Removed (`mac.*`) | Replacement (`mac.sign.*`) |
+|---|---|
+| `identity` | `sign.identity` |
+| `entitlements` | `sign.entitlements` |
+| `entitlementsInherit` | `sign.entitlementsInherit` |
+| `entitlementsLoginHelper` | `sign.entitlementsLoginHelper` |
+| `provisioningProfile` | `sign.provisioningProfile` |
+| `type` | `sign.type` |
+| `binaries` | `sign.binaries` |
+| `requirements` | `sign.requirements` |
+| `hardenedRuntime` | `sign.hardenedRuntime` |
+| `gatekeeperAssess` | `sign.gatekeeperAssess` |
+| `strictVerify` | `sign.strictVerify` |
+| `preAutoEntitlements` | `sign.preAutoEntitlements` |
+| `timestamp` | `sign.timestamp` |
+| `additionalArguments` | `sign.additionalArguments` |
+| `signIgnore` | `sign.ignore` *(renamed to the `@electron/osx-sign` canonical name)* |
+
+```json5
+// Before
+{ "mac": { "identity": "Developer ID Application: My Company (TEAMID)", "hardenedRuntime": true, "signIgnore": ["**/*.txt"] } }
+
+// After
+{ "mac": { "sign": { "identity": "Developer ID Application: My Company (TEAMID)", "hardenedRuntime": true, "ignore": ["**/*.txt"] } } }
+```
+
+To skip signing, use `mac.sign.identity: null` (or `mac.sign: null`). The same structure applies to `mas` and `masDev`.
+
+:::warning[Custom signing functions]
+If you used `mac.sign` as a **custom signing function or module path** (`sign: "./customSign.js"`) together with sibling fields like `identity`, the two can no longer coexist — `sign` is now a single union. `migrate-schema` leaves your custom signer untouched and prints a warning so you can decide whether to keep the custom function or switch to an `ElectronSignOptions` object.
+:::
+
+### `mac.universal`
+
+The universal-build options move from `mac` root into a `universal` object (typed as `ElectronUniversalOptions`, a pass-through to [`@electron/universal`](https://github.com/electron/universal)). They have no effect unless the target arch is `universal`.
+
+| Removed (`mac.*`) | Replacement (`mac.universal.*`) |
+|---|---|
+| `mergeASARs` | `universal.mergeASARs` |
+| `singleArchFiles` | `universal.singleArchFiles` |
+| `x64ArchFiles` | `universal.x64ArchFiles` |
+
+```json5
+{ "mac": { "mergeASARs": true, "singleArchFiles": "*.node" } }                       // Before
+{ "mac": { "universal": { "mergeASARs": true, "singleArchFiles": "*.node" } } }      // After
+```
+
+### Windows signing → `win.sign`
+
+In v26, Windows signing used two separate root-level keys (`signtoolOptions` and `azureSignOptions`). In v27, all Windows signing modes are expressed through a single `win.sign` key typed as a discriminated union:
+
+```typescript
+win.sign: { type: "signtool" | "hsm" | "pkcs11" | "azure", … } | false | null
+```
+
+`false` / `null` disables signing entirely. Unset means electron-builder discovers credentials from the environment (e.g. `WIN_CSC_LINK`).
+
+**`win.signtoolOptions` → `win.sign: { type: "signtool", … }`** — all fields move verbatim; add `type: "signtool"`.
+
+```json5
+{ "win": { "signtoolOptions": { "certificateFile": "cert.pfx", "publisherName": "CN=ACME Inc" } } }              // Before
+{ "win": { "sign": { "type": "signtool", "certificateFile": "cert.pfx", "publisherName": "CN=ACME Inc" } } }     // After
+```
+
+**`win.azureSignOptions` → `win.sign: { type: "azure", … }`** — fields move into `win.sign` with `type: "azure"`. The old index signature (`[k: string]: string`) that allowed arbitrary extra keys is replaced by an explicit `additionalMetadata` object. `migrate-schema` both restructures the key and moves any unrecognized extra keys into `additionalMetadata`.
+
+```json5
+// Before
+{ "win": { "azureSignOptions": { "endpoint": "https://weu.codesigning.azure.net/", "certificateProfileName": "my-profile", "ExcludeCredentials": "ManagedIdentityCredential" } } }
+
+// After
+{ "win": { "sign": { "type": "azure", "endpoint": "https://weu.codesigning.azure.net/", "certificateProfileName": "my-profile", "additionalMetadata": { "ExcludeCredentials": "ManagedIdentityCredential" } } } }
+```
+
+#### New signing modes (beta): `hsm` and `pkcs11`
+
+v27 introduces two new signing modes in `win.sign`:
+
+- **`type: "hsm"`** — Hardware Security Module via signtool `/csp /kc` (Windows-only; requires `toolsets.winCodeSign: "1.x"`).
+- **`type: "pkcs11"`** — PKCS#11 token via osslsigncode (cross-platform; runs on macOS/Linux CI without a Windows VM).
+
+```json5
+{
+  "win": {
+    "sign": {
+      "type": "pkcs11",
+      "pkcs11Module": "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so",
+      "pkcs11KeyUri": "pkcs11:token=MyToken;object=MyKey;type=private",
+      "certificateFile": "cert.pem"
+    }
+  },
+  "toolsets": { "winCodeSign": "1.3.0" }
+}
+```
+
+Both HSM and PKCS#11 are **beta** — the interfaces are stable but real-hardware test coverage is limited.
+
+#### `win.signExecutable` / `win.signAndEditExecutable` removed
+
+| Removed | Replacement |
+|---------|-------------|
+| `win.signExecutable: false` | `win.sign: false` (disables signing; resource editing still runs) |
+| `win.signExecutable: true` | *(deleted — signing is enabled by default when credentials are available)* |
+| `win.signAndEditExecutable: true` | *(deleted — resource editing always runs)* |
+| `win.signAndEditExecutable: false` | No direct equivalent — see note below |
+
+:::warning
+`win.signAndEditExecutable: false` formerly skipped both resource editing (icon, metadata) and signing. In v27 resource editing always runs. To skip only signing, use `win.sign: false`. If you need to skip resource editing for a specific artifact, apply resources manually after building.
+:::
+
+### `electronDownload` → `electronGet`
+
+The `electronDownload` configuration key is renamed to `electronGet` and reshaped to match [`@electron/get`](https://github.com/electron/get)'s options directly (v27 upgrades to `@electron/get` v5, which downloads via `fetch`).
+
+| Old `electronDownload.*` | New `electronGet.*` |
+|---|---|
+| `mirror` | `mirrorOptions.mirror` |
+| `isVerifyChecksum: false` | `unsafelyDisableChecksums: true` |
+| `cache`, `customDir`, `customFilename`, `strictSSL` | *(no equivalent — dropped by `migrate-schema` with a warning)* |
+
+```json5
+{ "electronDownload": { "mirror": "https://my-mirror/" } }                  // Before
+{ "electronGet": { "mirrorOptions": { "mirror": "https://my-mirror/" } } }  // After
+```
+
+### `snap` → `snapcraft`
+
+The top-level `snap` configuration key is removed. Use `snapcraft` with an explicit `base` field and per-base options nested under a sub-key named after the base.
+
+```json5
+// Before
+{ "build": { "snap": { "confinement": "strict", "stagePackages": ["libfoo"], "base": "core22" } } }
+
+// After
+{ "build": { "snapcraft": { "base": "core22", "core22": { "confinement": "strict", "stagePackages": ["libfoo"] } } } }
+```
+
+Supported `base` values: `"core18"`, `"core20"`, `"core22"`, `"core24"`, and `"custom"`. `migrate-schema` performs this restructuring; when the old config has no `base`, it assumes `"core20"` and warns so you can confirm. A `base: "custom"` config (inline/path `snapcraft.yaml`) is moved verbatim. The `SnapOptions` export is also removed — see [Removed exports](#removed-exports).
+
+---
+
+## CLI changes
+
+### Implicit `--publish` removed
+
+v27 no longer auto-publishes based on the presence of CI tag environment variables, git tags, or npm lifecycle events. Pass `--publish <always|onTag|onTagOrDraft|never>` explicitly in your release scripts, or set the `publish` option in your configuration.
+
+> **Why:** unexpected auto-publishing could accidentally expose secrets or publish unfinished work. Making publishing explicit closes that hole.
+
+### Removed flags: `--em.build`, `--em.directories`
+
+These flags are removed (they have thrown since v22).
+
+| Removed flag | Replacement |
+|---|---|
+| `--em.build` | `-c` (pass build config inline) |
+| `--em.directories` | `-c.directories` |
+
+### New command: `migrate-schema`
+
+v27 adds `electron-builder migrate-schema`, which rewrites your config to v27 form in place and auto-migrates **static** (`json`/`json5`/`yaml`/package.json) **and programmatic** (`.js`/`.ts`/`.cjs`/`.mjs`) configs. See the [walkthrough](./v26-to-v27#step-1-run-the-automated-migrator).
+
+---
+
+## Toolsets & environment variables
+
+### Toolset defaults resolve to `"latest"` (newest bundle)
+
+In v27 every `toolsets.*` property defaults to **`"latest"`** — an unset property, `null`, or the literal `"latest"` all resolve to the **newest published bundle** for that toolset. (Earlier v27 prereleases pinned a fixed default per toolset; those fixed defaults are gone.) The `null` value is no longer part of the `ToolsetConfig` type — it still works at runtime, but TypeScript/programmatic configs typed against `Configuration` should switch `null` → `"latest"` or omit the key. `migrate-schema` does not rewrite this.
+
+| Toolset | v26 default | v27 `"latest"` resolves to | What the upgrade entails |
+|---------|-------------|----------------------------|--------------------------|
+| `wine` | `0.0.0` (Wine 4.0.1, macOS only) | `1.0.1` | Wine 11.0; macOS arm64 via Rosetta. Linux uses host-installed `wine` (no bundle shipped) |
+| `winCodeSign` | `0.0.0` (winCodeSign 2.6.0) | `1.3.0` | Windows Kits 10.0.26100.0; `osslsigncode` 2.11 + native arm64; bundles the Azure Trusted Signing `dlib` + .NET 8 runtime |
+| `appimage` | `0.0.0` (FUSE2 runtime) | `1.1.0` | Static FUSE3-compatible runtime (runs without a host FUSE install); adds `unsquashfs` support |
+| `nsis` | `0.0.0` (NSIS 3.0.4.1, split bundle) | `1.2.1` | NSIS 3.12; unified single-archive bundle; entrypoint scripts auto-set `NSISDIR` |
+| `fpm` | `2.2.1` | `2.2.1` | Unchanged — FPM 1.17.0 / Ruby 3.4.3 |
+| `icons` | `1.2.1` | `1.2.1` | Unchanged — `wasm-vips` + `@resvg/resvg-wasm` |
+| `linuxToolsMac` | `1.0.0` | `1.0.0` | Unchanged — gnu-tar, lzip, binutils, etc. (macOS → Linux archives) |
+| `sevenZip` | `1.0.0` | `1.0.0` | Unchanged — only published version |
+
+**No action required** for most projects — the new bundles are drop-in replacements and produce identical output. If you hit a regression introduced by a newer bundle, pin back by setting the toolset version to `"0.0.0"`:
+
+```json5
+{ "build": { "toolsets": { "winCodeSign": "0.0.0", "nsis": "0.0.0", "appimage": "0.0.0", "wine": "0.0.0" } } }
+```
+
+This escape hatch is intended as a short-term workaround. The `"0.0.0"` alias may be removed in a future major release.
+
+### Toolset env-var overrides removed
+
+**This is a breaking change if you used env-var toolset overrides.** The following environment variables are **removed** — replace each with a [`ToolsetCustom`](#toolset-env-var-overrides-removed) object on the relevant `toolsets` key:
+
+| Removed env var | Toolset it controlled |
+|---|---|
+| `APPIMAGE_TOOLS_PATH` | AppImage build tools (`mksquashfs`, runtime) |
+| `LINUX_TOOLS_MAC_PATH` | Linux-tools-mac bundle (`ar`, `lzip`, `gtar`) |
+| `CUSTOM_FPM_PATH` | FPM executable |
+| `ELECTRON_BUILDER_NSIS_DIR` | NSIS compiler bundle directory |
+| `ELECTRON_BUILDER_NSIS_RESOURCES_DIR` | NSIS resources/plugins directory |
+| `CUSTOM_NSIS_RESOURCES` | Alternate NSIS resources bundle |
+| `ELECTRON_BUILDER_WINE_TOOLSET_DIR` | Wine bundle directory |
+| `USE_SYSTEM_WINE` | Forced the host-installed Wine instead of the downloaded bundle |
+| `USE_SYSTEM_SIGNCODE` | Forced the host `signtool`/`signcode` instead of the bundled `winCodeSign` toolset |
+| `USE_SYSTEM_OSSLSIGNCODE` | Forced the host `osslsigncode` instead of the bundled one |
+
+The three `USE_SYSTEM_*` variables above have **no env-var replacement** — configure signing through [`win.sign`](#windows-signing--winsign) and the `winCodeSign` toolset instead. (`USE_SYSTEM_FPM` is unchanged and still works.)
+
+The `url` accepts an `https://` URL (downloaded and cached automatically) or a `file://` path (used as-is). The bundle must mirror the directory layout of the corresponding built-in bundle (see [electron-builder-binaries/packages](https://github.com/electron-userland/electron-builder-binaries/tree/master/packages)).
+
+```json5
+// Remote bundle (URL)
+{ "build": { "toolsets": { "nsis": { "url": "https://example.com/my-nsis-bundle-1.0.tar.gz", "checksum": "sha256:abc123…", "version": "my-custom-1.0" } } } }
+
+// Local directory (no checksum required)
+{ "build": { "toolsets": { "appimage": { "url": "file:///path/to/my-appimage-tools-dir" } } } }
+```
+
+> **Wine note:** with `USE_SYSTEM_WINE` gone, Linux uses the host-installed `wine` by default (no bundle is shipped for Linux), and macOS uses the downloaded Wine 11.0 bundle. To point at a custom Wine build, supply a `ToolsetCustom` object on `toolsets.wine`.
+
+Supported archive formats: `.zip`, `.7z`, `.tar.gz`, `.tar.xz`. **Exception for `sevenZip`**: because 7-Zip is used to extract `.7z` and `.tar.xz` archives, a custom `sevenZip` bundle can only be supplied as a `.tar.gz`, `.zip`, or bare `file://` directory.
+
+### `CI_BUILD_TAG` environment variable
+
+Removed. Use `CI_COMMIT_TAG` (the standard GitLab CI variable) to provide the release tag.
+
+### Azure Trusted Signing `signtool /dlib` is the default
+
+Azure Trusted Signing (`win.sign: { type: "azure" }`) uses the faster `signtool /dlib` path automatically: the default `winCodeSign` (`"latest"` → `1.3.0`) ships the ATS `dlib` + .NET 8 payload, so no pin is required. To **force the legacy** PowerShell `Invoke-TrustedSigning` path instead (which requires the `TrustedSigning` PS module in the signing environment), pin `winCodeSign` below `1.3.0`:
+
+```json5
+{ "build": { "toolsets": { "winCodeSign": "1.2.1" } } } // or "0.0.0" — forces the legacy PowerShell signing path
+```
+
+The signer resolves the path from the `winCodeSign` value: unset / `null` / `"latest"` and any explicit version `>= 1.3.0` use `signtool /dlib`; a version below `1.3.0` (no `dlib` in the bundle) uses PowerShell. A `ToolsetCustom` object uses `dlib` from your supplied bundle.
+
+---
+
+## NSIS & behavior changes
+
+### NSIS file-association ProgID format changed
+
+NSIS installers that declare `fileAssociations` now register each association under a unique, Microsoft-recommendation-compliant **ProgID** instead of using the association `name` (or extension) verbatim. The previous value could collide with unrelated applications — most easily when forking a project without changing `fileAssociations[].name`.
+
+The generated ProgID has the form `<program>.<component>`: `<program>` is derived from your `productName` (so it stays readable in the registry) and `<component>` mixes a short readable prefix with a value derived from the app GUID. It is at most 39 characters, contains only letters, digits, and a single period, and never starts with a digit.
+
+**No config change is required, and there is nothing to auto-migrate.** `fileAssociations` and its `name` / `ext` / `description` fields are unchanged; the new ProgID is produced automatically. The installer and uninstaller derive the same ProgID, so registration and removal stay in sync.
+
+**Action is required only if** you ship a custom NSIS script (`nsis.include` / `nsis.script`) or external tooling that hard-codes the old ProgID — the association `name` or extension — for example to add extra shell verbs or registry entries under that key. Update those references to the new generated value.
+
+> On upgrade, an installer built with v27 registers the new ProgID. One-click installers run the previous version's uninstaller during the upgrade, which removes the old-format entry; with assisted installers that do not uninstall the prior version first, the old ProgID may remain in the registry until that version is removed.
+
+### Linux launcher entrypoint
+
+Every Linux target (deb/rpm, AppImage, snap, flatpak) now launches through a generated `<executableName>-launcher` shell script rather than invoking the executable directly. Two things change in the built artifact:
+
+- The package ships a **new file** — `<executableName>-launcher` (e.g. `/opt/<app>/MyApp-launcher`).
+- The generated `.desktop` **`Exec` key points at the launcher** instead of the executable (e.g. `Exec=/opt/MyApp/MyApp-launcher %U`), and `executableArgs` / `forceX11` flags are injected into the launcher rather than inlined into `Exec`.
+
+This makes `executableArgs` apply consistently across all Linux targets and keeps the `.desktop` `Exec` a plain command.
+
+**Action is required only if** you ship a custom `.desktop` override, an AppArmor/snap profile, a MIME handler, or external tooling that hard-codes the `Exec` command or assumes the executable itself is the launch target. Point those at the `*-launcher` script (or the executable, as appropriate).
+
+### `node_modules` are now arch/os-filtered on every build
+
+v27 filters `node_modules` by each package's `package.json` `cpu` / `os` fields against the **target** arch and platform on **every** build (previously this effectively only mattered for `universal` macOS builds). A dependency that declares an incompatible `cpu`/`os` for the target is excluded from the packaged app, whereas v26 copied host-installed `node_modules` verbatim.
+
+**No action is required for typical projects** — this fixes universal-build failures and produces correctly-scoped output. Be aware of it only if you *intentionally* bundled a cross-arch or cross-os optional binary that is now dropped; in that rare case, include it explicitly via `extraResources` / `files`.
+
+---
+
+## Programmatic & plugin-author API changes
+
+> **This section only affects you if you import from `app-builder-lib` and access the `packager` or `platformPackager` objects directly.** Standard project configurations are unaffected.
+
+### `info: Packager` is now `protected`
+
+`PlatformPackager` exposed a **public** `info: Packager` field in v26. In v27 it is **`protected`** — a **hard compile break**, not a soft deprecation: external code that chains through `.info.` (a custom target, or a plugin importing `app-builder-lib`) no longer type-checks. All commonly-needed properties are now directly accessible on `PlatformPackager` — drop the `.info.` chain:
+
+| Before (deprecated) | After |
+|---|---|
+| `packager.info.tempDirManager` | `packager.tempDirManager` |
+| `packager.info.metadata` | `packager.metadata` |
+| `packager.info.framework` | `packager.framework` |
+| `packager.info.cancellationToken` | `packager.cancellationToken` |
+| `packager.info.repositoryInfo` | `packager.repositoryInfo` |
+| `packager.info.relativeBuildResourcesDirname` | `packager.relativeBuildResourcesDirname` |
+| `packager.info.stageDirPathCustomizer` | `packager.stageDirPathCustomizer` |
+| `packager.info.areNodeModulesHandledExternally` | `packager.areNodeModulesHandledExternally` |
+| `packager.info.isPrepackedAppAsar` | `packager.isPrepackedAppAsar` |
+| `packager.info.appDir` | `packager.appDir` |
+| `packager.info.getWorkspaceRoot()` | `packager.getWorkspaceRoot()` |
+| `packager.info.emitArtifactBuildStarted(e)` | `packager.emitArtifactBuildStarted(e)` |
+| `packager.info.emitArtifactBuildCompleted(e)` | `packager.emitArtifactBuildCompleted(e)` |
+| `packager.info.emitArtifactCreated(e)` | `packager.emitArtifactCreated(e)` |
+| `packager.info.emitMsiProjectCreated(p)` | `packager.emitMsiProjectCreated(p)` |
+| `packager.info.emitAppxManifestCreated(p)` | `packager.emitAppxManifestCreated(p)` |
+
+The getters already on `PlatformPackager` in v26 are unchanged (`config`, `projectDir`, `buildResourcesDir`, `packagerOptions`, `appInfo`, `debugLogger`).
+
+### `platformSpecificBuildOptions` is now `protected`
+
+External consumers should use the two new public helpers instead:
+
+| Access pattern | v27 replacement |
+|---|---|
+| `packager.platformSpecificBuildOptions` (direct read) | `packager.platformOptions` |
+| `deepAssign({}, packager.platformSpecificBuildOptions, config.X)` | `packager.getOptionsForTarget<T>("X")` |
+
+`platformOptions` is a typed getter returning the same platform-level config object. `getOptionsForTarget<T>(key)` performs the standard merge of platform options with the named per-target key (e.g. `"appx"`, `"msi"`) and returns the result as `T`. All built-in targets have been migrated; custom targets extending `PlatformPackager` must update any direct `.platformSpecificBuildOptions` access.
+
+---
+
+## Removed exports
+
+`ProtonFramework`, `LibUiFramework`, and `SnapOptions` are removed from the public exports of `app-builder-lib` and `electron-builder`. Use the Electron framework and the [`snapcraft`](#snap--snapcraft) config shape respectively. The removed framework support means `framework: "proton" | "libui"` no longer has any effect — see [`framework` removed](#framework--nodeversion--launchuiversion).
+
+### Renamed type exports
+
+These exported TypeScript types were **renamed with no compatibility alias** — `import { OldName }` is now a hard compile error. Update the import to the new name:
+
+| v26 export | v27 export |
+|---|---|
+| `ElectronDownloadOptions` | `ElectronGetOptions` |
+| `WindowsAzureSigningConfiguration` | `WindowsAzureSigningConfig` |
+| `WindowsSigntoolConfiguration` | `WindowsSigntoolSigningConfig` |
+
+`ElectronGetOptions` is re-exported from the top-level `electron-builder` package, so this affects ordinary TypeScript consumers, not just `app-builder-lib` plugin authors.
+
+---
+
+## Design notes
+
+Rationale behind the user-facing breaking changes, for those who want full transparency.
+
+### Why native ESM?
+
+`electron-builder` historically shipped CommonJS. The move to native ESM was driven by the ecosystem: major dependencies (`chalk`, `figures`, `ora`, etc.) have dropped CJS support, and Node.js 22.12's stabilized `require(esm)` makes it safe to ship ESM without breaking CJS consumers. The minimum was set to 22.12.0 specifically because earlier Node.js versions require `--experimental-require-module` to `require()` an ESM package.
+
+### Why move native-module options under `nativeModules`?
+
+In v26, options like `buildDependenciesFromSource`, `nodeGypRebuild`, `npmRebuild`, and `nativeRebuilder` were scattered at the root of `Configuration` alongside unrelated properties. They were grouped under `nativeModules` for the same reason `directories` and `toolsets` are sub-keys: related options should be co-located. The rename `nativeRebuilder → rebuildMode` makes the field name consistent with other enum-style selectors.
+
+### Why unify all Windows signing under `win.sign`?
+
+In v26, Windows signing was split across two sibling root-level keys — `signtoolOptions` and `azureSignOptions` — with precedence rules that were easy to misconfigure (both present → Azure wins, silently). v27 replaces them with a single `win.sign` key typed as a discriminated union. This makes the active signing mode explicit, self-documenting in IntelliSense, and mirrors the macOS `mac.sign` shape so both platforms have the same mental model. The `win.sign: false` sentinel explicitly disables signing, distinguishing it from "not configured" (env-based discovery).
+
+### Why replace `[k: string]` in `WindowsAzureSigningConfiguration`?
+
+The v27 Azure integration switches from PowerShell `Invoke-TrustedSigning` to `signtool.exe /dlib /dmdf`, which reads a `metadata.json` file. An explicit `additionalMetadata: Record<string, string>` field is cleaner than an index signature because it makes intent visible in IntelliSense and prevents accidental shadowing of the typed fields. The legacy PowerShell path remains available (triggered when `toolsets.winCodeSign` is pinned below `"1.3.0"`).
+
+### Why restructure `snap` into `snapcraft`?
+
+The `snapcraft` shape makes the `base` explicit and nests per-base options under a base-named sub-key, so a single config can describe multiple bases unambiguously and core24 (which uses the snapcraft CLI directly) can coexist with legacy bases. `migrate-schema` automates the move but assumes `core20` when no base is present, because that is the v27 1-to-1 migration target — verify the assumption for your project.
+
+### Why consolidate macOS signing under `mac.sign`?
+
+In v26, ~15 signing options were scattered across the root of `MacConfiguration` intermixed with unrelated packaging options. Grouping them under a single `sign` object makes the signing surface self-documenting and matches the Windows `win.sign` grouping. `sign` is now a typed pass-through (`ElectronSignOptions`) to `@electron/osx-sign`, so upstream options are forwarded directly and new osx-sign fields are picked up automatically. `signIgnore` was renamed to `sign.ignore` to match the osx-sign canonical name. The same grouping rationale produced `mac.universal` (a pass-through to `@electron/universal`).
+
+### Why rename `electronDownload` to `electronGet`?
+
+v27 upgrades to `@electron/get` v5, which downloads via `fetch` (replacing the `got`-based path) and exposes a `mirrorOptions` object rather than the old flat `mirror`/`customDir` fields. Renaming the config key to `electronGet` and typing it directly as the library's own options removes electron-builder's hand-maintained translation layer — what you set is what `@electron/get` receives. A few legacy fields (`cache`, `customDir`, `customFilename`, `strictSSL`) have no v5 equivalent; `migrate-schema` drops them with a warning.
+
+### Why consolidate ASAR options under `asar`?
+
+In v26, `asarUnpack` lived alongside `asar`, and `disableSanityCheckAsar` / `disableAsarIntegrity` lived at the root of `Configuration`. This was confusing: `asarUnpack` is meaningless when `asar: false`, yet nothing in the type system expressed that relationship. Moving all options under a single `asar` key makes the dependency explicit. The `asar: true` sentinel was removed because having both `true` (enable with defaults) and `{}` (same meaning) was redundant.
+
+### `PlatformPackager.info` is now protected
+
+The public `info: Packager` field created a hard coupling: any internal `Packager` refactor became a breaking change for all plugins. In v27, direct pass-through getters and methods were added for the properties plugin authors actually need, and `info` was changed from `public` to **`protected`**. This is a hard break in v27 (not a deferred deprecation): external `packager.info.X` access no longer compiles, so migrate to the direct getters listed above.
+
+---
+
+## Internal changes (non-user-facing)
+
+These changes have no impact on your build configuration or the public API. They are listed for transparency about what shipped in v27.
+
+- **Native ESM build pipeline.** Babel was removed entirely; packages are compiled by `tsc` to native ESM with `exports` maps and full type declarations.
+- **Code-quality modernization.** Production code paths adopt native Node.js APIs and modern TypeScript patterns (`sleep()` from `timers/promises`, native process signal handlers, `Error.cause`, `Reflect.get`/`set`, the WHATWG `URL` API, SHA-256 for WiX directory-ID generation).
+- **Dead-code removal.** `ProtonFramework`, `LibUiFramework`, and `binDownload.ts` were deleted; all binary downloads were consolidated into a single `downloadBuilderToolset` path.
+- **Flags consolidation.** All boolean `process.env` flags were consolidated into a single `flags.ts`, and `validateShellEmbeddable` moved to `builder-util/envUtil`.
+- **Source reorganization.** Platform-specific files were split into per-platform subdirectories. The public API surface is unchanged.
+- **Test suite.** Duplicated test files were replaced by runtime-generated tests that fan out across toolset version combinations.
+- **`@electron/*` dependency major bumps.** `@electron/get` 3→5 (now `fetch`-based; drives the [`electronGet`](#electrondownload--electronget) rename), `@electron/osx-sign` 1→2 and `@electron/universal` 2→3 (drive the [`mac.sign`](#macos-signing--macsign) / [`mac.universal`](#macuniversal) pass-throughs), plus `@electron/asar` 3→4, `@electron/notarize` 2→3, and `@electron/fuses` 1→2. The fuses bump adds an optional `wasmTrapHandlers?: boolean` field to `electronFuses`; no existing fuse field was removed.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -170,6 +170,13 @@ const config: Config = {
         },
 
         {
+          type: "doc",
+          docId: "migration/v27-breaking-changes",
+          position: "left",
+          label: "v27 Breaking Changes",
+        },
+
+        {
           type: "docSidebar",
           sidebarId: "migrationSidebar",
           position: "left",

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -88,7 +88,8 @@ const sidebars: SidebarsConfig = {
   ],
 
   migrationSidebar: [
-    { type: "doc", id: "migration/v26-to-v27", label: "v26 → v27" },
+    { type: "doc", id: "migration/v27-breaking-changes", label: "v27 Breaking Changes" },
+    { type: "doc", id: "migration/v26-to-v27", label: "v26 → v27 Walkthrough" },
   ],
 
   tutorialsSidebar: [


### PR DESCRIPTION
### Summary

Restructures the v27 migration documentation so users cannot upgrade without encountering the breaking changes, and corrects two inaccuracies that survived in the existing migration guide (verified against the `release/v26` base at `512a57ec9`).

- **New canonical page `website/docs/migration/v27-breaking-changes.md`** — the authoritative "what changed" reference for v27. Every breaking change grouped by category (Runtime/ESM, Removed config options, Restructured config, CLI, Toolsets & env-vars, NSIS/behavior, Programmatic/plugin API, Removed exports), each with before/after snippets, an `Auto ✓` migrate-schema marker, a "breaking changes at a glance" table, design-notes rationale, and an internal-changes transparency section. Opens with a `:::danger` "read before upgrading" banner.

- **Inverted the information architecture** `website/docs/migration/v26-to-v27.md` is slimmed from a 1100-line catalogue into a task-oriented walkthrough: Step 1 run `migrate-schema` (with the auto-migration table + serialization caveats), Step 2 update Node.js, Step 3 the manual steps, then a summary checklist — every item links into the new breaking-changes page. The deep per-change prose now lives only on the canonical page (single source of truth).

- **Maximum nav prominence.** Added a dedicated top-level `v27 Breaking Changes` navbar item in `website/docusaurus.config.ts`, and listed the page as the first entry (above the walkthrough) in the `migrationSidebar` in `website/sidebars.ts`.

- **README + cross-links.** `README.md` Requirements callout now leads with a "read the breaking changes before upgrading" link. Updated `website/docs/cli.md` and `website/docs/linux.md` to point at the breaking-changes page (and fixed the stale `linux.syncDesktopName` anchor). Updated in-code references: `schemaValidator.ts` invalid-config error now points at `v27-breaking-changes`; `migrate-schema.ts` stdout adds a "full list of breaking changes" line.

- **`MIGRATION.md`** (repo-root summary) now leads with the breaking-changes link, and its toolset env-var row lists `USE_SYSTEM_WINE`.

### Audit-confirmed additions (were missing from the docs entirely)

A holistic audit cross-referenced every `major` changeset, the schema/exports diff, removed env vars, and the git history since `release/v26`. Newly documented, all confirmed in code:

- **Removed `USE_SYSTEM_*` env vars** — `USE_SYSTEM_WINE`, `USE_SYSTEM_SIGNCODE`, `USE_SYSTEM_OSSLSIGNCODE` (0 src refs at HEAD; were functional at base). No env-var replacement; configure via `win.sign` / `toolsets`. `USE_SYSTEM_FPM` is unchanged and still works.
- **Renamed public type exports with no compat alias** — `ElectronDownloadOptions` → `ElectronGetOptions` (re-exported from `electron-builder`, so it hits ordinary TS consumers), `WindowsAzureSigningConfiguration` → `WindowsAzureSigningConfig`, `WindowsSigntoolConfiguration` → `WindowsSigntoolSigningConfig`.
- **Linux launcher entrypoint** — every Linux target now ships a generated `<exe>-launcher` script and the `.desktop` `Exec` key points at it. Action required for custom `.desktop`/AppArmor/MIME tooling that hard-codes `Exec`.
- **node_modules arch/os filtering** — `node_modules` are now filtered by `package.json` `cpu`/`os` against the target on every build (not just universal).
- **`@electron/*` dep transparency** — `@electron/asar` 3→4, `@electron/notarize` 2→3, `@electron/fuses` 1→2 (adds optional `wasmTrapHandlers` to `electronFuses`).