### PR TITLE
fix(updater): close embedded blockmap files once

### DIFF
--- a/.changeset/close-embedded-blockmap-once.md
+++ b/.changeset/close-embedded-blockmap-once.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: close embedded blockmap files exactly once on parse failures

--- a/packages/electron-updater/src/differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader.ts
@@ -27,11 +27,8 @@ async function readEmbeddedBlockMapData(file: string): Promise<BlockMap> {
 
     const dataBuffer = Buffer.allocUnsafe(sizeBuffer.readUInt32BE(0))
     await fsExtra.read(fd, dataBuffer, 0, dataBuffer.length, fileSize - sizeBuffer.length - dataBuffer.length)
-    await fsExtra.close(fd)
-
     return readBlockMap(dataBuffer)
-  } catch (e: any) {
+  } finally {
     await fsExtra.close(fd)
-    throw e
   }
 }

--- a/test/src/updater/embeddedBlockMapTest.ts
+++ b/test/src/updater/embeddedBlockMapTest.ts
@@ -1,0 +1,47 @@
+import { CancellationToken } from "builder-util-runtime"
+import { FileWithEmbeddedBlockMapDifferentialDownloader } from "electron-updater/src/differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader"
+import fsExtra from "fs-extra"
+import { TmpDir } from "temp-file"
+import { deflateRawSync } from "zlib"
+import { expect, test } from "vitest"
+
+class TestDownloader extends FileWithEmbeddedBlockMapDifferentialDownloader {
+  constructor(
+    oldFile: string,
+    private readonly remoteMetadata: Buffer
+  ) {
+    super({ size: remoteMetadata.length, blockMapSize: remoteMetadata.length - 4, sha512: "unused" }, {} as any, {
+      oldFile,
+      newFile: `${oldFile}.new`,
+      newUrl: new URL("https://example.com/update"),
+      logger: { info() {}, warn() {}, error() {} },
+      requestHeaders: null,
+      cancellationToken: new CancellationToken(),
+    })
+  }
+
+  protected override async readRemoteBytes(): Promise<Buffer> {
+    return this.remoteMetadata
+  }
+}
+
+test("closes an old file once when its embedded blockmap is invalid", async () => {
+  const tmpDir = new TmpDir("embedded-blockmap-test")
+  try {
+    const oldFile = await tmpDir.getTempFile({ suffix: ".bin" })
+    const invalidBlockMap = Buffer.alloc(5)
+    invalidBlockMap.writeUInt32BE(1, 1)
+    await fsExtra.outputFile(oldFile, invalidBlockMap)
+
+    const compressedBlockMap = deflateRawSync(JSON.stringify({ version: "2", files: [] }))
+    const remoteMetadata = Buffer.concat([compressedBlockMap, Buffer.alloc(4)])
+    const error = await new TestDownloader(oldFile, remoteMetadata)
+      .download()
+      .then(() => null)
+      .catch(error => error)
+    expect(error).toBeInstanceOf(Error)
+    expect(error.code).not.toBe("EBADF")
+  } finally {
+    await tmpDir.cleanup()
+  }
+})


### PR DESCRIPTION
## Summary

- close the old update file from one `finally` block
- preserve the original embedded-blockmap parse error
- add a regression using an invalid embedded blockmap

## Why

The success path closed the descriptor before parsing, while the catch path closed it again when parsing failed. That second close could replace the useful parse failure with `EBADF`, obscuring why differential update validation failed.

## Verification

- `TEST_FILES=embeddedBlockMapTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.