### PR TITLE
fix(app-builder-lib): expand lower channels when channel name has a suffix

### DIFF
--- a/.changeset/channel-arch-suffix-expansion.md
+++ b/.changeset/channel-arch-suffix-expansion.md
@@ -1,0 +1,7 @@
+---
+"app-builder-lib": patch
+---
+
+fix(app-builder-lib): expand lower channels when the channel name has a suffix
+
+With `generateUpdatesFilesForAllChannels` enabled, the extra `alpha`/`beta` update files were only written when the channel was exactly `alpha`, `beta`, or `latest`. A per-arch feed configured as `channel: "${channel}-${arch}"` resolves to something like `beta-arm64`, which hit the default branch, so `alpha-arm64.yml` was never written and arm64 pre-release users stopped getting promoted. The base channel is now read off the front of the name and the suffix is reattached to the expanded channels, so `beta-arm64` yields `beta-arm64` and `alpha-arm64`, and `latest-arm64` yields all three.

--- a/.changeset/channel-arch-suffix-expansion.md
+++ b/.changeset/channel-arch-suffix-expansion.md
@@ -1,7 +1,9 @@
 ---
-"app-builder-lib": patch
+"app-builder-lib": major
 ---
 
 fix(app-builder-lib): expand lower channels when the channel name has a suffix
 
 With `generateUpdatesFilesForAllChannels` enabled, the extra `alpha`/`beta` update files were only written when the channel was exactly `alpha`, `beta`, or `latest`. A per-arch feed configured as `channel: "${channel}-${arch}"` resolves to something like `beta-arm64`, which hit the default branch, so `alpha-arm64.yml` was never written and arm64 pre-release users stopped getting promoted. The base channel is now read off the front of the name and the suffix is reattached to the expanded channels, so `beta-arm64` yields `beta-arm64` and `alpha-arm64`, and `latest-arm64` yields all three.
+
+Breaking: a suffixed `beta-*`/`latest-*` channel now publishes 2–3 update files instead of 1, so a `latest-x64` publish overwrites `beta-x64.yml`/`alpha-x64.yml` in the same bucket. Turn off `generateUpdatesFilesForAllChannels` if you relied on suffixed channels staying single-file.

--- a/packages/app-builder-lib/src/publish/updateInfoBuilder.ts
+++ b/packages/app-builder-lib/src/publish/updateInfoBuilder.ts
@@ -45,17 +45,19 @@ function isGenerateUpdatesFilesForAllChannels(packager: PlatformPackager<any>) {
  */
 function computeChannelNames(packager: PlatformPackager<any>, publishConfig: PublishConfiguration): Array<string> {
   const currentChannel: string = (publishConfig as GenericServerOptions).channel || "latest"
+  const baseChannel = ["alpha", "beta", "latest"].find(name => currentChannel === name || currentChannel.startsWith(`${name}-`)) || currentChannel
+  const suffix = currentChannel.slice(baseChannel.length)
   // for GitHub should be pre-release way be used
-  if (currentChannel === "alpha" || publishConfig.provider === "github" || !isGenerateUpdatesFilesForAllChannels(packager)) {
+  if (baseChannel === "alpha" || publishConfig.provider === "github" || !isGenerateUpdatesFilesForAllChannels(packager)) {
     return [currentChannel]
   }
 
-  switch (currentChannel) {
+  switch (baseChannel) {
     case "beta":
-      return [currentChannel, "alpha"]
+      return [currentChannel, `alpha${suffix}`]
 
     case "latest":
-      return [currentChannel, "alpha", "beta"]
+      return [currentChannel, `alpha${suffix}`, `beta${suffix}`]
 
     default:
       return [currentChannel]

--- a/test/src/updateInfoBuilderTest.ts
+++ b/test/src/updateInfoBuilderTest.ts
@@ -299,3 +299,39 @@ test("sha512 values are preserved correctly for each file entry", async ({ expec
     expect(byUrl["App-1.0.0-arm64.exe"]).toBe("sha512-arm64-value")
   })
 })
+
+function makeAllChannelsPackager(): any {
+  return { ...makePlatformPackager(), config: { releaseInfo: undefined, generateUpdatesFilesForAllChannels: true } }
+}
+
+test("beta channel with arch suffix expands to alpha carrying the same suffix", async ({ expect }) => {
+  await withTmpDir(async dir => {
+    const artifactFile = path.join(dir, "App-1.0.0-arm64.exe")
+    await fsp.writeFile(artifactFile, "fake")
+    const event: any = { file: artifactFile, arch: Arch.arm64, packager: makeAllChannelsPackager(), target: { outDir: dir } }
+    const tasks = await createUpdateInfoTasks(event, [{ provider: "s3", bucket: "test", channel: "beta-arm64" }] as any)
+    const names = tasks.map(t => path.basename(t.file)).sort()
+    expect(names).toEqual(["alpha-arm64.yml", "beta-arm64.yml"])
+  })
+})
+
+test("latest channel with arch suffix expands to alpha and beta carrying the same suffix", async ({ expect }) => {
+  await withTmpDir(async dir => {
+    const artifactFile = path.join(dir, "App-1.0.0-arm64.exe")
+    await fsp.writeFile(artifactFile, "fake")
+    const event: any = { file: artifactFile, arch: Arch.arm64, packager: makeAllChannelsPackager(), target: { outDir: dir } }
+    const tasks = await createUpdateInfoTasks(event, [{ provider: "s3", bucket: "test", channel: "latest-arm64" }] as any)
+    const names = tasks.map(t => path.basename(t.file)).sort()
+    expect(names).toEqual(["alpha-arm64.yml", "beta-arm64.yml", "latest-arm64.yml"])
+  })
+})
+
+test("alpha channel with arch suffix does not expand", async ({ expect }) => {
+  await withTmpDir(async dir => {
+    const artifactFile = path.join(dir, "App-1.0.0-arm64.exe")
+    await fsp.writeFile(artifactFile, "fake")
+    const event: any = { file: artifactFile, arch: Arch.arm64, packager: makeAllChannelsPackager(), target: { outDir: dir } }
+    const tasks = await createUpdateInfoTasks(event, [{ provider: "s3", bucket: "test", channel: "alpha-arm64" }] as any)
+    expect(tasks.map(t => path.basename(t.file))).toEqual(["alpha-arm64.yml"])
+  })
+})

--- a/test/src/updateInfoBuilderTest.ts
+++ b/test/src/updateInfoBuilderTest.ts
@@ -410,3 +410,39 @@ test("sha512 values are preserved correctly for each file entry", async ({ expec
     expect(byUrl["App-1.0.0-arm64.exe"]).toBe("sha512-arm64-value")
   })
 })
+
+function makeAllChannelsPackager(): any {
+  return { ...makePlatformPackager(), config: { releaseInfo: undefined, generateUpdatesFilesForAllChannels: true } }
+}
+
+test("beta channel with arch suffix expands to alpha carrying the same suffix", async ({ expect }) => {
+  await withTmpDir(async dir => {
+    const artifactFile = path.join(dir, "App-1.0.0-arm64.exe")
+    await fsp.writeFile(artifactFile, "fake")
+    const event: any = { file: artifactFile, arch: Arch.arm64, packager: makeAllChannelsPackager(), target: { outDir: dir } }
+    const tasks = await createUpdateInfoTasks(event, [{ provider: "s3", bucket: "test", channel: "beta-arm64" }] as any)
+    const names = tasks.map(t => path.basename(t.file)).sort()
+    expect(names).toEqual(["alpha-arm64.yml", "beta-arm64.yml"])
+  })
+})
+
+test("latest channel with arch suffix expands to alpha and beta carrying the same suffix", async ({ expect }) => {
+  await withTmpDir(async dir => {
+    const artifactFile = path.join(dir, "App-1.0.0-arm64.exe")
+    await fsp.writeFile(artifactFile, "fake")
+    const event: any = { file: artifactFile, arch: Arch.arm64, packager: makeAllChannelsPackager(), target: { outDir: dir } }
+    const tasks = await createUpdateInfoTasks(event, [{ provider: "s3", bucket: "test", channel: "latest-arm64" }] as any)
+    const names = tasks.map(t => path.basename(t.file)).sort()
+    expect(names).toEqual(["alpha-arm64.yml", "beta-arm64.yml", "latest-arm64.yml"])
+  })
+})
+
+test("alpha channel with arch suffix does not expand", async ({ expect }) => {
+  await withTmpDir(async dir => {
+    const artifactFile = path.join(dir, "App-1.0.0-arm64.exe")
+    await fsp.writeFile(artifactFile, "fake")
+    const event: any = { file: artifactFile, arch: Arch.arm64, packager: makeAllChannelsPackager(), target: { outDir: dir } }
+    const tasks = await createUpdateInfoTasks(event, [{ provider: "s3", bucket: "test", channel: "alpha-arm64" }] as any)
+    expect(tasks.map(t => path.basename(t.file))).toEqual(["alpha-arm64.yml"])
+  })
+})

--- a/website/docs/migration/v27-breaking-changes.md
+++ b/website/docs/migration/v27-breaking-changes.md
@@ -88,6 +88,7 @@ Rows marked **Auto ✓** are rewritten for you. For the shortlist of changes the
 | [Redundant production `dependencies` excluded, not rejected](#redundant-production-dependencies-are-excluded-not-rejected) | — | `electron`/`electron-builder` are excluded from the copied `node_modules` (was a hard error); tune the set via `ignoredProductionDependencies`. If you set `ALLOW_ELECTRON_BUILDER_AS_PRODUCTION_DEPENDENCY` (removed) to bundle `electron-builder`, override the list instead; `electron-prebuilt`/`electron-rebuild` no longer error and now ship if declared — remove them from `dependencies` |
 | [DMG `filesystem` defaults to APFS](#dmg-filesystem-defaults-to-apfs) | — | Set `dmg.filesystem: "HFS+"` only if you need pre-10.13 macOS compatibility |
 | [`disableWebInstaller` defaults to `true` (electron-updater)](#disablewebinstaller-defaults-to-true) | — | v27 warns but still downloads if you never set it; opt in with `disableWebInstaller: false` before v28 enforces it |
+| [Suffixed channels expand to lower channels](#suffixed-update-channels-now-expand-to-lower-channels) | — | Only with `generateUpdatesFilesForAllChannels`: a `beta-*`/`latest-*` channel now writes 2–3 yml files instead of 1 |
 | [`latest*.yml` drops legacy top-level `path`/`sha512`](#latestyml-drops-legacy-top-level-pathsha512) | — | None for electron-updater >=2.16 (all modern clients); set `electronUpdaterCompatibility` to a legacy-inclusive range only if you still ship apps embedding electron-updater 1.x–2.15 |
 | [`quitAndInstall` takes an options object (electron-updater)](#quitandinstall-takes-an-options-object) | — | Replace positional args: `quitAndInstall(true, false)` → `quitAndInstall({ isSilent: true, isForceRunAfter: false })` |
 | [`autoInstallOnAppQuit` replaced by `autoInstallEvent` enum (electron-updater)](#autoinstallevent-replaces-autoinstallonappquit) | — | `autoInstallOnAppQuit = false` → `autoInstallEvent = "manual"`; default `"onQuit"` preserves behavior |
@@ -695,6 +696,21 @@ The v26 hard error also rejected `electron-prebuilt` and `electron-rebuild` in `
 - Otherwise: move them to `devDependencies`, or add them to `ignoredProductionDependencies` (e.g. `["electron", "electron-builder", "electron-prebuilt", "electron-nightly"]`) if they must stay declared as production dependencies for tooling.
 
 This is a runtime behavior change, not a config-key rename, so `electron-builder migrate-schema` does not modify your config for it.
+
+---
+
+### Suffixed update channels now expand to lower channels
+
+With `generateUpdatesFilesForAllChannels` enabled and a non-GitHub provider, `beta` published `beta.yml` + `alpha.yml` and `latest` published all three — but only when the channel was *exactly* `alpha`, `beta`, or `latest`. A channel with a suffix, such as the per-arch `channel: "${channel}-${arch}"` pattern that resolves to `beta-arm64`, fell through and published a single file, so suffixed pre-release users were never promoted.
+
+v27 reads the base channel off the front of the name and reattaches the suffix:
+
+- `beta-arm64` → `beta-arm64.yml`, `alpha-arm64.yml`
+- `latest-arm64` → `latest-arm64.yml`, `alpha-arm64.yml`, `beta-arm64.yml`
+- `alpha-arm64` → unchanged (lowest channel)
+- bare `alpha` / `beta` / `latest` → unchanged
+
+**This only affects you if you use `generateUpdatesFilesForAllChannels` with a suffixed channel name on a non-GitHub provider.** In that case a suffixed channel now writes 2–3 update files where it previously wrote one, and a `latest-x64` publish overwrites `beta-x64.yml` / `alpha-x64.yml` in the same bucket — changing what live `beta-x64` users are offered. That is the same behaviour bare `latest` has always had, but it is new for suffixed channels. Set `generateUpdatesFilesForAllChannels: false` if you want suffixed channels to keep publishing a single file.
 
 ---
 


### PR DESCRIPTION
We publish a separate update feed per architecture using `channel: "${channel}-${arch}"`, so our channels resolve to names like `beta-arm64` and `latest-x64`. We need the arch in the channel name because that is the only way we found to keep the arm64 and x64 feeds apart. Without the suffix both architectures write to the same `latest.yml` / `beta.yml` and overwrite each other, so the per-arch suffix is what makes separate feeds possible in the first place. We also have `generateUpdatesFilesForAllChannels` turned on so that beta users get promoted to stable and alpha users get promoted to beta.

That promotion silently stopped working once the arch suffix was in play. `computeChannelNames` only expands the lower channels when the channel is exactly `alpha`, `beta`, or `latest`. Anything else falls through to the default branch and returns just the one channel, so `beta-arm64` never produced an `alpha-arm64.yml` and our arm64 alpha users were stuck.

This PR reads the base channel off the front of the name and reattaches the suffix to the expanded channels:

- `beta-arm64` produces `beta-arm64` and `alpha-arm64`
- `latest-arm64` produces `latest-arm64`, `alpha-arm64`, and `beta-arm64`
- `alpha-arm64` stays on its own, same as bare `alpha`
- bare `alpha` / `beta` / `latest` behave exactly as before

We have been running this as a patch against `app-builder-lib` in our desktop app for a while and it fixed the promotion problem for us.

Added tests to `updateInfoBuilderTest.ts` covering the suffixed beta, latest, and alpha cases. The full `updateInfoBuilderTest.ts` suite passes locally (21 tests).
