### PR TITLE
fix(updater): validate cached update filenames

### DIFF
--- a/.changeset/cached-update-filenames.md
+++ b/.changeset/cached-update-filenames.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: reject missing and path-valued cached update file names

--- a/packages/electron-updater/src/DownloadedUpdateHelper.ts
+++ b/packages/electron-updater/src/DownloadedUpdateHelper.ts
@@ -188,9 +188,10 @@ export class DownloadedUpdateHelper {
       return null
     }
 
-    const isCachedInfoFileNameValid = cachedInfo?.fileName !== null
+    const cachedFileName = cachedInfo?.fileName
+    const isCachedInfoFileNameValid = typeof cachedFileName === "string" && cachedFileName.length > 0 && path.basename(cachedFileName) === cachedFileName
     if (!isCachedInfoFileNameValid) {
-      logger.warn(`Cached update info is corrupted: no fileName, directory for cached update will be cleaned`)
+      logger.warn(`Cached update info is corrupted: invalid fileName, directory for cached update will be cleaned`)
       await this.cleanCacheDirForPendingUpdate()
       return null
     }
@@ -203,7 +204,7 @@ export class DownloadedUpdateHelper {
       return null
     }
 
-    const updateFile = path.join(this.cacheDirForPendingUpdate, cachedInfo.fileName)
+    const updateFile = path.join(this.cacheDirForPendingUpdate, cachedFileName)
     if (!(await fsExtra.pathExists(updateFile))) {
       logger.info("Cached update file doesn't exist")
       return null

--- a/test/src/updater/downloadedUpdateHelperTest.ts
+++ b/test/src/updater/downloadedUpdateHelperTest.ts
@@ -1,5 +1,6 @@
 import { createTempUpdateFile, DownloadedUpdateHelper } from "electron-updater/src/DownloadedUpdateHelper"
 import { outputFile, outputJson, pathExists } from "fs-extra"
+import { createHash } from "crypto"
 import * as path from "path"
 import { beforeEach, describe, expect, test } from "vitest"
 import type { Logger } from "electron-updater/src/types"
@@ -56,6 +57,32 @@ describe("downloadedUpdateHelper", { sequential: true }, () => {
       // cache directory is emptied, info file should be gone
       expect(await pathExists(infoFile)).toBe(false)
       expect(log.infos.some(m => m.includes("No cached update info"))).toBe(true)
+    })
+
+    test("returns null and cleans cache when update-info.json has no file name", async () => {
+      const pending = path.join(cacheDir, "pending")
+      const infoFile = path.join(pending, "update-info.json")
+      await outputJson(infoFile, { sha512: "sha512abc", isAdminRightsRequired: false })
+
+      await expect((helper as any).getValidCachedUpdateFile(makeFileInfo("sha512abc"), log)).resolves.toBeNull()
+      expect(await pathExists(infoFile)).toBe(false)
+      expect(log.warns.some(m => m.includes("invalid fileName"))).toBe(true)
+    })
+
+    test("does not read a cached update path outside the pending directory", async () => {
+      const pending = path.join(cacheDir, "pending")
+      const outsideFile = path.join(cacheDir, "outside.exe")
+      const content = Buffer.from("outside content")
+      const sha512 = createHash("sha512").update(content).digest("base64")
+      await outputFile(outsideFile, content)
+      await outputJson(path.join(pending, "update-info.json"), {
+        fileName: "../outside.exe",
+        sha512,
+        isAdminRightsRequired: false,
+      })
+
+      await expect((helper as any).getValidCachedUpdateFile(makeFileInfo(sha512), log)).resolves.toBeNull()
+      expect(await pathExists(outsideFile)).toBe(true)
     })
 
     test("returns null and cleans cache when sha512 in info does not match expected", async () => {


### PR DESCRIPTION
## What changed

- require cached update file names to be non-empty plain basenames
- treat missing and path-valued names as corrupted cache metadata and clean the pending cache
- add regressions for a missing name and a parent-directory path

## Why

The existing `fileName !== null` check accepted `undefined`, which then caused `path.join()` to throw instead of recovering from corrupt metadata. It also accepted path components from a modified cache record, allowing validation to read outside the pending-update directory.

## Verification

- `TEST_FILES=downloadedUpdateHelperTest pnpm ci:test`
- `pnpm compile`
- `pnpm ci:validate`
- `git diff --check`

No breaking changes. Valid cache records already persist basename-only file names.