### PR TITLE
chore(docs): remove dead link

### DIFF
--- a/.changeset/great-candies-share.md
+++ b/.changeset/great-candies-share.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(docs): fix broken tip cards in Windows code-signing docs

--- a/.changeset/lemon-yaks-clean.md
+++ b/.changeset/lemon-yaks-clean.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(docs): strikethrough for deprecated API members

--- a/.changeset/wild-otters-share.md
+++ b/.changeset/wild-otters-share.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(docs): remove dead link

--- a/packages/electron-updater/README.md
+++ b/packages/electron-updater/README.md
@@ -12,4 +12,4 @@ Supported OS:
 
 ## Credits
 
-Thanks to [Evolve Labs](https://www.evolvehq.com) for donating the npm package name.
+Thanks to Evolve Labs for donating the npm package name.

--- a/website/docs/features/code-signing/code-signing-win.md
+++ b/website/docs/features/code-signing/code-signing-win.md
@@ -2,7 +2,7 @@
 
 Windows code signing is supported and runs automatically once you configure a signing method — or simply provide signing credentials through environment variables. electron-builder signs every executable and installer it produces so that Windows SmartScreen and your auto-updater can verify your app's publisher and confirm it hasn't been tampered with.
 
-:::tip Dual signing
+:::tip[Dual signing]
 By default each binary is dual-signed with both SHA-1 and SHA-256 (`signingHashAlgorithms: ["sha1", "sha256"]`) so it validates on legacy as well as modern Windows. A few targets are fixed: `.msi` is single-signed and AppX/MSIX is SHA-256 only.
 :::
 
@@ -24,7 +24,7 @@ For file- or store-based signing you need a Windows code signing certificate fro
 
 Both grades work with auto-update.
 
-:::tip Signing without a Windows machine
+:::tip[Signing without a Windows machine]
 You don't need Windows to sign a Windows app. The default `signtool` method signs file-based certificates with `osslsigncode` on macOS/Linux, and the `pkcs11` and `azure` methods are designed for non-Windows CI. See also [Code Signing Windows Apps on Unix](../../tutorials/code-signing-windows-apps-on-unix.md).
 :::
 

--- a/website/scripts/docusaurus-plugin-prebuild.ts
+++ b/website/scripts/docusaurus-plugin-prebuild.ts
@@ -92,6 +92,8 @@ function fixTypedocAnchors(siteDir: string): void {
         return headings.has(slug) ? `[${text}](#${slug})` : text
       })
       fixed = fixed.replace(/\[([^\]]+)\]\((?:\.\/)?([^)#/]+)\.md(#[^)]*)?\)/g, (_match, text, filename, anchor = "") => `[${text}](/docs/api/${filename}${anchor})`)
+      // GFM `~~` doesn't strike through inside MDX headings
+      fixed = fixed.replace(/~~(.+?)~~/g, "<del>$1</del>")
       result.push(fixed)
     }
 


### PR DESCRIPTION
I stumbled upon this by accident while reading the updater's documentation