### PR TITLE
chore: Updating pnpm to latest 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,5 @@
     "node": ">=22.12.0",
     "pnpm": ">=11.1.0"
   },
-  "packageManager": "pnpm@11.1.0+sha512.0c44e842e5686b2c061a81adda8b2258bd8818e9704b2cf2c63d56b931a7b2e910092e085027003b96ca3911ab56a07f6df5abaed2be9925034cdd686a535b14"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }


### PR DESCRIPTION
Seeing if this will resolve renovate's PR issue for artifact update (even though all CI tests pass successfully)
```
/tmp/renovate/repos/github/electron-userland/electron-builder/packages/app-builder-lib:
[ERR_PNPM_MISSING_TIME] The metadata of tslib is missing the "time" field
```