### PR TITLE
fix: preserve repeated debug logger key segments

### DIFF
--- a/packages/builder-util/src/DebugLogger.ts
+++ b/packages/builder-util/src/DebugLogger.ts
@@ -15,25 +15,20 @@ export class DebugLogger {
 
     const dataPath = key.split(".")
     let o = this.data
-    let lastName: string | null = null
+    const lastName = dataPath.pop()!
     for (const p of dataPath) {
-      if (p === dataPath[dataPath.length - 1]) {
-        lastName = p
-        break
-      } else {
-        if (!o.has(p)) {
-          o.set(p, new Map<string, any>())
-        } else if (typeof o.get(p) === "string") {
-          o.set(p, [o.get(p)])
-        }
-        o = o.get(p)
+      if (!o.has(p)) {
+        o.set(p, new Map<string, any>())
+      } else if (typeof o.get(p) === "string") {
+        o.set(p, [o.get(p)])
       }
+      o = o.get(p)
     }
 
-    if (Array.isArray(o.get(lastName!))) {
-      o.set(lastName!, [...o.get(lastName!), value])
+    if (Array.isArray(o.get(lastName))) {
+      o.set(lastName, [...o.get(lastName), value])
     } else {
-      o.set(lastName!, value)
+      o.set(lastName, value)
     }
   }
 

--- a/test/src/builder-util/debugLoggerTest.ts
+++ b/test/src/builder-util/debugLoggerTest.ts
@@ -1,0 +1,9 @@
+import { DebugLogger } from "builder-util"
+
+test("preserves repeated nested key segments", ({ expect }) => {
+  const logger = new DebugLogger()
+
+  logger.add("build.build.result", "success")
+
+  expect(logger.data.get("build")?.get("build")?.get("result")).toBe("success")
+})


### PR DESCRIPTION
## Summary
- traverse nested debug keys by position instead of comparing segment values
- preserve repeated segments such as `build.build.result`
- add a focused regression test

## Why
The old traversal treated the first segment equal to the final segment as the leaf. Repeated names therefore flattened or misplaced debug data.

## Tests
- `TEST_FILES=builder-util/debugLoggerTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.