### PR TITLE
fix(updater): validate initial channel assignments

### DIFF
--- a/.changeset/valid-channels-reset.md
+++ b/.changeset/valid-channels-reset.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: validate the initial update channel and allow resetting a configured channel to the default

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -232,7 +232,7 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
    * `allowDowngrade` will be automatically set to `true`. If this behavior is not suitable for you, simple set `allowDowngrade` explicitly after.
    */
   set channel(value: string | null) {
-    if (this._channel != null) {
+    if (value != null) {
       // noinspection SuspiciousTypeOfGuard
       if (typeof value !== "string") {
         throw newError(`Channel must be a string, but got: ${value}`, "ERR_UPDATER_INVALID_CHANNEL")

--- a/test/src/updater/baseUpdaterUnitTest.ts
+++ b/test/src/updater/baseUpdaterUnitTest.ts
@@ -19,6 +19,29 @@ const stubApp: AppAdapter = {
 
 const installOpts: InstallOptions = { isSilent: false, isForceRunAfter: false, isAdminRightsRequired: false }
 
+describe("AppUpdater channel validation", () => {
+  let updater: DebUpdater
+
+  beforeEach(() => {
+    updater = new DebUpdater(null, stubApp)
+  })
+
+  it("rejects an empty initial channel", () => {
+    expect(() => (updater.channel = "")).toThrow(/Channel must be not an empty string/)
+  })
+
+  it("rejects a non-string initial channel", () => {
+    expect(() => (updater.channel = 1 as any)).toThrow(/Channel must be a string/)
+  })
+
+  it("allows a configured channel to be reset", () => {
+    updater.channel = "beta"
+    updater.channel = null
+
+    expect(updater.channel).toBeNull()
+  })
+})
+
 // ─── BaseUpdater.sanitizeEnvPath — PATH sanitization ─────────────────────────
 // Tests the extracted helper directly (vi.spyOn on ESM module exports is not
 // possible; testing the pure function avoids that limitation entirely).


### PR DESCRIPTION
## What changed

- validate non-null channel values on the first assignment, not only after a channel was already configured
- allow a configured channel to be reset to `null`, matching the public setter type
- add regressions for empty, non-string, and reset assignments

## Why

The guard checked the previous `_channel` value instead of the incoming value. As a result, an initial empty/non-string channel bypassed validation, while resetting a valid channel to `null` incorrectly threw.

## Verification

- `TEST_FILES=baseUpdaterUnitTest pnpm ci:test`
- `pnpm compile`
- `pnpm ci:validate`
- `git diff --check`

No breaking changes.