### PR TITLE
fix(runtime): cancel retry backoff promptly

### DIFF
--- a/.changeset/cancel-retry-backoff.md
+++ b/.changeset/cancel-retry-backoff.md
@@ -1,0 +1,5 @@
+---
+"builder-util-runtime": patch
+---
+
+fix: stop retry backoff immediately when cancelled

--- a/packages/builder-util-runtime/src/retry.ts
+++ b/packages/builder-util-runtime/src/retry.ts
@@ -12,10 +12,17 @@ export async function retry<T>(
     return await task()
   } catch (error: any) {
     if ((await Promise.resolve(shouldRetry?.(error) ?? true)) && retryCount > 0 && !cancellationToken.cancelled) {
-      await sleep(interval + backoff * attempt)
+      await sleepWithCancellation(interval + backoff * attempt, cancellationToken)
       return await retry(task, { ...options, retries: retryCount - 1, attempt: attempt + 1 })
     } else {
       throw error
     }
   }
+}
+
+function sleepWithCancellation(delay: number, cancellationToken: CancellationToken): Promise<void> {
+  return cancellationToken.createPromise<void>((resolve, _reject, onCancel) => {
+    const timer = setTimeout(resolve, delay)
+    onCancel(() => clearTimeout(timer))
+  })
 }

--- a/test/src/retryTest.ts
+++ b/test/src/retryTest.ts
@@ -1,0 +1,21 @@
+import { CancellationError, CancellationToken, retry } from "builder-util-runtime"
+import { afterEach, expect, test, vi } from "vitest"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test("cancels a retry during backoff without starting another attempt", async () => {
+  vi.useFakeTimers()
+  const cancellationToken = new CancellationToken()
+  const task = vi.fn().mockRejectedValue(new Error("temporary failure"))
+  const result = retry(task, { retries: 3, interval: 1000, cancellationToken })
+
+  await vi.advanceTimersByTimeAsync(0)
+  expect(task).toHaveBeenCalledOnce()
+  cancellationToken.cancel()
+
+  await expect(result).rejects.toBeInstanceOf(CancellationError)
+  expect(task).toHaveBeenCalledOnce()
+  expect(vi.getTimerCount()).toBe(0)
+})


### PR DESCRIPTION
## Summary

- make retry backoff waits cancellation-aware
- clear the pending timer when cancellation fires
- prevent another task attempt after cancellation
- add deterministic fake-timer regression coverage

## Why

Cancellation was checked only before entering `sleep()`. Cancelling during the backoff still waited the full interval and then invoked the task again.

## Verification

- `TEST_FILES=retryTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

Cancellation during a retry delay now rejects immediately with `CancellationError` instead of waiting and potentially returning a later task result.