### PR TITLE
Restore Mac Developer certificate support for development builds

### DIFF
--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -78,6 +78,18 @@ export interface ElectronSignOptions extends Omit<OnlySignOptions, "optionsForFi
    * @example ["--deep"]
    */
   readonly additionalArguments?: Array<string> | null
+  /**
+   * Signing type for `mac` (non-MAS) builds.
+   *
+   * - **Not set** (default): signs with a `Developer ID Application` certificate for direct distribution.
+   * - **`"development"`**: signs with a `Mac Developer` or `Apple Development` certificate instead.
+   *   The resulting app will be blocked by Gatekeeper on other machines; users must use the
+   *   right-click → Open workaround documented at https://support.apple.com/en-us/guide/mac-help/mh40616/mac.
+   *   Not suitable for production distribution and cannot be notarized.
+   *
+   * Has no effect on `mas` or `mas-dev` builds — those always use their respective certificate types.
+   */
+  readonly type?: "development"
 }
 
 export type MacOsTargetName = "default" | "dmg" | "mas" | "mas-dev" | "pkg" | "7z" | "zip" | "tar.xz" | "tar.lz" | "tar.gz" | "tar.bz2" | "dir"

--- a/packages/app-builder-lib/src/targets/mac/MacTargetHelper.ts
+++ b/packages/app-builder-lib/src/targets/mac/MacTargetHelper.ts
@@ -30,7 +30,7 @@ export class MacTargetHelper {
     signOpts: ElectronSignOptions | null | undefined
   ): Promise<Identity | null> {
     const isMas = MacTargetHelper.isMasTarget(targetPlatform)
-    const certificateTypes = MacTargetHelper.getCertificateTypes(targetPlatform)
+    const certificateTypes = MacTargetHelper.getCertificateTypes(targetPlatform, signOpts)
 
     let identity: Identity | null = null
     for (const certificateType of certificateTypes) {
@@ -256,13 +256,16 @@ export class MacTargetHelper {
     }
   }
 
-  static getCertificateTypes(targetPlatform: PlatformType): CertType[] {
+  static getCertificateTypes(targetPlatform: PlatformType, signOpts?: ElectronSignOptions | null): CertType[] {
     switch (targetPlatform) {
       case "mas-dev":
         return ["Mac Developer", "Apple Development"]
       case "mas":
         return ["Apple Distribution", "3rd Party Mac Developer Application"]
       default:
+        if (signOpts?.type === "development") {
+          return ["Mac Developer", "Apple Development"]
+        }
         return ["Developer ID Application"]
     }
   }

--- a/test/src/mac/MacTargetHelperTest.ts
+++ b/test/src/mac/MacTargetHelperTest.ts
@@ -2,17 +2,19 @@ import { afterEach, expect } from "vitest"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { MacTargetHelper, type PlatformType } from "app-builder-lib/internal"
+import { ElectronSignOptions } from "app-builder-lib"
 
 describe("MacTargetHelper", () => {
   describe("getCertificateTypes", () => {
-    const cases: [PlatformType, string[]][] = [
-      ["mas", ["Apple Distribution", "3rd Party Mac Developer Application"]],
-      ["mas-dev", ["Mac Developer", "Apple Development"]],
-      ["mac", ["Developer ID Application"]],
+    const cases: [PlatformType, ElectronSignOptions["type"], string[]][] = [
+      ["mas", undefined, ["Apple Distribution", "3rd Party Mac Developer Application"]],
+      ["mas-dev", undefined, ["Mac Developer", "Apple Development"]],
+      ["mac", undefined, ["Developer ID Application"]],
+      ["mac", "development", ["Mac Developer", "Apple Development"]],
     ]
 
-    test.each(cases)("%s", (targetPlatform, expected) => {
-      expect(MacTargetHelper.getCertificateTypes(targetPlatform)).toEqual(expected)
+    test.each(cases)("%s %s", (targetPlatform, signOpts, expected) => {
+      expect(MacTargetHelper.getCertificateTypes(targetPlatform, { type: signOpts })).toEqual(expected)
     })
   })
 


### PR DESCRIPTION
Removed here: https://github.com/electron-userland/electron-builder/pull/9889/changes/BASE..3823d46d458f5e5681efec3604402ebda79c07cc#diff-dea0e618f81a9de11d2ea7b8cdd07f3d196b5fae9262142cf2b2c1fca21e62b2

Re-adds the `type` property to sign config for backwards compat but only accepts `"development"`.

I didn't restore the log warning. I don't think it's necessary if it has been explicitly set in config, like `mas-dev`.

I haven't touched any docs. Feel free to edit as needed.