### PR TITLE
fix: restore console logger after asar failures

### DIFF
--- a/.changeset/eight-animals-move.md
+++ b/.changeset/eight-animals-move.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: restore console logger after `electron/asar` failures

--- a/packages/app-builder-lib/src/asar/asarUtil.ts
+++ b/packages/app-builder-lib/src/asar/asarUtil.ts
@@ -43,6 +43,23 @@ const ALLOWLIST = resolvePaths([
 ])
 
 /** @internal */
+export async function withElectronAsarLogging<T>(task: () => Promise<T>): Promise<T> {
+  // override logger temporarily to clean up console (electron/asar does some internal logging that blogs up the default electron-builder logs)
+  const consoleLogger = console.log
+  console.log = (...args) => {
+    if (args[0] === "Ordering file has 100% coverage.") {
+      return // no need to log, this means our ordering logic is working correctly
+    }
+    log.info({ args }, "logging @electron/asar")
+  }
+  try {
+    return await task()
+  } finally {
+    console.log = consoleLogger
+  }
+}
+
+/** @internal */
 export class AsarPackager {
   private readonly outFile: string
 
@@ -72,17 +89,10 @@ export class AsarPackager {
   }
 
   private async executeElectronAsar(streams: AsarStreamType[]) {
-    // override logger temporarily to clean up console (electron/asar does some internal logging that blogs up the default electron-builder logs)
-    const consoleLogger = console.log
-    console.log = (...args) => {
-      if (args[0] === "Ordering file has 100% coverage.") {
-        return // no need to log, this means our ordering logic is working correctly
-      }
-      log.info({ args }, "logging @electron/asar")
-    }
-    const { createPackageFromStreams } = await dynamicImport<typeof import("@electron/asar")>("@electron/asar")
-    await createPackageFromStreams(this.outFile, streams)
-    console.log = consoleLogger
+    await withElectronAsarLogging(async () => {
+      const { createPackageFromStreams } = await dynamicImport<typeof import("@electron/asar")>("@electron/asar")
+      await createPackageFromStreams(this.outFile, streams)
+    })
   }
 
   private async processFileSets(fileSets: ResolvedFileSet[]): Promise<AsarStreamType[]> {

--- a/test/src/asarLoggingTest.ts
+++ b/test/src/asarLoggingTest.ts
@@ -1,0 +1,13 @@
+import { withElectronAsarLogging } from "../../packages/app-builder-lib/src/asar/asarUtil"
+
+test("restores console logging when asar packaging fails", async ({ expect }) => {
+  const originalLogger = console.log
+
+  await expect(
+    withElectronAsarLogging(async () => {
+      throw new Error("packaging failed")
+    })
+  ).rejects.toThrow("packaging failed")
+
+  expect(console.log).toBe(originalLogger)
+})


### PR DESCRIPTION
## Summary
- restore the original `console.log` in a `finally` block
- keep the temporary @electron/asar log adapter scoped to packaging
- add a regression for a rejected packaging operation

## Why
When dynamic loading or ASAR creation threw, the temporary logger remained installed globally. Subsequent application output was then filtered or redirected through electron-builder logging.

## Tests
- `TEST_FILES=asarLoggingTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.