### PR TITLE
fix(runtime): drain unused HTTP responses

### DIFF
--- a/.changeset/drain-unused-http-responses.md
+++ b/.changeset/drain-unused-http-responses.md
@@ -1,0 +1,5 @@
+---
+"builder-util-runtime": patch
+---
+
+fix: drain response bodies before early HTTP exits

--- a/packages/builder-util-runtime/src/httpExecutor.ts
+++ b/packages/builder-util-runtime/src/httpExecutor.ts
@@ -201,6 +201,7 @@ export abstract class HttpExecutor<T extends Request> {
     // we handle any other >= 400 error on request end (read detailed message in the response body)
     if (response.statusCode === 404) {
       // error is clear, we don't need to read detailed error description
+      response.resume()
       reject(
         createHttpError(
           response,
@@ -213,6 +214,7 @@ Please double check that your authentication token is correct. Due to security r
       return
     } else if (response.statusCode === 204) {
       // on DELETE request
+      response.resume()
       resolve()
       return
     }
@@ -221,6 +223,7 @@ Please double check that your authentication token is correct. Due to security r
     const shouldRedirect = code >= 300 && code < 400
     const redirectUrl = safeGetHeader(response, "location")
     if (shouldRedirect && redirectUrl != null) {
+      response.resume()
       if (redirectCount > this.maxRedirects) {
         reject(this.createMaxRedirectError())
         return
@@ -310,6 +313,7 @@ Please double check that your authentication token is correct. Due to security r
   protected doDownload(requestOptions: RequestOptions, options: DownloadCallOptions, redirectCount: number) {
     const request = this.createRequest(requestOptions, (response: IncomingMessage) => {
       if (response.statusCode! >= 400) {
+        response.resume()
         options.callback(
           new Error(
             `Cannot download "${requestOptions.protocol || "https:"}//${requestOptions.hostname}${requestOptions.path}", status ${response.statusCode}: ${response.statusMessage}`
@@ -325,6 +329,7 @@ Please double check that your authentication token is correct. Due to security r
       // this code not relevant for Electron (redirect event instead handled)
       const redirectUrl = safeGetHeader(response, "location")
       if (redirectUrl != null) {
+        response.resume()
         if (redirectCount < this.maxRedirects) {
           this.doDownload(HttpExecutor.prepareRedirectUrlOptions(redirectUrl, requestOptions), options, redirectCount + 1)
         } else {

--- a/test/src/httpResponseDrainTest.ts
+++ b/test/src/httpResponseDrainTest.ts
@@ -1,0 +1,69 @@
+import { CancellationToken, HttpExecutor } from "builder-util-runtime"
+import { RequestOptions } from "http"
+import { expect, test, vi } from "vitest"
+
+function response(statusCode: number, location?: string) {
+  return {
+    statusCode,
+    statusMessage: "status",
+    headers: location == null ? {} : { location },
+    on() {},
+    resume: vi.fn(),
+    setEncoding() {},
+  }
+}
+
+class ResponseExecutor extends HttpExecutor<any> {
+  constructor(readonly responses: ReturnType<typeof response>[]) {
+    super()
+  }
+
+  createRequest(_options: RequestOptions, callback: (response: any) => void) {
+    const nextResponse = this.responses.shift()
+    return {
+      abort() {},
+      end: () => callback(nextResponse),
+      on() {},
+    }
+  }
+
+  runDownload(callback: (error: Error | null) => void) {
+    this.doDownload(
+      { protocol: "https:", hostname: "example.com", path: "/update" },
+      { responseHandler: null, onCancel: () => {}, callback, options: {} as any, destination: null },
+      0
+    )
+  }
+}
+
+test("drains an API response rejected before reading its body", async () => {
+  const rejectedResponse = response(404)
+  const executor = new ResponseExecutor([rejectedResponse])
+
+  await expect(executor.doApiRequest({ protocol: "https:", hostname: "example.com", path: "/missing" }, new CancellationToken(), request => request.end())).rejects.toThrow()
+  expect(rejectedResponse.resume).toHaveBeenCalledOnce()
+})
+
+test("drains an API redirect before following it", async () => {
+  const redirectResponse = response(302, "https://example.com/final")
+  const finalResponse = response(204)
+  const executor = new ResponseExecutor([redirectResponse, finalResponse])
+
+  await executor.doApiRequest({ protocol: "https:", hostname: "example.com", path: "/start" }, new CancellationToken(), request => request.end())
+
+  expect(redirectResponse.resume).toHaveBeenCalledOnce()
+  expect(finalResponse.resume).toHaveBeenCalledOnce()
+})
+
+test("drains a failed download response", () => {
+  const rejectedResponse = response(500)
+  const executor = new ResponseExecutor([rejectedResponse])
+  let error: Error | null = null
+
+  executor.runDownload(result => {
+    error = result
+  })
+
+  expect(error).toBeInstanceOf(Error)
+  expect(rejectedResponse.resume).toHaveBeenCalledOnce()
+})


### PR DESCRIPTION
## Summary

- drain API responses before early 404, 204, and redirect exits
- drain download responses before error and redirect exits
- add focused coverage for rejected and redirected responses

## Why

Returning before consuming an `IncomingMessage` prevents Node from reusing its socket and can accumulate idle connections during repeated checks or redirect chains. Calling `resume()` discards the unused body and lets the transport complete normally.

## Verification

- `TEST_FILES=httpResponseDrainTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.