### PR TITLE
fix: deduplicate publish tasks by value

### DIFF
--- a/packages/electron-builder/src/publish.ts
+++ b/packages/electron-builder/src/publish.ts
@@ -69,13 +69,27 @@ export async function publishArtifactsWithOptions(
   const buildOptions: BuildOptions = normalizeOptions({ config, publish: publishOptions?.publish })
   checkBuildRequestOptions(buildOptions)
 
-  const uniqueUploads = Array.from(new Set(uploadOptions))
-  const tasks: UploadTask[] = uniqueUploads.map(({ file, arch }) => {
-    const filename = path.basename(file)
-    return { file, arch: arch ? archFromString(arch) : null, safeArtifactName: computeSafeArtifactNameIfNeeded(filename, () => filename) }
-  })
+  const tasks = createUploadTasks(uploadOptions)
 
   return publishPackageWithTasks(buildOptions, tasks, buildVersion)
+}
+
+/** @internal */
+export function createUploadTasks(uploadOptions: { file: string; arch: string | null }[]): UploadTask[] {
+  const seen = new Set<string>()
+  return uploadOptions
+    .filter(({ file, arch }) => {
+      const key = `${file}\0${arch ?? ""}`
+      if (seen.has(key)) {
+        return false
+      }
+      seen.add(key)
+      return true
+    })
+    .map(({ file, arch }) => {
+      const filename = path.basename(file)
+      return { file, arch: arch ? archFromString(arch) : null, safeArtifactName: computeSafeArtifactNameIfNeeded(filename, () => filename) }
+    })
 }
 
 async function publishPackageWithTasks(

--- a/test/src/publishCliTest.ts
+++ b/test/src/publishCliTest.ts
@@ -1,0 +1,13 @@
+import { Arch } from "builder-util"
+import { createUploadTasks } from "../../packages/electron-builder/src/publish"
+
+test("deduplicates publish tasks by file and architecture", ({ expect }) => {
+  const tasks = createUploadTasks([
+    { file: "/tmp/app.zip", arch: "x64" },
+    { file: "/tmp/app.zip", arch: "x64" },
+    { file: "/tmp/app.zip", arch: "arm64" },
+  ])
+
+  expect(tasks).toHaveLength(2)
+  expect(tasks.map(task => task.arch)).toEqual([Arch.x64, Arch.arm64])
+})


### PR DESCRIPTION
## Summary
- deduplicate uploads by file path and architecture
- preserve distinct architecture uploads for the same artifact path
- add a focused regression test

## Why
`new Set(uploadOptions)` compares option objects by identity, so equivalent objects were never removed. Repeated CLI files or programmatic upload entries could therefore publish the same artifact more than once.

## Tests
- `TEST_FILES=publishCliTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- targeted ESLint
- `git diff --check`

## Breaking changes
Duplicate entries for the same file and architecture now produce one upload, matching the existing deduplication intent.