### PR TITLE
fix: cancel GitHub upload retry delays

### DIFF
--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -1,5 +1,5 @@
 import { Arch, assertVersionHasNoVPrefix, Fields, httpExecutor, isEmptyOrSpaces, isEnvTrue, log } from "builder-util"
-import { configureRequestOptions, GithubOptions, HttpError, parseJson, githubTagPrefix } from "builder-util-runtime"
+import { CancellationToken, configureRequestOptions, GithubOptions, HttpError, parseJson, githubTagPrefix } from "builder-util-runtime"
 import { ClientRequest } from "http"
 import { Lazy } from "lazy-val"
 import mime from "mime"
@@ -202,12 +202,10 @@ export class GitHubPublisher extends HttpPublisher {
         } else if (this.doesErrorMeanAlreadyExists(e)) {
           return this.overwriteArtifact(fileName, release).then(() => this.doUploadFile(attemptNumber + 1, parsedUrl, fileName, dataLength, requestProcessor, release))
         } else {
-          return new Promise((resolve, reject) => {
-            const newAttemptNumber = attemptNumber + 1
-            setTimeout(() => {
-              this.doUploadFile(newAttemptNumber, parsedUrl, fileName, dataLength, requestProcessor, release).then(resolve).catch(reject)
-            }, newAttemptNumber * 2000)
-          })
+          const newAttemptNumber = attemptNumber + 1
+          return cancellableDelay(newAttemptNumber * 2000, this.context.cancellationToken).then(() =>
+            this.doUploadFile(newAttemptNumber, parsedUrl, fileName, dataLength, requestProcessor, release)
+          )
         }
       })
   }
@@ -294,4 +292,12 @@ export class GitHubPublisher extends HttpPublisher {
   toString() {
     return `Github (owner: ${this.info.owner}, project: ${this.info.repo}, version: ${this.version})`
   }
+}
+
+/** @internal */
+export function cancellableDelay(delay: number, cancellationToken: CancellationToken): Promise<void> {
+  return cancellationToken.createPromise((resolve, _reject, onCancel) => {
+    const timer = setTimeout(resolve, delay)
+    onCancel(() => clearTimeout(timer))
+  })
 }

--- a/test/src/publisher/githubRetryTest.ts
+++ b/test/src/publisher/githubRetryTest.ts
@@ -1,0 +1,15 @@
+import { CancellationError, CancellationToken } from "builder-util-runtime"
+import { cancellableDelay } from "electron-publish/src/gitHubPublisher"
+import { vi } from "vitest"
+
+test("cancels an upload retry delay immediately", async ({ expect }) => {
+  vi.useFakeTimers()
+  const token = new CancellationToken()
+  const delay = cancellableDelay(10_000, token)
+
+  token.cancel()
+
+  await expect(delay).rejects.toBeInstanceOf(CancellationError)
+  expect(vi.getTimerCount()).toBe(0)
+  vi.useRealTimers()
+})


### PR DESCRIPTION
## Summary
- make GitHub upload retry backoff cancellation-aware
- clear the pending timer when publishing is cancelled
- add a fake-timer regression test

## Why
Cancellation during a retry delay left the timer alive. Once it elapsed, a cancelled publish attempted another upload before rejecting.

## Tests
- `TEST_FILES=publisher/githubRetryTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
Cancellation now rejects immediately with the existing `CancellationError` instead of waiting through the retry backoff.