### PR TITLE
fix(updater): show the install command in the Linux elevation dialog

### DIFF
--- a/.changeset/async-linux-install.md
+++ b/.changeset/async-linux-install.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: install Linux packages without freezing the app. Before, `LinuxUpdater` ran the package manager through `spawnSync`, so the main process was blocked for as long as the elevation dialog was open — while the user typed their password — and desktops reported the app as not responding. After, `quitAndInstall()` and `installPendingUpdateIfAvailable()` install through an asynchronous path and the app stays responsive; the command, the environment and the elevation helper are unchanged. The on-quit install keeps the synchronous path, which a quit handler cannot await, and other platforms are unaffected — `doInstallAsync` defaults to the existing synchronous `doInstall`. Each package manager now declares its commands once as an install plan, executed by both paths.

--- a/.changeset/linux-install-argv.md
+++ b/.changeset/linux-install-argv.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: show the install command in the Linux elevation dialog. Before, the privileged command was wrapped in `/bin/bash -c '…'`, so polkit displayed the wrapper rather than the command being authorized; the wrapper is also what forced the backslash-escaping of the installer path (paths containing a single quote were unsupported), and passing an args array with `shell: true` triggers Node's DEP0190 warning. After, the asynchronous install spawns the command with an argv array and no shell wherever the elevation helper accepts one — `pkexec` and `sudo` do, so the dialog reads `dpkg -i /path/app.deb` and the path is passed as-is. `gksudo`, `kdesudo` and `beesu` take a single command string and keep the wrapped form.

--- a/.changeset/prefer-pkexec.md
+++ b/.changeset/prefer-pkexec.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: prefer pkexec over gksudo and kdesudo when elevating a Linux install. Before, `determineSudoCommand` tried `gksudo` and `kdesudo` first, so a machine that still has either of them installed used it. Both are unmaintained and have been dropped from Debian (since Buster) and Ubuntu (since 18.04) — the Debian maintainers removed gksu as unsafe, upstream had stopped maintaining it, and neither works under Wayland. After, `pkexec` is tried first: it is the polkit-based mechanism those distributions point to, it works under Wayland, and it is the only supported helper that takes an argv array, so the authentication dialog shows the install command instead of a `/bin/bash -c '…'` wrapper and the installer path needs no shell escaping. gksudo, kdesudo and beesu remain as fallbacks for systems without polkit.

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -362,14 +362,19 @@ export abstract class BaseUpdater extends AppUpdater {
    */
   // https://github.com/electron-userland/electron-builder/issues/1129
   // Node 8 sends errors: https://nodejs.org/dist/latest-v8.x/docs/api/errors.html#errors_common_system_errors
-  /** {@link spawnSyncLog} without blocking the main process: same command, same environment, awaited instead. */
-  protected spawnAsyncLog(cmd: string, args: string[] = [], env = {}): Promise<string> {
+  /**
+   * {@link spawnSyncLog} without blocking the main process, awaited instead.
+   *
+   * `useShell` is opt-out: without a shell the arguments are passed as an argv array, so nothing has to be
+   * escaped and Node's DEP0190 warning about `shell: true` does not apply.
+   */
+  protected spawnAsyncLog(cmd: string, args: string[] = [], env = {}, useShell = true): Promise<string> {
     this._logger.info(`Executing: ${cmd} with args: ${args}`)
     const mergedEnv: NodeJS.ProcessEnv = { ...process.env, ...env }
     return new Promise<string>((resolve, reject) => {
       const child = spawn(cmd, args, {
         env: { ...mergedEnv, PATH: this.sanitizeEnvPath(mergedEnv.PATH ?? "") },
-        shell: true,
+        shell: useShell,
         stdio: ["ignore", "pipe", "pipe"],
       })
 

--- a/packages/electron-updater/src/BaseUpdater.ts
+++ b/packages/electron-updater/src/BaseUpdater.ts
@@ -37,16 +37,17 @@ export abstract class BaseUpdater extends AppUpdater {
     }
     this._logger.info(`Install on explicit quitAndInstall`)
     // If NOT in silent mode use `autoRunAppAfterInstall` to determine whether to force run the app
-    const isInstalled = this.install(isSilent, isSilent ? isForceRunAfter : this.autoRunAppAfterInstall)
-    if (isInstalled) {
-      setImmediate(() => {
-        // this event is normally emitted when calling quitAndInstall, this emulates that
-        require("electron").autoUpdater.emit("before-quit-for-update")
-        this.app.quit()
-      })
-    } else {
-      this.quitAndInstallCalled = false
-    }
+    void this.installAsync(isSilent, isSilent ? isForceRunAfter : this.autoRunAppAfterInstall).then(isInstalled => {
+      if (isInstalled) {
+        setImmediate(() => {
+          // this event is normally emitted when calling quitAndInstall, this emulates that
+          require("electron").autoUpdater.emit("before-quit-for-update")
+          this.app.quit()
+        })
+      } else {
+        this.quitAndInstallCalled = false
+      }
+    })
   }
 
   installPendingUpdateIfAvailable(): Promise<boolean> {
@@ -80,11 +81,18 @@ export abstract class BaseUpdater extends AppUpdater {
   // must be sync
   protected abstract doInstall(options: InstallOptions): boolean
 
-  // must be sync (because quit even handler is not async)
-  install(isSilent = false, isForceRunAfter = false): boolean {
+  /**
+   * Installs without blocking the main process. Defaults to the synchronous {@link doInstall}; targets whose
+   * install shows an elevation dialog override it.
+   */
+  protected doInstallAsync(options: InstallOptions): Promise<boolean> {
+    return Promise.resolve(this.doInstall(options))
+  }
+
+  private beginInstall(isSilent: boolean, isForceRunAfter: boolean): InstallOptions | null {
     if (this.quitAndInstallCalled) {
       this._logger.warn("install call ignored: quitAndInstallCalled is set to true")
-      return false
+      return null
     }
 
     const downloadedUpdateHelper = this.downloadedUpdateHelper
@@ -92,19 +100,49 @@ export abstract class BaseUpdater extends AppUpdater {
     const downloadedFileInfo = downloadedUpdateHelper == null ? null : downloadedUpdateHelper.downloadedFileInfo
     if (installerPath == null || downloadedFileInfo == null) {
       this.dispatchError(new Error("No update filepath provided, can't quit and install"))
-      return false
+      return null
     }
 
     // prevent calling several times
     this.quitAndInstallCalled = true
 
+    this._logger.info(`Install: isSilent: ${isSilent}, isForceRunAfter: ${isForceRunAfter}`)
+    return {
+      isSilent,
+      isForceRunAfter,
+      isAdminRightsRequired: downloadedFileInfo.isAdminRightsRequired,
+    }
+  }
+
+  // must be sync (because quit even handler is not async)
+  install(isSilent = false, isForceRunAfter = false): boolean {
+    const options = this.beginInstall(isSilent, isForceRunAfter)
+    if (options == null) {
+      return false
+    }
+
     try {
-      this._logger.info(`Install: isSilent: ${isSilent}, isForceRunAfter: ${isForceRunAfter}`)
-      return this.doInstall({
-        isSilent,
-        isForceRunAfter,
-        isAdminRightsRequired: downloadedFileInfo.isAdminRightsRequired,
-      })
+      return this.doInstall(options)
+    } catch (e: any) {
+      this.dispatchError(e)
+      return false
+    }
+  }
+
+  /**
+   * Same as {@link install}, without blocking the main process while the install runs. Targets whose install
+   * shows an elevation dialog need it: a synchronous spawn freezes the app for as long as the dialog is open,
+   * and the desktop reports it as not responding. Targets that do not override {@link doInstallAsync} keep
+   * installing synchronously, so their timing is unchanged.
+   */
+  async installAsync(isSilent = false, isForceRunAfter = false): Promise<boolean> {
+    const options = this.beginInstall(isSilent, isForceRunAfter)
+    if (options == null) {
+      return false
+    }
+
+    try {
+      return await this.doInstallAsync(options)
     } catch (e: any) {
       this.dispatchError(e)
       return false
@@ -194,7 +232,7 @@ export abstract class BaseUpdater extends AppUpdater {
     await downloadedUpdateHelper.clearPendingInstallMarker(this._logger)
     this.updateInfoAndProvider = updateInfoAndProvider
     this._logger.info(`Installing pending update ${latestInfo.version} on launch`)
-    const isInstalled = this.install(true, true)
+    const isInstalled = await this.installAsync(true, true)
     if (isInstalled) {
       setImmediate(() => this.app.quit())
     } else {
@@ -324,6 +362,34 @@ export abstract class BaseUpdater extends AppUpdater {
    */
   // https://github.com/electron-userland/electron-builder/issues/1129
   // Node 8 sends errors: https://nodejs.org/dist/latest-v8.x/docs/api/errors.html#errors_common_system_errors
+  /** {@link spawnSyncLog} without blocking the main process: same command, same environment, awaited instead. */
+  protected spawnAsyncLog(cmd: string, args: string[] = [], env = {}): Promise<string> {
+    this._logger.info(`Executing: ${cmd} with args: ${args}`)
+    const mergedEnv: NodeJS.ProcessEnv = { ...process.env, ...env }
+    return new Promise<string>((resolve, reject) => {
+      const child = spawn(cmd, args, {
+        env: { ...mergedEnv, PATH: this.sanitizeEnvPath(mergedEnv.PATH ?? "") },
+        shell: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+
+      let stdout = ""
+      let stderr = ""
+      child.stdout?.on("data", (chunk: Buffer) => (stdout += chunk.toString()))
+      child.stderr?.on("data", (chunk: Buffer) => (stderr += chunk.toString()))
+
+      child.on("error", error => reject(error))
+      child.on("close", status => {
+        if (status === 0) {
+          resolve(stdout.trim())
+          return
+        }
+        this._logger.error(stderr)
+        reject(new Error(`Command ${cmd} exited with code ${status}`))
+      })
+    })
+  }
+
   protected async spawnLog(cmd: string, args: string[] = [], env: any = undefined, stdio: StdioOptions = "ignore"): Promise<boolean> {
     this._logger.info(`Executing: ${cmd} with args: ${args}`)
     return new Promise<boolean>((resolve, reject) => {

--- a/packages/electron-updater/src/DebUpdater.ts
+++ b/packages/electron-updater/src/DebUpdater.ts
@@ -4,7 +4,7 @@ import { DownloadUpdateOptions } from "./AppUpdater.js"
 import { InstallOptions } from "./BaseUpdater.js"
 import { findFile } from "./providers/Provider.js"
 import { DOWNLOAD_PROGRESS, Logger } from "./types.js"
-import { LinuxUpdater } from "./LinuxUpdater.js"
+import { InstallPlan, LinuxUpdater, runInstallPlan } from "./LinuxUpdater.js"
 
 export class DebUpdater extends LinuxUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -29,19 +29,12 @@ export class DebUpdater extends LinuxUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const installerPath = this.installerPath
-    if (installerPath == null) {
-      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
       return false
     }
-    if (!this.hasCommand("dpkg") && !this.hasCommand("apt")) {
-      this.dispatchError(new Error("Neither dpkg nor apt command found. Cannot install .deb package."))
-      return false
-    }
-    const priorityList = ["dpkg", "apt"]
-    const packageManager = this.detectPackageManager(priorityList)
     try {
-      DebUpdater.installWithCommandRunner(packageManager as any, installerPath, this.runCommandWithSudoIfNeeded.bind(this), this._logger, this.allowUnverifiedLinuxPackages)
+      runInstallPlan(plan, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
     } catch (error: any) {
       this.dispatchError(error)
       return false
@@ -52,6 +45,36 @@ export class DebUpdater extends LinuxUpdater {
     return true
   }
 
+  protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
+      return false
+    }
+    try {
+      await this.runInstallPlanWithSudoIfNeededAsync(plan)
+    } catch (error: any) {
+      this.dispatchError(error)
+      return false
+    }
+    if (options.isForceRunAfter) {
+      this.app.relaunch()
+    }
+    return true
+  }
+
+  private planInstall(installerPath: string | null): InstallPlan | null {
+    if (installerPath == null) {
+      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+      return null
+    }
+    if (!this.hasCommand("dpkg") && !this.hasCommand("apt")) {
+      this.dispatchError(new Error("Neither dpkg nor apt command found. Cannot install .deb package."))
+      return null
+    }
+    const packageManager = this.detectPackageManager(["dpkg", "apt"])
+    return DebUpdater.planInstall(packageManager as any, installerPath, this._logger, this.allowUnverifiedLinuxPackages)
+  }
+
   static installWithCommandRunner(
     packageManager: "dpkg" | "apt",
     installerPath: string,
@@ -59,22 +82,21 @@ export class DebUpdater extends LinuxUpdater {
     logger: Logger,
     allowUnverified = true
   ) {
+    runInstallPlan(DebUpdater.planInstall(packageManager, installerPath, logger, allowUnverified), commandRunner, logger)
+  }
+
+  static planInstall(packageManager: "dpkg" | "apt", installerPath: string, logger: Logger, allowUnverified = true): InstallPlan {
     if (packageManager === "dpkg") {
       if (!allowUnverified) {
         logger.warn(
           "allowUnverifiedLinuxPackages=false has no effect when installing with dpkg: dpkg performs no signature verification. Enforcing .deb signature verification requires a debsig-verify/debsigs policy on the target system."
         )
       }
-      try {
-        // Primary: Install .deb directly with dpkg (dpkg performs no signature verification regardless of allowUnverified)
-        commandRunner(["dpkg", "-i", installerPath])
-      } catch (error: any) {
-        // Handle missing dependencies via apt-get
-        logger.warn(error.message ?? error)
-        logger.warn("dpkg installation failed, trying to fix broken dependencies with apt-get")
-        commandRunner(["apt-get", "install", "-f", "-y"])
-      }
-    } else if (packageManager === "apt") {
+      // dpkg performs no signature verification regardless of allowUnverified, and cannot resolve
+      // dependencies: apt-get repairs them when the install fails because of a missing one
+      return [[["dpkg", "-i", installerPath]], [["apt-get", "install", "-f", "-y"]]]
+    }
+    if (packageManager === "apt") {
       if (allowUnverified) {
         logger.info(
           "Installing a local .deb with apt; package signature verification is bypassed (allowUnverifiedLinuxPackages defaults to true since electron-builder does not sign Linux packages). Set it to false to enforce verification if you sign your packages."
@@ -82,17 +104,20 @@ export class DebUpdater extends LinuxUpdater {
       } else {
         logger.info("Installing a local .deb with apt with package signature verification enforced (allowUnverifiedLinuxPackages=false).")
       }
-      commandRunner([
-        "apt",
-        "install",
-        "-y",
-        ...(allowUnverified ? ["--allow-unauthenticated"] : []), // unsigned .debs only when explicitly opted in
-        "--allow-downgrades", // allow lower version installs
-        "--allow-change-held-packages",
-        installerPath,
-      ])
-    } else {
-      throw new Error(`Package manager ${packageManager} not supported`)
+      return [
+        [
+          [
+            "apt",
+            "install",
+            "-y",
+            ...(allowUnverified ? ["--allow-unauthenticated"] : []), // unsigned .debs only when explicitly opted in
+            "--allow-downgrades", // allow lower version installs
+            "--allow-change-held-packages",
+            installerPath,
+          ],
+        ],
+      ]
     }
+    throw new Error(`Package manager ${packageManager} not supported`)
   }
 }

--- a/packages/electron-updater/src/DebUpdater.ts
+++ b/packages/electron-updater/src/DebUpdater.ts
@@ -46,7 +46,7 @@ export class DebUpdater extends LinuxUpdater {
   }
 
   protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
-    const plan = this.planInstall(this.installerPath)
+    const plan = this.planInstall(this.asyncInstallerPath)
     if (plan == null) {
       return false
     }

--- a/packages/electron-updater/src/LinuxUpdater.ts
+++ b/packages/electron-updater/src/LinuxUpdater.ts
@@ -1,10 +1,33 @@
 import { AllPublishOptions } from "builder-util-runtime"
 import { AppAdapter } from "./AppAdapter.js"
 import { BaseUpdater } from "./BaseUpdater.js"
+import { Logger } from "./types.js"
 
 // Matches safe package manager names: alphanumeric, hyphens, underscores only.
 // Rejects names with shell metacharacters that could cause command injection.
 const SAFE_PM_REGEX = /^[a-zA-Z0-9_-]+$/
+
+/**
+ * An install plan: a list of alternatives, each a sequence of commands. The first alternative that succeeds
+ * wins; the next one is attempted only when the previous failed. It exists so the commands of a package
+ * manager are declared once and executed by both the synchronous on-quit path and the asynchronous one.
+ */
+export type InstallPlan = string[][][]
+
+/** Runs an {@link InstallPlan} synchronously, for the on-quit path where an async install cannot be awaited. */
+export function runInstallPlan(plan: InstallPlan, commandRunner: (commandWithArgs: string[]) => void, logger: Logger): void {
+  for (let i = 0; i < plan.length; i++) {
+    try {
+      plan[i].forEach(commandRunner)
+      return
+    } catch (error: any) {
+      if (i === plan.length - 1) {
+        throw error
+      }
+      logger.warn(`${error.message ?? error} — trying the next install command`)
+    }
+  }
+}
 
 export abstract class LinuxUpdater extends BaseUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -40,18 +63,55 @@ export abstract class LinuxUpdater extends BaseUpdater {
       return this.spawnSyncLog(commandWithArgs[0], commandWithArgs.slice(1))
     }
 
-    const { name } = this.app
-    // Strip characters that could break shell quoting in the sudo dialog comment string
-    const safeName = name.replace(/["`$\\!\n\r;|&<>(){}*?[\]#~]/g, "")
-    const installComment = `"${safeName} would like to update"`
-    const sudo = this.sudoWithArgs(installComment)
+    const sudo = this.sudoWithArgs(this.installComment())
     this._logger.info(`Running as non-root user, using sudo to install: ${sudo}`)
-    let wrapper = `"`
-    // some sudo commands dont want the command to be wrapped in " quotes
-    if (/pkexec/i.test(sudo[0]) || sudo[0] === "sudo") {
-      wrapper = ""
-    }
+    const wrapper = this.commandWrapperFor(sudo)
     return this.spawnSyncLog(sudo[0], [...(sudo.length > 1 ? sudo.slice(1) : []), `${wrapper}/bin/bash`, "-c", `'${commandWithArgs.join(" ")}'${wrapper}`])
+  }
+
+  private installComment(): string {
+    // Strip characters that could break shell quoting in the sudo dialog comment string
+    const safeName = this.app.name.replace(/["`$\\!\n\r;|&<>(){}*?[\]#~]/g, "")
+    return `"${safeName} would like to update"`
+  }
+
+  private commandWrapperFor(sudo: string[]): string {
+    // some sudo commands dont want the command to be wrapped in " quotes
+    return /pkexec/i.test(sudo[0]) || sudo[0] === "sudo" ? "" : `"`
+  }
+
+  /** {@link runCommandWithSudoIfNeeded} without blocking the main process while the elevation dialog is open. */
+  protected async runCommandWithSudoIfNeededAsync(commandWithArgs: string[]): Promise<void> {
+    if (this.isRunningAsRoot()) {
+      this._logger.info("Running as root, no need to use sudo")
+      await this.spawnAsyncLog(commandWithArgs[0], commandWithArgs.slice(1))
+      return
+    }
+
+    const sudo = this.sudoWithArgs(this.installComment())
+    this._logger.info(`Running as non-root user, using sudo to install: ${sudo}`)
+    const wrapper = this.commandWrapperFor(sudo)
+    await this.spawnAsyncLog(sudo[0], [...(sudo.length > 1 ? sudo.slice(1) : []), `${wrapper}/bin/bash`, "-c", `'${commandWithArgs.join(" ")}'${wrapper}`])
+  }
+
+  /**
+   * Runs an install plan: the first sequence of commands that succeeds wins, the next one is only attempted
+   * when the previous failed. Both install paths share it so the commands themselves live in one place.
+   */
+  protected async runInstallPlanWithSudoIfNeededAsync(plan: InstallPlan): Promise<void> {
+    for (let i = 0; i < plan.length; i++) {
+      try {
+        for (const command of plan[i]) {
+          await this.runCommandWithSudoIfNeededAsync(command)
+        }
+        return
+      } catch (error: any) {
+        if (i === plan.length - 1) {
+          throw error
+        }
+        this._logger.warn(`${error.message ?? error} — trying the next install command`)
+      }
+    }
   }
 
   protected sudoWithArgs(installComment: string): string[] {

--- a/packages/electron-updater/src/LinuxUpdater.ts
+++ b/packages/electron-updater/src/LinuxUpdater.ts
@@ -57,6 +57,15 @@ export abstract class LinuxUpdater extends BaseUpdater {
       .replace(/[\n\r]/g, "")
   }
 
+  /**
+   * The installer path as downloaded. {@link installerPath} escapes shell metacharacters, which is only
+   * correct when the command goes through a shell — passed as an argv element, the escapes would reach the
+   * package manager literally.
+   */
+  protected get rawInstallerPath(): string | null {
+    return super.installerPath
+  }
+
   protected runCommandWithSudoIfNeeded(commandWithArgs: string[]) {
     if (this.isRunningAsRoot()) {
       this._logger.info("Running as root, no need to use sudo")
@@ -77,21 +86,49 @@ export abstract class LinuxUpdater extends BaseUpdater {
 
   private commandWrapperFor(sudo: string[]): string {
     // some sudo commands dont want the command to be wrapped in " quotes
-    return /pkexec/i.test(sudo[0]) || sudo[0] === "sudo" ? "" : `"`
+    return this.takesArgv(sudo[0]) ? "" : `"`
   }
 
-  /** {@link runCommandWithSudoIfNeeded} without blocking the main process while the elevation dialog is open. */
+  /**
+   * {@link runCommandWithSudoIfNeeded} without blocking the main process, and without a shell wherever the
+   * elevation helper accepts an argv array.
+   *
+   * pkexec and sudo do, so their authentication dialog shows the command being authorized
+   * (`dpkg -i /path/app.deb`) instead of the `/bin/bash -c '…'` wrapper, the installer path needs no
+   * escaping, and no `shell: true` deprecation applies. gksudo, kdesudo and beesu take the command as a
+   * single string, so those keep the wrapped form.
+   */
   protected async runCommandWithSudoIfNeededAsync(commandWithArgs: string[]): Promise<void> {
     if (this.isRunningAsRoot()) {
       this._logger.info("Running as root, no need to use sudo")
-      await this.spawnAsyncLog(commandWithArgs[0], commandWithArgs.slice(1))
+      await this.spawnAsyncLog(commandWithArgs[0], commandWithArgs.slice(1), {}, false)
       return
     }
 
     const sudo = this.sudoWithArgs(this.installComment())
     this._logger.info(`Running as non-root user, using sudo to install: ${sudo}`)
+    const sudoArgs = sudo.length > 1 ? sudo.slice(1) : []
+
+    if (this.takesArgv(sudo[0])) {
+      await this.spawnAsyncLog(sudo[0], [...sudoArgs, ...commandWithArgs], {}, false)
+      return
+    }
+
     const wrapper = this.commandWrapperFor(sudo)
-    await this.spawnAsyncLog(sudo[0], [...(sudo.length > 1 ? sudo.slice(1) : []), `${wrapper}/bin/bash`, "-c", `'${commandWithArgs.join(" ")}'${wrapper}`])
+    await this.spawnAsyncLog(sudo[0], [...sudoArgs, `${wrapper}/bin/bash`, "-c", `'${commandWithArgs.join(" ")}'${wrapper}`])
+  }
+
+  /** Whether the elevation helper runs an argv array rather than a single command string. */
+  private takesArgv(sudo: string): boolean {
+    return /pkexec/i.test(sudo) || sudo === "sudo"
+  }
+
+  /**
+   * The installer path for the asynchronous path: unescaped when the command is passed as argv, escaped when
+   * it still goes through the `/bin/bash -c` wrapper.
+   */
+  protected get asyncInstallerPath(): string | null {
+    return this.isRunningAsRoot() || this.takesArgv(this.determineSudoCommand()) ? this.rawInstallerPath : this.installerPath
   }
 
   /**

--- a/packages/electron-updater/src/LinuxUpdater.ts
+++ b/packages/electron-updater/src/LinuxUpdater.ts
@@ -175,7 +175,11 @@ export abstract class LinuxUpdater extends BaseUpdater {
   }
 
   protected determineSudoCommand(): string {
-    const sudos = ["gksudo", "kdesudo", "pkexec", "beesu"]
+    // pkexec first: it is the maintained, polkit-based mechanism, it is the only helper here that takes an
+    // argv array (so the dialog shows the install command and the path needs no escaping), and it works under
+    // Wayland. gksudo and kdesudo are unmaintained and were removed from Debian and Ubuntu; they stay as
+    // fallbacks for systems without polkit.
+    const sudos = ["pkexec", "gksudo", "kdesudo", "beesu"]
     for (const sudo of sudos) {
       if (this.hasCommand(sudo)) {
         return sudo

--- a/packages/electron-updater/src/PacmanUpdater.ts
+++ b/packages/electron-updater/src/PacmanUpdater.ts
@@ -4,7 +4,7 @@ import { DownloadUpdateOptions } from "./AppUpdater.js"
 import { InstallOptions } from "./BaseUpdater.js"
 import { DOWNLOAD_PROGRESS, Logger } from "./types.js"
 import { findFile } from "./providers/Provider.js"
-import { LinuxUpdater } from "./LinuxUpdater.js"
+import { InstallPlan, LinuxUpdater, runInstallPlan } from "./LinuxUpdater.js"
 
 export class PacmanUpdater extends LinuxUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -29,13 +29,12 @@ export class PacmanUpdater extends LinuxUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const installerPath = this.installerPath
-    if (installerPath == null) {
-      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
       return false
     }
     try {
-      PacmanUpdater.installWithCommandRunner(installerPath, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
+      runInstallPlan(plan, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
     } catch (error: any) {
       this.dispatchError(error)
       return false
@@ -46,22 +45,38 @@ export class PacmanUpdater extends LinuxUpdater {
     return true
   }
 
-  static installWithCommandRunner(installerPath: string, commandRunner: (commandWithArgs: string[]) => void, logger: Logger) {
-    try {
-      commandRunner(["pacman", "-U", "--noconfirm", installerPath])
-    } catch (error: any) {
-      logger.warn(error.message ?? error)
-      logger.warn("pacman installation failed, attempting to update package database and retry")
-
-      try {
-        // Update package database (not a full upgrade, just sync)
-        commandRunner(["pacman", "-Sy", "--noconfirm"])
-        // Retry installation
-        commandRunner(["pacman", "-U", "--noconfirm", installerPath])
-      } catch (retryError: any) {
-        logger.error("Retry after pacman -Sy failed")
-        throw retryError
-      }
+  protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
+      return false
     }
+    try {
+      await this.runInstallPlanWithSudoIfNeededAsync(plan)
+    } catch (error: any) {
+      this.dispatchError(error)
+      return false
+    }
+    if (options.isForceRunAfter) {
+      this.app.relaunch()
+    }
+    return true
+  }
+
+  private planInstall(installerPath: string | null): InstallPlan | null {
+    if (installerPath == null) {
+      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+      return null
+    }
+    return PacmanUpdater.planInstall(installerPath)
+  }
+
+  static installWithCommandRunner(installerPath: string, commandRunner: (commandWithArgs: string[]) => void, logger: Logger) {
+    runInstallPlan(PacmanUpdater.planInstall(installerPath), commandRunner, logger)
+  }
+
+  static planInstall(installerPath: string): InstallPlan {
+    const install = ["pacman", "-U", "--noconfirm", installerPath]
+    // if the install fails, refresh the package database (not a full upgrade, just sync) and retry once
+    return [[install], [["pacman", "-Sy", "--noconfirm"], install]]
   }
 }

--- a/packages/electron-updater/src/PacmanUpdater.ts
+++ b/packages/electron-updater/src/PacmanUpdater.ts
@@ -46,7 +46,7 @@ export class PacmanUpdater extends LinuxUpdater {
   }
 
   protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
-    const plan = this.planInstall(this.installerPath)
+    const plan = this.planInstall(this.asyncInstallerPath)
     if (plan == null) {
       return false
     }

--- a/packages/electron-updater/src/RpmUpdater.ts
+++ b/packages/electron-updater/src/RpmUpdater.ts
@@ -46,7 +46,7 @@ export class RpmUpdater extends LinuxUpdater {
   }
 
   protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
-    const plan = this.planInstall(this.installerPath)
+    const plan = this.planInstall(this.asyncInstallerPath)
     if (plan == null) {
       return false
     }

--- a/packages/electron-updater/src/RpmUpdater.ts
+++ b/packages/electron-updater/src/RpmUpdater.ts
@@ -4,7 +4,7 @@ import { DownloadUpdateOptions } from "./AppUpdater.js"
 import { InstallOptions } from "./BaseUpdater.js"
 import { DOWNLOAD_PROGRESS, Logger } from "./types.js"
 import { findFile } from "./providers/Provider.js"
-import { LinuxUpdater } from "./LinuxUpdater.js"
+import { InstallPlan, LinuxUpdater, runInstallPlan } from "./LinuxUpdater.js"
 
 export class RpmUpdater extends LinuxUpdater {
   constructor(options?: AllPublishOptions | null, app?: AppAdapter) {
@@ -29,16 +29,12 @@ export class RpmUpdater extends LinuxUpdater {
   }
 
   protected doInstall(options: InstallOptions): boolean {
-    const installerPath = this.installerPath
-    if (installerPath == null) {
-      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
       return false
     }
-
-    const priorityList = ["zypper", "dnf", "yum", "rpm"]
-    const packageManager = this.detectPackageManager(priorityList)
     try {
-      RpmUpdater.installWithCommandRunner(packageManager as any, installerPath, this.runCommandWithSudoIfNeeded.bind(this), this._logger, this.allowUnverifiedLinuxPackages)
+      runInstallPlan(plan, this.runCommandWithSudoIfNeeded.bind(this), this._logger)
     } catch (error: any) {
       this.dispatchError(error)
       return false
@@ -49,6 +45,32 @@ export class RpmUpdater extends LinuxUpdater {
     return true
   }
 
+  protected async doInstallAsync(options: InstallOptions): Promise<boolean> {
+    const plan = this.planInstall(this.installerPath)
+    if (plan == null) {
+      return false
+    }
+    try {
+      await this.runInstallPlanWithSudoIfNeededAsync(plan)
+    } catch (error: any) {
+      this.dispatchError(error)
+      return false
+    }
+    if (options.isForceRunAfter) {
+      this.app.relaunch()
+    }
+    return true
+  }
+
+  private planInstall(installerPath: string | null): InstallPlan | null {
+    if (installerPath == null) {
+      this.dispatchError(new Error("No update filepath provided, can't quit and install"))
+      return null
+    }
+    const packageManager = this.detectPackageManager(["zypper", "dnf", "yum", "rpm"])
+    return RpmUpdater.planInstall(packageManager as any, installerPath, this._logger, this.allowUnverifiedLinuxPackages)
+  }
+
   static installWithCommandRunner(
     packageManager: "zypper" | "dnf" | "yum" | "rpm",
     installerPath: string,
@@ -56,6 +78,10 @@ export class RpmUpdater extends LinuxUpdater {
     logger: Logger,
     allowUnverified = true
   ) {
+    runInstallPlan(RpmUpdater.planInstall(packageManager, installerPath, logger, allowUnverified), commandRunner, logger)
+  }
+
+  static planInstall(packageManager: "zypper" | "dnf" | "yum" | "rpm", installerPath: string, logger: Logger, allowUnverified = true): InstallPlan {
     const logVerificationMode = () => {
       if (allowUnverified) {
         logger.info(
@@ -67,13 +93,13 @@ export class RpmUpdater extends LinuxUpdater {
     }
     if (packageManager === "zypper") {
       logVerificationMode()
-      return commandRunner(["zypper", "--non-interactive", "--no-refresh", "install", ...(allowUnverified ? ["--allow-unsigned-rpm"] : []), "-f", installerPath])
+      return [[["zypper", "--non-interactive", "--no-refresh", "install", ...(allowUnverified ? ["--allow-unsigned-rpm"] : []), "-f", installerPath]]]
     }
     if (packageManager === "dnf" || packageManager === "yum") {
       logVerificationMode()
       // Local package files are governed by localpkg_gpgcheck, which defaults to False on dnf4, dnf5, and yum,
       // so enforcement must enable it explicitly — merely omitting --nogpgcheck would not enforce anything.
-      return commandRunner([packageManager, "install", ...(allowUnverified ? ["--nogpgcheck"] : ["--setopt=localpkg_gpgcheck=1"]), "-y", installerPath])
+      return [[[packageManager, "install", ...(allowUnverified ? ["--nogpgcheck"] : ["--setopt=localpkg_gpgcheck=1"]), "-y", installerPath]]]
     }
     if (packageManager === "rpm") {
       if (!allowUnverified) {
@@ -84,7 +110,7 @@ export class RpmUpdater extends LinuxUpdater {
       // --nodeps is a dependency-resolution bypass, not a signature bypass, and the rpm branch is the
       // no-resolver fallback, so it is left in place regardless of allowUnverifiedLinuxPackages.
       logger.warn("Installing with rpm only (no dependency resolution).")
-      return commandRunner(["rpm", "-Uvh", "--replacepkgs", "--replacefiles", "--nodeps", installerPath])
+      return [[["rpm", "-Uvh", "--replacepkgs", "--replacefiles", "--nodeps", installerPath]]]
     }
     throw new Error(`Package manager ${packageManager} not supported`)
   }

--- a/test/src/updater/installOnNextLaunchTest.ts
+++ b/test/src/updater/installOnNextLaunchTest.ts
@@ -134,12 +134,23 @@ describe("install on next launch", { sequential: true }, () => {
     })
   })
 
+  /**
+   * Routes the async install path back to `doInstall`, which every assertion in this file spies on. Linux
+   * targets install asynchronously so their elevation dialog cannot block the main process; what those tests
+   * exercise is BaseUpdater's orchestration, and the Linux execution itself is covered by linuxUpdaterUnitTest.
+   */
+  function delegateAsyncInstallToSyncInstall(updater: DebUpdater | NsisUpdater): void {
+    ;(updater as any).doInstallAsync = (options: unknown) => Promise.resolve((updater as any).doInstall(options))
+  }
+
   describe("BaseUpdater quit handler", () => {
     function createUpdater(app = makeStubApp()) {
       const updater = new DebUpdater(null, app)
       updater.logger = log
       ;(updater as any).downloadedUpdateHelper = helper
       const doInstall = vi.spyOn(updater as any, "doInstall").mockReturnValue(true)
+      // Linux targets install through the async path; keep every assertion on the single doInstall spy
+      delegateAsyncInstallToSyncInstall(updater)
       ;(updater as any).addQuitHandler()
       return { updater, app, doInstall }
     }
@@ -222,6 +233,8 @@ describe("install on next launch", { sequential: true }, () => {
       updater.forceDevUpdateConfig = true
       ;(updater as any).downloadedUpdateHelper = helper
       const doInstall = vi.spyOn(updater as any, "doInstall").mockReturnValue(true)
+      // Linux targets install through the async path; keep every assertion on the single doInstall spy
+      delegateAsyncInstallToSyncInstall(updater)
       const getUpdateInfoAndProvider = vi.spyOn(updater as any, "getUpdateInfoAndProvider")
       if (latestUpdateInfo == null) {
         getUpdateInfoAndProvider.mockRejectedValue(new Error("network must not be hit"))

--- a/test/src/updater/linuxUpdaterUnitTest.ts
+++ b/test/src/updater/linuxUpdaterUnitTest.ts
@@ -171,13 +171,25 @@ describe("LinuxUpdater unit tests", { sequential: true }, () => {
       })
     })
 
-    it("runs the same command as the synchronous path, awaited instead of blocking", async () => {
-      setRawPath("/tmp/update-1.0.2.deb")
+    it("passes the command to pkexec as argv, without a shell and without escaping the path", async () => {
+      setRawPath("/tmp/a b/update-1.0.2.deb")
       const spawnAsyncLog = vi.spyOn(updater as any, "spawnAsyncLog").mockResolvedValue("")
 
       await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
 
-      expect(spawnAsyncLog).toHaveBeenCalledWith("pkexec", ["--disable-internal-agent", "/bin/bash", "-c", "'dpkg -i /tmp/update-1.0.2.deb'"])
+      // the dialog shows `dpkg -i …` instead of `/bin/bash -c '…'`, and the space is not backslash-escaped
+      expect(spawnAsyncLog).toHaveBeenCalledWith("pkexec", ["--disable-internal-agent", "dpkg", "-i", "/tmp/a b/update-1.0.2.deb"], {}, false)
+    })
+
+    it("keeps the wrapped command string for helpers that cannot take argv", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      vi.spyOn(updater as any, "determineSudoCommand").mockReturnValue("gksudo")
+      const spawnAsyncLog = vi.spyOn(updater as any, "spawnAsyncLog").mockResolvedValue("")
+
+      await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
+
+      // gksudo takes a single command string, so the bash wrapper and the shell stay
+      expect(spawnAsyncLog).toHaveBeenCalledWith("gksudo", ["--message", expect.any(String), `"/bin/bash`, "-c", `'dpkg -i /tmp/update-1.0.2.deb'"`])
     })
 
     it("never falls back to the blocking spawnSync path", async () => {
@@ -202,7 +214,10 @@ describe("LinuxUpdater unit tests", { sequential: true }, () => {
 
       await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
 
-      expect(spawnAsyncLog.mock.calls.map(([, argv]: any) => argv[argv.length - 1])).toEqual(["'dpkg -i /tmp/update-1.0.2.deb'", "'apt-get install -f -y'"])
+      expect(spawnAsyncLog.mock.calls.map(([, argv]: any) => argv.slice(1))).toEqual([
+        ["dpkg", "-i", "/tmp/update-1.0.2.deb"],
+        ["apt-get", "install", "-f", "-y"],
+      ])
     })
 
     it("reports the failure instead of relaunching when every command fails", async () => {

--- a/test/src/updater/linuxUpdaterUnitTest.ts
+++ b/test/src/updater/linuxUpdaterUnitTest.ts
@@ -158,6 +158,29 @@ describe("LinuxUpdater unit tests", { sequential: true }, () => {
     })
   })
 
+  describe("determineSudoCommand", () => {
+    it("prefers pkexec over the unmaintained helpers when both are installed", () => {
+      vi.spyOn(updater as any, "hasCommand").mockImplementation((...args: unknown[]) => {
+        const cmd = args[0] as string
+        return cmd === "pkexec" || cmd === "gksudo"
+      })
+
+      expect((updater as any).determineSudoCommand()).toBe("pkexec")
+    })
+
+    it("falls back to a legacy helper when polkit is not available", () => {
+      vi.spyOn(updater as any, "hasCommand").mockImplementation((...args: unknown[]) => (args[0] as string) === "gksudo")
+
+      expect((updater as any).determineSudoCommand()).toBe("gksudo")
+    })
+
+    it("falls back to sudo when no graphical helper is installed", () => {
+      vi.spyOn(updater as any, "hasCommand").mockReturnValue(false)
+
+      expect((updater as any).determineSudoCommand()).toBe("sudo")
+    })
+  })
+
   describe("async install", () => {
     const setRawPath = (rawPath: string) => {
       ;(updater as any).downloadedUpdateHelper = { file: rawPath }

--- a/test/src/updater/linuxUpdaterUnitTest.ts
+++ b/test/src/updater/linuxUpdaterUnitTest.ts
@@ -158,6 +158,65 @@ describe("LinuxUpdater unit tests", { sequential: true }, () => {
     })
   })
 
+  describe("async install", () => {
+    const setRawPath = (rawPath: string) => {
+      ;(updater as any).downloadedUpdateHelper = { file: rawPath }
+    }
+
+    beforeEach(() => {
+      vi.spyOn(updater as any, "isRunningAsRoot").mockReturnValue(false)
+      vi.spyOn(updater as any, "hasCommand").mockImplementation((...args: unknown[]) => {
+        const cmd = args[0] as string
+        return cmd === "dpkg" || cmd === "pkexec"
+      })
+    })
+
+    it("runs the same command as the synchronous path, awaited instead of blocking", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      const spawnAsyncLog = vi.spyOn(updater as any, "spawnAsyncLog").mockResolvedValue("")
+
+      await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
+
+      expect(spawnAsyncLog).toHaveBeenCalledWith("pkexec", ["--disable-internal-agent", "/bin/bash", "-c", "'dpkg -i /tmp/update-1.0.2.deb'"])
+    })
+
+    it("never falls back to the blocking spawnSync path", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      const spawnSyncLog = vi.spyOn(updater as any, "spawnSyncLog").mockReturnValue("")
+      vi.spyOn(updater as any, "spawnAsyncLog").mockResolvedValue("")
+
+      await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
+
+      // only the non-privileged `command -v` probes may be synchronous
+      const privileged = spawnSyncLog.mock.calls.filter(([cmd]) => cmd !== "command")
+      expect(privileged).toEqual([])
+    })
+
+    it("repairs dependencies with apt-get when dpkg fails, as a separate authenticated command", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      // first call is dpkg, second is the apt-get repair
+      const spawnAsyncLog = vi
+        .spyOn(updater as any, "spawnAsyncLog")
+        .mockRejectedValueOnce(new Error("Command pkexec exited with code 1"))
+        .mockResolvedValue("")
+
+      await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: false, isAdminRightsRequired: false })
+
+      expect(spawnAsyncLog.mock.calls.map(([, argv]: any) => argv[argv.length - 1])).toEqual(["'dpkg -i /tmp/update-1.0.2.deb'", "'apt-get install -f -y'"])
+    })
+
+    it("reports the failure instead of relaunching when every command fails", async () => {
+      setRawPath("/tmp/update-1.0.2.deb")
+      vi.spyOn(updater as any, "spawnAsyncLog").mockRejectedValue(new Error("Command pkexec exited with code 126"))
+      const dispatchError = vi.spyOn(updater as any, "dispatchError").mockReturnValue(undefined)
+
+      const installed = await (updater as any).doInstallAsync({ isSilent: true, isForceRunAfter: true, isAdminRightsRequired: false })
+
+      expect(installed).toBe(false)
+      expect(dispatchError).toHaveBeenCalled()
+    })
+  })
+
   describe("runCommandWithSudoIfNeeded app name handling", () => {
     beforeEach(() => {
       vi.spyOn(updater as any, "isRunningAsRoot").mockReturnValue(false)


### PR DESCRIPTION
Fixes #10093. Depends on #10094.

**Note on the diff:** this branch is stacked on the one in #10094, so the files changed here include that
PR's commits. The two commits belonging to this PR are the last two — `fix(updater): show the install command
in the Linux elevation dialog` and `fix(updater): prefer pkexec over gksudo and kdesudo`. I will rebase and
force-push once #10094 lands, or squash the three into one PR if you prefer that.

## Problem

The privileged command is wrapped in `/bin/bash -c '…'`, so the authentication dialog shows the wrapper
instead of the command the user is authorizing:

```
Authentication is needed to run '/bin/bash -c dpkg -i /home/…/pending/App-1.2.3.deb' as the super user
```

The wrapper is also what forces the manual metacharacter escaping in `installerPath` (documented as not
supporting paths containing a single quote), and passing an args array together with `shell: true` triggers
Node's `DEP0190` deprecation warning.

## Change

Two commits:

**1. Spawn with argv, without a shell, wherever the helper accepts it.**

| helper | before | after |
| --- | --- | --- |
| pkexec, sudo, running as root | `pkexec … /bin/bash -c 'dpkg -i /path/app\ 1.deb'` | `pkexec … dpkg -i "/path/app 1.deb"` (argv, no shell) |
| gksudo, kdesudo, beesu | unchanged | unchanged — they take a single command string |

On the argv path the dialog shows the real command, the installer path is passed as-is so it needs no
escaping (`asyncInstallerPath` selects the raw path only when the command is passed as argv), and
`shell: true` is gone along with the DEP0190 warning.

**2. Prefer pkexec over the legacy helpers.** `determineSudoCommand` tried `gksudo` and `kdesudo` first, so a
machine that still has either installed would never reach the improved path. Both are unmaintained and have
been removed from Debian (since Buster) and Ubuntu (since 18.04) — the Debian maintainers removed gksu as
unsafe, upstream had stopped maintaining it, and neither works under Wayland, which is what polkit replaced
them for.
`pkexec` is now tried first; the others stay as fallbacks for systems without polkit.

This is a behaviour change worth calling out: on a machine that has both, the prompt now comes from polkit
rather than gksudo.

## Scope and limits

- `gksudo`, `kdesudo` and `beesu` keep the wrapper and the escaping. They take the command as a single
  string, and since they are absent from current distributions they cannot realistically be tested here — a
  blind change to a legacy path is worse than no change. With commit 2 they are only used when polkit is
  missing.
- The `sudo` fallback takes the argv path too, but it is not usable for a graphical install either way:
  `stdio` is `ignore`, so sudo has nowhere to prompt. Pre-existing and untouched.
- **DEP0190 is not fully gone.** The synchronous on-quit install still goes through `spawnSyncLog`, which
  keeps `shell: true`; only the asynchronous path stops warning.

## Tests

`pnpm pretest` → lint-deps, lint, typecheck, typecheck:test all clean.
`TEST_FILES="linuxUpdaterUnit,baseUpdaterUnit,installOnNextLaunch" pnpm ci:test` → 83 passed.

Added: pkexec receives `["--disable-internal-agent", "dpkg", "-i", "/tmp/a b/update-1.0.2.deb"]` with the
shell disabled and the space unescaped; gksudo still receives the wrapped command string; and
`determineSudoCommand` prefers pkexec when both are installed, falls back to a legacy helper without polkit,
and to `sudo` when nothing graphical is installed.
