### PR TITLE
fix(updater): report accurate differential progress

### DIFF
--- a/.changeset/accurate-differential-progress.md
+++ b/.changeset/accurate-differential-progress.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: report accurate differential download progress deltas

--- a/packages/electron-updater/src/differentialDownloader/ProgressDifferentialDownloadCallbackTransform.ts
+++ b/packages/electron-updater/src/differentialDownloader/ProgressDifferentialDownloadCallbackTransform.ts
@@ -65,7 +65,7 @@ export class ProgressDifferentialDownloadCallbackTransform extends Transform {
         delta: this.delta,
         transferred: this.transferred,
         percent: (this.transferred / this.progressDifferentialDownloadInfo.grandTotal) * 100,
-        bytesPerSecond: Math.round(this.transferred / ((now - this.start) / 1000)),
+        bytesPerSecond: this.getBytesPerSecond(now),
       })
       this.delta = 0
     }
@@ -91,8 +91,9 @@ export class ProgressDifferentialDownloadCallbackTransform extends Transform {
         delta: this.delta,
         transferred: this.transferred,
         percent: (this.transferred / this.progressDifferentialDownloadInfo.grandTotal) * 100,
-        bytesPerSecond: Math.round(this.transferred / ((Date.now() - this.start) / 1000)),
+        bytesPerSecond: this.getBytesPerSecond(),
       })
+      this.delta = 0
     }
   }
 
@@ -108,11 +109,15 @@ export class ProgressDifferentialDownloadCallbackTransform extends Transform {
       delta: this.delta,
       transferred: this.transferred,
       percent: 100,
-      bytesPerSecond: Math.round(this.transferred / ((Date.now() - this.start) / 1000)),
+      bytesPerSecond: this.getBytesPerSecond(),
     })
     this.delta = 0
     this.transferred = 0
 
     callback(null)
+  }
+
+  private getBytesPerSecond(now = Date.now()): number {
+    return Math.round((this.transferred * 1000) / Math.max(now - this.start, 1))
   }
 }

--- a/test/src/updater/progressDifferentialDownloadTest.ts
+++ b/test/src/updater/progressDifferentialDownloadTest.ts
@@ -1,0 +1,31 @@
+import { CancellationToken } from "builder-util-runtime"
+import { ProgressDifferentialDownloadCallbackTransform, ProgressInfo } from "electron-updater/src/differentialDownloader/ProgressDifferentialDownloadCallbackTransform"
+import { afterEach, expect, test, vi } from "vitest"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test("reports per-event deltas and a finite rate for immediate range downloads", async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+  const progress: ProgressInfo[] = []
+  const transform = new ProgressDifferentialDownloadCallbackTransform({ expectedByteCounts: [3, 2], grandTotal: 5 }, new CancellationToken(), info => progress.push(info))
+  transform.resume()
+
+  transform.beginRangeDownload()
+  transform.write(Buffer.alloc(3))
+  transform.endRangeDownload()
+
+  transform.beginRangeDownload()
+  transform.write(Buffer.alloc(2))
+  transform.endRangeDownload()
+  await new Promise<void>((resolve, reject) => {
+    transform.once("error", reject)
+    transform.once("finish", resolve)
+    transform.end()
+  })
+
+  expect(progress.map(info => info.delta)).toEqual([3, 2])
+  expect(progress.every(info => Number.isFinite(info.bytesPerSecond))).toBe(true)
+})


### PR DESCRIPTION
## Summary

- reset `delta` after each emitted differential range update
- calculate transfer rates with a minimum one-millisecond elapsed time
- add deterministic coverage for consecutive immediate ranges

## Why

Range-end progress events did not clear their byte delta, so later events could report bytes already included in an earlier event. Downloads completing within the same millisecond could also divide by zero and expose `Infinity` as `bytesPerSecond`.

## Verification

- `TEST_FILES=progressDifferentialDownloadTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.