### PR TITLE
fix(migrate-schema): stop stripping `vPrefixedTagName` from GitLab publish entries

### DIFF
--- a/.changeset/migrate-schema-keep-gitlab-vprefixedtagname.md
+++ b/.changeset/migrate-schema-keep-gitlab-vprefixedtagname.md
@@ -1,0 +1,5 @@
+---
+"electron-builder": patch
+---
+
+fix(migrate-schema): stop stripping `vPrefixedTagName` from GitLab publish entries. The field is still supported on `GitlabOptions` (type, scheme, and runtime — `gitlabPublisher` honors it) and has no `tagNamePrefix` equivalent, so deleting it silently flipped GitLab release tags from `1.2.3` to `v1.2.3`. The migrator now leaves GitLab entries untouched and only converts GitHub `vPrefixedTagName` → `tagNamePrefix`.

--- a/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
+++ b/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
@@ -522,15 +522,13 @@ class ConfigCodemod {
         const isFalse = vPrefixed.initializer.kind === ts.SyntaxKind.FalseKeyword
         this.replaceRange(this.start(vPrefixed), vPrefixed.end, `tagNamePrefix: ${isFalse ? '""' : '"v"'}`)
         changed = true
-      } else if (provider === "gitlab") {
-        this.removeProp(vPrefixed)
-        changed = true
       }
+      // GitLab keeps vPrefixedTagName in v27 (no tagNamePrefix equivalent) — leave it untouched.
     }
     if (changed) {
       this.changes.push({
         key: `${prefix}${key}[].vPrefixedTagName`,
-        description: "replaced vPrefixedTagName with tagNamePrefix on GitHub publish entries; removed from GitLab entries",
+        description: "replaced vPrefixedTagName with tagNamePrefix on GitHub publish entries",
       })
     }
   }

--- a/packages/electron-builder/src/cli/migrate-schema.ts
+++ b/packages/electron-builder/src/cli/migrate-schema.ts
@@ -434,13 +434,11 @@ function migratePublishEntries(parent: Record<string, any>, key: string, changes
       delete entry.vPrefixedTagName
       changed = true
     }
-    if (entry != null && entry.provider === "gitlab" && "vPrefixedTagName" in entry) {
-      delete entry.vPrefixedTagName
-      changed = true
-    }
+    // GitLab keeps vPrefixedTagName in v27 — it remains in the type, scheme, and runtime
+    // (gitlabPublisher honors it) and has no tagNamePrefix equivalent, so leave it untouched.
   }
   if (changed) {
-    changes.push({ key: `${key}[].vPrefixedTagName`, description: "replaced vPrefixedTagName with tagNamePrefix on GitHub publish entries; removed from GitLab entries" })
+    changes.push({ key: `${key}[].vPrefixedTagName`, description: "replaced vPrefixedTagName with tagNamePrefix on GitHub publish entries" })
   }
 }
 

--- a/test/src/migrateProgrammaticSchemaTest.ts
+++ b/test/src/migrateProgrammaticSchemaTest.ts
@@ -209,6 +209,7 @@ describe("migrateProgrammaticSource — per-rule coverage (CJS, drift-checked vs
     snapBase: `module.exports = { snap: { base: "core22", confinement: "strict" } }\n`,
     snapNoBase: `module.exports = { snap: { confinement: "strict" } }\n`,
     publishGithub: `module.exports = { publish: [{ provider: "github", vPrefixedTagName: false }] }\n`,
+    publishGithubGitlab: `module.exports = { publish: [{ provider: "github", vPrefixedTagName: false }, { provider: "gitlab", vPrefixedTagName: false }] }\n`,
     electronDownload: `module.exports = { electronDownload: { mirror: "https://m", isVerifyChecksum: false, cache: "/tmp" } }\n`,
   }
 

--- a/test/src/migrateSchemaTest.ts
+++ b/test/src/migrateSchemaTest.ts
@@ -266,12 +266,13 @@ describe("migrateConfig — GitHub vPrefixedTagName", () => {
     expect(result.migrated.publish).toEqual({ provider: "github", tagNamePrefix: "v" })
   })
 
-  test("removes vPrefixedTagName from gitlab entries", () => {
+  test("preserves vPrefixedTagName on gitlab entries (still functional in v27)", () => {
     const result = migrateConfig({
       publish: { provider: "gitlab", vPrefixedTagName: false },
     })
-    expect("vPrefixedTagName" in result.migrated.publish).toBe(false)
-    expect("tagNamePrefix" in result.migrated.publish).toBe(false)
+    // GitLab keeps vPrefixedTagName — it must not be stripped (no tagNamePrefix equivalent on GitLab),
+    // otherwise the migrator would silently flip tags from "1.2.3" to "v1.2.3".
+    expect(result.migrated.publish).toEqual({ provider: "gitlab", vPrefixedTagName: false })
   })
 
   test("handles publish as array", () => {

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -82,7 +82,6 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | `mac.universal` fields → `universal` | `"mac": { "mergeASARs": true }` | `"mac": { "universal": { "mergeASARs": true } }` |
 | `electronDownload` → `electronGet` | `"electronDownload": { "mirror": "https://m/" }` | `"electronGet": { "mirrorOptions": { "mirror": "https://m/" } }` |
 | `GithubOptions.vPrefixedTagName` | `"vPrefixedTagName": false` | `"tagNamePrefix": ""` |
-| `GitlabOptions.vPrefixedTagName` | `"vPrefixedTagName": true` | *(deleted)* |
 | `win.azureSignOptions` → `win.sign` | `"win": { "azureSignOptions": { "endpoint": "…", … } }` | `"win": { "sign": { "type": "azure", "endpoint": "…", … } }` |
 | `win.signtoolOptions` → `win.sign` | `"win": { "signtoolOptions": { "certificateFile": "…" } }` | `"win": { "sign": { "type": "signtool", "certificateFile": "…" } }` |
 | Azure extra sign keys | `"win": { "azureSignOptions": { "ExcludeCredentials": "X" } }` | `"win": { "sign": { "type": "azure", "additionalMetadata": { "ExcludeCredentials": "X" } } }` |
@@ -111,7 +110,7 @@ Pass `--config <path>` to point at a non-default config file, or `--project-dir 
 | Implicit `--publish` removed | — | Pass `--publish` explicitly |
 | `snap` config key removed | ✓ | Restructured to `snapcraft` with an explicit `base` |
 | `GithubOptions.vPrefixedTagName` removed | ✓ | Use `tagNamePrefix` instead |
-| `GitlabOptions.vPrefixedTagName` removed | ✓ | Removed automatically |
+| `GitlabOptions.vPrefixedTagName` retained | — | None — still functional; only GitHub's was removed |
 | `framework`, `nodeVersion`, `launchUiVersion` removed | ✓ | Removed automatically |
 | ProtonFramework and LibUiFramework removed | — | Migrate to an Electron-based build setup |
 | `devMetadata`, `extraMetadata` in `PackagerOptions` removed | — | Use `config` / `config.extraMetadata` instead |
@@ -447,7 +446,7 @@ The `vPrefixedTagName` boolean on `GithubOptions` is removed. Use `tagNamePrefix
 
 To keep the default `v` prefix, simply remove `vPrefixedTagName` — `tagNamePrefix` defaults to `"v"`.
 
-`vPrefixedTagName` on `GitlabOptions` is also removed. GitLab releases now always use the `v`-prefixed tag (e.g. `v1.2.3`). There is no replacement option; update your release pipeline if your GitLab tags do not follow this convention.
+`vPrefixedTagName` on `GitlabOptions` is **unchanged** in v27 — only the GitHub field was removed. It still exists in the type, the schema, and the runtime, and continues to control the GitLab tag prefix (`vPrefixedTagName: false` → `1.2.3`; omit it → `v1.2.3`). `migrate-schema` leaves GitLab publish entries untouched.
 
 ### `devMetadata`, `extraMetadata` (programmatic `PackagerOptions`)
 


### PR DESCRIPTION
The field is still supported on `GitlabOptions` (type, scheme, and runtime — `gitlabPublisher` honors it) and has no `tagNamePrefix` equivalent