### PR TITLE
fix(runtime): preserve complete XML content

### DIFF
--- a/.changeset/complete-xml-parsing.md
+++ b/.changeset/complete-xml-parsing.md
@@ -1,0 +1,5 @@
+---
+"builder-util-runtime": patch
+---
+
+fix: preserve complete XML text and reject incomplete documents

--- a/packages/builder-util-runtime/src/xml.ts
+++ b/packages/builder-util-runtime/src/xml.ts
@@ -103,13 +103,13 @@ export function parseXml(data: string): XElement {
 
   parser.ontext = text => {
     if (elements.length > 0) {
-      elements[elements.length - 1].value = text
+      elements[elements.length - 1].value += text
     }
   }
 
   parser.oncdata = cdata => {
     const element = elements[elements.length - 1]
-    element.value = cdata
+    element.value += cdata
     element.isCData = true
   }
 
@@ -117,6 +117,9 @@ export function parseXml(data: string): XElement {
     throw err
   }
 
-  parser.write(data)
-  return rootElement!
+  parser.write(data).close()
+  if (rootElement == null) {
+    throw newError("No root element", "ERR_XML_MISSED_ELEMENT")
+  }
+  return rootElement
 }

--- a/test/src/xmlTest.ts
+++ b/test/src/xmlTest.ts
@@ -1,0 +1,17 @@
+import { parseXml } from "builder-util-runtime"
+import { expect, test } from "vitest"
+
+test("preserves adjacent text and CDATA segments", () => {
+  const root = parseXml("<root>before<![CDATA[middle]]>after</root>")
+
+  expect(root.value).toBe("beforemiddleafter")
+  expect(root.isCData).toBe(true)
+})
+
+test("rejects an unclosed document", () => {
+  expect(() => parseXml("<root>")).toThrow()
+})
+
+test("rejects a document without a root element", () => {
+  expect(() => parseXml("")).toThrow("No root element")
+})


### PR DESCRIPTION
## Summary

- append successive text and CDATA events instead of overwriting content
- close the strict SAX parser so truncated documents are rejected
- reject documents without a root element explicitly
- add mixed-content and malformed-document regressions

## Why

SAX may split one element value across text/CDATA events. Keeping only the last event silently truncated content such as release notes. Calling only `write()` also skipped end-of-document validation, allowing unclosed XML through.

## Verification

- `TEST_FILES=xmlTest corepack pnpm ci:test`
- `TEST_FILES=updateUtilTest corepack pnpm ci:test` (23 GitHub provider tests)
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

Malformed or rootless XML that was previously returned as incomplete data now throws a parsing error.