### PR TITLE
fix(nsis): detect Wine PowerShell stub before checking processes

### DIFF
--- a/.changeset/calm-wines-probe.md
+++ b/.changeset/calm-wines-probe.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(nsis): fall back to tasklist process detection when Wine's PowerShell stub ignores the capability probe

--- a/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
@@ -44,14 +44,17 @@
 
 !macro IS_POWERSHELL_AVAILABLE
   Var /GLOBAL IsPowerShellAvailable ; 0 = available, 1 = not available
-  # Try running PowerShell with a simple command to check if it's available
-  nsExec::Exec `"$PowerShellPath" -C "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }"`
-  Pop $0  # Return code (0 = success, other = error)
+  # Require a sentinel exit code to ensure PowerShell actually executes the command.
+  # Wine's PowerShell stub ignores the command and exits with 0.
+  nsExec::Exec `"$PowerShellPath" -C "if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) { exit 37 } else { exit 1 }"`
+  Pop $0  # Return code (37 = command executed successfully)
 
-  ${if} $0 == 0
+  ${if} $0 == 37
     # PowerShell is available, check if it's not blocked by policies
     nsExec::Exec `"$PowerShellPath" -C "if ((Get-ExecutionPolicy -Scope Process) -eq 'Restricted') { exit 1 } else { exit 0 }"`
     Pop $0
+  ${else}
+    StrCpy $0 1
   ${endIf}
 
   ${if} $0 != 0

--- a/test/src/windows/nsisAllowOnlyOneInstanceTest.ts
+++ b/test/src/windows/nsisAllowOnlyOneInstanceTest.ts
@@ -7,14 +7,32 @@ const uninstallerPath = path.join(__dirname, "../../../packages/app-builder-lib/
 
 let templateContent: string
 let findProcessMacro: string
+let powerShellAvailabilityMacro: string
 
 describe("allowOnlyOneInstallerInstance.nsh", { sequential: true }, () => {
   beforeAll(async () => {
     templateContent = await fs.readFile(templatePath, "utf8")
 
+    // Extract the PowerShell availability macro for focused probe assertions
+    const availabilityMatch = templateContent.match(/!macro IS_POWERSHELL_AVAILABLE[\s\S]*?!macroend/)
+    powerShellAvailabilityMacro = availabilityMatch ? availabilityMatch[0] : ""
+
     // Extract just the FIND_PROCESS macro body for targeted assertions
     const match = templateContent.match(/!macro FIND_PROCESS[\s\S]*?!macroend/)
     findProcessMacro = match ? match[0] : ""
+  })
+
+  describe("IS_POWERSHELL_AVAILABLE macro", () => {
+    test("requires proof that the capability probe was executed", () => {
+      expect(powerShellAvailabilityMacro).toContain("Get-Command Get-CimInstance")
+      expect(powerShellAvailabilityMacro).toContain("exit 37")
+      expect(powerShellAvailabilityMacro).toContain("${if} $0 == 37")
+      expect(powerShellAvailabilityMacro).toContain("Get-ExecutionPolicy -Scope Process")
+    })
+
+    test("marks every non-sentinel capability result as unavailable", () => {
+      expect(powerShellAvailabilityMacro).toContain("${else}\n    StrCpy $0 1\n  ${endIf}")
+    })
   })
 
   describe("FIND_PROCESS macro — PowerShell path", () => {


### PR DESCRIPTION
## Problem

While installing an Electron app through CrossOver, the NSIS installer repeatedly showed the “cannot be closed” dialog even though the app was not running.

Wine ships a `powershell.exe` stub that accepts the command line but does not execute it and exits with code 0. The NSIS `IS_POWERSHELL_AVAILABLE` probe currently treats that exit code as success.

The installer then selects the PowerShell `Get-CimInstance` process-check path. The stub again returns 0, which is interpreted as “the app is running”, so installation loops on the dialog.

Wine source:
https://github.com/wine-mirror/wine/blob/master/programs/powershell/main.c

## Fix

Require the capability probe to return sentinel exit code 37. Real Windows PowerShell returns 37 only after executing the supplied command. Any other result uses the existing tasklist fallback.

The existing execution-policy check and all process detection/termination paths are unchanged.

## Safety

- Normal Windows PowerShell still follows the existing PowerShell path.
- Restricted, missing, or non-functional PowerShell follows the existing fallback.
- No Wine-specific registry/version detection is added.
- No public API or configuration changes.

## Verification

- `TEST_FILES=nsisAllowOnlyOneInstanceTest pnpm ci:test` — 18 tests passed.
- `TEST_FILES=nsisWine pnpm ci:test` — 8 tests passed.
- `pnpm compile`
- `pnpm ci:validate`
- NSIS 3.12 `makensis -WX` compile harness.
- The patched installer completed in the same CrossOver environment where the unpatched installer hit the “cannot be closed” loop.

## Related

- #9784 fixed false positives in the non-PowerShell fallback; this PR fixes selection of the PowerShell path under Wine.
- #10024 changes process-path matching in the same template but is independent of this availability probe.
