### PR TITLE
fix: encode GitHub upload artifact names

### DIFF
--- a/packages/electron-publish/src/gitHubPublisher.ts
+++ b/packages/electron-publish/src/gitHubPublisher.ts
@@ -164,7 +164,7 @@ export class GitHubPublisher extends HttpPublisher {
       return
     }
 
-    const parsedUrl = parseUrl(`${release.upload_url.substring(0, release.upload_url.indexOf("{"))}?name=${fileName}`)
+    const parsedUrl = getUploadUrl(release.upload_url, fileName)
     return await this.doUploadFile(0, parsedUrl, fileName, dataLength, requestProcessor, release)
   }
 
@@ -294,4 +294,12 @@ export class GitHubPublisher extends HttpPublisher {
   toString() {
     return `Github (owner: ${this.info.owner}, project: ${this.info.repo}, version: ${this.version})`
   }
+}
+
+/** @internal */
+export function getUploadUrl(uploadUrl: string, fileName: string): UrlWithStringQuery {
+  const templateIndex = uploadUrl.indexOf("{")
+  const url = new URL(templateIndex === -1 ? uploadUrl : uploadUrl.slice(0, templateIndex))
+  url.searchParams.set("name", fileName)
+  return parseUrl(url.toString())
 }

--- a/test/src/publisher/githubPublisherTest.ts
+++ b/test/src/publisher/githubPublisherTest.ts
@@ -1,0 +1,8 @@
+import { getUploadUrl } from "electron-publish/src/gitHubPublisher"
+
+test("encodes artifact names in GitHub upload URLs", ({ expect }) => {
+  const upload = getUploadUrl("https://uploads.github.com/repos/acme/app/releases/1/assets{?name,label}", "app #1 & stable.zip")
+
+  expect(upload.pathname).toBe("/repos/acme/app/releases/1/assets")
+  expect(upload.query).toBe("name=app+%231+%26+stable.zip")
+})


### PR DESCRIPTION
## Summary
- build GitHub upload URLs with `URLSearchParams`
- preserve artifact names containing spaces, `#`, `&`, and other reserved characters
- tolerate upload URLs without a URI-template suffix
- add a focused regression test

## Why
Artifact names were interpolated directly into the query string. Reserved characters could truncate the name or introduce extra query parameters, causing uploads to use the wrong asset name or fail.

## Tests
- `TEST_FILES=publisher/githubPublisherTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.