### PR TITLE
fix(deb): multithread the data.tar xz compression

### DIFF
--- a/.changeset/plenty-moons-shave.md
+++ b/.changeset/plenty-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: multithread the deb payload compression. fpm's deb path pipes GNU `tar -J` exporting only `XZ_OPT=-<level>`, so `data.tar` compressed single-threaded while rpm already defaults to multithreaded `xzmt` (measured on the same 6.4 GiB tree in one run: deb 1,059 s vs rpm 171 s). Export `XZ_DEFAULTS=-T0` for the deb fpm invocation (xz parses it before `XZ_OPT`, keeping the compression level unchanged; an operator-provided `XZ_DEFAULTS` wins).

--- a/packages/app-builder-lib/src/targets/linux/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/linux/FpmTarget.ts
@@ -292,6 +292,16 @@ export default class FpmTarget extends Target {
       ...stripSensitiveEnvVars(process.env),
     }
 
+    // fpm compresses the deb data.tar by piping GNU tar -J, which exports only
+    // XZ_OPT=-<level> — so xz runs single-threaded regardless of the machine,
+    // while rpm already defaults to multithreaded "xzmt" (measured on one
+    // 6.4 GiB tree in one run: deb 1059s vs rpm 171s). xz parses XZ_DEFAULTS
+    // before XZ_OPT, so -T0 multithreads the deb pack at the unchanged
+    // compression level; an operator-provided XZ_DEFAULTS wins. Fixes #10045.
+    if (target === "deb" && process.env.XZ_DEFAULTS == null) {
+      (env as Record<string, string>).XZ_DEFAULTS = "-T0"
+    }
+
     // rpmbuild wants directory rpm with some default config files. Even if we can use dylibbundler, path to such config files are not changed (we need to replace in the binary)
     // so, for now, brew install rpm is still required.
     if (target !== "rpm" && (await isMacOsSierra())) {

--- a/packages/app-builder-lib/src/targets/linux/FpmTarget.ts
+++ b/packages/app-builder-lib/src/targets/linux/FpmTarget.ts
@@ -299,7 +299,7 @@ export default class FpmTarget extends Target {
     // before XZ_OPT, so -T0 multithreads the deb pack at the unchanged
     // compression level; an operator-provided XZ_DEFAULTS wins. Fixes #10045.
     if (target === "deb" && process.env.XZ_DEFAULTS == null) {
-      (env as Record<string, string>).XZ_DEFAULTS = "-T0"
+      env.XZ_DEFAULTS = "-T0"
     }
 
     // rpmbuild wants directory rpm with some default config files. Even if we can use dylibbundler, path to such config files are not changed (we need to replace in the binary)


### PR DESCRIPTION
Fixes #10045.

`FpmTarget` defaults rpm to multithreaded xz (`xzmt`) but deb to plain `xz`, and fpm's deb path pipes GNU `tar -J` exporting only `XZ_OPT=-<level>` — so the deb payload compresses on one core no matter the machine. Measured on the same 6.4 GiB tree in one run: **deb 1,059 s vs rpm 171 s**.

This exports `XZ_DEFAULTS=-T0` for the deb fpm invocation: xz parses `XZ_DEFAULTS` before `XZ_OPT`, so the compression level is unchanged and an operator-provided `XZ_DEFAULTS` wins. Multi-block xz output is standard liblzma decode — `dpkg-deb` itself emits threaded xz since 1.21.13 — and installs cleanly (verified on Debian 12 and Fedora 40 container smokes of a real 2.2 GB deb built this way).

No supported config value could achieve this (fpm's `--deb-compression` has no `xzmt` equivalent; its `zst` path is also single-threaded — jordansissel/fpm#1789). Changeset included.