### PR TITLE
feat(dmg): default DMG `filesystem` to `APFS` (BREAKING)

### DIFF
--- a/.changeset/dmg-filesystem-apfs-default.md
+++ b/.changeset/dmg-filesystem-apfs-default.md
@@ -1,0 +1,8 @@
+---
+"app-builder-lib": major
+"dmg-builder": major
+---
+
+feat(dmg): default DMG `filesystem` to APFS
+
+BREAKING CHANGE: The default DMG volume filesystem changed from `HFS+` to `APFS`. APFS is the modern macOS filesystem and produces smaller, faster-to-mount images on current macOS. If you must support pre-10.13 (High Sierra) macOS, which cannot mount APFS volumes, set `dmg.filesystem: "HFS+"` explicitly.

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -277,8 +277,8 @@ export interface DmgOptions extends TargetSpecificOptions {
 
   /**
    * The filesystem for the DMG volume (e.g. `"APFS"` or `"HFS+"`)
-   * This will be changed to APFS in the next major release, so it is recommended to set it explicitly to HFS+ if you want to keep using HFS+ (e.g. for better compatibility with older macOS versions).
-   * @default HFS+
+   * As of v27 this defaults to APFS. Set it explicitly to `"HFS+"` if you need compatibility with older macOS versions (pre-10.13 High Sierra cannot mount APFS volumes).
+   * @default APFS
    */
   readonly filesystem?: "HFS+" | "APFS" | null
 

--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -143,7 +143,7 @@ export async function customizeDmg({ appPath, artifactPath, volumeName, specific
     "text-size": iconTextSize,
 
     "compression-level": Number(process.env.ELECTRON_BUILDER_COMPRESSION_LEVEL || "9"),
-    filesystem: specification.filesystem || "HFS+",
+    filesystem: specification.filesystem || "APFS",
     format: specification.format,
     size: specification.size,
     shrink: specification.shrink,

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -145,6 +145,7 @@ import { build } from "electron-builder"
 - [ ] [Replace `CI_BUILD_TAG`](./v27-breaking-changes#ci_build_tag-environment-variable) with `CI_COMMIT_TAG`.
 - [ ] [Replace toolset env-var overrides](./v27-breaking-changes#toolset-env-var-overrides-removed) (`APPIMAGE_TOOLS_PATH`, `ELECTRON_BUILDER_NSIS_DIR`, `USE_SYSTEM_WINE`, …) with `toolsets.X: { url, checksum }`.
 - [ ] [Validate toolset pins](./v27-breaking-changes#toolset-defaults-resolve-to-latest-newest-bundle) — defaults now resolve to `"latest"` (newest bundle); pin to `"0.0.0"` only if a legacy bundle is needed.
+- [ ] **macOS DMG:** [the DMG `filesystem` default is now APFS](./v27-breaking-changes#dmg-filesystem-defaults-to-apfs) — set `dmg.filesystem: "HFS+"` only if you need pre-10.13 (High Sierra) compatibility.
 - [ ] **Plugin/custom-target authors:** [replace `packager.info.X` and `platformSpecificBuildOptions`](./v27-breaking-changes#programmatic--plugin-author-api-changes) with the new pass-through getters.
 
 ---
@@ -174,6 +175,8 @@ Run `electron-builder migrate-schema` first — it handles the items marked ✓ 
 - [ ] ✓ `snap` restructured to `snapcraft` (verify the assumed `base` if none was set)
 - [ ] ✓ `helper-bundle-id` → `mac.helperBundleId`; `squirrelWindows.noMsi` → `msi`; root-level `directories` → `build.directories`
 
+**Runtime defaults & auto-update**
+- [ ] DMG `filesystem` default is now APFS — set `dmg.filesystem: "HFS+"` only for pre-10.13 macOS compatibility
 **Manual steps** — see [Step 3](#step-3-apply-the-manual-steps) above.
 
 **Plugin and custom-target authors** — see the [programmatic API changes](./v27-breaking-changes#programmatic--plugin-author-api-changes).

--- a/website/docs/migration/v27-breaking-changes.md
+++ b/website/docs/migration/v27-breaking-changes.md
@@ -77,6 +77,7 @@ To stay on a legacy bundle, pin the toolset to `"0.0.0"`. Because `winCodeSign` 
 | [`PlatformPackager.info` & `platformSpecificBuildOptions` now `protected`](#programmatic--plugin-author-api-changes) | — | Plugin authors: hard break — `.info` no longer compiles externally; use the new pass-through getters |
 | [Linux `.desktop` `Exec` now runs a generated `*-launcher` script](#linux-launcher-entrypoint) | — | Update custom `.desktop`/AppArmor/MIME tooling that hard-codes the `Exec` command |
 | [`node_modules` arch/os-filtered on every build](#node_modules-are-now-archos-filtered-on-every-build) | — | Awareness — packages whose `cpu`/`os` mismatch the target are now excluded |
+| [DMG `filesystem` defaults to APFS](#dmg-filesystem-defaults-to-apfs) | — | Set `dmg.filesystem: "HFS+"` only if you need pre-10.13 macOS compatibility |
 | [Renamed type exports (`ElectronDownloadOptions`, `WindowsAzureSigningConfiguration`, …)](#removed-exports) | — | Import the new names — no compat aliases |
 | [`SnapOptions`, `ProtonFramework`, `LibUiFramework` exports removed](#removed-exports) | — | Use the `snapcraft` config shape / Electron framework |
 
@@ -596,6 +597,23 @@ This makes `executableArgs` apply consistently across all Linux targets and keep
 v27 filters `node_modules` by each package's `package.json` `cpu` / `os` fields against the **target** arch and platform on **every** build (previously this effectively only mattered for `universal` macOS builds). A dependency that declares an incompatible `cpu`/`os` for the target is excluded from the packaged app, whereas v26 copied host-installed `node_modules` verbatim.
 
 **No action is required for typical projects** — this fixes universal-build failures and produces correctly-scoped output. Be aware of it only if you *intentionally* bundled a cross-arch or cross-os optional binary that is now dropped; in that rare case, include it explicitly via `extraResources` / `files`.
+
+---
+
+## macOS DMG
+
+### DMG `filesystem` defaults to APFS
+
+The default DMG volume filesystem changed from **`HFS+`** to **`APFS`**. APFS is the modern macOS filesystem and produces smaller, faster-to-mount images on current macOS.
+
+- **No action** for most projects.
+- **If you must support pre-10.13 (High Sierra) macOS**, which cannot mount APFS volumes, set the filesystem back to `HFS+` explicitly:
+
+```json5
+{ "dmg": { "filesystem": "HFS+" } }
+```
+
+This is a runtime default, not a config-key rename, so `migrate-schema` does not change it.
 
 ---
 


### PR DESCRIPTION
The default DMG volume filesystem changed from `HFS+` to `APFS`. APFS is the modern macOS filesystem and produces smaller, faster-to-mount images on current macOS. If you must support pre-10.13 (High Sierra) macOS, which cannot mount APFS volumes, set `dmg.filesystem: "HFS+"` explicitly.