### PR TITLE
feat(toolsets)!: remove `USE_SYSTEM_FPM` env override; require an explicit custom toolset on Windows (BREAKING)

### DIFF
--- a/.changeset/remove-use-system-fpm.md
+++ b/.changeset/remove-use-system-fpm.md
@@ -1,0 +1,9 @@
+---
+"app-builder-lib": major
+---
+
+feat(toolsets)!: remove `USE_SYSTEM_FPM` env override; require an explicit custom toolset on Windows
+
+- Remove the `USE_SYSTEM_FPM` environment flag — the last of the `USE_SYSTEM_*` toolset overrides. To use a non-bundled fpm, configure `toolsets.fpm` with a custom toolset pointing at the directory containing the `fpm` executable, e.g. `{ url: "file:///opt/homebrew/bin" }`.
+- A custom toolset is now honored before the platform fallback in `getFpmPath()` and `getOsslSigncodeBundle()`, so an explicit override is respected on every platform (previously it was silently ignored on Windows).
+- On Windows with no custom toolset configured, `getFpmPath()` now throws `InvalidConfigurationError` instead of resolving a bare `fpm` from `$PATH`, closing a binary-hijack vector (`getOsslSigncodeBundle()` throws as defense-in-depth on the same path).

--- a/packages/app-builder-lib/src/toolsets/fpm.ts
+++ b/packages/app-builder-lib/src/toolsets/fpm.ts
@@ -1,7 +1,7 @@
+import { InvalidConfigurationError } from "builder-util"
 import * as path from "path"
 import { ToolsetConfig } from "../configuration.js"
 import { downloadBuilderToolset } from "../util/electronGet.js"
-import { isUseSystemFpm } from "../util/flags.js"
 import { getCustomToolsetPath } from "./custom.js"
 import { resolveToolsetVersion } from "./version.js"
 
@@ -20,13 +20,18 @@ const fpmChecksums = {
 
 export async function getFpmPath(toolset: ToolsetConfig["fpm"], resourcesDir: string) {
   const exec = "fpm"
-  if (process.platform === "win32" || isUseSystemFpm()) {
-    return exec
-  }
-
+  // A custom toolset is an explicit user override — honored on every platform, before any platform default/fallback.
   if (typeof toolset === "object" && toolset != null) {
     const vendorPath = await getCustomToolsetPath(toolset, resourcesDir)
     return path.resolve(vendorPath, exec)
+  }
+
+  if (process.platform === "win32") {
+    // No fpm binary is bundled for Windows. Rather than resolving a bare `fpm` from $PATH (a binary-hijack
+    // vector), require an explicit custom toolset pointing at the directory that contains the fpm executable.
+    throw new InvalidConfigurationError(
+      `fpm is not bundled for Windows. Configure a custom toolset pointing at the directory containing your fpm executable, e.g. toolsets: { fpm: { url: "file:///absolute/path/to/fpm/dir" } }`
+    )
   }
 
   const getKey = () => {

--- a/packages/app-builder-lib/src/toolsets/winCodeSign.ts
+++ b/packages/app-builder-lib/src/toolsets/winCodeSign.ts
@@ -1,4 +1,4 @@
-import { sanitizeDirPath } from "builder-util"
+import { InvalidConfigurationError, sanitizeDirPath } from "builder-util"
 import { Nullish } from "builder-util-runtime"
 import * as os from "os"
 import * as path from "path"
@@ -146,13 +146,18 @@ async function getWindowsSignToolExe({ winCodeSign, resourcesDir = "" }: { winCo
 }
 
 async function getOsslSigncodeBundle(winCodeSign: ToolsetConfig["winCodeSign"] | Nullish, resourcesDir = "") {
-  if (process.platform === "win32") {
-    return { path: "osslsigncode" }
-  }
-
+  // A custom toolset is an explicit user override — honored on every platform, before any platform default/fallback.
   if (typeof winCodeSign === "object" && winCodeSign != null) {
     const vendorPath = sanitizeDirPath(await getCustomToolsetPath(winCodeSign, resourcesDir), resourcesDir || undefined)
     return { path: path.join(vendorPath, "osslsigncode") }
+  }
+
+  if (process.platform === "win32") {
+    // Unreachable in normal flow: osslsigncode is only requested when the host is not Windows (Windows signs via
+    // signtool). Kept as defense-in-depth — fail loudly instead of resolving a bare `osslsigncode` from $PATH.
+    throw new InvalidConfigurationError(
+      `osslsigncode is not used on Windows (signing uses signtool). To override, configure a custom toolset: toolsets: { winCodeSign: { url: "file:///absolute/path/to/dir" } }`
+    )
   }
 
   const version = resolveToolsetVersion(winCodeSign, WIN_CODESIGN_LATEST)

--- a/packages/app-builder-lib/src/util/flags.ts
+++ b/packages/app-builder-lib/src/util/flags.ts
@@ -48,10 +48,6 @@ export function isTravis() {
 
 // ─── Platform toolset overrides ───────────────────────────────────────────────
 
-export function isUseSystemFpm() {
-  return isEnvTrue(process.env.USE_SYSTEM_FPM)
-}
-
 export function isFpmDebug() {
   return isEnvTrue(process.env.FPM_DEBUG)
 }


### PR DESCRIPTION
### Summary

- Removed the `USE_SYSTEM_FPM` environment flag entirely, following the same deprecation pattern already applied to `USE_SYSTEM_WINE`, `USE_SYSTEM_SIGNCODE`, and `USE_SYSTEM_OSSLSIGNCODE`. Deleted `isUseSystemFpm()` from `packages/app-builder-lib/src/util/flags.ts`.
- Made the custom-toolset check the first checkpoint in `getFpmPath()` (`toolsets/fpm.ts`) and `getOsslSigncodeBundle()` (`toolsets/winCodeSign.ts`), ahead of their `process.platform === "win32"` guards. Previously, on Windows an explicitly configured `toolsets.fpm` / `toolsets.winCodeSign` custom toolset was silently ignored in favor of a bare `fpm` / `osslsigncode` `$PATH` command. An explicit user override is now honored on every platform.
- Locked down the win32 no-config path: with no custom toolset configured, `getFpmPath()` and `getOsslSigncodeBundle()` now throw `InvalidConfigurationError` on Windows instead of returning a bare `fpm` / `osslsigncode` command resolved from `$PATH`.
- Added `test/src/fpmToolsetTest.ts` covering custom-toolset precedence and the win32 throw.
- Added changeset `.changeset/remove-use-system-fpm.md` (`app-builder-lib`: major) documenting the breaking removal.

### Behavior

To use a system-installed (or otherwise non-bundled) fpm, configure a custom toolset pointing at the directory that contains the `fpm` executable:

```jsonc
"toolsets": {
  "fpm": { "url": "file:///opt/homebrew/bin" }
}
```

A `directory`-type custom toolset resolves to the given absolute path, and `getFpmPath()` then returns `<dir>/fpm`. The bundled-download default (config unset/null/"latest") is unchanged on Linux/macOS.

On Windows: there is no bundled fpm binary, so a custom toolset is now required to build fpm-based targets — the previous bare-`fpm`-from-`$PATH` fallback is gone.

### Security rationale

- Removing `USE_SYSTEM_FPM` and the win32 `$PATH` fallbacks closes a binary-hijack vector: the old behavior executed a bare `fpm` / `osslsigncode` resolved via `$PATH`, so a malicious binary placed earlier on the path could run. Custom toolsets require an explicit, validated absolute path instead.

### Design notes

- Precedence audit: the other toolset resolvers (nsis, icons, linuxToolsMac, winCodeSign kits/rcedit) already check the custom toolset first. Wine intentionally hard-throws on Windows before the custom check because wine cannot run on Windows at all. Only `getFpmPath()` and `getOsslSigncodeBundle()` had a `win32` guard ahead of the custom check; this change brings them in line.
- `getOsslSigncodeBundle()` is only reached from `getSignToolPath()`'s non-`isWin` branch, and both call sites set `isWin = (process.platform === "win32") || ...`. Its `win32` branch is therefore unreachable in normal flow; the throw is defense-in-depth (fail loudly rather than silently resolve a `$PATH` binary or a wrong-platform download). The live, reachable lockdown is `getFpmPath()`.
- A custom toolset with `url: file:///usr/bin` is not a drop-in equivalent of the old `USE_SYSTEM_FPM` flag: the old flag used `$PATH` discovery, whereas a directory toolset hardcodes one directory. fpm is a Ruby gem and commonly lives in `/usr/local/bin`, `/opt/homebrew/bin`, `~/.gem/ruby/X.Y.Z/bin`, or rbenv/rvm shims rather than `/usr/bin`, so users must point the toolset at the directory that actually contains their `fpm` binary (`dirname $(which fpm)`).
