### PR TITLE
fix: cancel original async tasks

### DIFF
--- a/.changeset/moody-hornets-tan.md
+++ b/.changeset/moody-hornets-tan.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: cancel original async tasks in AsyncTaskManager

--- a/packages/builder-util/src/asyncTaskManager.ts
+++ b/packages/builder-util/src/asyncTaskManager.ts
@@ -5,6 +5,7 @@ import { NestedError } from "./promise.js"
 export class AsyncTaskManager {
   readonly tasks: Array<Promise<any>> = []
   private readonly errors: Array<Error> = []
+  private readonly cancellableTasks = new Set<Promise<any> & { cancel: () => void }>()
 
   constructor(private readonly cancellationToken: CancellationToken) {}
 
@@ -23,21 +24,30 @@ export class AsyncTaskManager {
       return
     }
 
+    const cancellableTask = "cancel" in promise ? (promise as Promise<any> & { cancel: () => void }) : null
+    if (cancellableTask != null) {
+      this.cancellableTasks.add(cancellableTask)
+    }
     this.tasks.push(
-      promise.catch(it => {
-        log.debug({ error: it.message || it.toString() }, "async task error")
-        this.errors.push(it)
-        return Promise.resolve(null)
-      })
+      promise
+        .catch(it => {
+          log.debug({ error: it.message || it.toString() }, "async task error")
+          this.errors.push(it)
+          return Promise.resolve(null)
+        })
+        .finally(() => {
+          if (cancellableTask != null) {
+            this.cancellableTasks.delete(cancellableTask)
+          }
+        })
     )
   }
 
   cancelTasks() {
-    for (const task of this.tasks) {
-      if ("cancel" in task) {
-        ;(task as any).cancel()
-      }
+    for (const task of this.cancellableTasks) {
+      task.cancel()
     }
+    this.cancellableTasks.clear()
     this.tasks.length = 0
   }
 

--- a/test/src/builder-util/asyncTaskManagerTest.ts
+++ b/test/src/builder-util/asyncTaskManagerTest.ts
@@ -1,0 +1,14 @@
+import { CancellationToken } from "builder-util-runtime"
+import { AsyncTaskManager } from "builder-util"
+import { vi } from "vitest"
+
+test("cancels the original cancellable promise", ({ expect }) => {
+  const manager = new AsyncTaskManager(new CancellationToken())
+  const task = new Promise(() => {}) as Promise<void> & { cancel: () => void }
+  task.cancel = vi.fn()
+
+  manager.addTask(task)
+  manager.cancelTasks()
+
+  expect(task.cancel).toHaveBeenCalledOnce()
+})


### PR DESCRIPTION
## Summary
- retain active cancellable promises separately from their rejection wrappers
- invoke `cancel()` on the original task
- remove settled cancellable tasks from tracking
- add a focused regression test

## Why
`addTask` stored the promise returned by `.catch()`, which does not inherit a custom `cancel()` method. `cancelTasks()` therefore never cancelled promises that were cancellable when supplied.

## Tests
- `TEST_FILES=builder-util/asyncTaskManagerTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- targeted ESLint
- `git diff --check`

## Breaking changes
None.