### PR TITLE
fix(mac): pass the keychain password to security set-key-partition-list

### DIFF
--- a/.changeset/fix-mac-keychain-partition-list-password.md
+++ b/.changeset/fix-mac-keychain-partition-list-password.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): pass the temporary keychain's own password to `security set-key-partition-list -k` instead of the certificate's import password. The import password is only valid for `security import -P`; `set-key-partition-list` authenticates against the keychain itself, so on macOS versions that verify the password, `CSC_LINK`-based signing failed with `SecKeychainUnlock: The user name or passphrase you entered is not correct` (see #10066).

--- a/packages/app-builder-lib/src/codeSign/mac/macCodeSign.ts
+++ b/packages/app-builder-lib/src/codeSign/mac/macCodeSign.ts
@@ -190,17 +190,19 @@ export async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink
   if (cscIKeyPassword != null) {
     cscPasswords.push(cscIKeyPassword)
   }
-  return await importCerts(keychainFile, certPaths, cscPasswords)
+  return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)
 }
 
-async function importCerts(keychainFile: string, paths: Array<string>, keyPasswords: Array<string>): Promise<CodeSigningInfo> {
+async function importCerts(keychainFile: string, paths: Array<string>, keyPasswords: Array<string>, keychainPassword: string): Promise<CodeSigningInfo> {
   for (let i = 0; i < paths.length; i++) {
     const password = keyPasswords[i] ?? ""
     await exec("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password])
 
     // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
     // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
-    await exec("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile])
+    // `-k` expects the keychain's own unlock password (as used by create-keychain/unlock-keychain above),
+    // not the imported item's password used by `security import -P`.
+    await exec("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile])
   }
 
   return {

--- a/test/src/helpers/packTester.ts
+++ b/test/src/helpers/packTester.ts
@@ -407,6 +407,8 @@ function getFileTypePriority(file: string): number {
  * 3. Tertiary: Filename (alphabetical)
  * 4. Quaternary: Presence of updateInfo (with updateInfo < without updateInfo)
  * 5. Quinary: Safe artifact name (alphabetical)
+ * 6. Senary: Publish provider (alphabetical)
+ * 7. Final: File content bytes — same provider may be configured multiple times
  */
 function sortArtifacts(a: ArtifactCreated, b: ArtifactCreated): number {
   // Primary sort: by file extension type
@@ -442,11 +444,22 @@ function sortArtifacts(a: ArtifactCreated, b: ArtifactCreated): number {
     return hasUpdateInfoA - hasUpdateInfoB
   }
 
-  // Quinary sort: by safeArtifactName (final tiebreaker)
-  const safeNameA = a.safeArtifactName ?? ""
-  const safeNameB = b.safeArtifactName ?? ""
+  // Quinary sort: by safeArtifactName
+  const safeNameCompare = (a.safeArtifactName ?? "").localeCompare(b.safeArtifactName ?? "", "en")
+  if (safeNameCompare !== 0) {
+    return safeNameCompare
+  }
 
-  return safeNameA.localeCompare(safeNameB, "en")
+  // Senary sort: by publish provider. Update-info yml files emitted per publisher share
+  // basename/arch/updateInfo/safeArtifactName, so without this their relative order depends on
+  // async write completion in writeUpdateInfoFiles (asyncPool) and is nondeterministic.
+  const providerCompare = (a.publishConfig?.provider ?? "").localeCompare(b.publishConfig?.provider ?? "", "en")
+  if (providerCompare !== 0) {
+    return providerCompare
+  }
+
+  // Final tiebreaker: file content bytes (same provider can be configured multiple times)
+  return Buffer.compare(a.fileContent ?? Buffer.alloc(0), b.fileContent ?? Buffer.alloc(0))
 }
 
 async function packAndCheck(

--- a/test/src/mac/keychainPartitionListTest.ts
+++ b/test/src/mac/keychainPartitionListTest.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest"
+
+// All `/usr/bin/security` invocations are intercepted so the temporary-keychain setup can be asserted
+// deterministically on any platform — no real keychain, certificate, or Apple tooling required.
+vi.mock("builder-util", async () => {
+  const actual = await vi.importActual<typeof import("builder-util")>("builder-util")
+  return { ...actual, exec: vi.fn().mockResolvedValue("") }
+})
+
+import { createKeychain } from "app-builder-lib/internal"
+import { exec } from "builder-util"
+import { outputFile } from "fs-extra"
+import { rm } from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+
+// Keep the bundled root-certs keychain copy (the only real fs side effect of createKeychain's
+// keychain setup) inside a sandbox instead of the user's real cache directory.
+const cacheDir = path.join(os.tmpdir(), `eb-keychain-test-${process.pid}-${Date.now()}`)
+
+beforeAll(() => {
+  vi.stubEnv("ELECTRON_BUILDER_CACHE", cacheDir)
+})
+
+beforeEach(() => {
+  vi.mocked(exec).mockClear()
+})
+
+afterAll(async () => {
+  vi.unstubAllEnvs()
+  await rm(cacheDir, { recursive: true, force: true })
+})
+
+async function createDummyCert(tmpDir: { getTempFile: (opts?: { suffix?: string }) => Promise<string> }, name: string): Promise<string> {
+  const certPath = await tmpDir.getTempFile({ suffix: `-${name}.p12` })
+  await outputFile(certPath, Buffer.from("not a real p12 — only the path is used"))
+  return certPath
+}
+
+function securityCalls(): Array<Array<string>> {
+  return vi
+    .mocked(exec)
+    .mock.calls.filter(([file]) => file === "/usr/bin/security")
+    .map(([, args]) => args as Array<string>)
+}
+
+function flagValue(args: Array<string>, flag: string): string | undefined {
+  const index = args.indexOf(flag)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+describe("createKeychain security command wiring", { sequential: true }, () => {
+  const cscKeyPassword = "p12-import-password"
+
+  // The keychain password is random; recover it from the create-keychain call instead of mocking crypto.
+  function keychainPasswordFromCalls(): string {
+    const createCall = securityCalls().find(args => args[0] === "create-keychain")
+    expect(createCall).toBeDefined()
+    return flagValue(createCall!, "-p")!
+  }
+
+  test("set-key-partition-list receives the keychain password, not the certificate import password", async ({ tmpDir }) => {
+    const cscLink = await createDummyCert(tmpDir, "app")
+    await createKeychain({ tmpDir, cscLink, cscKeyPassword, currentDir: process.cwd() })
+
+    const calls = securityCalls()
+    const importCall = calls.find(args => args[0] === "import")
+    const partitionCall = calls.find(args => args[0] === "set-key-partition-list")
+    expect(importCall).toBeDefined()
+    expect(partitionCall).toBeDefined()
+
+    // `security import -P` keeps the certificate's own import password...
+    expect(flagValue(importCall!, "-P")).toBe(cscKeyPassword)
+    // ...while `set-key-partition-list -k` needs the keychain's unlock password (same value used by
+    // create-keychain/unlock-keychain), otherwise SecKeychainUnlock rejects it and the build fails.
+    expect(flagValue(partitionCall!, "-k")).toBe(keychainPasswordFromCalls())
+  })
+
+  test("every imported certificate gets its partition list set with the keychain password", async ({ tmpDir }) => {
+    const cscLink = await createDummyCert(tmpDir, "app")
+    const cscILink = await createDummyCert(tmpDir, "installer")
+    const cscIKeyPassword = "installer-p12-password"
+    await createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscIKeyPassword, currentDir: process.cwd() })
+
+    const calls = securityCalls()
+    const importCalls = calls.filter(args => args[0] === "import")
+    const partitionCalls = calls.filter(args => args[0] === "set-key-partition-list")
+    expect(importCalls).toHaveLength(2)
+    expect(partitionCalls).toHaveLength(2)
+
+    // Each certificate is imported with its own password...
+    expect(importCalls.map(args => flagValue(args, "-P")).sort()).toEqual([cscIKeyPassword, cscKeyPassword].sort())
+    // ...but every set-key-partition-list call authenticates against the keychain itself.
+    const keychainPassword = keychainPasswordFromCalls()
+    for (const args of partitionCalls) {
+      expect(flagValue(args, "-k")).toBe(keychainPassword)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`security set-key-partition-list -k` authenticates against the **keychain itself**, so it requires the temporary keychain's own unlock password (the random one already used by `create-keychain`/`unlock-keychain` two lines above) — not the imported certificate's `.p12` password, which is only valid for `security import -P`.

Passing the import password makes `set-key-partition-list` fail with:

```
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

which breaks `CSC_LINK`-based macOS signing (the CI flow). Fixes #10066.

## Reproduction

Verified on macOS 26 (Darwin 25.6.0, arm64) with the repo's own test suite — `selfSignedIdentityTest` exercises the real `/usr/bin/security` binary through `createKeychain` and fails on unmodified `master`:

```
Command failed: /usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -k eb-self-signed /var/folders/…/….keychain
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

With this change the same tests pass.

## Changes

- `packages/app-builder-lib/src/codeSign/mac/macCodeSign.ts` — thread `keychainPassword` from `createKeychain()` into `importCerts()` and use it for the `-k` flag of `set-key-partition-list`. `security import -P` keeps the per-certificate import password.
- `test/src/mac/keychainPartitionListTest.ts` — platform-independent regression test: mocks only `/usr/bin/security` via `exec`, then asserts
  - `import` still receives each certificate's own password via `-P`, and
  - every `set-key-partition-list` call receives the keychain password (recovered from the `create-keychain -p` call) rather than the import password.
  Fails on the previous behavior, passes with the fix.
- Changeset (`app-builder-lib: patch`).

## Validation

- `pnpm compile`, `pnpm typecheck:test`
- `pnpm lint`, `pnpm lint-deps`, prettier clean
- `TEST_FILES=keychainPartitionListTest pnpm ci:test` — 2 passed (and 2 failed when the fix is reverted)
- `TEST_FILES=selfSignedIdentityTest,macCodeSignTest pnpm ci:test` — passed on macOS with real `security` binary
