### PR TITLE
fix(updater): preserve web package headers

### DIFF
--- a/.changeset/preserve-web-package-headers.md
+++ b/.changeset/preserve-web-package-headers.md
@@ -1,0 +1,5 @@
+---
+"electron-updater": patch
+---
+
+fix: preserve provider headers for differential web package downloads

--- a/packages/electron-updater/src/NsisUpdater.ts
+++ b/packages/electron-updater/src/NsisUpdater.ts
@@ -247,7 +247,7 @@ export class NsisUpdater extends BaseUpdater {
         oldFile: path.join(this.downloadedUpdateHelper!.cacheDir, CURRENT_APP_PACKAGE_FILE_NAME),
         logger: this._logger,
         newFile: packagePath,
-        requestHeaders: this.requestHeaders,
+        requestHeaders: downloadUpdateOptions.requestHeaders,
         isUseMultipleRangeRequest: provider.isUseMultipleRangeRequest,
         cancellationToken: downloadUpdateOptions.cancellationToken,
       }

--- a/test/src/updater/nsisWebPackageHeadersTest.ts
+++ b/test/src/updater/nsisWebPackageHeadersTest.ts
@@ -1,0 +1,52 @@
+import { CancellationToken, PackageFileInfo } from "builder-util-runtime"
+import { NsisUpdater } from "electron-updater"
+import type { AppAdapter } from "electron-updater/src/AppAdapter"
+import { FileWithEmbeddedBlockMapDifferentialDownloader } from "electron-updater/src/differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader"
+import { afterEach, expect, test, vi } from "vitest"
+
+const stubApp: AppAdapter = {
+  name: "TestApp",
+  version: "1.0.0",
+  isPackaged: false,
+  appUpdateConfigPath: "/tmp/app-update.yml",
+  userDataPath: "/tmp",
+  baseCachePath: "/tmp",
+  whenReady: () => Promise.resolve(),
+  relaunch() {},
+  quit() {},
+  onQuit() {},
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test("passes provider-computed headers to differential web package downloads", async () => {
+  const updater = new NsisUpdater(null, stubApp)
+  ;(updater as any).downloadedUpdateHelper = { cacheDir: "/tmp/updater-cache" }
+  let requestHeaders: unknown
+  vi.spyOn(FileWithEmbeddedBlockMapDifferentialDownloader.prototype, "download").mockImplementation(function (this: FileWithEmbeddedBlockMapDifferentialDownloader) {
+    requestHeaders = this.options.requestHeaders
+    return Promise.resolve()
+  })
+  const headers = { authorization: "Bearer private-release-token", accept: "*/*" }
+  const packageInfo: PackageFileInfo = {
+    path: "https://example.com/package.7z",
+    sha512: "checksum",
+    blockMapSize: 10,
+  }
+
+  const requiresFullDownload = await (updater as any).differentialDownloadWebPackage(
+    {
+      updateInfoAndProvider: { info: { version: "1.0.1" } },
+      requestHeaders: headers,
+      cancellationToken: new CancellationToken(),
+    },
+    packageInfo,
+    "/tmp/package.7z",
+    { isUseMultipleRangeRequest: false }
+  )
+
+  expect(requiresFullDownload).toBe(false)
+  expect(requestHeaders).toBe(headers)
+})


### PR DESCRIPTION
## Summary

- pass the computed download headers into NSIS web-package differential requests
- preserve provider-specific authorization and caller headers
- add a direct regression against the downloader options

## Why

The installer differential path used `downloadUpdateOptions.requestHeaders`, but the web package path fell back to `this.requestHeaders`. That dropped provider-added headers (notably private-release authorization), forcing an avoidable full download or failure.

## Verification

- `TEST_FILES=nsisWebPackageHeadersTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes

None.