### PR TITLE
fix(updater): settle multipart downloads once

### DIFF
--- a/.changeset/settle-multipart-downloads.md
+++ b/.changeset/settle-multipart-downloads.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: settle multipart range downloads without stale abort timers

--- a/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
@@ -93,17 +93,40 @@ function doExecuteTasks(differentialDownloader: DifferentialDownloader, options:
 
   const requestOptions = differentialDownloader.createRequestOptions()
   requestOptions.headers!.Range = ranges.substring(0, ranges.length - 2)
+  let responseEndTimer: NodeJS.Timeout | undefined
+  let isSettled = false
+  const complete = () => {
+    if (isSettled) {
+      return
+    }
+    isSettled = true
+    if (responseEndTimer != null) {
+      clearTimeout(responseEndTimer)
+    }
+    resolve()
+  }
+  const fail = (error: Error) => {
+    if (isSettled) {
+      return
+    }
+    isSettled = true
+    if (responseEndTimer != null) {
+      clearTimeout(responseEndTimer)
+    }
+    reject(error)
+  }
   const request = differentialDownloader.httpExecutor.createRequest(requestOptions, response => {
-    response.on("error", reject)
+    response.on("error", fail)
+    response.on("aborted", () => fail(new Error("response has been aborted by the server")))
 
-    if (!checkIsRangesSupported(response, reject)) {
+    if (!checkIsRangesSupported(response, fail)) {
       return
     }
 
     const contentType = safeGetHeader(response, "content-type")
     const m = /^multipart\/.+?\s*;\s*boundary=(?:"([^"]+)"|([^\s";]+))\s*$/i.exec(contentType)
     if (m == null) {
-      reject(new Error(`Content-Type "multipart/byteranges" is expected, but got "${contentType}"`))
+      fail(new Error(`Content-Type "multipart/byteranges" is expected, but got "${contentType}"`))
       return
     }
 
@@ -113,22 +136,25 @@ function doExecuteTasks(differentialDownloader: DifferentialDownloader, options:
       partIndexToTaskIndex,
       m[1] || m[2],
       partIndexToLength,
-      resolve,
+      complete,
       grandTotalBytes,
       differentialDownloader.options.onProgress,
       differentialDownloader.logger
     )
-    dicer.on("error", reject)
+    dicer.on("error", fail)
     response.pipe(dicer)
 
     response.on("end", () => {
-      setTimeout(() => {
+      if (isSettled) {
+        return
+      }
+      responseEndTimer = setTimeout(() => {
         request.abort()
-        reject(new Error("Response ends without calling any handlers"))
+        fail(new Error("Response ends without calling any handlers"))
       }, 10000)
     })
   })
-  differentialDownloader.httpExecutor.addErrorAndTimeoutHandlers(request, reject)
+  differentialDownloader.httpExecutor.addErrorAndTimeoutHandlers(request, fail)
   request.end()
 }
 

--- a/test/src/updater/multipleRangeDownloaderTest.ts
+++ b/test/src/updater/multipleRangeDownloaderTest.ts
@@ -1,11 +1,11 @@
 import { executeTasksUsingMultipleRangeRequests } from "electron-updater/src/differentialDownloader/multipleRangeDownloader"
 import { OperationKind } from "electron-updater/src/differentialDownloader/downloadPlanBuilder"
 import { PassThrough, Writable } from "stream"
-import { describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
 import type { DifferentialDownloader } from "electron-updater/src/differentialDownloader/DifferentialDownloader"
 import type { Operation } from "electron-updater/src/differentialDownloader/downloadPlanBuilder"
 
-function createFakeDifferentialDownloader(response: PassThrough): DifferentialDownloader {
+function createFakeDifferentialDownloader(response: PassThrough, abort = () => {}): DifferentialDownloader {
   return {
     options: {},
     logger: null,
@@ -13,12 +13,16 @@ function createFakeDifferentialDownloader(response: PassThrough): DifferentialDo
     httpExecutor: {
       createRequest: (_options: unknown, callback: (response: unknown) => void) => ({
         end: () => callback(response),
-        abort: () => {},
+        abort,
       }),
       addErrorAndTimeoutHandlers: () => {},
     },
   } as unknown as DifferentialDownloader
 }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe("executeTasksUsingMultipleRangeRequests", () => {
   test("rejects instead of emitting an unhandled error when the multipart range response fails mid-download", async () => {
@@ -42,5 +46,59 @@ describe("executeTasksUsingMultipleRangeRequests", () => {
       setImmediate(() => response.emit("error", new Error("read ECONNRESET")))
     })
     expect(error.message).toBe("read ECONNRESET")
+  })
+
+  test("does not retain an abort timer after a successful multipart response", async () => {
+    const tasks: Array<Operation> = [
+      { kind: OperationKind.DOWNLOAD, start: 0, end: 3 },
+      { kind: OperationKind.DOWNLOAD, start: 3, end: 6 },
+    ]
+    const output: Buffer[] = []
+    const out = new Writable({
+      write: (chunk, _encoding, callback) => {
+        output.push(Buffer.from(chunk))
+        callback()
+      },
+    })
+    const response = new PassThrough() as PassThrough & { statusCode: number; headers: Record<string, string> }
+    response.statusCode = 206
+    response.headers = { "content-type": "multipart/byteranges; boundary=boundary" }
+    const abort = vi.fn()
+    const timerHandle = {} as NodeJS.Timeout
+    const timeout = vi.spyOn(globalThis, "setTimeout").mockReturnValue(timerHandle)
+    const clearTimer = vi.spyOn(globalThis, "clearTimeout")
+
+    await new Promise<void>((resolve, reject) => {
+      const w = executeTasksUsingMultipleRangeRequests(createFakeDifferentialDownloader(response, abort), tasks, out, -1, reject)
+      w(0)
+      out.once("finish", resolve)
+      out.once("error", reject)
+      response.end("--boundary\r\nContent-Range: bytes 0-2/6\r\n\r\nabc\r\n--boundary\r\nContent-Range: bytes 3-5/6\r\n\r\ndef\r\n--boundary--\r\n")
+    })
+
+    expect(Buffer.concat(output).toString()).toBe("abcdef")
+    const endTimerWasCreated = timeout.mock.calls.some(call => call[1] === 10000)
+    if (endTimerWasCreated) {
+      expect(clearTimer).toHaveBeenCalledWith(timerHandle)
+    }
+    expect(abort).not.toHaveBeenCalled()
+  })
+
+  test("rejects immediately when a multipart response is aborted", async () => {
+    const tasks: Array<Operation> = [
+      { kind: OperationKind.DOWNLOAD, start: 0, end: 3 },
+      { kind: OperationKind.DOWNLOAD, start: 3, end: 6 },
+    ]
+    const response = new PassThrough() as PassThrough & { statusCode: number; headers: Record<string, string> }
+    response.statusCode = 206
+    response.headers = { "content-type": "multipart/byteranges; boundary=boundary" }
+
+    const error = await new Promise<Error>(resolve => {
+      const w = executeTasksUsingMultipleRangeRequests(createFakeDifferentialDownloader(response), tasks, new Writable(), -1, resolve)
+      w(0)
+      response.emit("aborted")
+    })
+
+    expect(error.message).toBe("response has been aborted by the server")
   })
 })


### PR DESCRIPTION
## Summary

- settle multipart range downloads through one guarded completion path
- clear the response-end fallback timer when parsing completes
- reject aborted multipart responses immediately
- add regression coverage for successful and aborted responses

## Why

Every successful multipart response scheduled a ten-second fallback after the response ended. The timer remained live after parsing succeeded and later aborted the already-completed request. Aborted responses also had no direct handler and could wait for the fallback instead of failing promptly.

## Verification

- `TEST_FILES=multipleRangeDownloaderTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.