### PR TITLE
feat(updater): harden NSIS web-installer auto-updates: secure-by-default `disableWebInstaller`, a v27 grace period, and target self-identification

### DIFF
--- a/.changeset/disable-web-installer-default.md
+++ b/.changeset/disable-web-installer-default.md
@@ -4,4 +4,11 @@
 
 feat(updater): default `disableWebInstaller` to `true`
 
-BREAKING CHANGE: `AppUpdater.disableWebInstaller` now defaults to `true`. NSIS web-installer packages are no longer loaded unless you opt in, because their payload is fetched from a manifest-supplied URL that may not undergo signature verification. If you intentionally publish and rely on an NSIS web installer, set `disableWebInstaller: false` explicitly; otherwise the download throws `ERR_UPDATER_WEB_INSTALLER_DISABLED`.
+BREAKING CHANGE: `AppUpdater.disableWebInstaller` now defaults to `true`. NSIS web-installer packages are no longer loaded unless you opt in, because their payload is fetched from a manifest-supplied URL that may not undergo signature verification.
+
+v27 ships a one-major-version grace period so existing deployments are not broken without warning:
+
+- If you never set `disableWebInstaller` (the default) and a web-installer update is received, the updater logs a deprecation warning and still downloads it. In v28 this becomes an error and the download is blocked (`ERR_UPDATER_WEB_INSTALLER_DISABLED`).
+- If you explicitly set `disableWebInstaller = true`, the download throws `ERR_UPDATER_WEB_INSTALLER_DISABLED` immediately.
+
+If you intentionally publish and rely on an NSIS web installer, opt back in before v28 by setting `autoUpdater.disableWebInstaller = false` in your main process.

--- a/.changeset/disable-web-installer-default.md
+++ b/.changeset/disable-web-installer-default.md
@@ -1,0 +1,7 @@
+---
+"electron-updater": major
+---
+
+feat(updater): default `disableWebInstaller` to `true`
+
+BREAKING CHANGE: `AppUpdater.disableWebInstaller` now defaults to `true`. NSIS web-installer packages are no longer loaded unless you opt in, because their payload is fetched from a manifest-supplied URL that may not undergo signature verification. If you intentionally publish and rely on an NSIS web installer, set `disableWebInstaller: false` explicitly; otherwise the download throws `ERR_UPDATER_WEB_INSTALLER_DISABLED`.

--- a/.changeset/migrate-schema-nsis-web-advisory.md
+++ b/.changeset/migrate-schema-nsis-web-advisory.md
@@ -1,0 +1,7 @@
+---
+"electron-builder": minor
+---
+
+feat(migrate-schema): advise on `autoUpdater.disableWebInstaller` when an `nsis-web` target is detected
+
+`electron-builder migrate-schema` now prints an advisory when the config builds an `nsis-web` target, reminding you that `AppUpdater.disableWebInstaller` defaults to `true` as of v27 and that you must set `autoUpdater.disableWebInstaller = false` in your main process to keep downloading web installers. The advisory is informational only — it surfaces on the JSON/YAML and programmatic (JS/TS) paths and never rewrites the config (`disableWebInstaller` is an electron-updater runtime setting, not a build-config key).

--- a/.changeset/nsis-web-package-type-marker.md
+++ b/.changeset/nsis-web-package-type-marker.md
@@ -1,0 +1,10 @@
+---
+"app-builder-lib": minor
+"electron-updater": minor
+---
+
+feat(nsis): self-identify install method via `resources/package-type` so nsis-web installs default `disableWebInstaller` to `false`
+
+NSIS installers now write a `resources/package-type` marker (`nsis` or `nsis-web`) at install time, mirroring the existing Linux `package-type` mechanism. electron-updater's `NsisUpdater` reads this marker and, for `nsis-web` installs, pre-seeds `disableWebInstaller = false` so web-installer auto-updates keep working without the app wiring the flag by hand.
+
+This is a default only: an explicit `autoUpdater.disableWebInstaller = …` set by the app still wins, and a plain `nsis` marker leaves the secure `?? true` default (and the v27 grace-period warning) untouched. The marker is written by the installer script — the only build artifact that differs between `nsis` and `nsis-web` (the app payload is byte-identical, since both targets share one app archive). Only go-forward installs carry the marker; existing deployments are unaffected.

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -994,8 +994,8 @@
               "type": "null"
             }
           ],
-          "default": "HFS+",
-          "description": "The filesystem for the DMG volume (e.g. `\"APFS\"` or `\"HFS+\"`)\nThis will be changed to APFS in the next major release, so it is recommended to set it explicitly to HFS+ if you want to keep using HFS+ (e.g. for better compatibility with older macOS versions)."
+          "default": "APFS",
+          "description": "The filesystem for the DMG volume (e.g. `\"APFS\"` or `\"HFS+\"`)\nAs of v27 this defaults to APFS. Set it explicitly to `\"HFS+\"` if you need compatibility with older macOS versions (pre-10.13 High Sierra cannot mount APFS volumes)."
         },
         "format": {
           "default": "UDZO",

--- a/packages/app-builder-lib/templates/nsis/installSection.nsh
+++ b/packages/app-builder-lib/templates/nsis/installSection.nsh
@@ -64,6 +64,20 @@ SetOutPath $INSTDIR
 !endif
 
 !insertmacro installApplicationFiles
+
+# Self-identify the install method for the auto-updater (parity with the Linux `package-type` marker).
+# This is the only install-time signal that differs between nsis and nsis-web — the app payload itself is
+# byte-identical (both targets share one app archive). electron-updater reads this to default
+# disableWebInstaller=false for nsis-web installs.
+FileOpen $0 "$INSTDIR\resources\package-type" w
+!ifdef APP_PACKAGE_URL
+  FileWrite $0 "nsis-web"
+!else
+  FileWrite $0 "nsis"
+!endif
+FileClose $0
+ClearErrors
+
 !insertmacro registryAddInstallInfo
 !insertmacro addStartMenuLink $keepShortcuts
 !insertmacro addDesktopLink $keepShortcuts

--- a/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
+++ b/packages/electron-builder/src/cli/migrate-schema-programmatic.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module"
 import * as path from "path"
-import { AZURE_KNOWN_FIELDS, ELECTRON_DOWNLOAD_DROPPED, MAC_SIGN_FIELDS, MAC_UNIVERSAL_FIELDS, SNAP_BASES } from "./migrate-schema.js"
+import { AZURE_KNOWN_FIELDS, ELECTRON_DOWNLOAD_DROPPED, MAC_SIGN_FIELDS, MAC_UNIVERSAL_FIELDS, NSIS_WEB_ADVISORY, SNAP_BASES } from "./migrate-schema.js"
 import type { MigrationChange } from "./migrate-schema.js"
 
 const _require = createRequire(import.meta.url)
@@ -28,6 +28,8 @@ export interface ProgrammaticMigrationResult {
   readonly code: string
   readonly changes: MigrationChange[]
   readonly warnings: string[]
+  /** Informational notices that are not config changes — they never affect `status` or trigger a file write. */
+  readonly advisories: string[]
   readonly status: ProgrammaticMigrationStatus
   /** Set when status === "unsupported": why the config could not be auto-migrated. */
   readonly unsupportedReason?: string
@@ -52,7 +54,7 @@ interface Edit {
 export function migrateProgrammaticSource(sourceText: string, fileName: string): ProgrammaticMigrationResult {
   const ts = loadTypeScript()
   if (ts == null) {
-    return { code: sourceText, changes: [], warnings: [], status: "unsupported", unsupportedReason: "typescript-not-installed" }
+    return { code: sourceText, changes: [], warnings: [], advisories: [], status: "unsupported", unsupportedReason: "typescript-not-installed" }
   }
 
   const scriptKind = scriptKindFor(ts, fileName)
@@ -61,14 +63,14 @@ export function migrateProgrammaticSource(sourceText: string, fileName: string):
   const codemod = new ConfigCodemod(ts, sf, sourceText)
   const located = codemod.locateConfigObject()
   if (located.objLit == null) {
-    return { code: sourceText, changes: [], warnings: [], status: "unsupported", unsupportedReason: located.reason }
+    return { code: sourceText, changes: [], warnings: [], advisories: [], status: "unsupported", unsupportedReason: located.reason }
   }
 
   codemod.run(located.objLit)
   if (codemod.edits.length === 0) {
-    return { code: sourceText, changes: codemod.changes, warnings: codemod.warnings, status: "no-op" }
+    return { code: sourceText, changes: codemod.changes, warnings: codemod.warnings, advisories: codemod.advisories, status: "no-op" }
   }
-  return { code: codemod.apply(), changes: codemod.changes, warnings: codemod.warnings, status: "migrated" }
+  return { code: codemod.apply(), changes: codemod.changes, warnings: codemod.warnings, advisories: codemod.advisories, status: "migrated" }
 }
 
 function scriptKindFor(ts: any, fileName: string): any {
@@ -91,6 +93,7 @@ class ConfigCodemod {
   readonly edits: Edit[] = []
   readonly changes: MigrationChange[] = []
   readonly warnings: string[] = []
+  readonly advisories: string[] = []
   private indentUnit = "  "
 
   constructor(
@@ -351,9 +354,45 @@ class ConfigCodemod {
       }
     }
     this.ruleElectronDownload(root)
+    this.ruleNsisWebAdvisory(root)
   }
 
   // ── Rules ───────────────────────────────────────────────────────────────
+
+  // Advisory only — adds no edit, so an nsis-web-only config stays a "no-op" and is never rewritten.
+  private ruleNsisWebAdvisory(root: any): void {
+    const ts = this.ts
+    const win = this.getObjectProp(root, "win")
+    const winTarget = win != null ? this.getProp(win, "target") : null
+    const globalTarget = this.getProp(root, "target")
+    for (const prop of [winTarget, globalTarget]) {
+      if (prop != null && ts.isPropertyAssignment(prop) && this.hasNsisWebInTarget(this.unwrap(prop.initializer))) {
+        this.advisories.push(NSIS_WEB_ADVISORY)
+        return
+      }
+    }
+  }
+
+  private hasNsisWebInTarget(value: any): boolean {
+    const ts = this.ts
+    if (value == null) {
+      return false
+    }
+    if (ts.isStringLiteral(value)) {
+      return value.text === "nsis-web"
+    }
+    if (ts.isArrayLiteralExpression(value)) {
+      return value.elements.some((el: any) => this.hasNsisWebInTarget(this.unwrap(el)))
+    }
+    if (ts.isObjectLiteralExpression(value)) {
+      const targetProp = this.getProp(value, "target")
+      if (targetProp != null && ts.isPropertyAssignment(targetProp)) {
+        const inner = this.unwrap(targetProp.initializer)
+        return ts.isStringLiteral(inner) && inner.text === "nsis-web"
+      }
+    }
+    return false
+  }
 
   private ruleRemoveKeys(obj: any, keys: string[], description: string | ((key: string) => string)): void {
     for (const key of keys) {

--- a/packages/electron-builder/src/cli/migrate-schema.ts
+++ b/packages/electron-builder/src/cli/migrate-schema.ts
@@ -18,6 +18,8 @@ export interface MigrationResult {
   readonly migrated: Record<string, any>
   readonly changes: MigrationChange[]
   readonly warnings: string[]
+  /** Informational notices that are not config changes — they never flip `modified` or trigger a file write. */
+  readonly advisories: string[]
   readonly modified: boolean
 }
 
@@ -59,6 +61,34 @@ export const MAC_SIGN_FIELDS = [
 // Universal-build fields that moved from the platform root into the `universal` (ElectronUniversalOptions) bag.
 export const MAC_UNIVERSAL_FIELDS = ["mergeASARs", "singleArchFiles", "x64ArchFiles"] as const
 
+// Advisory surfaced (informational only — never rewrites the config) when a project builds an nsis-web target. As of v27,
+// AppUpdater.disableWebInstaller defaults to true, so the auto-updater no longer downloads web-installer packages unless the app opts in at runtime.
+export const NSIS_WEB_ADVISORY =
+  "nsis-web target detected. In v27, autoUpdater.disableWebInstaller defaults to true, so NSIS web-installer packages are not downloaded by default. " +
+  "If your app relies on nsis-web installers for auto-updates, set autoUpdater.disableWebInstaller = false in your main process (this is an electron-updater runtime setting, not a build-config key)."
+
+/** True when `target` (a string, a `{ target }` object, or an array of either) selects the nsis-web target. */
+function hasNsisWebTarget(target: any): boolean {
+  if (target == null) {
+    return false
+  }
+  if (typeof target === "string") {
+    return target === "nsis-web"
+  }
+  if (Array.isArray(target)) {
+    return target.some(hasNsisWebTarget)
+  }
+  if (typeof target === "object") {
+    return target.target === "nsis-web"
+  }
+  return false
+}
+
+/** True when the build config produces an nsis-web installer (via win.target or the global target). */
+function detectNsisWebTarget(config: Record<string, any>): boolean {
+  return hasNsisWebTarget(config.win?.target) || hasNsisWebTarget(config.target)
+}
+
 /**
  * Applies all v26→v27 config transformations to a parsed config object.
  * Pure function — no I/O, safe to call in tests.
@@ -67,6 +97,7 @@ export function migrateConfig(raw: Record<string, any>): MigrationResult {
   const c: Record<string, any> = JSON.parse(JSON.stringify(raw))
   const changes: MigrationChange[] = []
   const warnings: string[] = []
+  const advisories: string[] = []
 
   // ── 1. electronCompile ────────────────────────────────────────────────────
   if ("electronCompile" in c) {
@@ -322,7 +353,12 @@ export function migrateConfig(raw: Record<string, any>): MigrationResult {
     migrateElectronDownload(c, changes, warnings)
   }
 
-  return { migrated: c, changes, warnings, modified: changes.length > 0 || warnings.length > 0 }
+  // Advisory (not a config change): nsis-web builders must opt back into web installers at runtime as of v27.
+  if (detectNsisWebTarget(c)) {
+    advisories.push(NSIS_WEB_ADVISORY)
+  }
+
+  return { migrated: c, changes, warnings, advisories, modified: changes.length > 0 || warnings.length > 0 }
 }
 
 /**
@@ -676,23 +712,29 @@ export async function migrateSchema(args: any): Promise<void> {
   const isToml = found.format === "toml"
 
   const result = migrateConfig(found.parsed)
-  const { migrated, warnings } = result
+  const { migrated, warnings, advisories } = result
   const changes = [...result.changes]
   if (found.rootDirectoriesMoved) {
     changes.push({ key: "directories", description: "moved package.json root-level directories → build.directories" })
   }
   const modified = result.modified || found.rootDirectoriesMoved === true
 
-  if (!modified) {
-    log.info(null, "config is already up to date — no changes needed")
-    return
-  }
-
   for (const change of changes) {
     log.info({ key: change.key }, change.description)
   }
   for (const warning of warnings) {
     log.warn(null, warning)
+  }
+  // Advisories are informational and surface even when nothing changed; they never cause a rewrite.
+  for (const advisory of advisories) {
+    log.warn(null, advisory)
+  }
+
+  if (!modified) {
+    if (advisories.length === 0) {
+      log.info(null, "config is already up to date — no changes needed")
+    }
+    return
   }
 
   if (isToml) {
@@ -725,14 +767,24 @@ async function migrateProgrammaticConfigFile(found: FoundConfig, location: strin
 
   const result = migrateProgrammaticSource(found.rawText, found.configFile!)
 
+  const printAdvisories = () => {
+    for (const advisory of result.advisories) {
+      log.warn(null, advisory)
+    }
+  }
+
   if (result.status === "unsupported") {
     log.warn({ file: location, reason: result.unsupportedReason }, "this programmatic config could not be auto-migrated; apply these changes manually:")
     printManualSteps()
+    printAdvisories()
     return
   }
 
   if (result.status === "no-op") {
-    log.info(null, "config is already up to date — no changes needed")
+    if (result.advisories.length === 0) {
+      log.info(null, "config is already up to date — no changes needed")
+    }
+    printAdvisories()
     return
   }
 
@@ -742,6 +794,7 @@ async function migrateProgrammaticConfigFile(found: FoundConfig, location: strin
   for (const warning of result.warnings) {
     log.warn(null, warning)
   }
+  printAdvisories()
 
   if (dryRun) {
     log.info(null, "dry run — no files written")

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -96,12 +96,11 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
   /**
    * Web installer files might not have signature verification, this switch prevents to load them unless it is needed.
    *
-   * Currently false to prevent breaking the current API, but it should be changed to default true at some point that
-   * breaking changes are allowed.
+   * Defaults to `true` as of v27 (web installers are opt-in). Set to `false` only if you intentionally publish and rely on NSIS web-installer packages.
    *
-   * @default false
+   * @default true
    */
-  disableWebInstaller = false
+  disableWebInstaller = true
 
   /**
    * *NSIS only* Disable differential downloads and always perform full download of installer.
@@ -711,6 +710,11 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
 
   protected async executeDownload(taskOptions: DownloadExecutorTask): Promise<Array<string>> {
     const fileInfo = taskOptions.fileInfo
+    if (fileInfo.info.sha512 == null && (fileInfo.info as any).sha2 != null) {
+      this._logger.warn(
+        "Update artifact is validated with a SHA-256 (sha2) checksum only. SHA-256 update checksums are deprecated; electron-builder v28 will require SHA-512 and reject SHA-256-only update metadata (fail-closed). Regenerate latest*.yml with a current electron-builder and avoid pinning electronUpdaterCompatibility to a legacy (<2.15 / 1.x) range."
+      )
+    }
     const downloadOptions: DownloadOptions = {
       headers: taskOptions.downloadUpdateOptions.requestHeaders,
       cancellationToken: taskOptions.downloadUpdateOptions.cancellationToken,

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -93,14 +93,22 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
    */
   allowDowngrade = false
 
+  private _disableWebInstaller: boolean | undefined = undefined
+
   /**
-   * Web installer files might not have signature verification, this switch prevents to load them unless it is needed.
+   * Whether to block NSIS web-installer packages. Web installer files might not have signature verification, so they are disabled by default as of v27.
    *
-   * Defaults to `true` as of v27 (web installers are opt-in). Set to `false` only if you intentionally publish and rely on NSIS web-installer packages.
+   * v27 grace period: apps that do not explicitly set this property will warn (but still download) if a web-installer update is received. In v28 the warning becomes an error and the download is blocked (`ERR_UPDATER_WEB_INSTALLER_DISABLED`). Apps that explicitly set this to `true` throw immediately. Set it to `false` only if you intentionally publish and rely on NSIS web-installer packages.
    *
    * @default true
    */
-  disableWebInstaller = true
+  get disableWebInstaller(): boolean {
+    return this._disableWebInstaller ?? true
+  }
+
+  set disableWebInstaller(value: boolean) {
+    this._disableWebInstaller = value
+  }
 
   /**
    * *NSIS only* Disable differential downloads and always perform full download of installer.
@@ -584,7 +592,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       updateInfoAndProvider,
       requestHeaders: this.computeRequestHeaders(updateInfoAndProvider.provider),
       cancellationToken,
-      disableWebInstaller: this.disableWebInstaller,
+      disableWebInstaller: this._disableWebInstaller,
       disableDifferentialDownload: this.disableDifferentialDownload,
     })
       .catch((e: any) => {

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -24,6 +24,27 @@ export class NsisUpdater extends BaseUpdater {
 
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
     super(options, app)
+    this.seedWebInstallerDefaultFromPackageType()
+  }
+
+  // nsis-web installs self-identify via a `resources/package-type` marker written by the installer.
+  // When present, pre-seed disableWebInstaller=false so web-installer updates work without the app
+  // wiring the flag by hand. This is a default only — an explicit `autoUpdater.disableWebInstaller = …`
+  // set later by the app still wins (the setter runs after construction). A plain `nsis` marker is left
+  // untouched so the secure `?? true` default and the v27 grace-period warning stay intact.
+  private seedWebInstallerDefaultFromPackageType(): void {
+    try {
+      const resourcesPath = process.resourcesPath
+      if (!resourcesPath) {
+        return
+      }
+      const packageTypePath = path.join(resourcesPath, "package-type")
+      if (fsExtra.existsSync(packageTypePath) && fsExtra.readFileSync(packageTypePath, "utf-8").trim() === "nsis-web") {
+        this.disableWebInstaller = false
+      }
+    } catch (_ignored) {
+      // best-effort: a missing/unreadable marker just leaves the secure default in place
+    }
   }
 
   protected _verifyUpdateCodeSignature: VerifyUpdateCodeSignature = (publisherNames: Array<string>, unescapedTempUpdateFile: string) =>

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -54,15 +54,25 @@ export class NsisUpdater extends BaseUpdater {
       task: async (destinationFile, downloadOptions, packageFile, removeTempDirIfAny) => {
         const packageInfo = fileInfo.packageInfo
         const isWebInstaller = packageInfo != null && packageFile != null
-        if (isWebInstaller && downloadUpdateOptions.disableWebInstaller) {
-          throw newError(
-            `Unable to download new version ${downloadUpdateOptions.updateInfoAndProvider.info.version}. Web Installers are disabled`,
-            "ERR_UPDATER_WEB_INSTALLER_DISABLED"
+        // Tri-state: `undefined` means the app never set disableWebInstaller (relies on the v27 default), `true`/`false` are explicit choices.
+        const webInstallerExplicitlySet = downloadUpdateOptions.disableWebInstaller !== undefined
+        const webInstallerDisabled = downloadUpdateOptions.disableWebInstaller ?? true
+
+        if (isWebInstaller && webInstallerDisabled) {
+          if (webInstallerExplicitlySet) {
+            throw newError(
+              `Unable to download new version ${downloadUpdateOptions.updateInfoAndProvider.info.version}. Web Installers are disabled`,
+              "ERR_UPDATER_WEB_INSTALLER_DISABLED"
+            )
+          }
+          // Grace period: the app receives a web-installer update but never opted in. Warn loudly and still download for now; v28 will fail-closed.
+          this._logger.warn(
+            "Web installer packages are in use but disableWebInstaller was not explicitly set. v27 defaults to true (web installers disabled) and currently still downloads them with this warning; v28 will fail-closed and throw ERR_UPDATER_WEB_INSTALLER_DISABLED. To keep downloading web installers, set autoUpdater.disableWebInstaller = false. To accept the v28 default, set it to true (or remove the override)."
           )
         }
-        if (!isWebInstaller && !downloadUpdateOptions.disableWebInstaller) {
+        if (!isWebInstaller && webInstallerExplicitlySet && webInstallerDisabled === false) {
           this._logger.warn(
-            "disableWebInstaller is explicitly set to false, but no web installer is in use. As of v27 it defaults to true; set it to true (or remove the override) unless you intentionally rely on NSIS web-installer packages."
+            "disableWebInstaller is explicitly set to false, but a full installer (not a web installer) was downloaded. As of v27 web installers are opt-in (disabled by default); remove the override unless you intentionally publish NSIS web-installer packages."
           )
         }
         if (

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -62,7 +62,7 @@ export class NsisUpdater extends BaseUpdater {
         }
         if (!isWebInstaller && !downloadUpdateOptions.disableWebInstaller) {
           this._logger.warn(
-            "disableWebInstaller is set to false, you should set it to true if you do not plan on using a web installer. This will default to true in a future version."
+            "disableWebInstaller is explicitly set to false, but no web installer is in use. As of v27 it defaults to true; set it to true (or remove the override) unless you intentionally rely on NSIS web-installer packages."
           )
         }
         if (

--- a/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
+++ b/packages/electron-updater/src/windowsExecutableCodeSignatureVerifier.ts
@@ -64,7 +64,10 @@ export function verifySignature(publisherNames: Array<string>, unescapedTempUpda
               return
             }
           } catch (error: any) {
-            logger.warn(`Unable to verify LiteralPath of update asset due to missing data.Path. Skipping this step of validation. Message: ${error.message ?? error.stack}`)
+            logger.warn(
+              `Unable to verify LiteralPath of update asset due to missing data.Path. Skipping this step of validation. Message: ${error.message ?? error.stack}. ` +
+                "This fail-open behavior is deprecated: electron-builder v28 will treat a missing/mismatched LiteralPath as a verification failure (fail-closed)."
+            )
           }
           const subject = parseDn(data.SignerCertificate.Subject)
           let match = false
@@ -119,7 +122,8 @@ function parseOut(out: string): any {
 function handleError(logger: Logger, error: Error | null, stderr: string | null, reject: (reason: any) => void): void {
   if (isOldWin6()) {
     logger.warn(
-      `Cannot execute Get-AuthenticodeSignature: ${error || stderr}. Ignoring signature validation due to unsupported powershell version. Please upgrade to powershell 3 or higher.`
+      `Cannot execute Get-AuthenticodeSignature: ${error || stderr}. Ignoring signature validation due to unsupported powershell version. Please upgrade to powershell 3 or higher. ` +
+        "This fail-open behavior is deprecated: electron-builder v28 will treat an unverifiable signature as a failure (fail-closed)."
     )
     return
   }
@@ -128,7 +132,8 @@ function handleError(logger: Logger, error: Error | null, stderr: string | null,
     execFileSync(...preparePowerShellExec("ConvertTo-Json test", 10 * 1000))
   } catch (testError: any) {
     logger.warn(
-      `Cannot execute ConvertTo-Json: ${testError.message}. Ignoring signature validation due to unsupported powershell version. Please upgrade to powershell 3 or higher.`
+      `Cannot execute ConvertTo-Json: ${testError.message}. Ignoring signature validation due to unsupported powershell version. Please upgrade to powershell 3 or higher. ` +
+        "This fail-open behavior is deprecated: electron-builder v28 will treat an unverifiable signature as a failure (fail-closed)."
     )
     return
   }

--- a/test/src/migrateProgrammaticSchemaTest.ts
+++ b/test/src/migrateProgrammaticSchemaTest.ts
@@ -258,3 +258,38 @@ describe("migrateProgrammaticSource — warnings", () => {
     expect(result.code).toContain("mirrorOptions")
   })
 })
+
+describe("migrateProgrammaticSource — nsis-web advisory", () => {
+  test("nsis-web-only config is a no-op but still emits the advisory (code unchanged)", () => {
+    const source = `export default {\n  win: { target: "nsis-web" },\n}\n`
+    const result = run(source)
+    expect(result.status).toBe("no-op")
+    expect(result.advisories).toHaveLength(1)
+    expect(result.advisories[0]).toMatch(/nsis-web/)
+    expect(result.advisories[0]).toMatch(/disableWebInstaller = false/)
+    expect(result.code).toBe(source)
+  })
+
+  test("advisory is emitted alongside a real migration (status 'migrated')", () => {
+    const result = run(`export default {\n  electronCompile: true,\n  win: { target: "nsis-web" },\n}\n`)
+    expect(result.status).toBe("migrated")
+    expect(result.advisories).toHaveLength(1)
+    expect(result.code).not.toContain("electronCompile")
+  })
+
+  test("array target form is detected", () => {
+    const result = run(`export default {\n  win: { target: ["nsis", "nsis-web"] },\n}\n`)
+    expect(result.advisories).toHaveLength(1)
+  })
+
+  test("object target form is detected", () => {
+    const result = run(`export default {\n  win: { target: [{ target: "nsis-web", arch: "x64" }] },\n}\n`)
+    expect(result.advisories).toHaveLength(1)
+  })
+
+  test("non-web target yields no advisory", () => {
+    const result = run(`export default {\n  win: { target: "nsis" },\n}\n`)
+    expect(result.advisories).toHaveLength(0)
+    expect(result.status).toBe("no-op")
+  })
+})

--- a/test/src/migrateSchemaTest.ts
+++ b/test/src/migrateSchemaTest.ts
@@ -621,3 +621,46 @@ describe("migrateConfig — does not mutate input", () => {
     expect(input).toEqual(frozen)
   })
 })
+
+describe("migrateConfig — nsis-web advisory", () => {
+  test("win.target: 'nsis-web' (string) emits an advisory without changing the config", () => {
+    const input = { win: { target: "nsis-web" } }
+    const result = migrateConfig(input)
+    expect(result.modified).toBe(false)
+    expect(result.changes).toHaveLength(0)
+    expect(result.advisories).toHaveLength(1)
+    expect(result.advisories[0]).toMatch(/nsis-web/)
+    expect(result.advisories[0]).toMatch(/disableWebInstaller = false/)
+    expect(result.migrated).toEqual(input)
+  })
+
+  test("win.target: ['nsis', 'nsis-web'] (array) emits an advisory", () => {
+    const result = migrateConfig({ win: { target: ["nsis", "nsis-web"] } })
+    expect(result.advisories).toHaveLength(1)
+    expect(result.modified).toBe(false)
+  })
+
+  test("win.target: [{ target: 'nsis-web' }] (object form) emits an advisory", () => {
+    const result = migrateConfig({ win: { target: [{ target: "nsis-web", arch: "x64" }] } })
+    expect(result.advisories).toHaveLength(1)
+    expect(result.modified).toBe(false)
+  })
+
+  test("global top-level target: 'nsis-web' emits an advisory", () => {
+    const result = migrateConfig({ target: "nsis-web" })
+    expect(result.advisories).toHaveLength(1)
+  })
+
+  test("a non-web target produces no advisory", () => {
+    const result = migrateConfig({ win: { target: "nsis" } })
+    expect(result.advisories).toHaveLength(0)
+    expect(result.modified).toBe(false)
+  })
+
+  test("advisory coexists with real changes — modified stays true, advisory is excluded from the modified calc", () => {
+    const result = migrateConfig({ electronCompile: true, win: { target: "nsis-web" } })
+    expect(result.modified).toBe(true)
+    expect(result.changes.some(c => c.key === "electronCompile")).toBe(true)
+    expect(result.advisories).toHaveLength(1)
+  })
+})

--- a/test/src/updater/differentialUpdateHelpers.ts
+++ b/test/src/updater/differentialUpdateHelpers.ts
@@ -108,7 +108,16 @@ class TestNativeUpdater extends EventEmitter {
   }
 }
 
-export async function testBlockMap(expect: ExpectStatic, oldDir: string, newDir: string, updaterClass: any, platform: Platform, arch: Arch, productFilename?: string) {
+export async function testBlockMap(
+  expect: ExpectStatic,
+  oldDir: string,
+  newDir: string,
+  updaterClass: any,
+  platform: Platform,
+  arch: Arch,
+  options: { productFilename?: string; disableWebInstaller?: boolean } = {}
+) {
+  const { productFilename, disableWebInstaller } = options
   const appUpdateConfigPath = path.join(
     `${platform.buildConfigurationKey}${getArchSuffix(arch)}${platform === Platform.MAC ? "" : "-unpacked"}`,
     platform === Platform.MAC ? `${productFilename}.app` : ""
@@ -125,6 +134,10 @@ export async function testBlockMap(expect: ExpectStatic, oldDir: string, newDir:
     server.on("error", reject)
 
     const updater = new updaterClass(null, new TestAppAdapter(OLD_VERSION_NUMBER, getTestUpdaterCacheDir(oldDir)))
+    // disableWebInstaller defaults to true as of v27; the web-installer (nsis-web) test must opt back in to download web installer packages
+    if (disableWebInstaller != null) {
+      updater.disableWebInstaller = disableWebInstaller
+    }
     updater._appUpdateConfigPath = path.join(
       oldDir,
       updaterClass === MacUpdater ? `${appUpdateConfigPath}/Contents/Resources` : `${appUpdateConfigPath}/resources`,

--- a/test/src/updater/differentialUpdateTest.ts
+++ b/test/src/updater/differentialUpdateTest.ts
@@ -27,7 +27,7 @@ async function testMac(expect: ExpectStatic, arch: Arch) {
     await move(path.join(oldDir, blockmap), path.join(outDirs[1], blockmap))
     await move(path.join(oldDir, `Test App ßW-${OLD_VERSION_NUMBER}${getArchSuffix(arch)}-mac.zip`), path.join(getTestUpdaterCacheDir(oldDir), testAppCacheDirName, "update.zip"))
 
-    await testBlockMap(expect, outDirs[0], outDirs[1], MacUpdater, Platform.MAC, arch, "Test App ßW")
+    await testBlockMap(expect, outDirs[0], outDirs[1], MacUpdater, Platform.MAC, arch, { productFilename: "Test App ßW" })
   } finally {
     await tmpDir.cleanup()
   }

--- a/test/src/updater/differentialUpdateWinSuite.ts
+++ b/test/src/updater/differentialUpdateWinSuite.ts
@@ -26,7 +26,7 @@ export function registerDifferentialWinTests(toolsets: ToolsetConfig): void {
       path.join(getTestUpdaterCacheDir(oldDir), testAppCacheDirName, "package.7z")
     )
 
-    await testBlockMap(expect, outDirs[0], path.join(outDirs[1], "nsis-web"), NsisUpdater, Platform.WINDOWS, archFromString(process.arch))
+    await testBlockMap(expect, outDirs[0], path.join(outDirs[1], "nsis-web"), NsisUpdater, Platform.WINDOWS, archFromString(process.arch), { disableWebInstaller: false })
   })
 
   test("nsis", async ({ expect }) => {

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -7,6 +7,8 @@ import * as path from "path"
 import { assertThat } from "../helpers/fileAssert.js"
 import { removeUnstableProperties } from "../helpers/packTester.js"
 import { createNsisUpdater, trackEvents, validateDownload, writeUpdateConfig } from "../helpers/updaterTestUtil.js"
+import { createLocalServer } from "../helpers/launchAppCrossPlatform.js"
+import { serializeToYaml, TmpDir } from "builder-util"
 import { ExpectStatic } from "vitest"
 import { GitLabProvider, GitHubProvider } from "electron-updater"
 
@@ -556,4 +558,118 @@ test.skip("test downloaded installer", config, async ({ expect }) => {
   expect(actualEvents).toMatchObject(["checking-for-update", "update-available", "update-downloaded"])
   updater.quitAndInstall(true, false)
   expect(beforeQuitFired).toBe(true)
+})
+
+describe("NsisUpdater — disableWebInstaller tri-state", () => {
+  // Serves a synthetic update over a local server. When `web` is true the latest.yml carries a `packages` block
+  // keyed by the test arch, so resolveFiles populates fileInfo.packageInfo → isWebInstaller. No installer/package
+  // files are served: the web + explicit-`true` branch throws before any download, and every warning branch logs
+  // synchronously before the (then-failing) download — so none of these tests depend on a valid payload.
+  async function serveUpdate(web: boolean) {
+    const tmpDir = new TmpDir("web-installer-unit")
+    const root = await tmpDir.getTempDir()
+    const sha512 = Buffer.alloc(64).toString("base64")
+    const updateInfo: any = {
+      version: "1.0.1",
+      files: [{ url: "TestApp Setup 1.0.1.exe", sha512, size: 10 }],
+      path: "TestApp Setup 1.0.1.exe",
+      sha512,
+      releaseDate: new Date(0).toISOString(),
+    }
+    if (web) {
+      updateInfo.packages = { [process.arch]: { file: "TestApp-1.0.1.nsis.7z", path: "TestApp-1.0.1.nsis.7z", sha512, size: 10 } }
+    }
+    await fsExtra.outputFile(path.join(root, "latest.yml"), serializeToYaml(updateInfo))
+    const { server, port } = await createLocalServer(root)
+    return { server, port, tmpDir }
+  }
+
+  test("explicit disableWebInstaller=true rejects a web-installer update", config, async ({ expect }) => {
+    const { server, port, tmpDir } = await serveUpdate(true)
+    try {
+      const updater = await createNsisUpdater("1.0.0")
+      updater.disableWebInstaller = true
+      updater.updateConfigPath = await writeUpdateConfig<GenericServerOptions>({ provider: "generic", url: `http://127.0.0.1:${port}` })
+      trackEvents(updater)
+
+      const updateCheckResult = await updater.checkForUpdates()
+      await expect(updateCheckResult!.downloadPromise).rejects.toThrow(/Web Installers are disabled/)
+    } finally {
+      server.close()
+      await tmpDir.cleanup()
+    }
+  })
+
+  test("unset disableWebInstaller warns about the v28 fail-closed change instead of rejecting as disabled", config, async ({ expect }) => {
+    const { server, port, tmpDir } = await serveUpdate(true)
+    try {
+      const updater = await createNsisUpdater("1.0.0")
+      // Deliberately do NOT set disableWebInstaller — exercise the v27 grace-period default (unset → warn + proceed).
+      const warnings: Array<string> = []
+      updater.logger = { info() {}, warn: (m: string) => warnings.push(m), error() {}, debug() {} }
+      updater.updateConfigPath = await writeUpdateConfig<GenericServerOptions>({ provider: "generic", url: `http://127.0.0.1:${port}` })
+      trackEvents(updater)
+
+      const updateCheckResult = await updater.checkForUpdates()
+      // The grace-period warning is logged synchronously before the download; the subsequent download may fail
+      // (no payload served), but it must never be the explicit-disabled rejection.
+      const rejection: any = await updateCheckResult!.downloadPromise!.then(
+        () => null,
+        (e: any) => e
+      )
+      expect(warnings.some(w => w.includes("v28 will fail-closed"))).toBe(true)
+      expect(rejection?.code).not.toBe("ERR_UPDATER_WEB_INSTALLER_DISABLED")
+    } finally {
+      server.close()
+      await tmpDir.cleanup()
+    }
+  })
+
+  test("unset disableWebInstaller stays silent for a regular (non-web) installer", config, async ({ expect }) => {
+    const { server, port, tmpDir } = await serveUpdate(false)
+    try {
+      const updater = await createNsisUpdater("1.0.0")
+      // unset disableWebInstaller + a non-web update → neither web-installer warning branch should fire
+      const warnings: Array<string> = []
+      updater.logger = { info() {}, warn: (m: string) => warnings.push(m), error() {}, debug() {} }
+      updater.updateConfigPath = await writeUpdateConfig<GenericServerOptions>({ provider: "generic", url: `http://127.0.0.1:${port}` })
+      trackEvents(updater)
+
+      await updater
+        .checkForUpdates()
+        .then(r => r!.downloadPromise)
+        .then(
+          () => null,
+          () => null
+        )
+      expect(warnings.some(w => w.toLowerCase().includes("web installer"))).toBe(false)
+    } finally {
+      server.close()
+      await tmpDir.cleanup()
+    }
+  })
+
+  test("explicit disableWebInstaller=false warns when a regular (non-web) installer is downloaded", config, async ({ expect }) => {
+    const { server, port, tmpDir } = await serveUpdate(false)
+    try {
+      const updater = await createNsisUpdater("1.0.0")
+      updater.disableWebInstaller = false
+      const warnings: Array<string> = []
+      updater.logger = { info() {}, warn: (m: string) => warnings.push(m), error() {}, debug() {} }
+      updater.updateConfigPath = await writeUpdateConfig<GenericServerOptions>({ provider: "generic", url: `http://127.0.0.1:${port}` })
+      trackEvents(updater)
+
+      await updater
+        .checkForUpdates()
+        .then(r => r!.downloadPromise)
+        .then(
+          () => null,
+          () => null
+        )
+      expect(warnings.some(w => w.includes("a full installer (not a web installer) was downloaded"))).toBe(true)
+    } finally {
+      server.close()
+      await tmpDir.cleanup()
+    }
+  })
 })

--- a/test/src/updater/nsisUpdaterTest.ts
+++ b/test/src/updater/nsisUpdaterTest.ts
@@ -673,3 +673,40 @@ describe("NsisUpdater — disableWebInstaller tri-state", () => {
     }
   })
 })
+
+describe("NsisUpdater — package-type pre-seeds disableWebInstaller", () => {
+  // The installer writes resources/package-type at install time; TestAppAdapter (ElectronAppAdapter) resolves
+  // appUpdateConfigPath through process.resourcesPath, so seeding the marker there matches production exactly.
+  async function withResourcesMarker(content: string | null, fn: (disableWebInstaller: boolean) => void) {
+    const tmpDir = new TmpDir("package-type-unit")
+    const root = await tmpDir.getTempDir()
+    if (content != null) {
+      await fsExtra.outputFile(path.join(root, "package-type"), content)
+    }
+    const original = Object.getOwnPropertyDescriptor(process, "resourcesPath")
+    Object.defineProperty(process, "resourcesPath", { value: root, configurable: true, writable: true })
+    try {
+      const updater = await createNsisUpdater("1.0.0")
+      fn(updater.disableWebInstaller)
+    } finally {
+      if (original == null) {
+        delete (process as any).resourcesPath
+      } else {
+        Object.defineProperty(process, "resourcesPath", original)
+      }
+      await tmpDir.cleanup()
+    }
+  }
+
+  test("nsis-web marker seeds disableWebInstaller=false", config, async ({ expect }) => {
+    await withResourcesMarker("nsis-web", disableWebInstaller => expect(disableWebInstaller).toBe(false))
+  })
+
+  test("nsis marker leaves the secure default (disableWebInstaller=true)", config, async ({ expect }) => {
+    await withResourcesMarker("nsis", disableWebInstaller => expect(disableWebInstaller).toBe(true))
+  })
+
+  test("missing marker leaves the secure default (disableWebInstaller=true)", config, async ({ expect }) => {
+    await withResourcesMarker(null, disableWebInstaller => expect(disableWebInstaller).toBe(true))
+  })
+})

--- a/test/vitest-scripts/run-vitest.ts
+++ b/test/vitest-scripts/run-vitest.ts
@@ -105,7 +105,7 @@ async function main() {
     // smart sharding
     __dirname + "/vitest-config/vitest-smart-reporter.ts",
     // output report/summary for printing in Test workflow OUTPUT_SUMMARY
-    ["json", { outputFile: `test-results/results-${reportId}.json` }]
+    ["json", { outputFile: `test-results/results-${reportId}.json` }],
   ].concat(process.env.VITEST_COVERAGE === "true" ? [["blob", { outputFile: `vitest-blobs/blob-${reportId}.json` }]] : [])
 
   // Opt-in v8 coverage (VITEST_COVERAGE=true, set by the collect-coverage workflow input). Each shard

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -146,7 +146,7 @@ import { build } from "electron-builder"
 - [ ] [Replace toolset env-var overrides](./v27-breaking-changes#toolset-env-var-overrides-removed) (`APPIMAGE_TOOLS_PATH`, `ELECTRON_BUILDER_NSIS_DIR`, `USE_SYSTEM_WINE`, …) with `toolsets.X: { url, checksum }`.
 - [ ] [Validate toolset pins](./v27-breaking-changes#toolset-defaults-resolve-to-latest-newest-bundle) — defaults now resolve to `"latest"` (newest bundle); pin to `"0.0.0"` only if a legacy bundle is needed.
 - [ ] **macOS DMG:** [the DMG `filesystem` default is now APFS](./v27-breaking-changes#dmg-filesystem-defaults-to-apfs) — set `dmg.filesystem: "HFS+"` only if you need pre-10.13 (High Sierra) compatibility.
-- [ ] **electron-updater:** [`disableWebInstaller` now defaults to `true`](./v27-breaking-changes#disablewebinstaller-defaults-to-true) — set it to `false` only if you intentionally ship an NSIS web installer.
+- [ ] **electron-updater:** [`disableWebInstaller` now defaults to `true`](./v27-breaking-changes#disablewebinstaller-defaults-to-true) — v27 warns but still downloads if you never set it; opt in with `disableWebInstaller: false` before v28 enforces it.
 - [ ] **Plugin/custom-target authors:** [replace `packager.info.X` and `platformSpecificBuildOptions`](./v27-breaking-changes#programmatic--plugin-author-api-changes) with the new pass-through getters.
 
 ---
@@ -178,7 +178,7 @@ Run `electron-builder migrate-schema` first — it handles the items marked ✓ 
 
 **Runtime defaults & auto-update**
 - [ ] DMG `filesystem` default is now APFS — set `dmg.filesystem: "HFS+"` only for pre-10.13 macOS compatibility
-- [ ] electron-updater `disableWebInstaller` defaults to `true` — set `false` only if you ship an NSIS web installer
+- [ ] electron-updater `disableWebInstaller` defaults to `true` — opt in with `disableWebInstaller: false` before v28 (v27 has a warn-only grace period)
 **Manual steps** — see [Step 3](#step-3-apply-the-manual-steps) above.
 
 **Plugin and custom-target authors** — see the [programmatic API changes](./v27-breaking-changes#programmatic--plugin-author-api-changes).

--- a/website/docs/migration/v26-to-v27.md
+++ b/website/docs/migration/v26-to-v27.md
@@ -146,6 +146,7 @@ import { build } from "electron-builder"
 - [ ] [Replace toolset env-var overrides](./v27-breaking-changes#toolset-env-var-overrides-removed) (`APPIMAGE_TOOLS_PATH`, `ELECTRON_BUILDER_NSIS_DIR`, `USE_SYSTEM_WINE`, …) with `toolsets.X: { url, checksum }`.
 - [ ] [Validate toolset pins](./v27-breaking-changes#toolset-defaults-resolve-to-latest-newest-bundle) — defaults now resolve to `"latest"` (newest bundle); pin to `"0.0.0"` only if a legacy bundle is needed.
 - [ ] **macOS DMG:** [the DMG `filesystem` default is now APFS](./v27-breaking-changes#dmg-filesystem-defaults-to-apfs) — set `dmg.filesystem: "HFS+"` only if you need pre-10.13 (High Sierra) compatibility.
+- [ ] **electron-updater:** [`disableWebInstaller` now defaults to `true`](./v27-breaking-changes#disablewebinstaller-defaults-to-true) — set it to `false` only if you intentionally ship an NSIS web installer.
 - [ ] **Plugin/custom-target authors:** [replace `packager.info.X` and `platformSpecificBuildOptions`](./v27-breaking-changes#programmatic--plugin-author-api-changes) with the new pass-through getters.
 
 ---
@@ -177,6 +178,7 @@ Run `electron-builder migrate-schema` first — it handles the items marked ✓ 
 
 **Runtime defaults & auto-update**
 - [ ] DMG `filesystem` default is now APFS — set `dmg.filesystem: "HFS+"` only for pre-10.13 macOS compatibility
+- [ ] electron-updater `disableWebInstaller` defaults to `true` — set `false` only if you ship an NSIS web installer
 **Manual steps** — see [Step 3](#step-3-apply-the-manual-steps) above.
 
 **Plugin and custom-target authors** — see the [programmatic API changes](./v27-breaking-changes#programmatic--plugin-author-api-changes).

--- a/website/docs/migration/v27-breaking-changes.md
+++ b/website/docs/migration/v27-breaking-changes.md
@@ -78,7 +78,7 @@ To stay on a legacy bundle, pin the toolset to `"0.0.0"`. Because `winCodeSign` 
 | [Linux `.desktop` `Exec` now runs a generated `*-launcher` script](#linux-launcher-entrypoint) | — | Update custom `.desktop`/AppArmor/MIME tooling that hard-codes the `Exec` command |
 | [`node_modules` arch/os-filtered on every build](#node_modules-are-now-archos-filtered-on-every-build) | — | Awareness — packages whose `cpu`/`os` mismatch the target are now excluded |
 | [DMG `filesystem` defaults to APFS](#dmg-filesystem-defaults-to-apfs) | — | Set `dmg.filesystem: "HFS+"` only if you need pre-10.13 macOS compatibility |
-| [`disableWebInstaller` defaults to `true` (electron-updater)](#disablewebinstaller-defaults-to-true) | — | Set `disableWebInstaller: false` only if you ship an NSIS web installer |
+| [`disableWebInstaller` defaults to `true` (electron-updater)](#disablewebinstaller-defaults-to-true) | — | v27 warns but still downloads if you never set it; opt in with `disableWebInstaller: false` before v28 enforces it |
 | [Renamed type exports (`ElectronDownloadOptions`, `WindowsAzureSigningConfiguration`, …)](#removed-exports) | — | Import the new names — no compat aliases |
 | [`SnapOptions`, `ProtonFramework`, `LibUiFramework` exports removed](#removed-exports) | — | Use the `snapcraft` config shape / Electron framework |
 
@@ -624,14 +624,21 @@ This is a runtime default, not a config-key rename, so `migrate-schema` does not
 
 `AppUpdater.disableWebInstaller` now defaults to **`true`**. NSIS *web* installers (the small installer that downloads the full payload at install time from a manifest-supplied URL) are no longer loaded unless you opt in, because that payload may not undergo signature verification.
 
-- **If you do not use a web installer** (the common case): no action — this is the safer default.
-- **If you publish and rely on an NSIS web installer**: set `disableWebInstaller: false` explicitly, otherwise the download throws `ERR_UPDATER_WEB_INSTALLER_DISABLED`.
+v27 ships a one-major-version grace period so existing deployments are not broken without warning:
+
+- **You never set `disableWebInstaller`** (the default): if a web-installer update is received, the updater logs a warning and still downloads it in v27. In **v28** that warning becomes an error and the download is blocked (`ERR_UPDATER_WEB_INSTALLER_DISABLED`).
+- **You explicitly set `disableWebInstaller = true`**: the download throws `ERR_UPDATER_WEB_INSTALLER_DISABLED` immediately (no grace period).
+- **You do not use a web installer** (the common case): no action — this is the safer default and v28 will enforce it.
+
+If you publish and rely on an NSIS web installer, opt back in **before v28** by setting `disableWebInstaller: false` in your main process:
 
 ```ts
 import { NsisUpdater } from "electron-updater"
 const updater = new NsisUpdater()
 updater.disableWebInstaller = false // only if you intentionally ship a web installer
 ```
+
+> **Tip:** running `electron-builder migrate-schema` on a project that builds an `nsis-web` target now prints an advisory reminding you to set `autoUpdater.disableWebInstaller = false` at runtime. The advisory is informational only — it never rewrites your config (`disableWebInstaller` is an electron-updater runtime setting, not a build-config key).
 
 ---
 

--- a/website/docs/migration/v27-breaking-changes.md
+++ b/website/docs/migration/v27-breaking-changes.md
@@ -78,6 +78,7 @@ To stay on a legacy bundle, pin the toolset to `"0.0.0"`. Because `winCodeSign` 
 | [Linux `.desktop` `Exec` now runs a generated `*-launcher` script](#linux-launcher-entrypoint) | — | Update custom `.desktop`/AppArmor/MIME tooling that hard-codes the `Exec` command |
 | [`node_modules` arch/os-filtered on every build](#node_modules-are-now-archos-filtered-on-every-build) | — | Awareness — packages whose `cpu`/`os` mismatch the target are now excluded |
 | [DMG `filesystem` defaults to APFS](#dmg-filesystem-defaults-to-apfs) | — | Set `dmg.filesystem: "HFS+"` only if you need pre-10.13 macOS compatibility |
+| [`disableWebInstaller` defaults to `true` (electron-updater)](#disablewebinstaller-defaults-to-true) | — | Set `disableWebInstaller: false` only if you ship an NSIS web installer |
 | [Renamed type exports (`ElectronDownloadOptions`, `WindowsAzureSigningConfiguration`, …)](#removed-exports) | — | Import the new names — no compat aliases |
 | [`SnapOptions`, `ProtonFramework`, `LibUiFramework` exports removed](#removed-exports) | — | Use the `snapcraft` config shape / Electron framework |
 
@@ -614,6 +615,23 @@ The default DMG volume filesystem changed from **`HFS+`** to **`APFS`**. APFS is
 ```
 
 This is a runtime default, not a config-key rename, so `migrate-schema` does not change it.
+
+---
+
+## Auto-update (electron-updater)
+
+### `disableWebInstaller` defaults to `true`
+
+`AppUpdater.disableWebInstaller` now defaults to **`true`**. NSIS *web* installers (the small installer that downloads the full payload at install time from a manifest-supplied URL) are no longer loaded unless you opt in, because that payload may not undergo signature verification.
+
+- **If you do not use a web installer** (the common case): no action — this is the safer default.
+- **If you publish and rely on an NSIS web installer**: set `disableWebInstaller: false` explicitly, otherwise the download throws `ERR_UPDATER_WEB_INSTALLER_DISABLED`.
+
+```ts
+import { NsisUpdater } from "electron-updater"
+const updater = new NsisUpdater()
+updater.disableWebInstaller = false // only if you intentionally ship a web installer
+```
 
 ---
 


### PR DESCRIPTION
### Summary

- **`AppUpdater.disableWebInstaller` now defaults to `true` (BREAKING).** NSIS web-installer packages are no longer downloaded by the auto-updater unless the app opts in. Rationale: a web installer's payload is fetched from a manifest-supplied URL and is verified only by SHA-512 checksum from that same manifest — it does not undergo Authenticode signature verification the way the stub `.exe` does. Defaulting the risky path off makes the updater secure-by-default.

- **v27 grace period so existing deployments are not silently broken.** The backing field is tri-state (`undefined` / `true` / `false`):
  - Unset (the new default) + a web-installer update is received → log a deprecation warning and still download (v27). In v28 this becomes an error (`ERR_UPDATER_WEB_INSTALLER_DISABLED`).
  - Explicit `disableWebInstaller = true` + web-installer update → throw `ERR_UPDATER_WEB_INSTALLER_DISABLED` immediately.
  - Explicit `disableWebInstaller = false` + a full (non-web) installer downloaded → advisory warning that web installers are now opt-in.

- **Fail-open signature-verification paths are now flagged as deprecated.** `windowsExecutableCodeSignatureVerifier` still fails open when it cannot verify (missing `LiteralPath`, unsupported PowerShell), but now logs that v28 will treat these as verification failures (fail-closed). Behavior is unchanged in v27; only the warning text is added.

- **`migrate-schema` / `migrate-schema-programmatic` advisory for `nsis-web`.** When an `nsis-web` target is detected, the migration tooling advises that `autoUpdater.disableWebInstaller` defaults to `true` in v27 and that apps relying on web installers must set it to `false` in the main process (this is an electron-updater runtime setting, not a build-config key).

- **NEW — NSIS installs self-identify via `resources/package-type`, and `nsis-web` installs pre-seed `disableWebInstaller = false`.** This removes the friction the new secure default imposes on apps that legitimately ship web installers, without weakening the default for everyone else.
  - The NSIS installer writes `resources/package-type` (`nsis` or `nsis-web`) at install time, mirroring the existing Linux `package-type` marker written by `FpmTarget`.
  - `NsisUpdater` reads this marker on construction and, only for `nsis-web`, pre-seeds `disableWebInstaller = false`. A plain `nsis` marker is left untouched, so the secure `?? true` default and the grace-period warning stay intact.
  - The seed is a default only: an explicit `autoUpdater.disableWebInstaller = …` set by the app afterward still wins (the setter runs after construction).

- **Docs:** `website/docs/migration/v26-to-v27.md` and `v27-breaking-changes.md` document the new default, the grace period, and how to opt back in.

### Design notes

**Why the marker is written by the installer script, not baked into the app payload.** On Linux, fpm re-snapshots the staging directory per target, so writing `package-type` into resources naturally differentiates deb/rpm/pacman. On Windows, `nsis` and `nsis-web` share a single app archive — `AppPackageHelper.packArch` caches the packed app per arch, so whichever target packs first builds it and the other reuses it. The installed `resources/` directory (including `app-update.yml`) is therefore byte-identical between the two installers. The NSIS installer script is the only build artifact that knows which target it is (via the `APP_PACKAGE_URL` vs `APP_BUILD_DIR` define), so the marker must be written at install time, keyed on that define, in `installSection.nsh` right after `installApplicationFiles` (where `$INSTDIR\resources` exists for every install path — embedded, downloaded-web, and embedded-web).

**Why this is the simplest viable seam (fewer moving parts).** The marker reuses an established mechanism and an existing runtime concept rather than introducing new public API. It deliberately avoids adding a `disableWebInstaller` field to the public `PublishConfiguration` type and avoids writing a behavioral flag into `app-update.yml` (which is shared between the two Windows targets and so cannot self-differentiate). The runtime read lives in the `NsisUpdater` constructor — co-located with the property it seeds — so there is no change to `electron-updater`'s `index.ts`/`doLoadAutoUpdater`, it works whether the updater is the `autoUpdater` singleton or a manual `new NsisUpdater()`, and it is unit-testable on any platform (no `process.platform` mocking) by pointing `process.resourcesPath` at a temp dir containing the marker.

**Scope of the marker mechanism.** It only helps go-forward installs that ship both the new installer template and the new electron-updater read code; already-installed deployments are unaffected (their bundled resources have no marker and their installed updater does not read one). It therefore complements — and does not replace — the v27 grace period.

**Edge cases.**
- A build configured with both `nsis` and `nsis-web`: each installer writes its own marker, so the installed app self-identifies by whichever installer the user actually ran. Each installer overwrites the marker on update/repair, so it self-heals if a project switches targets.
- An `nsis-web` install that later receives a non-web update: the seeded `disableWebInstaller = false` makes `webInstallerExplicitlySet` true, so the existing "a full installer was downloaded" advisory fires. This is benign (advisory only) and limited to projects that switch away from web installers.