### PR TITLE
fix(updater): preserve fractional staged rollouts

### DIFF
--- a/.changeset/fractional-staged-rollouts.md
+++ b/.changeset/fractional-staged-rollouts.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: preserve fractional staged rollout percentages

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -486,8 +486,8 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       return true
     }
 
-    stagingPercentage = parseInt(stagingPercentage as any, 10)
-    if (isNaN(stagingPercentage)) {
+    stagingPercentage = Number(stagingPercentage)
+    if (!Number.isFinite(stagingPercentage)) {
       this._logger.warn(`Staging percentage is NaN: ${rawStagingPercentage}`)
       return true
     }

--- a/test/src/updater/baseUpdaterUnitTest.ts
+++ b/test/src/updater/baseUpdaterUnitTest.ts
@@ -19,6 +19,15 @@ const stubApp: AppAdapter = {
 
 const installOpts: InstallOptions = { isSilent: false, isForceRunAfter: false, isAdminRightsRequired: false }
 
+it("preserves fractional staged rollout percentages", async () => {
+  const updater = new DebUpdater(null, stubApp)
+  Object.defineProperty(updater, "stagingUserIdPromise", {
+    value: { value: Promise.resolve("1aa70172-80f8-5cc4-8131-28f500800000") },
+  })
+
+  await expect((updater as any).isStagingMatch({ stagingPercentage: 0.5 })).resolves.toBe(true)
+})
+
 // ─── BaseUpdater.sanitizeEnvPath — PATH sanitization ─────────────────────────
 // Tests the extracted helper directly (vi.spyOn on ESM module exports is not
 // possible; testing the pure function avoids that limitation entirely).


### PR DESCRIPTION
## What changed

- convert staged rollout metadata without truncating fractional percentages
- reject non-finite values through the existing invalid-metadata fallback
- add a deterministic regression for a user inside a 0.5% rollout

## Why

`parseInt()` turned valid fractional percentages such as `0.5` into `0`, excluding every user from the rollout. `stagingPercentage` is documented as a numeric percentage, so fractional values should retain their precision.

## Verification

- `TEST_FILES=baseUpdaterUnitTest pnpm ci:test`
- `pnpm compile`
- `pnpm ci:validate`
- `git diff --check`

No breaking changes.