### PR TITLE
fix: strip credential env vars from child-process environment on Windows

### DIFF
--- a/.changeset/win-child-env-secret-stripping.md
+++ b/.changeset/win-child-env-secret-stripping.md
@@ -1,0 +1,7 @@
+---
+"builder-util": patch
+---
+
+fix(security): strip credential env vars from child-process environment on Windows
+
+Previously, child processes spawned during a Windows build (signtool, makeappx, package managers) inherited the full environment, including credential variables such as `CSC_KEY_PASSWORD`, `WIN_CSC_KEY_PASSWORD`, and publish tokens. `getProcessEnv` now applies the same credential deny-list on Windows that the other platforms already use, so these secrets are no longer passed down to spawned tools. Signing tools receive the certificate password as an explicit CLI argument (not via the environment), and required Windows system variables (`PATH`, `SYSTEMROOT`, `TEMP`, etc.) are preserved unchanged.

--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -104,10 +104,14 @@ export function filterSensitiveEnv(env: Record<string, string | undefined>): Rec
 }
 
 function getProcessEnv(env: Record<string, string | undefined> | Nullish): NodeJS.ProcessEnv | undefined {
-  // Windows: passing a filtered env to execFile drops critical system vars (PATH, SYSTEMROOT, TEMP)
-  // that many tools require. Credential stripping is therefore not applied on Windows.
+  // Windows does not need the LC_* locale normalisation below, but child processes (signtool, makeappx,
+  // package managers) MUST still have credential env vars (CSC_KEY_PASSWORD, tokens, etc.) stripped before they
+  // inherit them. Signing tools receive the certificate password as an explicit CLI argument (e.g. signtool
+  // `/p <password>`), never via the environment, so stripping these keys does not break signing.
+  // stripSensitiveEnvVars only removes credential-named keys and preserves required Windows system vars
+  // (PATH, SYSTEMROOT, TEMP, etc.).
   if (process.platform === "win32") {
-    return env == null ? undefined : env
+    return stripSensitiveEnvVars(env == null ? process.env : env)
   }
 
   // When no explicit env is provided, strip credential env vars so child processes

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -1,6 +1,6 @@
 import { parseValidEnvVarUrl } from "builder-util/internal"
 import { resolveEnvShellValue, validateShellEmbeddable } from "builder-util/src/envUtil"
-import { removePassword, filterSensitiveEnv, spawnAndWriteWithOutput, ExecError } from "builder-util"
+import { removePassword, filterSensitiveEnv, stripSensitiveEnvVars, spawnAndWriteWithOutput, ExecError } from "builder-util"
 import { afterEach, expect, vi } from "vitest"
 
 const testValue = "secretValue"
@@ -258,6 +258,61 @@ describe("filterSensitiveEnv", () => {
     const result = filterSensitiveEnv({ GITHUB_LINK: "https://github.com", ELECTRON_CACHE: "/tmp" })
     expect(result.GITHUB_LINK).toBe("https://github.com")
     expect(result.ELECTRON_CACHE).toBe("/tmp")
+  })
+})
+
+describe("stripSensitiveEnvVars (Windows child-process env hardening, F1)", () => {
+  test("removes credential-bearing keys entirely", ({ expect }) => {
+    const secretKeys = ["CSC_KEY_PASSWORD", "WIN_CSC_KEY_PASSWORD", "CSC_LINK", "GH_TOKEN", "GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY", "API_KEY", "NODE_AUTH_TOKEN"]
+    const result = stripSensitiveEnvVars(Object.fromEntries(secretKeys.map(k => [k, "secret"])))
+    for (const key of secretKeys) {
+      expect(Object.prototype.hasOwnProperty.call(result, key)).toBe(false)
+    }
+  })
+
+  test("preserves required Windows system vars verbatim", ({ expect }) => {
+    const systemEnv: Record<string, string> = {
+      PATH: "C:\\Windows",
+      SystemRoot: "C:\\Windows",
+      TEMP: "C:\\Temp",
+      TMP: "C:\\Temp",
+      windir: "C:\\Windows",
+      COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      PATHEXT: ".COM;.EXE;.BAT",
+      PROCESSOR_ARCHITECTURE: "AMD64",
+      NUMBER_OF_PROCESSORS: "8",
+      APPDATA: "C:\\Users\\u\\AppData\\Roaming",
+      LOCALAPPDATA: "C:\\Users\\u\\AppData\\Local",
+      PROGRAMDATA: "C:\\ProgramData",
+      ProgramFiles: "C:\\Program Files",
+      "ProgramFiles(x86)": "C:\\Program Files (x86)",
+      USERPROFILE: "C:\\Users\\u",
+      USERNAME: "u",
+      COMPUTERNAME: "PC",
+      HOMEDRIVE: "C:",
+      HOMEPATH: "\\Users\\u",
+      SystemDrive: "C:",
+      ALLUSERSPROFILE: "C:\\ProgramData",
+      PSModulePath: "C:\\Program Files\\PowerShell\\Modules",
+    }
+    const result = stripSensitiveEnvVars(systemEnv)
+    for (const [key, value] of Object.entries(systemEnv)) {
+      expect(result[key]).toBe(value)
+    }
+  })
+
+  test("keeps non-sensitive app vars and drops prototype-polluting keys", ({ expect }) => {
+    const polluted = Object.fromEntries([
+      ["__proto__", "x"],
+      ["constructor", "y"],
+      ["prototype", "z"],
+      ["NODE_ENV", "production"],
+    ])
+    const result = stripSensitiveEnvVars(polluted)
+    expect(result.NODE_ENV).toBe("production")
+    for (const key of ["__proto__", "constructor", "prototype"]) {
+      expect(Object.prototype.hasOwnProperty.call(result, key)).toBe(false)
+    }
   })
 })
 


### PR DESCRIPTION
- `getProcessEnv` previously returned the Windows environment unchanged, so every spawned tool (signtool, makeappx, package managers) inherited credential vars such as `CSC_KEY_PASSWORD`, `WIN_CSC_KEY_PASSWORD`, and publish tokens. It now applies the same credential deny-list (`stripSensitiveEnvVars`) on Windows that the other platforms already use, for both the explicit-env and inherited-env paths. Required Windows system vars (`PATH`, `SYSTEMROOT`, `TEMP`, etc.) are preserved, and signing tools already receive the certificate password as an explicit CLI argument rather than via the environment, so signing is unaffected.