### PR TITLE
fix: enforce workspace path boundaries for asar

### DIFF
--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -17,6 +17,11 @@ const resolvePaths = async (filepaths: (string | undefined)[]) => {
   return Promise.all(filepaths.map(resolvePath)).then(paths => paths.filter((it): it is string => it != null))
 }
 
+/** @internal */
+export function isPathInside(root: string, target: string): boolean {
+  return target === root || target.startsWith(root + path.sep)
+}
+
 const DENYLIST = resolvePaths([
   "/usr",
   "/lib",
@@ -314,7 +319,7 @@ export class AsarPackager {
     }
 
     for (const root of allowRoots) {
-      if (resolved === root || resolved.startsWith(root + path.sep)) {
+      if (isPathInside(root, resolved)) {
         return true
       }
     }
@@ -328,7 +333,7 @@ export class AsarPackager {
     const workspace = await resolvePath(workspaceRoot)
 
     // If in workspace, always safe
-    if (workspace && resolved?.startsWith(workspace)) {
+    if (workspace && resolved && isPathInside(workspace, resolved)) {
       return
     }
 

--- a/test/src/asarPathSafetyTest.ts
+++ b/test/src/asarPathSafetyTest.ts
@@ -1,0 +1,9 @@
+import * as path from "path"
+import { isPathInside } from "../../packages/app-builder-lib/src/asar/asarUtil"
+
+test("does not treat sibling paths with a shared prefix as descendants", ({ expect }) => {
+  const workspace = path.resolve("workspace")
+
+  expect(isPathInside(workspace, path.join(workspace, "app", "index.js"))).toBe(true)
+  expect(isPathInside(workspace, workspace + "-outside")).toBe(false)
+})


### PR DESCRIPTION
## Summary
- require a real path boundary when accepting files inside the workspace
- reuse the same containment predicate for allow/deny roots
- add a regression for sibling paths sharing the workspace prefix

## Why
The workspace fast path used a raw string prefix check. For a workspace such as `/build/app`, `/build/app-outside/...` was incorrectly treated as inside the workspace, bypassing the remaining unsafe-path checks.

## Tests
- `TEST_FILES=asarPathSafetyTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None. Paths outside the workspace no longer qualify merely because their names share its prefix.