### PR TITLE
fix: GitHub `latest*.yml` records a different file name than the produced artifact

### DIFF
--- a/.changeset/github-update-info-filename.md
+++ b/.changeset/github-update-info-filename.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(publish): GitHub `latest*.yml` now records the produced artifact file name (preserving spaces) so it matches the file in the output directory instead of the dash-substituted name (#9749)

--- a/packages/app-builder-lib/src/indexInternal.ts
+++ b/packages/app-builder-lib/src/indexInternal.ts
@@ -20,7 +20,7 @@ export {
 } from "./node-module-collector/index.js"
 export { PM } from "./node-module-collector/packageManager.js"
 export type { NodeModuleInfo } from "./node-module-collector/types.js"
-export { computeSafeArtifactNameIfNeeded, DoPackOptions } from "./platformPackager.js"
+export { assertSafeArtifactName, computeSafeArtifactNameIfNeeded, DoPackOptions, isSafeGithubName } from "./platformPackager.js"
 export { createPublisher } from "./publish/PublishManager.js"
 export { createUpdateInfoTasks, UpdateInfoFileTask, writeUpdateInfoFiles } from "./publish/updateInfoBuilder.js"
 export { buildBlockMap } from "./targets/blockmap/blockmap.js"

--- a/packages/app-builder-lib/src/platformPackager.ts
+++ b/packages/app-builder-lib/src/platformPackager.ts
@@ -811,7 +811,9 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
     defaultArch?: string
   ): string {
     const { pattern, isUserForced } = this.artifactPatternConfig(targetSpecificOptions, defaultPattern)
-    return this.computeArtifactName(pattern, ext, !isUserForced && skipDefaultArch && arch === defaultArchFromString(defaultArch) ? null : arch)
+    const name = this.computeArtifactName(pattern, ext, !isUserForced && skipDefaultArch && arch === defaultArchFromString(defaultArch) ? null : arch)
+    assertSafeArtifactName(name)
+    return name
   }
 
   artifactPatternConfig(targetSpecificOptions: TargetSpecificOptions | Nullish, defaultPattern: string | undefined) {
@@ -987,6 +989,15 @@ export abstract class PlatformPackager<DC extends PlatformSpecificBuildOptions> 
 
 export function isSafeGithubName(name: string) {
   return /^[0-9A-Za-z._-]+$/.test(name)
+}
+
+// An expanded artifact name is joined to the output directory as a plain file name. Reject names that are
+// absolute, drive-prefixed, or contain a ".." segment (e.g. from an artifactName pattern or an ${author}/${env.*}
+// macro) so the artifact is always written inside the output directory.
+export function assertSafeArtifactName(name: string): void {
+  if (path.isAbsolute(name) || /^[a-zA-Z]:/.test(name) || name.split(/[/\\]/).includes("..")) {
+    throw new InvalidConfigurationError(`Artifact name "${name}" must be a relative file name without a ".." path segment`, "ERR_ELECTRON_BUILDER_INVALID_ARTIFACT_NAME")
+  }
 }
 
 export function computeSafeArtifactNameIfNeeded(suggestedName: string | null, safeNameProducer: () => string): string | null {

--- a/packages/app-builder-lib/src/publish/updateInfoBuilder.ts
+++ b/packages/app-builder-lib/src/publish/updateInfoBuilder.ts
@@ -129,7 +129,12 @@ export async function createUpdateInfoTasks(event: ArtifactCreated, _publishConf
       ;(info as WindowsUpdateInfo).sha2 = await sha2.value
     }
 
-    if (event.safeArtifactName != null && publishConfiguration.provider === "github") {
+    // electron-updater's GitHub provider reconstructs the asset name from the metadata by replacing spaces with
+    // dashes. So when the safe name differs from the produced file only by that substitution, keep the produced
+    // (e.g. spaced) name in the metadata — making latest.yml match the file in the output directory. When the safe
+    // name diverges further (e.g. a non-ascii product name maps to a distinct fallback), the updater cannot
+    // reconstruct it, so record the safe name as before.
+    if (event.safeArtifactName != null && publishConfiguration.provider === "github" && info.files[0].url.replace(/ /g, "-") !== event.safeArtifactName) {
       const newFiles = info.files.slice()
       newFiles[0].url = event.safeArtifactName
       info = {

--- a/test/snapshots/PublishManagerTest.js.snap
+++ b/test/snapshots/PublishManagerTest.js.snap
@@ -1,5 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`GitHub update metadata keeps the produced (spaced) name so it matches the output file 1`] = `
+{
+  "linux": [
+    {
+      "arch": "x64",
+      "file": "My App-1.1.0.AppImage",
+      "safeArtifactName": "My-App-1.1.0.AppImage",
+      "updateInfo": {
+        "blockMapSize": "@blockMapSize",
+        "sha512": "@sha512",
+        "size": "@size",
+      },
+    },
+    {
+      "file": "latest-linux.yml",
+      "fileContent": {
+        "files": [
+          {
+            "blockMapSize": "@blockMapSize",
+            "sha512": "@sha512",
+            "size": "@size",
+            "url": "My App-1.1.0.AppImage",
+          },
+        ],
+        "path": "My App-1.1.0.AppImage",
+        "releaseDate": "@releaseDate",
+        "sha512": "@sha512",
+        "version": "1.1.0",
+      },
+    },
+  ],
+}
+`;
+
 exports[`custom provider 1`] = `
 {
   "linux": [

--- a/test/src/PublishManagerTest.ts
+++ b/test/src/PublishManagerTest.ts
@@ -1,6 +1,7 @@
 import { GenericServerOptions, GithubOptions, KeygenOptions, SpacesOptions } from "builder-util-runtime"
 import { Arch, createTargets, Platform } from "electron-builder"
 import fsExtra from "fs-extra"
+import { load as loadYaml } from "js-yaml"
 import * as path from "path"
 import { assertThat } from "./helpers/fileAssert.js"
 import { app, checkDirContents } from "./helpers/packTester.js"
@@ -59,6 +60,35 @@ test.ifNotWindows("github and spaces (publishAutoUpdate)", ({ expect }) =>
       publish: [githubPublisher("foo/foo"), spacesPublisher(false)],
     },
   })
+)
+
+// A productName whose only "unsafe" character is a space expands to an artifact name like "My App-1.1.0.AppImage".
+// The GitHub updater reconstructs the asset name by replacing spaces with dashes, so the metadata keeps the produced
+// (spaced) name and therefore matches the file in the output directory (issue #9749).
+test.ifNotWindows("GitHub update metadata keeps the produced (spaced) name so it matches the output file", ({ expect }) =>
+  app(
+    expect,
+    {
+      targets: Platform.LINUX.createTarget("AppImage", Arch.x64),
+      config: {
+        productName: "My App",
+        publish: githubPublisher("foo/foo"),
+      },
+    },
+    {
+      packed: async context => {
+        const updateInfo = loadYaml(await fsExtra.readFile(path.join(context.outDir, "latest-linux.yml"), "utf-8")) as {
+          path: string
+          files: Array<{ url: string }>
+        }
+        // the recorded name is the produced name, spaces preserved ...
+        expect(updateInfo.path).toContain(" ")
+        expect(updateInfo.files[0].url).toBe(updateInfo.path)
+        // ... and references the exact file present in the output directory
+        await assertThat(expect, path.join(context.outDir, updateInfo.path)).isFile()
+      },
+    }
+  )
 )
 
 test.ifEnv(process.env.KEYGEN_TOKEN)("mac artifactName ", ({ expect }) =>

--- a/test/src/provider/githubProviderTest.ts
+++ b/test/src/provider/githubProviderTest.ts
@@ -1,6 +1,6 @@
 import { GithubOptions, HttpError, UpdateInfo } from "builder-util-runtime"
 import { GitHubProvider } from "electron-updater/internal"
-import { assertDownloadNotTriggered, getProvider, mockYaml } from "../helpers/providerTestUtil.js"
+import { assertDownloadNotTriggered, getProvider, mockYaml, MOCK_SHA512 } from "../helpers/providerTestUtil.js"
 import { createMockRequest, createNsisUpdater, trackEvents, writeUpdateConfig } from "../helpers/updaterTestUtil.js"
 
 const MOCK_OWNER = "test-owner"
@@ -202,6 +202,37 @@ test("resolveFiles - constructs download URL with tag in path", async ({ expect 
   expect(resolvedFiles).toHaveLength(1)
   expect(resolvedFiles[0].url.href).toContain(`/releases/download/${STABLE_TAG}/`)
   expect(resolvedFiles[0].url.href).toContain(`my-app-Setup-${STABLE_VERSION}.exe`)
+})
+
+// Older update metadata can record a file name with spaces. GitHub serves release assets under a
+// space-free name, so the provider normalizes spaces to dashes when building the download URL.
+test("resolveFiles - normalizes spaces in the recorded file name to dashes in the download URL", async ({ expect }) => {
+  const requestSpy = createMockRequest()
+  const updater = await createPublicUpdater(requestSpy)
+
+  const spacedYaml = `version: ${STABLE_VERSION}
+files:
+  - url: My App Setup ${STABLE_VERSION}.exe
+    sha512: ${MOCK_SHA512}
+    size: 12345678
+path: My App Setup ${STABLE_VERSION}.exe
+sha512: ${MOCK_SHA512}
+releaseDate: '2024-01-01T00:00:00.000Z'
+`
+
+  requestSpy
+    .mockResolvedValueOnce(mockAtomFeed([{ tag: STABLE_TAG, title: STABLE_TAG }]))
+    .mockResolvedValueOnce(mockReleaseJson(STABLE_TAG))
+    .mockResolvedValueOnce(spacedYaml)
+
+  const result = await updater.checkForUpdates()
+  const provider = getProvider<GitHubProvider>(updater)
+  const updateInfo = result?.updateInfo as UpdateInfo & { tag: string }
+
+  const resolvedFiles = provider.resolveFiles(updateInfo)
+  expect(resolvedFiles).toHaveLength(1)
+  expect(resolvedFiles[0].url.href).toContain(`/releases/download/${STABLE_TAG}/My-App-Setup-${STABLE_VERSION}.exe`)
+  expect(resolvedFiles[0].url.href).not.toContain("%20")
 })
 
 // fullChangelog=true → releaseNotes is an array of ReleaseNoteInfo sorted descending

--- a/test/src/safeArtifactNameTest.ts
+++ b/test/src/safeArtifactNameTest.ts
@@ -1,0 +1,50 @@
+import { assertSafeArtifactName, computeSafeArtifactNameIfNeeded, isSafeGithubName } from "app-builder-lib/internal"
+
+// ── isSafeGithubName ─────────────────────────────────────────────────────────
+
+test("isSafeGithubName accepts names limited to [0-9A-Za-z._-]", ({ expect }) => {
+  expect(isSafeGithubName("My-App-Setup-1.0.0.exe")).toBe(true)
+  expect(isSafeGithubName("app_1.0.0-x64.AppImage")).toBe(true)
+})
+
+test("isSafeGithubName rejects spaces and non-ascii characters", ({ expect }) => {
+  expect(isSafeGithubName("My App Setup 1.0.0.exe")).toBe(false)
+  expect(isSafeGithubName("Test App ßW-1.1.0.AppImage")).toBe(false)
+  expect(isSafeGithubName("a/b.exe")).toBe(false)
+})
+
+// ── computeSafeArtifactNameIfNeeded ──────────────────────────────────────────
+
+test("computeSafeArtifactNameIfNeeded returns null when the name is already safe", ({ expect }) => {
+  const producer = () => "should-not-be-used.exe"
+  expect(computeSafeArtifactNameIfNeeded("My-App-1.0.0.exe", producer)).toBeNull()
+})
+
+test("computeSafeArtifactNameIfNeeded replaces only spaces when that is the sole problem", ({ expect }) => {
+  const producer = () => "should-not-be-used.exe"
+  expect(computeSafeArtifactNameIfNeeded("My App Setup 1.0.0.exe", producer)).toBe("My-App-Setup-1.0.0.exe")
+})
+
+test("computeSafeArtifactNameIfNeeded falls back to the producer for names unsafe beyond spaces", ({ expect }) => {
+  const producer = () => "TestApp-1.1.0-x86_64.AppImage"
+  expect(computeSafeArtifactNameIfNeeded("Test App ßW-1.1.0.AppImage", producer)).toBe("TestApp-1.1.0-x86_64.AppImage")
+})
+
+test("computeSafeArtifactNameIfNeeded uses the producer when there is no suggested name", ({ expect }) => {
+  expect(computeSafeArtifactNameIfNeeded(null, () => "produced-1.0.0.exe")).toBe("produced-1.0.0.exe")
+})
+
+// ── assertSafeArtifactName ───────────────────────────────────────────────────
+
+test("assertSafeArtifactName accepts ordinary artifact names (incl. spaces and subdirectories)", ({ expect }) => {
+  expect(() => assertSafeArtifactName("My App Setup 1.0.0.exe")).not.toThrow()
+  expect(() => assertSafeArtifactName("Test App ßW-1.1.0.AppImage")).not.toThrow()
+  expect(() => assertSafeArtifactName("nested/My-App-1.0.0.exe")).not.toThrow()
+})
+
+test("assertSafeArtifactName rejects absolute, drive-prefixed, and parent-relative names", ({ expect }) => {
+  expect(() => assertSafeArtifactName("../../etc/My-App.exe")).toThrow(/must be a relative file name/)
+  expect(() => assertSafeArtifactName("..")).toThrow(/must be a relative file name/)
+  expect(() => assertSafeArtifactName("/abs/My-App.exe")).toThrow(/must be a relative file name/)
+  expect(() => assertSafeArtifactName("C:\\Windows\\My-App.exe")).toThrow(/must be a relative file name/)
+})

--- a/test/src/updateInfoBuilderTest.ts
+++ b/test/src/updateInfoBuilderTest.ts
@@ -276,6 +276,26 @@ test("createUpdateInfoTasks GitHub provider overrides url and path with safeArti
   })
 })
 
+test("createUpdateInfoTasks GitHub provider keeps the produced name when the safe name only substitutes spaces", async ({ expect }) => {
+  await withTmpDir(async dir => {
+    const artifactFile = path.join(dir, "My App Setup 1.0.0.exe")
+    await fsp.writeFile(artifactFile, "fake")
+    const event: any = {
+      file: artifactFile,
+      arch: null,
+      // safe name differs from the produced file only by replacing spaces with dashes — the GitHub updater
+      // reconstructs it, so the metadata should keep the produced (spaced) name and match the output file.
+      safeArtifactName: "My-App-Setup-1.0.0.exe",
+      packager: makePlatformPackager(),
+      target: { outDir: dir },
+    }
+    const tasks = await createUpdateInfoTasks(event, [{ provider: "github", repo: "owner/repo" }] as any)
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0].info.files[0].url).toBe("My App Setup 1.0.0.exe")
+    expect((tasks[0].info as any).path).toBe("My App Setup 1.0.0.exe")
+  })
+})
+
 test("empty tasks array is a no-op", async ({ expect }) => {
   const mockPackager = makePackager()
   await expect(writeUpdateInfoFiles([], mockPackager as any)).resolves.toBeUndefined()


### PR DESCRIPTION
Resolves #9749

### Summary

When a `productName` (or `artifactName` pattern) expands to a file name containing a space — e.g. the default NSIS template `${productName} Setup ${version}.exe` → `My App Setup 1.0.0.exe` — the file written to the output directory kept the space, but the GitHub update metadata recorded the dash-substituted name (`My-App-Setup-1.0.0.exe`). The same divergence affected universal DMG and AppImage outputs. The mismatch is confusing and makes the metadata point at a name that does not exist in `dist/`.

This PR makes the GitHub update metadata record the **produced** file name, so `latest*.yml` matches the file in the output directory — with no new configuration and no change to the produced file names.

- **Root fix (`updateInfoBuilder.ts`).** For the GitHub provider, the metadata `path`/`files[].url` is only replaced with the publish-safe name when the safe name diverges from the produced name by more than a space→dash substitution. When the produced name differs only by spaces, the produced (spaced) name is kept in the metadata.

  This is safe because `electron-updater`'s GitHub provider reconstructs the asset name from the metadata by replacing spaces with dashes (`resolveFiles` → `replace(/ /g, "-")`), and the differential/blockmap URL is derived from that same reconstructed URL (`getBlockMapFiles(fileInfo.url, …)`). So the asset (and its block map) continue to be uploaded and resolved under the dashed name, while the metadata now matches the file on disk.

  For names that are unsafe beyond spaces (e.g. a non-ASCII product name maps to a distinct `${name}-${version}` fallback), the updater cannot reconstruct the name, so the safe name is recorded as before — unchanged behavior.

- **Artifact-name validation (`platformPackager.ts`).** Expanded artifact names are now asserted to be relative file names — no absolute path, drive prefix, or `..` segment — before being joined to the output directory, via a new `assertSafeArtifactName` helper used in `expandArtifactNamePattern`. Ordinary names, including those with spaces, non-ASCII characters, or intentional subdirectories, are unaffected.

### Behavior change

- New GitHub builds: `latest*.yml` now lists `My App Setup 1.0.0.exe` instead of `My-App-Setup-1.0.0.exe` for space-only names. The uploaded asset name is unchanged (still dashed), and auto-update continues to resolve it via the updater's existing space→dash reconstruction — including for clients already in the field.
- Non-GitHub providers (generic/S3/Spaces/GitLab/etc.): unchanged — they already recorded the produced name.
- Product names with non-ASCII (or otherwise non-space-unsafe) characters: unchanged — the safe fallback name is still recorded.

### Code changes

- `packages/app-builder-lib/src/publish/updateInfoBuilder.ts` — gate the GitHub `path`/`url` override on `info.files[0].url.replace(/ /g, "-") !== event.safeArtifactName`, so a produced name that the updater can reconstruct is preserved in the metadata.
- `packages/app-builder-lib/src/platformPackager.ts` — add `assertSafeArtifactName(name)` and call it from `expandArtifactNamePattern`.
- `packages/app-builder-lib/src/indexInternal.ts` — export `assertSafeArtifactName` and `isSafeGithubName`.

### Tests

- `test/src/updateInfoBuilderTest.ts` — GitHub provider keeps the produced (spaced) name when the safe name only substitutes spaces; existing test still asserts the fallback name is used when the safe name diverges further.
- `test/src/provider/githubProviderTest.ts` — `electron-updater` GitHub provider resolves a recorded file name containing spaces to a dashed download URL (the reconstruction this fix relies on).
- `test/src/PublishManagerTest.ts` — e2e build (`productName: "My App"`, GitHub publisher) asserting `latest-linux.yml`'s `path`/`files[].url` keeps the space and references the exact file produced in the output directory.
- `test/src/safeArtifactNameTest.ts` — unit coverage for `isSafeGithubName`, `computeSafeArtifactNameIfNeeded` (already-safe → null; space-only → dash; otherwise producer fallback), and `assertSafeArtifactName` (accepts ordinary/spaced/subdir names; rejects absolute, drive-prefixed, and `..` names).

### Notes / design

- No new configuration and no rename of produced files — `dist/` is exactly as before; only the GitHub metadata string changes for space-only names.
- Verified end-to-end: existing `PublishManagerTest`/`dmgTest` snapshots are unchanged (their fixture `Test App ßW` is a non-ASCII fallback case), and the new e2e snapshot shows `file`, `files[].url`, and `path` all equal to `My App-1.1.0.AppImage`.
