### PR TITLE
feat(publish): support Bitbucket Cloud access tokens (Bearer auth)

### DIFF
--- a/.changeset/bitbucket-access-token-auth.md
+++ b/.changeset/bitbucket-access-token-auth.md
@@ -1,0 +1,7 @@
+---
+"electron-publish": minor
+---
+
+fix(publish): authenticate Bitbucket Cloud uploads with access tokens (Bearer auth)
+
+Bitbucket Cloud is deprecating app passwords (https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens). The Bitbucket publisher now selects the auth scheme by whether a username is set: with a username it sends HTTP Basic auth (Bitbucket username + app password, or Atlassian account email + API token); without a username it sends the token as a repository/project/workspace access token via `Authorization: Bearer`. Previously a token was always sent as Basic auth using the repo owner as the username, so access tokens could not be used.

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -451,7 +451,7 @@
     },
     "BitbucketOptions": {
       "additionalProperties": false,
-      "description": "Bitbucket options.\nhttps://bitbucket.org/\nDefine `BITBUCKET_TOKEN` environment variable.\n\nFor converting an app password to a usable token, you can utilize this\n```typescript\nconvertAppPassword(owner: string, appPassword: string) {\nconst base64encodedData = Buffer.from(`${owner}:${appPassword.trim()}`).toString(\"base64\")\nreturn `Basic ${base64encodedData}`\n}\n```",
+      "description": "Bitbucket options.\nhttps://bitbucket.org/\nDefine `BITBUCKET_TOKEN` environment variable.\n\nBitbucket Cloud is [retiring app passwords](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens) in favor of API tokens and access tokens. Authentication is selected by whether a `username` is provided:\n- With `username` — the token is sent via HTTP Basic auth. Use a Bitbucket username + [app password](https://bitbucket.org/account/settings/app-passwords), or an Atlassian account email + [API token](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/).\n- Without `username` — the token is sent as a repository/project/workspace [access token](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/) via Bearer auth.\n\nFor the auto-updater on a private repository, pass the matching header to `autoUpdater.addAuthHeader(...)`:\n```typescript\n// access token (no username)\nautoUpdater.addAuthHeader(`Bearer ${token}`)\n// app password or API token (with username)\nautoUpdater.addAuthHeader(`Basic ${Buffer.from(`${username}:${token}`).toString(\"base64\")}`)\n```",
       "properties": {
         "channel": {
           "default": "latest",
@@ -505,7 +505,7 @@
           ]
         },
         "token": {
-          "description": "The [app password](https://bitbucket.org/account/settings/app-passwords) to support auto-update from private bitbucket repositories.",
+          "description": "The token to support auto-update from private bitbucket repositories. Depending on `username`, this is a Bitbucket [app password](https://bitbucket.org/account/settings/app-passwords), an Atlassian [API token](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/), or a repository/project/workspace [access token](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/).",
           "type": [
             "null",
             "string"
@@ -518,7 +518,7 @@
           ]
         },
         "username": {
-          "description": "The user name to support auto-update from private bitbucket repositories.",
+          "description": "The user name to support auto-update from private bitbucket repositories. Provide a Bitbucket username (for an app password) or an Atlassian account email (for an API token) to authenticate with HTTP Basic auth. Leave unset to send `token` as a Bearer access token.",
           "type": [
             "null",
             "string"

--- a/packages/builder-util-runtime/src/publishOptions.ts
+++ b/packages/builder-util-runtime/src/publishOptions.ts
@@ -283,12 +283,16 @@ export interface KeygenOptions extends PublishConfiguration {
  * https://bitbucket.org/
  * Define `BITBUCKET_TOKEN` environment variable.
  *
- * For converting an app password to a usable token, you can utilize this
+ * Bitbucket Cloud is [retiring app passwords](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens) in favor of API tokens and access tokens. Authentication is selected by whether a `username` is provided:
+ * - With `username` — the token is sent via HTTP Basic auth. Use a Bitbucket username + [app password](https://bitbucket.org/account/settings/app-passwords), or an Atlassian account email + [API token](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/).
+ * - Without `username` — the token is sent as a repository/project/workspace [access token](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/) via Bearer auth.
+ *
+ * For the auto-updater on a private repository, pass the matching header to `autoUpdater.addAuthHeader(...)`:
 ```typescript
-convertAppPassword(owner: string, appPassword: string) {
-  const base64encodedData = Buffer.from(`${owner}:${appPassword.trim()}`).toString("base64")
-  return `Basic ${base64encodedData}`
-}
+// access token (no username)
+autoUpdater.addAuthHeader(`Bearer ${token}`)
+// app password or API token (with username)
+autoUpdater.addAuthHeader(`Basic ${Buffer.from(`${username}:${token}`).toString("base64")}`)
 ```
  */
 export interface BitbucketOptions extends PublishConfiguration {
@@ -303,12 +307,12 @@ export interface BitbucketOptions extends PublishConfiguration {
   readonly owner: string
 
   /**
-   * The [app password](https://bitbucket.org/account/settings/app-passwords) to support auto-update from private bitbucket repositories.
+   * The token to support auto-update from private bitbucket repositories. Depending on `username`, this is a Bitbucket [app password](https://bitbucket.org/account/settings/app-passwords), an Atlassian [API token](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/), or a repository/project/workspace [access token](https://support.atlassian.com/bitbucket-cloud/docs/using-access-tokens/).
    */
   readonly token?: string | null
 
   /**
-   * The user name to support auto-update from private bitbucket repositories.
+   * The user name to support auto-update from private bitbucket repositories. Provide a Bitbucket username (for an app password) or an Atlassian account email (for an API token) to authenticate with HTTP Basic auth. Leave unset to send `token` as a Bearer access token.
    */
   readonly username?: string | null
 

--- a/packages/electron-publish/src/bitbucketPublisher.ts
+++ b/packages/electron-publish/src/bitbucketPublisher.ts
@@ -25,12 +25,18 @@ export class BitbucketPublisher extends HttpPublisher {
       throw new InvalidConfigurationError(`Bitbucket token is not set using env "BITBUCKET_TOKEN" (see https://www.electron.build/publish#BitbucketOptions)`)
     }
 
-    if (isEmptyOrSpaces(username)) {
-      log.warn('No Bitbucket username provided via "BITBUCKET_USERNAME". Defaulting to use repo owner.')
-    }
-
     this.info = info
-    this.auth = BitbucketPublisher.convertAppPassword(username ?? this.info.owner, token)
+    // Bitbucket Cloud is retiring app passwords (https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens).
+    // - With a username, the token is sent as HTTP Basic auth: a Bitbucket username + app password, or an Atlassian account email + API token.
+    // - Without a username, the token is treated as a repository/project/workspace access token and sent as Bearer auth.
+    if (isEmptyOrSpaces(username)) {
+      log.info(
+        'No Bitbucket username provided via "BITBUCKET_USERNAME"; sending the token as an access token (Bearer auth). Set "BITBUCKET_USERNAME" to authenticate with an app password or API token instead.'
+      )
+      this.auth = BitbucketPublisher.convertAccessToken(token)
+    } else {
+      this.auth = BitbucketPublisher.convertAppPassword(username, token)
+    }
     this.basePath = `/2.0/repositories/${this.info.owner}/${this.info.slug}/downloads`
   }
 
@@ -73,5 +79,9 @@ export class BitbucketPublisher extends HttpPublisher {
   static convertAppPassword(username: string, token: string) {
     const base64encodedData = Buffer.from(`${username}:${token.trim()}`).toString("base64")
     return `Basic ${base64encodedData}`
+  }
+
+  static convertAccessToken(token: string) {
+    return `Bearer ${token.trim()}`
   }
 }

--- a/test/src/ArtifactPublisherTest.ts
+++ b/test/src/ArtifactPublisherTest.ts
@@ -163,6 +163,70 @@ test.ifEnv(process.env.BITBUCKET_TOKEN)("Bitbucket upload", async ({ expect }) =
   expect(await publisher.upload({ file: iconPath, arch: Arch.x64, timeout })).toThrowError("Request timed out")
 })
 
+// Temporarily clear env vars so auth-selection unit tests are deterministic regardless of the ambient environment.
+function withoutEnv<T>(keys: Array<string>, fn: () => T): T {
+  const saved = keys.map(key => [key, process.env[key]] as const)
+  for (const key of keys) {
+    delete process.env[key]
+  }
+  try {
+    return fn()
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
+// With a username, the token is sent via HTTP Basic auth (Bitbucket username + app password, or Atlassian email + API token).
+test("Bitbucket auth - username selects HTTP Basic auth", ({ expect }) => {
+  const publisher = new BitbucketPublisher(publishContext, {
+    provider: "bitbucket",
+    owner: "test-owner",
+    slug: "test-repo",
+    username: "user@example.com",
+    token: "api-token-123",
+  })
+  expect((publisher as any).auth).toBe(`Basic ${Buffer.from("user@example.com:api-token-123").toString("base64")}`)
+})
+
+// Without a username, the token is treated as a repository/project/workspace access token and sent via Bearer auth (issue #9995).
+test("Bitbucket auth - no username selects Bearer auth (access token)", ({ expect }) => {
+  withoutEnv(["BITBUCKET_USERNAME"], () => {
+    const publisher = new BitbucketPublisher(publishContext, {
+      provider: "bitbucket",
+      owner: "test-owner",
+      slug: "test-repo",
+      token: "access-token-123",
+    })
+    expect((publisher as any).auth).toBe("Bearer access-token-123")
+  })
+})
+
+// A missing token is a hard configuration error.
+test("Bitbucket auth - missing token throws InvalidConfigurationError", ({ expect }) => {
+  withoutEnv(["BITBUCKET_TOKEN"], () => {
+    expect(
+      () =>
+        new BitbucketPublisher(publishContext, {
+          provider: "bitbucket",
+          owner: "test-owner",
+          slug: "test-repo",
+        })
+    ).toThrow(/Bitbucket token is not set/)
+  })
+})
+
+// The static header builders trim the token and apply the correct scheme.
+test("Bitbucket auth - convertAppPassword and convertAccessToken build the expected headers", ({ expect }) => {
+  expect(BitbucketPublisher.convertAppPassword("alice", " secret ")).toBe(`Basic ${Buffer.from("alice:secret").toString("base64")}`)
+  expect(BitbucketPublisher.convertAccessToken(" access-token-123 ")).toBe("Bearer access-token-123")
+})
+
 const mockRelease = { id: 1, tag_name: "v1.0.0", draft: true, prerelease: false, published_at: "", upload_url: "https://uploads.github.com/{?name}" }
 
 function mockGithubRequest(publisher: GitHubPublisher): { getData: () => any } {


### PR DESCRIPTION
Resolves #9995 

### Summary

Bitbucket Cloud is retiring app passwords (basic-auth) in favor of API tokens and access tokens (see https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens). The `BitbucketPublisher` always built an HTTP `Basic` header via `convertAppPassword`, so it could never send an `Authorization: Bearer <token>` header — meaning repository/project/workspace access tokens (the recommended replacement) could not be used to publish. As the app-password brownouts roll out, publishing breaks.

- Bitbucket publisher now selects the auth scheme based on whether a username is provided:
  - **With a username** → HTTP Basic auth. Covers a Bitbucket username + app password, or an Atlassian account email + API token (API tokens require the account email as the username).
  - **Without a username** → the token is treated as a repository/project/workspace access token and sent via `Authorization: Bearer <token>`.
- Added `BitbucketPublisher.convertAccessToken(token)` static helper (mirrors the existing `convertAppPassword`) that returns `Bearer <trimmed-token>`.
- Replaced the previous "default username to repo owner" fallback + warning with a clear `log.info` explaining that a token supplied without a username is sent as a Bearer access token.
- No changes required on the auto-updater side: `BitbucketProvider` already honors `autoUpdater.addAuthHeader("Bearer <token>")`, and `configureRequestOptions` already passes through any token that starts with `Bearer`.

Core selection logic in `packages/electron-publish/src/bitbucketPublisher.ts`:

```ts
if (isEmptyOrSpaces(username)) {
  log.info('No Bitbucket username provided via "BITBUCKET_USERNAME"; sending the token as an access token (Bearer auth). Set "BITBUCKET_USERNAME" to authenticate with an app password or API token instead.')
  this.auth = BitbucketPublisher.convertAccessToken(token)
} else {
  this.auth = BitbucketPublisher.convertAppPassword(username, token)
}
```

```ts
static convertAccessToken(token: string) {
  return `Bearer ${token.trim()}`
}
```

### Docs / schema

- Rewrote the `BitbucketOptions` JSDoc (`packages/builder-util-runtime/src/publishOptions.ts`) to document the three supported credential types (app password, API token, access token), which auth scheme each uses, and how to build the matching header for `autoUpdater.addAuthHeader(...)` on a private repository.
- Updated the `token` and `username` field docs accordingly.
- Regenerated `packages/app-builder-lib/scheme.json` from the updated JSDoc (`pnpm generate:schema`) — only the three Bitbucket descriptions changed.

### Tests

Added deterministic unit tests to `test/src/ArtifactPublisherTest.ts` (no network or real credentials needed; a small `withoutEnv` helper isolates ambient `BITBUCKET_*` env vars):

- username present → `auth` is `Basic base64(username:token)`
- no username → `auth` is `Bearer <token>` (the issue #9995 scenario)
- missing token → throws `InvalidConfigurationError`
- `convertAppPassword` / `convertAccessToken` build the expected headers and trim the token

### Behavior change / migration

Previously a config of `{ owner, slug, token }` with no username produced `Basic base64(owner:token)`. It now produces `Bearer <token>`. This only affects setups that relied on the repo owner doubling as the Basic-auth username with an app password — a path that Bitbucket is removing regardless. To keep Basic auth, set `BITBUCKET_USERNAME` (or `username`) to your Bitbucket username (app password) or Atlassian account email (API token).