### PR TITLE
fix(runtime): stop oversized buffer downloads

### DIFF
--- a/.changeset/stop-oversized-buffer-downloads.md
+++ b/.changeset/stop-oversized-buffer-downloads.md
@@ -1,0 +1,5 @@
+---
+"builder-util-runtime": patch
+---
+
+fix: stop oversized in-memory downloads at the configured limit

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -289,16 +289,28 @@ Please double check that your authentication token is correct. Due to security r
           },
           responseHandler: (response, callback) => {
             let receivedLength = 0
+            let isDone = false
+            const finish = (error: Error | null) => {
+              if (isDone) {
+                return
+              }
+              isDone = true
+              callback(error)
+            }
             response.on("data", (chunk: Buffer) => {
+              if (isDone) {
+                return
+              }
               receivedLength += chunk.length
               if (receivedLength > 524288000) {
-                callback(new Error("Maximum allowed size is 500 MB"))
+                finish(new Error("Maximum allowed size is 500 MB"))
+                response.destroy()
                 return
               }
               responseChunks.push(chunk)
             })
             response.on("end", () => {
-              callback(null)
+              finish(null)
             })
           },
         },

--- a/test/src/downloadToBufferTest.ts
+++ b/test/src/downloadToBufferTest.ts
@@ -1,0 +1,33 @@
+import { CancellationToken, HttpExecutor } from "builder-util-runtime"
+import { EventEmitter } from "events"
+import { expect, test, vi } from "vitest"
+
+class BufferExecutor extends HttpExecutor<any> {
+  readonly response = Object.assign(new EventEmitter(), {
+    statusCode: 200,
+    statusMessage: "OK",
+    headers: {},
+    destroy: vi.fn(),
+  })
+
+  createRequest(_options: unknown, callback: (response: any) => void) {
+    return Object.assign(new EventEmitter(), {
+      abort: vi.fn(),
+      end: () => callback(this.response),
+    })
+  }
+}
+
+test("stops reading a buffer download after the size limit", async () => {
+  const executor = new BufferExecutor()
+  const download = executor.downloadToBuffer(new URL("https://example.com/update"), {
+    cancellationToken: new CancellationToken(),
+  })
+
+  executor.response.emit("data", { length: 524288001 } as Buffer)
+  executor.response.emit("data", Buffer.from("ignored"))
+  executor.response.emit("end")
+
+  await expect(download).rejects.toThrow("Maximum allowed size is 500 MB")
+  expect(executor.response.destroy).toHaveBeenCalledOnce()
+})


### PR DESCRIPTION
## Summary

- settle oversized in-memory downloads once
- destroy the response immediately after crossing the 500 MB limit
- ignore subsequent data/end events
- add a synthetic regression that does not allocate a 500 MB buffer

## Why

The limit rejected the public promise but kept reading and appending every later response chunk. A malicious or misconfigured server could therefore continue growing memory after the size guard had already fired.

## Verification

- `TEST_FILES=downloadToBufferTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.