### PR TITLE
fix: contain mapped app file destinations

### DIFF
--- a/packages/app-builder-lib/src/util/appFileCopier.ts
+++ b/packages/app-builder-lib/src/util/appFileCopier.ts
@@ -25,7 +25,7 @@ export function getDestinationPath(file: string, fileSet: ResolvedFileSet) {
   const src = fileSet.src
   const dest = fileSet.destination
   // get node_modules path relative to src and then append to dest
-  if (file.startsWith(src)) {
+  if (file.startsWith(src + path.sep)) {
     return path.join(dest, path.relative(src, file))
   }
   return dest

--- a/test/src/appFileDestinationTest.ts
+++ b/test/src/appFileDestinationTest.ts
@@ -1,0 +1,15 @@
+import * as path from "path"
+import { getDestinationPath } from "app-builder-lib/src/util/appFileCopier"
+
+const fileSet = {
+  src: path.resolve("source"),
+  destination: path.resolve("output"),
+} as any
+
+test("maps descendants below the destination", ({ expect }) => {
+  expect(getDestinationPath(path.join(fileSet.src, "nested", "app.js"), fileSet)).toBe(path.join(fileSet.destination, "nested", "app.js"))
+})
+
+test("does not map sibling paths that share the source prefix", ({ expect }) => {
+  expect(getDestinationPath(path.join(fileSet.src + "-outside", "app.js"), fileSet)).toBe(fileSet.destination)
+})


### PR DESCRIPTION
## Summary
- require a path-separator boundary before mapping a source descendant
- keep sibling paths with a shared prefix from producing `..` destinations
- cover normal descendants and prefix-collision siblings

## Why
A raw prefix check considered `/project/app-copy/file` a child of `/project/app`. `path.relative` then yielded an escaping path, which `path.join` could map outside the intended destination.

## Tests
- `TEST_FILES=appFileDestinationTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None. Only files outside the declared source root stop being mapped as descendants.