### PR TITLE
feat(dmg): support ULMO (lzma) disk image format

### DIFF
--- a/.changeset/heavy-pandas-shake.md
+++ b/.changeset/heavy-pandas-shake.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat(dmg): support `ULMO` (lzma-compressed) disk image format, macOS 10.15+

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -999,14 +999,15 @@
         },
         "format": {
           "default": "UDZO",
-          "description": "The disk image format. `ULFO` (lzfse-compressed image (OS X 10.11+ only)).",
+          "description": "The disk image format. `ULFO` (lzfse-compressed image (OS X 10.11+ only)). `ULMO` (lzma-compressed image (macOS 10.15+ only)).",
           "enum": [
             "UDBZ",
             "UDCO",
             "UDRO",
             "UDRW",
             "UDZO",
-            "ULFO"
+            "ULFO",
+            "ULMO"
           ],
           "type": "string"
         },

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -270,10 +270,10 @@ export interface DmgOptions extends TargetSpecificOptions {
   contents?: Array<DmgContent>
 
   /**
-   * The disk image format. `ULFO` (lzfse-compressed image (OS X 10.11+ only)).
+   * The disk image format. `ULFO` (lzfse-compressed image (OS X 10.11+ only)). `ULMO` (lzma-compressed image (macOS 10.15+ only)).
    * @default UDZO
    */
-  format?: "UDRW" | "UDRO" | "UDCO" | "UDZO" | "UDBZ" | "ULFO"
+  format?: "UDRW" | "UDRO" | "UDCO" | "UDZO" | "UDBZ" | "ULFO" | "ULMO"
 
   /**
    * The filesystem for the DMG volume (e.g. `"APFS"` or `"HFS+"`)

--- a/website/docs/dmg.md
+++ b/website/docs/dmg.md
@@ -111,11 +111,12 @@ The `format` option controls the compression algorithm:
 |---|---|---|
 | `UDZO` | zlib-compressed (default) | Good balance of size and compatibility |
 | `ULFO` | LZFSE-compressed | Faster decompression, macOS 10.11+ only |
+| `ULMO` | LZMA-compressed | Best compression, slower to mount, macOS 10.15+ only |
 | `UDBZ` | bzip2-compressed | Better compression than UDZO, slower |
 | `UDRO` | Read-only, uncompressed | Largest size, fastest to open |
 | `UDRW` | Read-write | Only for development/testing |
 
-For most cases, leave `format` at the default `UDZO`. Use `ULFO` if you are targeting macOS 10.11+ and want faster mount times for large apps.
+For most cases, leave `format` at the default `UDZO`. Use `ULFO` if you are targeting macOS 10.11+ and want faster mount times for large apps. Use `ULMO` if you are targeting macOS 10.15+ and want the smallest download — it typically compresses an Electron app's DMG ~30% smaller than `UDZO`, at the cost of a few extra seconds to mount and copy at install time.
 
 ## DMG Size
 


### PR DESCRIPTION
Closes #10017

Adds `"ULMO"` (lzma-compressed UDIF, mountable on macOS 10.15+) to `DmgOptions.format`. hdiutil has supported it for years and dmg-builder already passes the format string through untyped (`format?: string` in the spec), so the union + generated schema were the only gates — no runtime change needed.

### Changes

- `macOptions.ts`: add `"ULMO"` to the `format` union, extend the JSDoc with the 10.15+ note (mirrors the existing `ULFO` 10.11+ wording)
- `scheme.json`: regenerated via `pnpm generate:schema`
- `website/docs/dmg.md`: format table row + selection guidance
- changeset: `app-builder-lib` minor

### Validation

Built a real Electron app (~258MB installed, arm64) with this branch and `dmg.format: "ULMO"`:

- `hdiutil imageinfo` reports `Format: ULMO`; image attaches and the app copies out cleanly
- 82.4 MiB vs 121.4 MiB for the `UDZO` default (−32%); install-time cost is ~4s of extra one-time mount/copy (full benchmark table in #10017)
- `pnpm generate:schema` is idempotent over the committed `scheme.json`; `pnpm compile` passes

No test added since there's no per-format test precedent in `test/src/mac/dmgTest.ts` — happy to add one if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
