### PR TITLE
fix: only replace terminal platform icon extensions

### DIFF
--- a/packages/builder-util/src/util.ts
+++ b/packages/builder-util/src/util.ts
@@ -512,11 +512,14 @@ export function getPlatformIconFileName(value: string | Nullish, isMac: boolean)
     return null
   }
 
-  if (!value.includes(".")) {
-    return `${value}.${isMac ? "icns" : "ico"}`
+  const targetExtension = isMac ? ".icns" : ".ico"
+  const sourceExtension = isMac ? ".ico" : ".icns"
+  const extension = path.extname(value)
+  if (extension === "") {
+    return value + targetExtension
   }
 
-  return value.replace(isMac ? ".ico" : ".icns", isMac ? ".icns" : ".ico")
+  return extension.toLowerCase() === sourceExtension ? value.slice(0, -extension.length) + targetExtension : value
 }
 
 export function isPullRequest() {

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -1,12 +1,24 @@
 import { parseValidEnvVarUrl } from "builder-util/internal"
 import { resolveEnvShellValue, validateShellEmbeddable } from "builder-util/src/envUtil"
-import { removePassword, removePasswordFromArgs, filterSensitiveEnv, spawnAndWriteWithOutput, ExecError } from "builder-util"
+import { removePassword, removePasswordFromArgs, filterSensitiveEnv, spawnAndWriteWithOutput, ExecError, getPlatformIconFileName } from "builder-util"
 import { afterEach, expect, vi } from "vitest"
 
 const testValue = "secretValue"
 const testQuoted = "secret with spaces"
 
 const keys = ["--accessKey", "--secretKey", "-p", "-pass", "-String", "/p", "pass:"]
+
+describe("getPlatformIconFileName", () => {
+  test.each([
+    ["icon", true, "icon.icns"],
+    ["icon.ico", true, "icon.icns"],
+    ["icon.ICO", true, "icon.icns"],
+    ["icon.icns", false, "icon.ico"],
+    ["assets/.ico-cache/icon.png", true, "assets/.ico-cache/icon.png"],
+  ])("maps %s for isMac=%s", (value, isMac, expected) => {
+    expect(getPlatformIconFileName(value, isMac)).toBe(expected)
+  })
+})
 
 keys.forEach(key => {
   describe(`removePassword: ${key}`, () => {


### PR DESCRIPTION
## Summary
- inspect the actual terminal extension before converting platform icons
- preserve directory names and unrelated file extensions
- support uppercase `.ico`/`.icns` inputs

## Why
`getPlatformIconFileName` previously used a substring replacement. A path such as `assets/.ico-cache/icon.png` could therefore rewrite a directory component even though the file itself was not an ICO.

## Tests
- `TEST_FILES=builder-util/utilTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None. Existing supported icon conversions are preserved; only accidental substring rewrites are removed.