### PR TITLE
fix(updater): handle notification download failures

### DIFF
--- a/.changeset/notify-download-failures.md
+++ b/.changeset/notify-download-failures.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: handle background download rejections from `checkForUpdatesAndNotify`

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -456,10 +456,15 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
         return it
       }
 
-      void it.downloadPromise.then(() => {
-        const notificationContent = AppUpdater.formatDownloadNotification(it.updateInfo.version, this.app.name, downloadNotification)
-        new (require("electron").Notification)(notificationContent).show()
-      })
+      void it.downloadPromise.then(
+        () => {
+          const notificationContent = AppUpdater.formatDownloadNotification(it.updateInfo.version, this.app.name, downloadNotification)
+          new (require("electron").Notification)(notificationContent).show()
+        },
+        () => {
+          // downloadUpdate already dispatches the error event
+        }
+      )
 
       return it
     })

--- a/test/src/updater/baseUpdaterUnitTest.ts
+++ b/test/src/updater/baseUpdaterUnitTest.ts
@@ -19,6 +19,18 @@ const stubApp: AppAdapter = {
 
 const installOpts: InstallOptions = { isSilent: false, isForceRunAfter: false, isAdminRightsRequired: false }
 
+it("handles a failed checkForUpdatesAndNotify background download", async () => {
+  const updater = new DebUpdater(null, stubApp)
+  const result = {
+    updateInfo: { version: "2.0.0" },
+    downloadPromise: Promise.reject(new Error("download failed")),
+  } as any
+  vi.spyOn(updater, "checkForUpdates").mockResolvedValue(result)
+
+  await expect(updater.checkForUpdatesAndNotify()).resolves.toBe(result)
+  await new Promise(resolve => setImmediate(resolve))
+})
+
 // ─── BaseUpdater.sanitizeEnvPath — PATH sanitization ─────────────────────────
 // Tests the extracted helper directly (vi.spyOn on ESM module exports is not
 // possible; testing the pure function avoids that limitation entirely).


### PR DESCRIPTION
## What changed

- attach a rejection handler to the background download observed by `checkForUpdatesAndNotify()`
- keep the existing error-event dispatch as the single reporting path
- add a regression for a rejected background download

## Why

The success-only `.then()` created a second rejected promise when `downloadUpdate()` failed. Because that derived promise was intentionally discarded, Node could report an unhandled rejection even though `downloadUpdate()` had already emitted the updater error event.

## Verification

- `TEST_FILES=baseUpdaterUnitTest pnpm ci:test`
- `pnpm compile`
- `pnpm ci:validate`
- `git diff --check`

No breaking changes.