### PR TITLE
fix(updater): handle deferred macOS install once

### DIFF
--- a/.changeset/mac-update-install-once.md
+++ b/.changeset/mac-update-install-once.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: handle a deferred native macOS update download only once

--- a/packages/electron-updater/src/MacUpdater.ts
+++ b/packages/electron-updater/src/MacUpdater.ts
@@ -288,7 +288,7 @@ export class MacUpdater extends AppUpdater {
       this.handleUpdateDownloaded()
     } else {
       // Quit and install as soon as Squirrel get the update
-      this.nativeUpdater.on("update-downloaded", () => this.handleUpdateDownloaded())
+      this.nativeUpdater.once("update-downloaded", () => this.handleUpdateDownloaded())
 
       if (this.autoInstallEvent === "manual") {
         /**

--- a/test/src/updater/macUpdaterTest.ts
+++ b/test/src/updater/macUpdaterTest.ts
@@ -11,6 +11,7 @@ import { createTestAppAdapter, httpExecutor, trackEvents, tuneTestUpdater, write
 import { mockForNodeRequire } from "vitest-mock-commonjs"
 
 class TestNativeUpdater extends EventEmitter {
+  quitAndInstallCalls = 0
   private updateUrl: string | null = null
   // Squirrel.Mac sends the headers from setFeedURL (incl. the Basic auth the proxy server requires) with
   // every request — mirror that here so the mock can authenticate against MacUpdater's local proxy.
@@ -35,7 +36,23 @@ class TestNativeUpdater extends EventEmitter {
     this.updateUrl = updateUrl.url
     this.headers = updateUrl.headers ?? {}
   }
+
+  quitAndInstall() {
+    this.quitAndInstallCalls++
+  }
 }
+
+test.ifMac("quitAndInstall handles one future native download", async ({ expect }) => {
+  const mockNativeUpdater = new TestNativeUpdater()
+  mockForNodeRequire("electron", { autoUpdater: mockNativeUpdater })
+  const updater = new MacUpdater(undefined, await createTestAppAdapter())
+
+  updater.quitAndInstall()
+  mockNativeUpdater.emit("update-downloaded")
+  mockNativeUpdater.emit("update-downloaded")
+
+  expect(mockNativeUpdater.quitAndInstallCalls).toBe(1)
+})
 
 test.ifMac("mac updates", async ({ expect }) => {
   const mockNativeUpdater = new TestNativeUpdater()


### PR DESCRIPTION
## Summary

- register the deferred macOS `update-downloaded` install handler with `once`
- prevent a completed manual install request from handling later native updater events
- add a regression test that emits two native download events and verifies one install

## Why

When `quitAndInstall()` is called before Squirrel has emitted `update-downloaded`, the listener remained attached after handling the pending download. A later native updater event could therefore call `quitAndInstall()` again from the stale request.

## Verification

- `TEST_FILES=macUpdaterTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.