### PR TITLE
fix: reject shell line-break characters

### DIFF
--- a/.changeset/easy-garlics-post.md
+++ b/.changeset/easy-garlics-post.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: reject shell line-break characters

--- a/packages/builder-util/src/envUtil.ts
+++ b/packages/builder-util/src/envUtil.ts
@@ -6,9 +6,9 @@ import { isEmptyOrSpaces } from "./stringUtil.js"
  * `$`, backtick, `"`, `\`, and newlines.
  */
 export function validateShellEmbeddable(value: string, fieldName: string): void {
-  if (/[$`"\\\n]/.test(value)) {
+  if (/[$`"\\\r\n]/.test(value)) {
     throw new Error(
-      `${fieldName} contains characters that are not safe in shell scripts: ${JSON.stringify(value)}. ` + `Avoid $, backtick, double-quote, backslash, and newline characters.`
+      `${fieldName} contains characters that are not safe in shell scripts: ${JSON.stringify(value)}. ` + `Avoid $, backtick, double-quote, backslash, and line-break characters.`
     )
   }
 }
@@ -20,7 +20,7 @@ export function resolveEnvShellValue(envVarName: string): string | null {
   }
   const trimmed = rawValue.trim()
   // On Windows, backslash is the native path separator and must not be rejected
-  const shellUnsafeChars = process.platform === "win32" ? /[;&|`$<>"']/ : /[;&|`$<>"'\\]/
+  const shellUnsafeChars = process.platform === "win32" ? /[;&|`$<>"'\r\n]/ : /[;&|`$<>"'\\\r\n]/
   if (shellUnsafeChars.test(trimmed)) {
     throw new Error(`${envVarName} contains shell-unsafe characters: ${trimmed}`)
   }

--- a/test/src/builder-util/utilTest.ts
+++ b/test/src/builder-util/utilTest.ts
@@ -373,7 +373,7 @@ describe("resolveEnvShellValue", () => {
     expect(resolveEnvShellValue(VAR)).toBe("/some/path")
   })
 
-  const UNSAFE_CHARS = [";", "&", "|", "`", "$", "<", ">", '"', "'"]
+  const UNSAFE_CHARS = [";", "&", "|", "`", "$", "<", ">", '"', "'", "\n", "\r"]
   for (const ch of UNSAFE_CHARS) {
     test(`throws on shell-unsafe character: ${ch}`, ({ expect }) => {
       vi.stubEnv(VAR, `/some/path${ch}foo`)
@@ -478,6 +478,7 @@ describe("validateShellEmbeddable", () => {
       ['index.js"evil"', "double-quote"],
       ["index.js\\evil", "backslash"],
       ["index.js\nevil", "newline"],
+      ["index.js\revil", "carriage return"],
       ["$(rm -rf /)", "command substitution"],
       ["`id`", "backtick substitution"],
     ])("rejects %j (contains %s)", value => {


### PR DESCRIPTION
## Summary
- reject embedded CR and LF in shell-bound environment values on every platform
- reject carriage returns alongside newlines in generated command fields
- cover both control characters with regression tests

## Why
The shell validators rejected common metacharacters but `resolveEnvShellValue` still accepted embedded line breaks, and `validateShellEmbeddable` only rejected LF. This allowed a validated value to alter generated shell script structure.

## Tests
- `TEST_FILES=builder-util/utilTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
Values containing embedded CR or LF are now rejected. Such values cannot be represented safely in the generated shell commands.