### PR TITLE
fix(updater): parse split multipart headers

### DIFF
--- a/.changeset/split-multipart-headers.md
+++ b/.changeset/split-multipart-headers.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: handle multipart headers split across download chunks

--- a/packages/electron-updater/src/differentialDownloader/DataSplitter.ts
+++ b/packages/electron-updater/src/differentialDownloader/DataSplitter.ts
@@ -80,6 +80,7 @@ export class DataSplitter extends Writable {
   _write(data: Buffer, encoding: string, callback: (error?: Error) => void): void {
     if (this.isFinished) {
       this.logger?.error?.(`Trailing ignored data: ${data.length} bytes`)
+      callback()
       return
     }
 
@@ -217,18 +218,18 @@ export class DataSplitter extends Writable {
   }
 
   private searchHeaderListEnd(chunk: Buffer, readOffset: number): number {
-    const headerListEnd = chunk.indexOf(DOUBLE_CRLF, readOffset)
+    const partialChunk = readOffset === 0 ? chunk : chunk.subarray(readOffset)
+    const bufferedLength = this.headerListBuffer?.length ?? 0
+    const searchBuffer = this.headerListBuffer == null ? partialChunk : Buffer.concat([this.headerListBuffer, partialChunk])
+    const headerListEnd = searchBuffer.indexOf(DOUBLE_CRLF)
     if (headerListEnd !== -1) {
-      return headerListEnd + DOUBLE_CRLF.length
+      return readOffset + headerListEnd + DOUBLE_CRLF.length - bufferedLength
     }
 
-    // not all headers data were received, save to buffer
-    const partialChunk = readOffset === 0 ? chunk : chunk.slice(readOffset)
-    if (this.headerListBuffer == null) {
-      this.headerListBuffer = partialChunk
-    } else {
-      this.headerListBuffer = Buffer.concat([this.headerListBuffer, partialChunk])
-    }
+    // Only the delimiter prefix at the end can affect the next chunk. Copying at most
+    // three bytes avoids retaining whole network chunks or repeatedly joining headers.
+    const suffixLength = Math.min(DOUBLE_CRLF.length - 1, searchBuffer.length)
+    this.headerListBuffer = Buffer.from(searchBuffer.subarray(searchBuffer.length - suffixLength))
     return -1
   }
 

--- a/test/src/updater/multipleRangeDownloaderTest.ts
+++ b/test/src/updater/multipleRangeDownloaderTest.ts
@@ -1,4 +1,5 @@
 import { executeTasksUsingMultipleRangeRequests } from "electron-updater/src/differentialDownloader/multipleRangeDownloader"
+import { DataSplitter } from "electron-updater/src/differentialDownloader/DataSplitter"
 import { OperationKind } from "electron-updater/src/differentialDownloader/downloadPlanBuilder"
 import { PassThrough, Writable } from "stream"
 import { describe, expect, test } from "vitest"
@@ -42,5 +43,56 @@ describe("executeTasksUsingMultipleRangeRequests", () => {
       setImmediate(() => response.emit("error", new Error("read ECONNRESET")))
     })
     expect(error.message).toBe("read ECONNRESET")
+  })
+})
+
+describe("DataSplitter", () => {
+  test("handles a multipart header terminator split across chunks", async () => {
+    const output: Buffer[] = []
+    const out = new Writable({
+      write: (chunk, _encoding, callback) => {
+        output.push(Buffer.from(chunk))
+        callback()
+      },
+    })
+    let finishCount = 0
+    const splitter = new DataSplitter(
+      out,
+      {
+        oldFileFd: -1,
+        tasks: [{ kind: OperationKind.DOWNLOAD, start: 0, end: 3 }],
+        start: 0,
+        end: 1,
+      },
+      new Map([[0, 0]]),
+      "boundary",
+      [3],
+      () => finishCount++,
+      3
+    )
+
+    const write = (chunk: string) =>
+      new Promise<void>((resolve, reject) => {
+        splitter.write(Buffer.from(chunk), error => (error == null ? resolve() : reject(error)))
+      })
+
+    await write("--boundary\r\nContent-Range: bytes 0-2/3\r\n\r")
+    await write("\nabc\r\n--boundary--\r\n")
+
+    expect(Buffer.concat(output).toString()).toBe("abc")
+    expect(finishCount).toBe(1)
+  })
+
+  test("acknowledges trailing writes after completion", () => {
+    const splitter = new DataSplitter(new Writable(), { oldFileFd: -1, tasks: [], start: 0, end: 0 }, new Map(), "boundary", [], () => {}, 0)
+    splitter.partIndex = 0
+    let callbackCalled = false
+
+    splitter._write(Buffer.from("trailing"), "buffer", error => {
+      expect(error).toBeUndefined()
+      callbackCalled = true
+    })
+
+    expect(callbackCalled).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- recognize multipart header terminators split across network chunks
- retain only the three-byte delimiter suffix instead of whole header chunks
- acknowledge trailing writes after the splitter has completed
- add focused regression coverage for both stream edge cases

## Why

`DataSplitter` saved incomplete header data but never searched it with the next chunk. If `\r\n\r\n` crossed a chunk boundary, the part body was not parsed. Its completed `_write` path also returned without invoking the stream callback, which could stall a trailing write.

## Verification

- `TEST_FILES=multipleRangeDownloaderTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.