### PR TITLE
fix: honor uppercase proxy environment variables

### DIFF
--- a/packages/builder-util/src/nodeHttpExecutor.ts
+++ b/packages/builder-util/src/nodeHttpExecutor.ts
@@ -9,10 +9,16 @@ export class NodeHttpExecutor extends HttpExecutor<ClientRequest> {
   // noinspection JSMethodCanBeStatic
   // noinspection JSUnusedGlobalSymbols
   createRequest(options: any, callback: (response: any) => void): ClientRequest {
-    if (process.env["https_proxy"] !== undefined && options.protocol === "https:") {
-      options.agent = new HttpsProxyAgent(process.env["https_proxy"])
-    } else if (process.env["http_proxy"] !== undefined && options.protocol === "http:") {
-      options.agent = new HttpProxyAgent(process.env["http_proxy"])
+    if (options.protocol === "https:") {
+      const proxy = getProxyEnv("HTTPS_PROXY", "https_proxy")
+      if (proxy != null) {
+        options.agent = new HttpsProxyAgent(proxy)
+      }
+    } else if (options.protocol === "http:") {
+      const proxy = getProxyEnv("HTTP_PROXY", "http_proxy")
+      if (proxy != null) {
+        options.agent = new HttpProxyAgent(proxy)
+      }
     }
     return (options.protocol === "http:" ? httpRequest : https.request)(options, callback)
   }
@@ -20,10 +26,13 @@ export class NodeHttpExecutor extends HttpExecutor<ClientRequest> {
 
 export const httpExecutor = new NodeHttpExecutor()
 
+function getProxyEnv(uppercaseName: "HTTP_PROXY" | "HTTPS_PROXY", lowercaseName: "http_proxy" | "https_proxy"): string | undefined {
+  return [process.env[uppercaseName], process.env[lowercaseName]].find(value => !isEmptyOrSpaces(value))
+}
+
 export function buildGotProxyAgent(): { http?: HttpProxyAgent<string>; https?: HttpsProxyAgent<string> } | undefined {
-  // Use Array.find so a whitespace-only uppercase var doesn't block the lowercase fallback.
-  const httpsProxy = [process.env.HTTPS_PROXY, process.env.https_proxy].find(v => !isEmptyOrSpaces(v))
-  const httpProxy = [process.env.HTTP_PROXY, process.env.http_proxy].find(v => !isEmptyOrSpaces(v))
+  const httpsProxy = getProxyEnv("HTTPS_PROXY", "https_proxy")
+  const httpProxy = getProxyEnv("HTTP_PROXY", "http_proxy")
   if (!httpsProxy && !httpProxy) {
     return undefined
   }

--- a/test/src/builder-util/nodeHttpExecutorTest.ts
+++ b/test/src/builder-util/nodeHttpExecutorTest.ts
@@ -163,6 +163,21 @@ describe("NodeHttpExecutor.createRequest", { sequential: true }, () => {
       expect(options.agent?.constructor?.name).toBe("HttpProxyAgent")
     })
 
+    test("sets HttpsProxyAgent when HTTPS_PROXY is set", ({ expect }) => {
+      vi.stubEnv("HTTPS_PROXY", "https://proxy.example.com:8080")
+      const options: any = { protocol: "https:" }
+      callCreateRequest(executor, options)
+      expect(options.agent?.constructor?.name).toBe("HttpsProxyAgent")
+    })
+
+    test("falls back to lowercase proxy when the uppercase value is whitespace", ({ expect }) => {
+      vi.stubEnv("HTTP_PROXY", "   ")
+      vi.stubEnv("http_proxy", "http://proxy.example.com:3128")
+      const options: any = { protocol: "http:" }
+      callCreateRequest(executor, options)
+      expect(options.agent?.constructor?.name).toBe("HttpProxyAgent")
+    })
+
     test("does not set agent when no proxy env vars are set", ({ expect }) => {
       const options: any = { protocol: "https:" }
       callCreateRequest(executor, options)


### PR DESCRIPTION
## Summary
- make `NodeHttpExecutor` honor standard uppercase proxy variables
- share proxy lookup and precedence with the got-based client
- ignore whitespace-only uppercase values and fall back to lowercase values

## Why
The got path supported both uppercase and lowercase proxy variables, but `NodeHttpExecutor` only used lowercase variables and attempted to construct agents from whitespace-only values. Builds and updater requests could therefore bypass a configured uppercase proxy or fail with an invalid proxy URL.

## Tests
- `TEST_FILES=builder-util/nodeHttpExecutorTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.