### PR TITLE
fix(nsis): reliably install the main executable and native binaries on x64 and arm64

### DIFF
--- a/.changeset/nsis-app-archive-decodable-filter.md
+++ b/.changeset/nsis-app-archive-decodable-filter.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): pack the app archive with a filter the install-time extractor can decode so the main executable and native binaries are reliably installed on x64 and arm64 (#9983)

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -8,7 +8,10 @@ import { CompressionLevel, Platform } from "../core"
 import { getLinuxToolsMacToolset } from "../toolsets/linux"
 import { getPath7za } from "../toolsets/7zip"
 
-const ALLOWED_7Z_FILTERS = new Set(["BCJ", "BCJ2", "ARM", "ARMT", "IA64", "PPC", "SPARC", "DELTA"])
+// Values accepted by ELECTRON_BUILDER_7Z_FILTER (passed through as `-mf=<value>`). "OFF" disables the
+// branch/exec filter entirely (plain LZMA2); the rest are 7-Zip branch converters. 7za matches these
+// case-insensitively, so the value is canonicalized to uppercase before use.
+const ALLOWED_7Z_FILTERS = new Set(["OFF", "BCJ", "BCJ2", "ARM", "ARMT", "IA64", "PPC", "SPARC", "DELTA"])
 
 function validateCompressionLevel(level: string): void {
   if (!/^[0-9]$/.test(level)) {
@@ -93,6 +96,18 @@ export interface ArchiveOptions {
    * @default false
    */
   preserveSymlinks?: boolean
+
+  /**
+   * Restrict the 7z filter to one the install-time extractor (the self-vendored Nsis7z plugin) can
+   * decode. Modern 7za (24.09) auto-applies a CPU branch converter to executable content at
+   * `-mx>=1` — `BCJ2` on x86/x64 and `ARM64` on arm64 — which that decoder silently skips, dropping
+   * every executable from the install. When set, the archive is pinned to the single-stream `BCJ`
+   * filter while compressing (decodable, and the best-ratio filter that decoder supports) and to
+   * plain `Copy` while storing. Deliberately NOT overridable by `ELECTRON_BUILDER_7Z_FILTER`, which
+   * could otherwise reintroduce an unreadable archive. Only affects the 7z format. See #9983.
+   * @default false
+   */
+  installTimeDecodable?: boolean
 }
 
 /**
@@ -103,6 +118,22 @@ export interface ArchiveOptions {
  */
 export function shouldPreserveSymlinks(platform: Platform): boolean {
   return platform !== Platform.WINDOWS
+}
+
+/**
+ * Builds the exclude switches for the given masks, rejecting any pattern that contains a path
+ * traversal sequence. `prefix` is the tool-specific flag (`-xr!` for 7za, `-x` for native zip).
+ */
+function buildExcludeArgs(excluded: Array<string> | null | undefined, prefix: string): Array<string> {
+  if (excluded == null) {
+    return []
+  }
+  return excluded.map(mask => {
+    if (mask.includes("..")) {
+      throw new Error(`Excluded archive pattern contains path traversal sequence: "${mask}"`)
+    }
+    return `${prefix}${mask}`
+  })
 }
 
 export function compute7zCompressArgs(format: string, options: ArchiveOptions = {}) {
@@ -146,12 +177,25 @@ export function compute7zCompressArgs(format: string, options: ArchiveOptions = 
       args.push("-mhc=off")
     }
 
-    const sevenZFilter = process.env.ELECTRON_BUILDER_7Z_FILTER
-    if (sevenZFilter) {
-      if (!ALLOWED_7Z_FILTERS.has(sevenZFilter.toUpperCase())) {
-        throw new Error(`ELECTRON_BUILDER_7Z_FILTER must be one of: ${[...ALLOWED_7Z_FILTERS].join(", ")}`)
+    // Branch/exec filter selection. installTimeDecodable archives are unpacked by the self-vendored
+    // Nsis7z extractor, whose decoder only understands plain LZMA2/Copy and the single-stream BCJ
+    // filter — not the CPU branch converters modern 7za auto-applies (BCJ2 on x86/x64, ARM64 on
+    // arm64). So pin them to BCJ while compressing (the best filter that decoder can read; Copy
+    // needs none) and do not honor ELECTRON_BUILDER_7Z_FILTER, which could reintroduce an unreadable
+    // archive. Any other 7z archive may use ELECTRON_BUILDER_7Z_FILTER, else 7za's auto-selection.
+    if (options.installTimeDecodable) {
+      if (!storeOnly) {
+        args.push("-mf=BCJ")
       }
-      args.push(`-mf=${sevenZFilter}`)
+    } else {
+      const sevenZFilter = process.env.ELECTRON_BUILDER_7Z_FILTER
+      if (sevenZFilter) {
+        const canonicalFilter = sevenZFilter.toUpperCase()
+        if (!ALLOWED_7Z_FILTERS.has(canonicalFilter)) {
+          throw new Error(`ELECTRON_BUILDER_7Z_FILTER must be one of: ${[...ALLOWED_7Z_FILTERS].join(", ")}`)
+        }
+        args.push(`-mf=${canonicalFilter}`)
+      }
     }
 
     args.push("-mtm=off", "-mta=off")
@@ -198,14 +242,7 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     }
     await unlinkIfExists(outFile)
     args.push(outFile, options.withoutDir ? "." : path.basename(dirToArchive))
-    if (options.excluded != null) {
-      for (const mask of options.excluded) {
-        if (mask.includes("..")) {
-          throw new Error(`Excluded archive pattern contains path traversal sequence: "${mask}"`)
-        }
-        args.push(`-xr!${mask}`)
-      }
-    }
+    args.push(...buildExcludeArgs(options.excluded, "-xr!"))
 
     try {
       await exec(await getPath7za(), args, { cwd: options.withoutDir ? dirToArchive : path.dirname(dirToArchive) }, debug7z.enabled)
@@ -229,14 +266,7 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     }
     await unlinkIfExists(outFile)
     args.push(outFile, options.withoutDir ? "." : path.basename(dirToArchive))
-    if (options.excluded != null) {
-      for (const mask of options.excluded) {
-        if (mask.includes("..")) {
-          throw new Error(`Excluded archive pattern contains path traversal sequence: "${mask}"`)
-        }
-        args.push(`-x${mask}`)
-      }
-    }
+    args.push(...buildExcludeArgs(options.excluded, "-x"))
     await exec("zip", args, { cwd: options.withoutDir ? dirToArchive : path.dirname(dirToArchive) }, debug7z.enabled)
   }
 

--- a/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/nsis/NsisTarget.ts
@@ -115,6 +115,11 @@ export class NsisTarget extends Target {
     const archiveOptions: ArchiveOptions = {
       withoutDir: true,
       compression: packager.compression,
+      // The install-time Nsis7z extractor only decodes plain LZMA2/Copy and single-stream BCJ — not
+      // the CPU branch converters modern 7za applies to executables (BCJ2 on x86/x64, ARM64 on
+      // arm64), which it silently skips, dropping the main exe and every native binary from the
+      // install. Pin the payload to a filter it can decode. See #9983.
+      installTimeDecodable: true,
       excluded: preCompressedFileExtensions == null ? null : preCompressedFileExtensions.map(it => `*${it}`),
     }
 

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -9,6 +9,7 @@ import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
 import { afterEach, beforeEach, vi } from "vitest"
+import { listArchiveEntries, listArchiveMethods, NON_DECODABLE_NSIS_FILTER } from "./helpers/archiveHelper"
 
 let tmpDir: string
 
@@ -29,6 +30,50 @@ async function makeSrcDir(files: Record<string, string> = { "hello.txt": "hello 
     await fs.writeFile(abs, content)
   }
   return src
+}
+
+// Builds a minimal but structurally valid PE32+ whose `.text` section 7za recognizes as executable
+// code for `machine` (0x8664 = x64, 0x14c = x86, 0xaa64 = arm64). 7za selects the branch filter by
+// content (a synthetic byte blob does not trigger it), so a real PE header + machine type is needed
+// to reproduce the #9983 condition. The section is filled with dense x86 CALL rel32 + NOP so the
+// converter has real work to do.
+function buildMinimalPE(machine: number, codeSize = 120_000): Buffer {
+  const dos = Buffer.alloc(64)
+  dos.write("MZ", 0)
+  dos.writeUInt32LE(64, 0x3c) // e_lfanew → PE header immediately after the DOS header
+  const peSig = Buffer.from("PE\0\0", "latin1")
+  const coff = Buffer.alloc(20)
+  coff.writeUInt16LE(machine, 0) // Machine
+  coff.writeUInt16LE(1, 2) // NumberOfSections
+  coff.writeUInt16LE(0xf0, 16) // SizeOfOptionalHeader (PE32+)
+  coff.writeUInt16LE(0x22, 18) // Characteristics: EXECUTABLE_IMAGE | LARGE_ADDRESS_AWARE
+  const opt = Buffer.alloc(0xf0)
+  opt.writeUInt16LE(0x20b, 0) // PE32+ magic
+  opt.writeUInt32LE(0x1000, 16) // AddressOfEntryPoint
+  opt.writeUInt32LE(0x1000, 20) // BaseOfCode
+  opt.writeUInt32LE(0x40000000, 24) // ImageBase low 32 bits (0x1_40000000)
+  opt.writeUInt32LE(0x1, 28) // ImageBase high 32 bits
+  opt.writeUInt32LE(0x1000, 32) // SectionAlignment
+  opt.writeUInt32LE(0x200, 36) // FileAlignment
+  const section = Buffer.alloc(40)
+  section.write(".text", 0)
+  section.writeUInt32LE(codeSize, 8) // VirtualSize
+  section.writeUInt32LE(0x1000, 12) // VirtualAddress
+  section.writeUInt32LE(codeSize, 16) // SizeOfRawData
+  const header = Buffer.concat([dos, peSig, coff, opt, section])
+  const rawPtr = Math.ceil(header.length / 0x200) * 0x200
+  section.writeUInt32LE(rawPtr, 20) // PointerToRawData
+  section.writeUInt32LE(0x60000020, 36) // Characteristics: CODE | EXECUTE | READ
+  const code = Buffer.alloc(codeSize)
+  let p = 0
+  while (p < code.length - 6) {
+    code[p++] = 0xe8 // CALL rel32
+    code.writeInt32LE(((p * 7) % 5000) - 2500, p)
+    p += 4
+    code[p++] = 0x90 // NOP
+  }
+  // `section` was mutated after the first concat — rebuild the header so the updated section is used.
+  return Buffer.concat([dos, peSig, coff, opt, section, Buffer.alloc(rawPtr - header.length), code])
 }
 
 // ─── compute7zCompressArgs ───────────────────────────────────────────────────
@@ -109,6 +154,43 @@ describe("compute7zCompressArgs", () => {
   test("valid ELECTRON_BUILDER_7Z_FILTER is included", ({ expect }) => {
     vi.stubEnv("ELECTRON_BUILDER_7Z_FILTER", "BCJ2")
     expect(compute7zCompressArgs("7z", {})).toContain("-mf=BCJ2")
+  })
+
+  test("ELECTRON_BUILDER_7Z_FILTER is normalized to canonical uppercase", ({ expect }) => {
+    vi.stubEnv("ELECTRON_BUILDER_7Z_FILTER", "bcj")
+    expect(compute7zCompressArgs("7z", {})).toContain("-mf=BCJ")
+  })
+
+  test("ELECTRON_BUILDER_7Z_FILTER=off disables the filter (plain LZMA2)", ({ expect }) => {
+    vi.stubEnv("ELECTRON_BUILDER_7Z_FILTER", "off")
+    expect(compute7zCompressArgs("7z", {})).toContain("-mf=OFF")
+  })
+
+  // #9983: NSIS packs with installTimeDecodable so 7za uses a filter (BCJ, never BCJ2/ARM64) the
+  // install-time Nsis7z extractor can actually read.
+  test("installTimeDecodable pins the 7z filter to BCJ when compressing", ({ expect }) => {
+    expect(compute7zCompressArgs("7z", { installTimeDecodable: true })).toContain("-mf=BCJ")
+  })
+
+  test("installTimeDecodable adds no filter in store mode (Copy needs none)", ({ expect }) => {
+    const args = compute7zCompressArgs("7z", { installTimeDecodable: true, compression: "store" })
+    expect(args.some((a: string) => a.startsWith("-mf="))).toBe(false)
+    expect(args).toContain("-mx=0")
+  })
+
+  test("no -mf flag is emitted by default (7za auto-selects the filter)", ({ expect }) => {
+    expect(compute7zCompressArgs("7z", {}).some((a: string) => a.startsWith("-mf="))).toBe(false)
+  })
+
+  test("installTimeDecodable is a no-op for non-7z formats", ({ expect }) => {
+    expect(compute7zCompressArgs("zip", { installTimeDecodable: true }).some((a: string) => a.startsWith("-mf="))).toBe(false)
+  })
+
+  test("installTimeDecodable ignores ELECTRON_BUILDER_7Z_FILTER (cannot be overridden to a non-decodable filter)", ({ expect }) => {
+    vi.stubEnv("ELECTRON_BUILDER_7Z_FILTER", "BCJ2")
+    const args = compute7zCompressArgs("7z", { installTimeDecodable: true })
+    expect(args).toContain("-mf=BCJ")
+    expect(args).not.toContain("-mf=BCJ2")
   })
 
   test("dictSize adds -md flag", ({ expect }) => {
@@ -245,5 +327,64 @@ describe.runIf(process.platform !== "win32")("archive() symlink preservation", {
   test("excluded pattern with '..' throws when preserveSymlinks is set", async ({ expect }) => {
     const src = await makeSrcDir()
     await expect(archive("zip", path.join(tmpDir, "out.zip"), src, { excluded: ["../secret"], preserveSymlinks: true })).rejects.toThrow("path traversal sequence")
+  })
+})
+
+// ─── archive() — 7z branch filter (#9983) ────────────────────────────────────
+// Modern 7za auto-applies a CPU branch filter to executable content (BCJ2 on x86/x64, ARM64 on
+// arm64). The install-time Nsis7z decoder can't read those streams and silently drops every PE,
+// shipping an installer with no main exe. installTimeDecodable must pin the filter to one that
+// decoder can read (BCJ). These pack real (minimal) PE headers through the same archive() path the
+// NSIS target uses, then read back the codec actually applied.
+
+describe("archive() 7z branch filter", () => {
+  async function makePayloadDir(): Promise<string> {
+    const dir = path.join(tmpDir, "payload")
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(path.join(dir, "app.exe"), buildMinimalPE(0x8664)) // x64 PE → BCJ2 by default
+    await fs.writeFile(path.join(dir, "native.exe"), buildMinimalPE(0xaa64)) // arm64 PE → ARM64 by default
+    await fs.writeFile(path.join(dir, "resources.pak"), Buffer.alloc(40_000, 7)) // data → plain LZMA2
+    return dir
+  }
+
+  // Guards that the synthetic PEs really do trigger the filter — otherwise the fix-side assertion
+  // below would pass vacuously and stop protecting against the regression.
+  test("default packing applies a CPU branch filter to executables (reproduces the regression)", async ({ expect }) => {
+    const dir = await makePayloadDir()
+    const outFile = path.join(tmpDir, "default.7z")
+    await archive("7z", outFile, dir, { withoutDir: true })
+    // Both arch filters must appear, so the fix-side assertion below covers both x64 (BCJ2) and arm64 (ARM64).
+    const methods = (await listArchiveMethods(outFile)).join("\n")
+    expect(methods, "x64 PE should be packed with BCJ2 by default").toMatch(/BCJ2/)
+    expect(methods, "arm64 PE should be packed with ARM64 by default").toMatch(/ARM64/)
+  })
+
+  test("installTimeDecodable packs with a decoder-readable filter (BCJ, never BCJ2/ARM64)", async ({ expect }) => {
+    const dir = await makePayloadDir()
+    const outFile = path.join(tmpDir, "fixed.7z")
+    await archive("7z", outFile, dir, { withoutDir: true, installTimeDecodable: true })
+    const methods = (await listArchiveMethods(outFile)).join("\n")
+    // The decodable BCJ filter is applied to the executables…
+    expect(methods, "expected the decodable BCJ filter to be applied").toMatch(/\bBCJ\b/)
+    // …and none of the filters the install-time decoder can't read appear (notably BCJ2/ARM64).
+    expect(methods).not.toMatch(NON_DECODABLE_NSIS_FILTER)
+  })
+})
+
+// ─── buildExcludeArgs (via archive()) — happy-path coverage ───────────────────
+// The "../" throw path is covered by the guard tests above; this exercises the extracted helper's
+// positive branch through the 7za "-xr!" prefix (recursive exclude) end-to-end.
+
+describe("archive() exclude masks", () => {
+  test("7z drops files matching an excluded mask recursively and keeps the rest", async ({ expect }) => {
+    const src = await makeSrcDir({ "keep.txt": "keep", "debug.log": "log", "nested/trace.log": "log2" })
+    const outFile = path.join(tmpDir, "excluded.7z")
+    await archive("7z", outFile, src, { withoutDir: true, excluded: ["*.log"] })
+    const entries = await listArchiveEntries(outFile)
+    expect(entries).toContain("keep.txt")
+    expect(
+      entries.some(e => e.endsWith(".log")),
+      `no *.log should remain, got: ${entries.join(", ")}`
+    ).toBe(false)
   })
 })

--- a/test/src/helpers/archiveHelper.ts
+++ b/test/src/helpers/archiveHelper.ts
@@ -1,0 +1,51 @@
+import { getPath7za } from "app-builder-lib/src/toolsets/7zip"
+import { execFile } from "child_process"
+import { promisify } from "util"
+
+const execFileAsync = promisify(execFile)
+
+// Runs `7za l -slt` and returns its stdout. execFile (no shell) avoids quoting issues with paths
+// that contain spaces; the large maxBuffer covers the technical listing of big payloads.
+async function list7z(archivePath: string): Promise<string> {
+  const { stdout } = await execFileAsync(await getPath7za(), ["l", "-slt", archivePath], { maxBuffer: 64 * 1024 * 1024 })
+  return stdout
+}
+
+// Lists entry paths inside any archive 7-Zip can read (.7z, .zip, .nupkg, …) using the technical
+// listing (`-slt`), which prints one `Path = <entry>` line per entry — robust against entry names
+// that contain spaces (column-splitting the human-readable table is not).
+export async function listArchiveEntries(archivePath: string): Promise<Array<string>> {
+  const stdout = await list7z(archivePath)
+  const archiveAsEntry = archivePath.replace(/\\/g, "/")
+  return stdout
+    .split(/\r?\n/)
+    .filter(line => line.startsWith("Path = "))
+    .map(line => line.slice("Path = ".length).trim().replace(/\\/g, "/"))
+    .filter(entry => entry.length > 0 && entry !== archiveAsEntry)
+}
+
+// True if the archive contains `entry` (matched as a full path or as a trailing path segment, so
+// "resources/elevate.exe" matches "lib/net45/resources/elevate.exe" too).
+export async function archiveContains(archivePath: string, entry: string): Promise<boolean> {
+  const normalized = entry.replace(/\\/g, "/")
+  const entries = await listArchiveEntries(archivePath)
+  return entries.some(it => it === normalized || it.endsWith("/" + normalized))
+}
+
+// Branch/exec filters the self-vendored install-time Nsis7z decoder cannot read — every 7z filter
+// except plain LZMA2/Copy and the single-stream BCJ filter the fix pins to. An NSIS app archive
+// whose entries use any of these would have those entries silently dropped at install time (#9983).
+// `BCJ` is intentionally excluded (word boundaries keep it from matching the unrelated `BCJ2`).
+export const NON_DECODABLE_NSIS_FILTER = /\b(BCJ2|ARM64|ARMT|ARM|IA64|PPC|SPARC|DELTA)\b/
+
+// Lists the 7-Zip codec/method strings reported for the archive (the `Method = …` lines of the
+// technical listing — one per entry plus an archive-level summary). Used to assert that an NSIS app
+// package contains no CPU branch filter the install-time Nsis7z decoder can't read (#9983).
+export async function listArchiveMethods(archivePath: string): Promise<Array<string>> {
+  const stdout = await list7z(archivePath)
+  return stdout
+    .split(/\r?\n/)
+    .filter(line => line.startsWith("Method = "))
+    .map(line => line.slice("Method = ".length).trim())
+    .filter(method => method.length > 0)
+}

--- a/test/src/windows/webInstallerTest.ts
+++ b/test/src/windows/webInstallerTest.ts
@@ -1,29 +1,60 @@
 import { Arch, Platform } from "electron-builder"
+import * as fs from "fs/promises"
+import * as path from "path"
+import { listArchiveEntries, listArchiveMethods, NON_DECODABLE_NSIS_FILTER } from "../helpers/archiveHelper"
 import { app, assertPack } from "../helpers/packTester"
 
 // tests are heavy, to distribute tests across CircleCI machines evenly, these tests were moved from oneClickInstallerTest
 
 test("web installer", ({ expect }) =>
-  app(expect, {
-    targets: Platform.WINDOWS.createTarget(["nsis-web"], Arch.x64, Arch.arm64),
-    config: {
-      publish: {
-        provider: "s3",
-        bucket: "develar",
-        path: "test",
-      },
-      electronFuses: {
-        runAsNode: true,
-        enableCookieEncryption: true,
-        enableNodeOptionsEnvironmentVariable: true,
-        enableNodeCliInspectArguments: true,
-        enableEmbeddedAsarIntegrityValidation: true,
-        onlyLoadAppFromAsar: true,
-        loadBrowserProcessSpecificV8Snapshot: true,
-        grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+  app(
+    expect,
+    {
+      targets: Platform.WINDOWS.createTarget(["nsis-web"], Arch.x64, Arch.arm64),
+      config: {
+        publish: {
+          provider: "s3",
+          bucket: "develar",
+          path: "test",
+        },
+        electronFuses: {
+          runAsNode: true,
+          enableCookieEncryption: true,
+          enableNodeOptionsEnvironmentVariable: true,
+          enableNodeCliInspectArguments: true,
+          enableEmbeddedAsarIntegrityValidation: true,
+          onlyLoadAppFromAsar: true,
+          loadBrowserProcessSpecificV8Snapshot: true,
+          grantFileProtocolExtraPrivileges: undefined, // unsupported on current electron version in our tests
+        },
       },
     },
-  }))
+    {
+      packed: async context => {
+        const archives = (await fs.readdir(context.outDir, { recursive: true })).filter(f => f.endsWith(".nsis.7z"))
+        expect(archives.length, "expected at least one .nsis.7z web app package").toBeGreaterThan(0)
+        for (const rel of archives) {
+          const archivePath = path.join(context.outDir, rel)
+
+          // #9983: the install-time Nsis7z decoder silently drops entries packed with a CPU branch
+          // filter it can't read (BCJ2 on x64, ARM64 on arm64) — the main exe and every native
+          // binary go missing. The whole payload (x64 + arm64) must use only decoder-readable codecs
+          // (plain LZMA2/Copy or the single-stream BCJ).
+          const methods = await listArchiveMethods(archivePath)
+          expect(methods.length, `${rel} should report codec methods`).toBeGreaterThan(0)
+          for (const method of methods) {
+            expect(method, `${rel} entry packed with a non-decodable branch filter: "${method}"`).not.toMatch(NON_DECODABLE_NSIS_FILTER)
+          }
+
+          // Tie "no branch filter" to the literal #9983 symptom: the payload must actually contain
+          // the main app exe (a PE that would have been the first thing silently dropped).
+          const entries = await listArchiveEntries(archivePath)
+          const appExes = entries.filter(e => e.toLowerCase().endsWith(".exe"))
+          expect(appExes.length, `${rel} must contain the main app exe (PE files must not be dropped); entries: ${entries.join(", ")}`).toBeGreaterThan(0)
+        }
+      },
+    }
+  ))
 
 test("web installer (default github)", ({ expect }) =>
   app(expect, {


### PR DESCRIPTION
Backport of https://github.com/electron-userland/electron-builder/pull/9988 from v27 to v26

Fixes https://github.com/electron-userland/electron-builder/issues/9983