### PR TITLE
fix(updater): validate update cache filenames

### DIFF
--- a/.changeset/validate-update-cache-filename.md
+++ b/.changeset/validate-update-cache-filename.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: reject traversal segments as update cache filenames

--- a/packages/electron-updater/src/AppUpdater.ts
+++ b/packages/electron-updater/src/AppUpdater.ts
@@ -809,22 +809,10 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
     const version = updateInfo.version
     const packageInfo = fileInfo.packageInfo
 
-    function getCacheUpdateFileName(): string {
-      // NodeJS URL doesn't decode automatically
-      const urlPath = decodeURIComponent(taskOptions.fileInfo.url.pathname)
-      if (urlPath.toLowerCase().endsWith(`.${taskOptions.fileExtension.toLowerCase()}`)) {
-        return path.basename(urlPath)
-      } else {
-        // url like /latest — use basename so a server-supplied path like "../../etc/evil"
-        // cannot escape the cache directory via path.join
-        return path.basename(taskOptions.fileInfo.info.url)
-      }
-    }
-
     const downloadedUpdateHelper = await this.getOrCreateDownloadHelper()
     const cacheDir = downloadedUpdateHelper.cacheDirForPendingUpdate
     await fsExtra.mkdir(cacheDir, { recursive: true })
-    const updateFileName = getCacheUpdateFileName()
+    const updateFileName = getCacheUpdateFileName(taskOptions.fileInfo, taskOptions.fileExtension)
     let updateFile = path.join(cacheDir, updateFileName)
     const packageFile = packageInfo == null ? null : path.join(cacheDir, `package-${version}${path.extname(packageInfo.path) || ".7z"}`)
 
@@ -972,6 +960,19 @@ export abstract class AppUpdater extends (EventEmitter as new () => TypedEmitter
       return true
     }
   }
+}
+
+/** @internal */
+export function getCacheUpdateFileName(fileInfo: ResolvedUpdateFileInfo, fileExtension: string): string {
+  // NodeJS URL doesn't decode automatically
+  const urlPath = decodeURIComponent(fileInfo.url.pathname)
+  const fileName = path.basename(urlPath.toLowerCase().endsWith(`.${fileExtension.toLowerCase()}`) ? urlPath : fileInfo.info.url)
+  // basename(".") and basename("..") remain traversal segments. Reject them explicitly,
+  // along with values that cannot be represented as a single portable filename.
+  if (fileName.length === 0 || fileName === "." || fileName === ".." || fileName.includes("\0") || fileName.includes("/") || fileName.includes("\\")) {
+    throw newError(`Invalid update file name: ${JSON.stringify(fileName)}`, "ERR_UPDATER_INVALID_FILE_NAME")
+  }
+  return fileName
 }
 
 export interface DownloadUpdateOptions {

--- a/test/src/updater/updateCacheFilenameTest.ts
+++ b/test/src/updater/updateCacheFilenameTest.ts
@@ -1,0 +1,22 @@
+import { getCacheUpdateFileName } from "electron-updater/src/AppUpdater"
+import { ResolvedUpdateFileInfo } from "electron-updater/src/types"
+import { expect, test } from "vitest"
+
+function fileInfo(manifestUrl: string, downloadUrl = "https://example.com/latest"): ResolvedUpdateFileInfo {
+  return {
+    url: new URL(downloadUrl),
+    info: { url: manifestUrl, sha512: "checksum" },
+  }
+}
+
+test.each(["", ".", "..", "bad\0name.exe"])("rejects unsafe manifest filename %j", manifestUrl => {
+  expect(() => getCacheUpdateFileName(fileInfo(manifestUrl), "exe")).toThrowError(expect.objectContaining({ code: "ERR_UPDATER_INVALID_FILE_NAME" }))
+})
+
+test("keeps the basename of a nested manifest path", () => {
+  expect(getCacheUpdateFileName(fileInfo("../../safe.exe"), "exe")).toBe("safe.exe")
+})
+
+test("prefers a matching decoded download URL filename", () => {
+  expect(getCacheUpdateFileName(fileInfo("fallback.exe", "https://example.com/My%20App.exe"), "exe")).toBe("My App.exe")
+})


### PR DESCRIPTION
## Summary

- extract update cache filename resolution into a focused helper
- reject empty, dot-segment, null-byte, and non-portable separator results
- preserve safe basenames for nested manifest paths
- add traversal and valid-path regressions

## Why

`path.basename()` neutralizes ordinary nested paths, but `path.basename("..")` remains `".."`. Joining that result to the pending cache directory resolves to its parent, so a hostile update manifest could place the downloaded file outside the intended directory.

## Verification

- `TEST_FILES=updateCacheFilenameTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

Manifests whose resolved artifact filename is empty, `.`/`..`, contains a null byte, or remains path-like after basename normalization now fail with `ERR_UPDATER_INVALID_FILE_NAME`.