### PR TITLE
fix: exclude slnx files

### DIFF
--- a/.changeset/warm-dodos-stare.md
+++ b/.changeset/warm-dodos-stare.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+Added slnx to default file exclusions

--- a/packages/app-builder-lib/src/fileMatcher.ts
+++ b/packages/app-builder-lib/src/fileMatcher.ts
@@ -64,6 +64,7 @@ export const DEFAULT_EXCLUDED_EXTENSIONS: ReadonlyArray<string> = [
   "swp",
   "csproj",
   "sln",
+  "slnx",
   "suo",
   "xproj",
   "cc",

--- a/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
+++ b/packages/app-builder-lib/src/options/PlatformSpecificBuildOptions.ts
@@ -81,7 +81,7 @@ Defaults to:
   "!**\/node_modules/*\/{test,__tests__,tests,powered-test,example,examples}",
   "!**\/node_modules/*.d.ts",
   "!**\/node_modules/.bin",
-  "!**\/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}",
+  "!**\/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,slnx,xproj}",
   "!.editorconfig",
   "!**\/._*",
   "!**\/{.DS_Store,.git,.hg,.svn,CVS,RCS,SCCS,.gitignore,.gitattributes}",

--- a/test/src/filterTest.ts
+++ b/test/src/filterTest.ts
@@ -48,7 +48,7 @@ describe("createFilter – build/app/**/* partial directory matching (test-app-b
     "build/app/**/*.html",
     "!build/dist/*-unpacked{,/**/*}",
     "package.json",
-    "!**/*.{iml,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,suo,xproj,cc,d.ts,mk,a,o,obj,forge-meta,pdb}",
+    "!**/*.{iml,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,slnx,suo,xproj,cc,d.ts,mk,a,o,obj,forge-meta,pdb}",
     "!**/._*",
     "!**/electron-builder.{yaml,yml,json,json5,toml,ts}",
   ])

--- a/website/docs/contents.md
+++ b/website/docs/contents.md
@@ -15,7 +15,7 @@ By default, electron-builder includes all files matching `**/*` from the app dir
 
 **Always excluded:**
 - `node_modules` dev dependencies (only production dependencies are included)
-- `*.iml`, `*.o`, `*.hprof`, `*.pyc`, `*.pyo`, `*.rbc`, `*.swp`, `.csproj`, `.sln`, `.xproj`
+- `*.iml`, `*.o`, `*.hprof`, `*.pyc`, `*.pyo`, `*.rbc`, `*.swp`, `.csproj`, `.sln`, `.slnx`, `.xproj`
 - `.editorconfig`, `._*`, `.DS_Store`, `.git`, `.hg`, `.svn`, `.gitignore`, `.gitattributes`
 - `__pycache__`, `.flowconfig`, `.idea`, `.vs`, `.nyc_output`
 - `appveyor.yml`, `.travis.yml`, `circle.yml`


### PR DESCRIPTION
Along with `sln` files, `slnx` are solution files but a recent replacement based on a simple `xml` format. Since `sln` files are excluded I assume that their replacement `slnx` files should be excluded too.