### PR TITLE
fix(runtime): report finite download rates

### DIFF
--- a/.changeset/finite-download-progress.md
+++ b/.changeset/finite-download-progress.md
@@ -1,0 +1,5 @@
+---
+"builder-util-runtime": patch
+---
+
+fix: report finite transfer rates for immediate downloads

--- a/packages/builder-util-runtime/src/ProgressCallbackTransform.ts
+++ b/packages/builder-util-runtime/src/ProgressCallbackTransform.ts
@@ -42,7 +42,7 @@ export class ProgressCallbackTransform extends Transform {
         delta: this.delta,
         transferred: this.transferred,
         percent: (this.transferred / this.total) * 100,
-        bytesPerSecond: Math.round(this.transferred / ((now - this.start) / 1000)),
+        bytesPerSecond: this.getBytesPerSecond(now),
       })
       this.delta = 0
     }
@@ -61,10 +61,14 @@ export class ProgressCallbackTransform extends Transform {
       delta: this.delta,
       transferred: this.total,
       percent: 100,
-      bytesPerSecond: Math.round(this.transferred / ((Date.now() - this.start) / 1000)),
+      bytesPerSecond: this.getBytesPerSecond(),
     })
     this.delta = 0
 
     callback(null)
+  }
+
+  private getBytesPerSecond(now = Date.now()): number {
+    return Math.round((this.transferred * 1000) / Math.max(now - this.start, 1))
   }
 }

--- a/test/src/progressCallbackTransformTest.ts
+++ b/test/src/progressCallbackTransformTest.ts
@@ -1,0 +1,25 @@
+import { CancellationToken, ProgressCallbackTransform, ProgressInfo } from "builder-util-runtime"
+import { afterEach, expect, test, vi } from "vitest"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test("reports a finite rate when a download completes immediately", async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+  const progress: ProgressInfo[] = []
+  const transform = new ProgressCallbackTransform(3, new CancellationToken(), info => progress.push(info))
+  transform.resume()
+  transform.write(Buffer.alloc(3))
+
+  await new Promise<void>((resolve, reject) => {
+    transform.once("error", reject)
+    transform.once("finish", resolve)
+    transform.end()
+  })
+
+  expect(progress).toHaveLength(1)
+  expect(progress[0]).toMatchObject({ total: 3, delta: 3, transferred: 3, percent: 100 })
+  expect(Number.isFinite(progress[0].bytesPerSecond)).toBe(true)
+})


### PR DESCRIPTION
## Summary

- clamp elapsed transfer time to at least one millisecond
- reuse one rate calculation for periodic and final progress events
- add deterministic coverage for an immediate download

## Why

A download that completed within the same millisecond it started divided by zero and exposed `Infinity` as `bytesPerSecond`.

## Verification

- `TEST_FILES=progressCallbackTransformTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.