### PR TITLE
fix(updater): install Linux packages without freezing the app

### DIFF
--- a/.changeset/async-linux-install.md
+++ b/.changeset/async-linux-install.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: install Linux packages without freezing the app. Before, `LinuxUpdater` ran the package manager through `spawnSync`, so the main process was blocked for as long as the elevation dialog was open — while the user typed their password — and desktops reported the app as not responding. After, `quitAndInstall()` and `installPendingUpdateIfAvailable()` install through an asynchronous path and the app stays responsive; the command, the environment and the elevation helper are unchanged. The on-quit install keeps the synchronous path, which a quit handler cannot await, and other platforms are unaffected — `doInstallAsync` defaults to the existing synchronous `doInstall`. Each package manager now declares its commands once as an install plan, executed by both paths.

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -37,16 +37,17 @@ export abstract class BaseUpdater extends AppUpdater {
     }
     this._logger.info(`Install on explicit quitAndInstall`)
     // If NOT in silent mode use `autoRunAppAfterInstall` to determine whether to force run the app
-    const isInstalled = this.install(isSilent, isSilent ? isForceRunAfter : this.autoRunAppAfterInstall)
-    if (isInstalled) {
-      setImmediate(() => {
-        // this event is normally emitted when calling quitAndInstall, this emulates that
-        require("electron").autoUpdater.emit("before-quit-for-update")
-        this.app.quit()
-      })
-    } else {
-      this.quitAndInstallCalled = false
-    }
+    void this.installAsync(isSilent, isSilent ? isForceRunAfter : this.autoRunAppAfterInstall).then(isInstalled => {
+      if (isInstalled) {
+        setImmediate(() => {
+          // this event is normally emitted when calling quitAndInstall, this emulates that
+          require("electron").autoUpdater.emit("before-quit-for-update")
+          this.app.quit()
+        })
+      } else {
+        this.quitAndInstallCalled = false
+      }
+    })
   }
 
   installPendingUpdateIfAvailable(): Promise<boolean> {
@@ -80,11 +81,18 @@ export abstract class BaseUpdater extends AppUpdater {
   // must be sync
   protected abstract doInstall(options: InstallOptions): boolean
 
-  // must be sync (because quit even handler is not async)
-  install(isSilent = false, isForceRunAfter = false): boolean {
+  /**
+   * Installs without blocking the main process. Defaults to the synchronous {@link doInstall}; targets whose
+   * install shows an elevation dialog override it.
+   */
+  protected doInstallAsync(options: InstallOptions): Promise<boolean> {
+    return Promise.resolve(this.doInstall(options))
+  }
+
+  private beginInstall(isSilent: boolean, isForceRunAfter: boolean): InstallOptions | null {
     if (this.quitAndInstallCalled) {
       this._logger.warn("install call ignored: quitAndInstallCalled is set to true")
-      return false
+      return null
     }
 
     const downloadedUpdateHelper = this.downloadedUpdateHelper
@@ -92,19 +100,49 @@ export abstract class BaseUpdater extends AppUpdater {
     const downloadedFileInfo = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.downloadedFileInfo
     if (installerPath == null || downloadedFileInfo == null) {
       this.dispatchError(new Error("No update filepath provided, can't quit and install"))
-      return false
+      return null
     }
 
     // prevent calling several times
     this.quitAndInstallCalled = true
 
+    this._logger.info(`Install: isSilent: ${isSilent}, isForceRunAfter: ${isForceRunAfter}`)
+    return {
+      isSilent,
+      isForceRunAfter,
+      isAdminRightsRequired: downloadedFileInfo.isAdminRightsRequired,
+    }
+  }
+
+  // must be sync (because quit even handler is not async)
+  install(isSilent = false, isForceRunAfter = false): boolean {
+    const options = this.beginInstall(isSilent, isForceRunAfter)
+    if (options == null) {
+      return false
+    }
+
     try {
-      this._logger.info(`Install: isSilent: ${isSilent}, isForceRunAfter: ${isForceRunAfter}`)
-      return this.doInstall({
-        isSilent,
-        isForceRunAfter,
-        isAdminRightsRequired: downloadedFileInfo.isAdminRightsRequired,
-      })
+      return this.doInstall(options)
+    } catch (e: any) {
+      this.dispatchError(e)
+      return false
+    }
+  }
+
+  /**
+   * Same as {@link install}, without blocking the main process while the install runs. Targets whose install
+   * shows an elevation dialog need it: a synchronous spawn freezes the app for as long as the dialog is open,
+   * and the desktop reports it as not responding. Targets that do not override {@link doInstallAsync} keep
+   * installing synchronously, so their timing is unchanged.
+   */
+  async installAsync(isSilent = false, isForceRunAfter = false): Promise<boolean> {
+    const options = this.beginInstall(isSilent, isForceRunAfter)
+    if (options == null) {
+      return false
+    }
+
+    try {
+      return await this.doInstallAsync(options)
     } catch (e: any) {
       this.dispatchError(e)
       return false
@@ -194,7 +232,7 @@ export abstract class BaseUpdater extends AppUpdater {
     await downloadedUpdateHelper.clearPendingInstallMarker(this._logger)
     this.updateInfoAndProvider = updateInfoAndProvider
     this._logger.info(`Installing pending update ${latestInfo.version} on launch`)
-    const isInstalled = this.install(true, true)
+    const isInstalled = await this.installAsync(true, true)
     if (isInstalled) {
       setImmediate(() => this.app.quit())
     } else {
@@ -324,6 +362,34 @@ export abstract class BaseUpdater extends AppUpdater {
    */
   // https://github.com/electron-userland/electron-builder/issues/1129
   // Node 8 sends errors: https://nodejs.org/dist/latest-v8.x/docs/api/errors.html#errors_common_system_errors
+  /** {@link spawnSyncLog} without blocking the main process: same command, same environment, awaited instead. */
+  protected spawnAsyncLog(cmd: string, args: string[] = [], env = {}): Promise<string> {
+    this._logger.info(`Executing: ${cmd} with args: ${args}`)
+    const mergedEnv: NodeJS.ProcessEnv = { ...process.env, ...env }
+    return new Promise<string>((resolve, reject) => {
+      const child = spawn(cmd, args, {
+        env: { ...mergedEnv, PATH: this.sanitizeEnvPath(mergedEnv.PATH ?? "") },
+        shell: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+
+      let stdout = ""
+      let stderr = ""
+      child.stdout?.on("data", (chunk: Buffer) => (stdout += chunk.toString()))
+      child.stderr?.on("data", (chunk: Buffer) => (stderr += chunk.toString()))
+
+      child.on("error", error => reject(error))
+      child.on("close", status => {
+        if (status === 0) {
+          resolve(stdout.trim())
+          return
+        }
+        this._logger.error(stderr)
+        reject(new Error(`Command ${cmd} exited with code ${status}`))
+      })
+    })
+  }
+
   protected async spawnLog(cmd: string, args: string[] = [], env: any = undefined, stdio: StdioOptions = "ignore"): Promise<boolean> {
     this._logger.info(`Executing: ${cmd} with args: ${args}`)
     return new Promise<boolean>((resolve, reject) => {

--- a/packages/electron-updater/src/DebUpdater.ts
+++ b/packages/electron-updater/src/DebUpdater.ts
@@ -4,7 +4,7 @@ import { DownloadUpdateOptions } from "./AppUpdater.js"
 import { InstallOptions } from "./BaseUpdater.js"
 import { findFile } from "./providers/Provider.js"
 import { DOWNLOAD_PROGRESS, Logger } from "./types.js"
-import { LinuxUpdater } from "./LinuxUpdater.js"
+import { InstallPlan, LinuxUpdater, runInstallPlan } from "./LinuxUpdater.js"
 
 export class DebUpdater extends LinuxUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -29,19 +29,12 @@ export class DebUpdater extends LinuxUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const installerPath = this.installerPath
-    if (installerPath == null) {
-      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
       return false
     }
-    if (!this.hasCommand("dpkg") && !this.hasCommand("apt")) {
-      this.dispatchError(new Error("Neither dpkg nor apt command found. Cannot install .deb package."))
-      return false
-    }
-    const priorityList = ["dpkg", "apt"]
-    const packageManager = this.detectPackageManager(priorityList)
     try {
-      DebUpdater.installWithCommandRunner(packageManager as any, installerPath, this.runCommandWithSudoIfNeeded.bind(this), this._logger, this.allowUnverifiedLinuxPackages)
+      runInstallPlan(plan, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
     } catch (error: any) {
       this.dispatchError(error)
       return false
@@ -52,6 +45,36 @@ export class DebUpdater extends LinuxUpdater {
     return true
   }
 
+  protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
+      return false
+    }
+    try {
+      await this.runInstallPlanWithSudoIfNeededAsync(plan)
+    } catch (error: any) {
+      this.dispatchError(error)
+      return false
+    }
+    if (options.isForceRunAfter) {
+      this.app.relaunch()
+    }
+    return true
+  }
+
+  private planInstall(installerPath: string | null): InstallPlan | null {
+    if (installerPath == null) {
+      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+      return null
+    }
+    if (!this.hasCommand("dpkg") && !this.hasCommand("apt")) {
+      this.dispatchError(new Error("Neither dpkg nor apt command found. Cannot install .deb package."))
+      return null
+    }
+    const packageManager = this.detectPackageManager(["dpkg", "apt"])
+    return DebUpdater.planInstall(packageManager as any, installerPath, this._logger, this.allowUnverifiedLinuxPackages)
+  }
+
   static installWithCommandRunner(
     packageManager: "dpkg" | "apt",
     installerPath: string,
@@ -59,22 +82,21 @@ export class DebUpdater extends LinuxUpdater {
     logger: Logger,
     allowUnverified = true
   ) {
+    runInstallPlan(DebUpdater.planInstall(packageManager, installerPath, logger, allowUnverified), commandRunner, logger)
+  }
+
+  static planInstall(packageManager: "dpkg" | "apt", installerPath: string, logger: Logger, allowUnverified = true): InstallPlan {
     if (packageManager === "dpkg") {
       if (!allowUnverified) {
         logger.warn(
           "allowUnverifiedLinuxPackages=false has no effect when installing with dpkg: dpkg performs no signature verification. Enforcing .deb signature verification requires a debsig-verify/debsigs policy on the target system."
         )
       }
-      try {
-        // Primary: Install .deb directly with dpkg (dpkg performs no signature verification regardless of allowUnverified)
-        commandRunner(["dpkg", "-i", installerPath])
-      } catch (error: any) {
-        // Handle missing dependencies via apt-get
-        logger.warn(error.message ?? error)
-        logger.warn("dpkg installation failed, trying to fix broken dependencies with apt-get")
-        commandRunner(["apt-get", "install", "-f", "-y"])
-      }
-    } else if (packageManager === "apt") {
+      // dpkg performs no signature verification regardless of allowUnverified, and cannot resolve
+      // dependencies: apt-get repairs them when the install fails because of a missing one
+      return [[["dpkg", "-i", installerPath]], [["apt-get", "install", "-f", "-y"]]]
+    }
+    if (packageManager === "apt") {
       if (allowUnverified) {
         logger.info(
           "Installing a local .deb with apt; package signature verification is bypassed (allowUnverifiedLinuxPackages defaults to true since electron-builder does not sign Linux packages). Set it to false to enforce verification if you sign your packages."
@@ -82,17 +104,20 @@ export class DebUpdater extends LinuxUpdater {
       } else {
         logger.info("Installing a local .deb with apt with package signature verification enforced (allowUnverifiedLinuxPackages=false).")
       }
-      commandRunner([
-        "apt",
-        "install",
-        "-y",
-        ...(allowUnverified ? ["--allow-unauthenticated"] : []), // unsigned .debs only when explicitly opted in
-        "--allow-downgrades", // allow lower version installs
-        "--allow-change-held-packages",
-        installerPath,
-      ])
-    } else {
-      throw new Error(`Package manager ${packageManager} not supported`)
+      return [
+        [
+          [
+            "apt",
+            "install",
+            "-y",
+            ...(allowUnverified ? ["--allow-unauthenticated"] : []), // unsigned .debs only when explicitly opted in
+            "--allow-downgrades", // allow lower version installs
+            "--allow-change-held-packages",
+            installerPath,
+          ],
+        ],
+      ]
     }
+    throw new Error(`Package manager ${packageManager} not supported`)
   }
 }

--- a/packages/electron-updater/src/LinuxUpdater.ts
+++ b/packages/electron-updater/src/LinuxUpdater.ts
@@ -1,10 +1,33 @@
 import { AllPublishOptions } from "builder-util-runtime"
 import { AppAdapter } from "./AppAdapter.js"
 import { BaseUpdater } from "./BaseUpdater.js"
+import { Logger } from "./types.js"
 
 // Matches safe package manager names: alphanumeric, hyphens, underscores only.
 // Rejects names with shell metacharacters that could cause command injection.
 const SAFE_PM_REGEX = /^[a-zA-Z0-9_-]+$/
+
+/**
+ * An install plan: a list of alternatives, each a sequence of commands. The first alternative that succeeds
+ * wins; the next one is attempted only when the previous failed. It exists so the commands of a package
+ * manager are declared once and executed by both the synchronous on-quit path and the asynchronous one.
+ */
+export type InstallPlan = string[][][]
+
+/** Runs an {@link InstallPlan} synchronously, for the on-quit path where an async install cannot be awaited. */
+export function runInstallPlan(plan: InstallPlan, commandRunner: (commandWithArgs: string[]) => void, logger: Logger): void {
+  for (let i = 0; i < plan.length; i++) {
+    try {
+      plan[i].forEach(commandRunner)
+      return
+    } catch (error: any) {
+      if (i === plan.length - 1) {
+        throw error
+      }
+      logger.warn(`${error.message ?? error} — trying the next install command`)
+    }
+  }
+}
 
 export abstract class LinuxUpdater extends BaseUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -40,18 +63,55 @@ export abstract class LinuxUpdater extends BaseUpdater {
       return this.spawnSyncLog(commandWithArgs[0], commandWithArgs.slice(1))
     }
 
-    const { name } = this.app
-    // Strip characters that could break shell quoting in the sudo dialog comment string
-    const safeName = name.replace(/["`$\\!\n\r;|&<>(){}*?[\]#~]/g, "")
-    const installComment = `"${safeName} would like to update"`
-    const sudo = this.sudoWithArgs(installComment)
+    const sudo = this.sudoWithArgs(this.installComment())
     this._logger.info(`Running as non-root user, using sudo to install: ${sudo}`)
-    let wrapper = `"`
-    // some sudo commands dont want the command to be wrapped in " quotes
-    if (/pkexec/i.test(sudo[0]) || sudo[0] === "sudo") {
-      wrapper = ""
-    }
+    const wrapper = this.commandWrapperFor(sudo)
     return this.spawnSyncLog(sudo[0], [...(sudo.length > 1 ? sudo.slice(1) : []), `${wrapper}/bin/bash`, "-c", `'${commandWithArgs.join(" ")}'${wrapper}`])
+  }
+
+  private installComment(): string {
+    // Strip characters that could break shell quoting in the sudo dialog comment string
+    const safeName = this.app.name.replace(/["`$\\!\n\r;|&<>(){}*?[\]#~]/g, "")
+    return `"${safeName} would like to update"`
+  }
+
+  private commandWrapperFor(sudo: string[]): string {
+    // some sudo commands dont want the command to be wrapped in " quotes
+    return /pkexec/i.test(sudo[0]) || sudo[0] === "sudo" ? "" : `"`
+  }
+
+  /** {@link runCommandWithSudoIfNeeded} without blocking the main process while the elevation dialog is open. */
+  protected async runCommandWithSudoIfNeededAsync(commandWithArgs: string[]): Promise<void> {
+    if (this.isRunningAsRoot()) {
+      this._logger.info("Running as root, no need to use sudo")
+      await this.spawnAsyncLog(commandWithArgs[0], commandWithArgs.slice(1))
+      return
+    }
+
+    const sudo = this.sudoWithArgs(this.installComment())
+    this._logger.info(`Running as non-root user, using sudo to install: ${sudo}`)
+    const wrapper = this.commandWrapperFor(sudo)
+    await this.spawnAsyncLog(sudo[0], [...(sudo.length > 1 ? sudo.slice(1) : []), `${wrapper}/bin/bash`, "-c", `'${commandWithArgs.join(" ")}'${wrapper}`])
+  }
+
+  /**
+   * Runs an install plan: the first sequence of commands that succeeds wins, the next one is only attempted
+   * when the previous failed. Both install paths share it so the commands themselves live in one place.
+   */
+  protected async runInstallPlanWithSudoIfNeededAsync(plan: InstallPlan): Promise<void> {
+    for (let i = 0; i < plan.length; i++) {
+      try {
+        for (const command of plan[i]) {
+          await this.runCommandWithSudoIfNeededAsync(command)
+        }
+        return
+      } catch (error: any) {
+        if (i === plan.length - 1) {
+          throw error
+        }
+        this._logger.warn(`${error.message ?? error} — trying the next install command`)
+      }
+    }
   }
 
   protected sudoWithArgs(installComment: string): string[] {

--- a/packages/electron-updater/src/PacmanUpdater.ts
+++ b/packages/electron-updater/src/PacmanUpdater.ts
@@ -4,7 +4,7 @@ import { DownloadUpdateOptions } from "./AppUpdater.js"
 import { InstallOptions } from "./BaseUpdater.js"
 import { DOWNLOAD_PROGRESS, Logger } from "./types.js"
 import { findFile } from "./providers/Provider.js"
-import { LinuxUpdater } from "./LinuxUpdater.js"
+import { InstallPlan, LinuxUpdater, runInstallPlan } from "./LinuxUpdater.js"
 
 export class PacmanUpdater extends LinuxUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -29,13 +29,12 @@ export class PacmanUpdater extends LinuxUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const installerPath = this.installerPath
-    if (installerPath == null) {
-      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
       return false
     }
     try {
-      PacmanUpdater.installWithCommandRunner(installerPath, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
+      runInstallPlan(plan, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
     } catch (error: any) {
       this.dispatchError(error)
       return false
@@ -46,22 +45,38 @@ export class PacmanUpdater extends LinuxUpdater {
     return true
   }
 
-  static installWithCommandRunner(installerPath: string, commandRunner: (commandWithArgs: string[]) => void, logger: Logger) {
-    try {
-      commandRunner(["pacman", "-U", "--noconfirm", installerPath])
-    } catch (error: any) {
-      logger.warn(error.message ?? error)
-      logger.warn("pacman installation failed, attempting to update package database and retry")
-
-      try {
-        // Update package database (not a full upgrade, just sync)
-        commandRunner(["pacman", "-Sy", "--noconfirm"])
-        // Retry installation
-        commandRunner(["pacman", "-U", "--noconfirm", installerPath])
-      } catch (retryError: any) {
-        logger.error("Retry after pacman -Sy failed")
-        throw retryError
-      }
+  protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
+      return false
     }
+    try {
+      await this.runInstallPlanWithSudoIfNeededAsync(plan)
+    } catch (error: any) {
+      this.dispatchError(error)
+      return false
+    }
+    if (options.isForceRunAfter) {
+      this.app.relaunch()
+    }
+    return true
+  }
+
+  private planInstall(installerPath: string | null): InstallPlan | null {
+    if (installerPath == null) {
+      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+      return null
+    }
+    return PacmanUpdater.planInstall(installerPath)
+  }
+
+  static installWithCommandRunner(installerPath: string, commandRunner: (commandWithArgs: string[]) => void, logger: Logger) {
+    runInstallPlan(PacmanUpdater.planInstall(installerPath), commandRunner, logger)
+  }
+
+  static planInstall(installerPath: string): InstallPlan {
+    const install = ["pacman", "-U", "--noconfirm", installerPath]
+    // if the install fails, refresh the package database (not a full upgrade, just sync) and retry once
+    return [[install], [["pacman", "-Sy", "--noconfirm"], install]]
   }
 }

--- a/packages/electron-updater/src/RpmUpdater.ts
+++ b/packages/electron-updater/src/RpmUpdater.ts
@@ -4,7 +4,7 @@ import { DownloadUpdateOptions } from "./AppUpdater.js"
 import { InstallOptions } from "./BaseUpdater.js"
 import { DOWNLOAD_PROGRESS, Logger } from "./types.js"
 import { findFile } from "./providers/Provider.js"
-import { LinuxUpdater } from "./LinuxUpdater.js"
+import { InstallPlan, LinuxUpdater, runInstallPlan } from "./LinuxUpdater.js"
 
 export class RpmUpdater extends LinuxUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -29,16 +29,12 @@ export class RpmUpdater extends LinuxUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const installerPath = this.installerPath
-    if (installerPath == null) {
-      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
       return false
     }
-
-    const priorityList = ["zypper", "dnf", "yum", "rpm"]
-    const packageManager = this.detectPackageManager(priorityList)
     try {
-      RpmUpdater.installWithCommandRunner(packageManager as any, installerPath, this.runCommandWithSudoIfNeeded.bind(this), this._logger, this.allowUnverifiedLinuxPackages)
+      runInstallPlan(plan, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
     } catch (error: any) {
       this.dispatchError(error)
       return false
@@ -49,6 +45,32 @@ export class RpmUpdater extends LinuxUpdater {
     return true
   }
 
+  protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
+      return false
+    }
+    try {
+      await this.runInstallPlanWithSudoIfNeededAsync(plan)
+    } catch (error: any) {
+      this.dispatchError(error)
+      return false
+    }
+    if (options.isForceRunAfter) {
+      this.app.relaunch()
+    }
+    return true
+  }
+
+  private planInstall(installerPath: string | null): InstallPlan | null {
+    if (installerPath == null) {
+      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+      return null
+    }
+    const packageManager = this.detectPackageManager(["zypper", "dnf", "yum", "rpm"])
+    return RpmUpdater.planInstall(packageManager as any, installerPath, this._logger, this.allowUnverifiedLinuxPackages)
+  }
+
   static installWithCommandRunner(
     packageManager: "zypper" | "dnf" | "yum" | "rpm",
     installerPath: string,
@@ -56,6 +78,10 @@ export class RpmUpdater extends LinuxUpdater {
     logger: Logger,
     allowUnverified = true
   ) {
+    runInstallPlan(RpmUpdater.planInstall(packageManager, installerPath, logger, allowUnverified), commandRunner, logger)
+  }
+
+  static planInstall(packageManager: "zypper" | "dnf" | "yum" | "rpm", installerPath: string, logger: Logger, allowUnverified = true): InstallPlan {
     const logVerificationMode = () => {
       if (allowUnverified) {
         logger.info(
@@ -67,13 +93,13 @@ export class RpmUpdater extends LinuxUpdater {
     }
     if (packageManager === "zypper") {
       logVerificationMode()
-      return commandRunner(["zypper", "--non-interactive", "--no-refresh", "install", ...(allowUnverified ? ["--allow-unsigned-rpm"] : []), "-f", installerPath])
+      return [[["zypper", "--non-interactive", "--no-refresh", "install", ...(allowUnverified ? ["--allow-unsigned-rpm"] : []), "-f", installerPath]]]
     }
     if (packageManager === "dnf" || packageManager === "yum") {
       logVerificationMode()
       // Local package files are governed by localpkg_gpgcheck, which defaults to False on dnf4, dnf5, and yum,
       // so enforcement must enable it explicitly — merely omitting --nogpgcheck would not enforce anything.
-      return commandRunner([packageManager, "install", ...(allowUnverified ? ["--nogpgcheck"] : ["--setopt=localpkg_gpgcheck=1"]), "-y", installerPath])
+      return [[[packageManager, "install", ...(allowUnverified ? ["--nogpgcheck"] : ["--setopt=localpkg_gpgcheck=1"]), "-y", installerPath]]]
     }
     if (packageManager === "rpm") {
       if (!allowUnverified) {
@@ -84,7 +110,7 @@ export class RpmUpdater extends LinuxUpdater {
       // --nodeps is a dependency-resolution bypass, not a signature bypass, and the rpm branch is the
       // no-resolver fallback, so it is left in place regardless of allowUnverifiedLinuxPackages.
       logger.warn("Installing with rpm only (no dependency resolution).")
-      return commandRunner(["rpm", "-Uvh", "--replacepkgs", "--replacefiles", "--nodeps", installerPath])
+      return [[["rpm", "-Uvh", "--replacepkgs", "--replacefiles", "--nodeps", installerPath]]]
     }
     throw new Error(`Package manager ${packageManager} not supported`)
   }

--- a/test/src/updater/installOnNextLaunchTest.ts
+++ b/test/src/updater/installOnNextLaunchTest.ts
@@ -134,12 +134,23 @@ describe("install on next launch", { sequential: true }, () => {
     })
   })
 
+  /**
+   * Routes the async install path back to `doInstall`, which every assertion in this file spies on. Linux
+   * targets install asynchronously so their elevation dialog cannot block the main process; what those tests
+   * exercise is BaseUpdater's orchestration, and the Linux execution itself is covered by linuxUpdaterUnitTest.
+   */
+  function delegateAsyncInstallToSyncInstall(updater: DebUpdater | NsisUpdater): void {
+    ;(updater as any).doInstallAsync = (options: unknown) => Promise.resolve((updater as any).doInstall(options))
+  }
+
   describe("BaseUpdater quit handler", () => {
     function createUpdater(app = makeStubApp()) {
       const updater = new DebUpdater(null, app)
       updater.logger = log
       ;(updater as any).downloadedUpdateHelper = helper
       const doInstall = vi.spyOn(updater as any, "doInstall").mockReturnValue(true)
+      // Linux targets install through the async path; keep every assertion on the single doInstall spy
+      delegateAsyncInstallToSyncInstall(updater)
       ;(updater as any).addQuitHandler()
       return { updater, app, doInstall }
     }
@@ -222,6 +233,8 @@ describe("install on next launch", { sequential: true }, () => {
       updater.forceDevUpdateConfig = true
       ;(updater as any).downloadedUpdateHelper = helper
       const doInstall = vi.spyOn(updater as any, "doInstall").mockReturnValue(true)
+      // Linux targets install through the async path; keep every assertion on the single doInstall spy
+      delegateAsyncInstallToSyncInstall(updater)
       const getUpdateInfoAndProvider = vi.spyOn(updater as any, "getUpdateInfoAndProvider")
       if (latestUpdateInfo == null) {
         getUpdateInfoAndProvider.mockRejectedValue(new Error("network must not be hit"))

--- a/test/src/updater/linuxUpdaterUnitTest.ts
+++ b/test/src/updater/linuxUpdaterUnitTest.ts
@@ -158,6 +158,65 @@ describe("LinuxUpdater unit tests", { sequential: true }, () => {
     })
   })
 
+  describe("async install", () => {
+    const setRawPath = (rawPath: string) => {
+      ;(updater as any).downloadedUpdateHelper = { file: rawPath }
+    }
+
+    beforeEach(() => {
+      vi.spyOn(updater as any, "isRunningAsRoot").mockReturnValue(false)
+      vi.spyOn(updater as any, "hasCommand").mockImplementation((...args: unknown[]) => {
+        const cmd = args[0] as string
+        return cmd === "dpkg" || cmd === "pkexec"
+      })
+    })
+
+    it("runs the same command as the synchronous path, awaited instead of blocking", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      const spawnAsyncLog = vi.spyOn(updater as any, "spawnAsyncLog").mockResolvedValue("")
+
+      await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
+
+      expect(spawnAsyncLog).toHaveBeenCalledWith("pkexec", ["--disable-internal-agent", "/bin/bash", "-c", "'dpkg -i /tmp/update-1.0.2.deb'"])
+    })
+
+    it("never falls back to the blocking spawnSync path", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      const spawnSyncLog = vi.spyOn(updater as any, "spawnSyncLog").mockReturnValue("")
+      vi.spyOn(updater as any, "spawnAsyncLog").mockResolvedValue("")
+
+      await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
+
+      // only the non-privileged `command -v` probes may be synchronous
+      const privileged = spawnSyncLog.mock.calls.filter(([cmd]) => cmd !== "command")
+      expect(privileged).toEqual([])
+    })
+
+    it("repairs dependencies with apt-get when dpkg fails, as a separate authenticated command", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      // first call is dpkg, second is the apt-get repair
+      const spawnAsyncLog = vi
+        .spyOn(updater as any, "spawnAsyncLog")
+        .mockRejectedValueOnce(new Error("Command pkexec exited with code 1"))
+        .mockResolvedValue("")
+
+      await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
+
+      expect(spawnAsyncLog.mock.calls.map(([, argv]: any) => argv[argv.length - 1])).toEqual(["'dpkg -i /tmp/update-1.0.2.deb'", "'apt-get install -f -y'"])
+    })
+
+    it("reports the failure instead of relaunching when every command fails", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      vi.spyOn(updater as any, "spawnAsyncLog").mockRejectedValue(new Error("Command pkexec exited with code 126"))
+      const dispatchError = vi.spyOn(updater as any, "dispatchError").mockReturnValue(undefined)
+
+      const installed = await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: true, isAdminRightsRequired: false })
+
+      expect(installed).toBe(false)
+      expect(dispatchError).toHaveBeenCalled()
+    })
+  })
+
   describe("runCommandWithSudoIfNeeded app name handling", () => {
     beforeEach(() => {
       vi.spyOn(updater as any, "isRunningAsRoot").mockReturnValue(false)


### PR DESCRIPTION
Fixes #10092.

## Problem

`LinuxUpdater.runCommandWithSudoIfNeeded` installs through `spawnSyncLog`, so the Electron main process is
blocked for as long as the elevation dialog is open — that is, while the user is typing their password. The
desktop notices the unresponsive process and offers to force-quit the app:

> "App" is not responding — Force Quit / Wait

Timers cannot run either, so any app-side safety net is frozen too.

## Change

`quitAndInstall()` and `installPendingUpdateIfAvailable()` install through a new asynchronous path:

- `BaseUpdater.installAsync()` mirrors `install()` and calls `doInstallAsync()`, which **defaults to the
  synchronous `doInstall`** — Windows and macOS keep their exact behaviour and timing, since `doInstall` is
  still evaluated synchronously before the promise settles.
- `spawnAsyncLog` mirrors `spawnSyncLog`: same command, same environment, same `shell: true`, awaited instead
  of blocking. **What gets executed does not change in this PR**, only when the main process is free.
- the on-quit install keeps the synchronous path: a quit handler cannot await, and the app is exiting anyway.

The `must be sync` constraint on `doInstall` comes from that quit handler. It does not apply to the two paths
above: `quitAndInstall()` is called by the app, and elevation targets are already excluded from the automatic
install at launch in favour of an explicit `installPendingUpdateIfAvailable()`.

To avoid two divergent implementations, each package manager now declares its commands once as an
`InstallPlan` — a list of alternatives, the next one attempted only if the previous failed — executed by both
`runInstallPlan` (sync) and `runInstallPlanWithSudoIfNeededAsync`. `DebUpdater.installWithCommandRunner`,
`RpmUpdater.installWithCommandRunner` and `PacmanUpdater.installWithCommandRunner` keep their signatures and
behaviour; they now run the plan.

## Tests

`pnpm pretest` → lint-deps, lint, typecheck, typecheck:test all clean.
`TEST_FILES="linuxUpdaterUnit,baseUpdaterUnit,installOnNextLaunch" pnpm ci:test` → 79 passed.

Added to `linuxUpdaterUnitTest.ts`: the async install issues the same command as the synchronous path, never
reaches the blocking `spawnSync` (only the unprivileged `command -v` probes may be sync), still repairs
dependencies with apt-get when dpkg fails, and reports the error instead of relaunching when everything fails.

The existing `installWithCommandRunner` tests are untouched and still pass, which is the check that the sync
on-quit path did not change. `installOnNextLaunchTest.ts` needed one helper: its assertions spy on
`doInstall`, so the async path is routed back to that spy for the Linux fixtures.

## Notes

`quitAndInstall()` returns before the install finishes on the Linux path. It already returned `void` and quit
from a `setImmediate`, and the quit now happens once the install resolved, but it is a timing change worth
knowing about for that platform.

Follow-up in #10093: now that the command is spawned asynchronously, it can also be spawned
without a shell, which makes the authentication dialog show the actual command.
