### PR TITLE
fix(runtime): enforce API redirect limit

### DIFF
--- a/.changeset/enforce-api-redirect-limit.md
+++ b/.changeset/enforce-api-redirect-limit.md
@@ -1,0 +1,5 @@
+---
+"builder-util-runtime": patch
+---
+
+fix: enforce the configured API redirect limit without an extra hop

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -221,7 +221,7 @@ Please double check that your authentication token is correct. Due to security r
     const shouldRedirect = code >= 300 && code < 400
     const redirectUrl = safeGetHeader(response, "location")
     if (shouldRedirect && redirectUrl != null) {
-      if (redirectCount > this.maxRedirects) {
+      if (redirectCount >= this.maxRedirects) {
         reject(this.createMaxRedirectError())
         return
       }

--- a/test/src/httpExecutorTest.ts
+++ b/test/src/httpExecutorTest.ts
@@ -885,7 +885,7 @@ describe("HttpExecutor redirect limit", () => {
     await expect(executor.doApiRequest({ protocol: "https:", hostname: "example.com", path: "/start" }, new CancellationToken(), request => request.end())).rejects.toThrow(
       /Too many redirects/
     )
-    // guard is `redirectCount > maxRedirects`, allowing one extra hop before rejecting
-    expect(executor.requestCount).toBe(executor["maxRedirects"] + 2)
+    // Same limit as doDownload: maxRedirects recursions + the initial request
+    expect(executor.requestCount).toBe(executor["maxRedirects"] + 1)
   })
 })


### PR DESCRIPTION
## Summary

- reject API redirects once the configured limit is reached
- align API-request behavior with the download path
- update the existing redirect-loop regression expectation

## Why

The API path used `redirectCount > maxRedirects`, permitting one extra redirect beyond the documented limit. With a limit of 10 it created 12 requests instead of the initial request plus 10 redirects.

## Verification

- `TEST_FILES=httpExecutorTest corepack pnpm ci:test` (72 tests)
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None for valid redirect chains. Requests exceeding ten redirects now fail one hop earlier, at the configured boundary.