### PR TITLE
fix: encode GitLab package path segments

### DIFF
--- a/.changeset/hungry-ads-open.md
+++ b/.changeset/hungry-ads-open.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: encode GitLab publisher package path segments

--- a/packages/electron-publish/src/gitlabPublisher.ts
+++ b/packages/electron-publish/src/gitlabPublisher.ts
@@ -183,8 +183,7 @@ export class GitlabPublisher extends HttpPublisher {
     if (uploadTarget === "generic_package") {
       await this.uploadToGenericPackages(fileName, dataLength, requestProcessor)
       // For generic packages, construct the download URL
-      const projectId = encodeURIComponent(this.projectId)
-      assetPath = `${this.baseApiPath}/projects/${projectId}/packages/generic/releases/${this.version}/${fileName}`
+      assetPath = getGenericPackageUrl(this.baseApiPath, this.projectId, this.version, fileName)
     } else {
       // Default to project_upload
       const uploadResult = await this.uploadToProjectUpload(fileName, filePath)
@@ -257,7 +256,7 @@ export class GitlabPublisher extends HttpPublisher {
   }
 
   private async uploadToGenericPackages(fileName: string, dataLength: number, requestProcessor: RequestProcessor): Promise<any> {
-    const uploadUrl = `${this.baseApiPath}/projects/${encodeURIComponent(this.projectId)}/packages/generic/releases/${this.version}/${fileName}`
+    const uploadUrl = getGenericPackageUrl(this.baseApiPath, this.projectId, this.version, fileName)
     const parsedUrl = new URL(uploadUrl)
 
     return httpExecutor.doApiRequest(
@@ -350,4 +349,9 @@ export class GitlabPublisher extends HttpPublisher {
   toString() {
     return `GitLab (project: ${this.projectId}, version: ${this.version})`
   }
+}
+
+/** @internal */
+export function getGenericPackageUrl(baseApiPath: string, projectId: string, version: string, fileName: string): string {
+  return `${baseApiPath}/projects/${encodeURIComponent(projectId)}/packages/generic/releases/${encodeURIComponent(version)}/${encodeURIComponent(fileName)}`
 }

--- a/test/src/publisher/gitlab/gitlabPackageUrlTest.ts
+++ b/test/src/publisher/gitlab/gitlabPackageUrlTest.ts
@@ -1,0 +1,7 @@
+import { getGenericPackageUrl } from "electron-publish/src/gitlabPublisher"
+
+test("encodes GitLab generic package path segments", ({ expect }) => {
+  expect(getGenericPackageUrl("https://gitlab.com/api/v4", "team/app", "1.0.0+stable", "app #1 & stable.zip")).toBe(
+    "https://gitlab.com/api/v4/projects/team%2Fapp/packages/generic/releases/1.0.0%2Bstable/app%20%231%20%26%20stable.zip"
+  )
+})


### PR DESCRIPTION
## Summary
- encode GitLab generic-package project, version, and filename segments
- use the same canonical URL for upload and release asset links
- add a regression covering reserved characters

## Why
Version and artifact names were interpolated directly into the URL path. Characters such as `#`, `?`, `/`, spaces, or `+` could change URL structure and upload to or link the wrong location.

## Tests
- `TEST_FILES=publisher/gitlab/gitlabPackageUrlTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.