### PR TITLE
fix: escape Squirrel project URLs in nuspec XML

### DIFF
--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module"
-import { InvalidConfigurationError, log, isEmptyOrSpaces, exists } from "builder-util"
+import { InvalidConfigurationError, log, isEmptyOrSpaces, exists, escapeForXml } from "builder-util"
 
 const _requireResolve = createRequire(import.meta.url).resolve
 import { downloadBuilderToolset, withToolsetLock } from "app-builder-lib/internal"
@@ -228,8 +228,7 @@ export default class SquirrelWindowsTarget extends Target {
     if (projectUrl != null) {
       const nuspecTemplate = await this.packager.tempDirManager.getTempFile({ prefix: "template", suffix: ".nuspectemplate" })
       let templateContent = await fs.promises.readFile(templatePath, "utf8")
-      const searchString = "<copyright><%- copyright %></copyright>"
-      templateContent = templateContent.replace(searchString, `${searchString}\n    <projectUrl>${projectUrl}</projectUrl>`)
+      templateContent = addProjectUrl(templateContent, projectUrl)
       await fs.promises.writeFile(nuspecTemplate, templateContent)
       return nuspecTemplate
     }
@@ -307,6 +306,12 @@ export default class SquirrelWindowsTarget extends Target {
 
     return options
   }
+}
+
+/** @internal */
+export function addProjectUrl(template: string, projectUrl: string): string {
+  const searchString = "<copyright><%- copyright %></copyright>"
+  return template.replace(searchString, `${searchString}\n    <projectUrl>${escapeForXml(projectUrl)}</projectUrl>`)
 }
 
 function checkConflictingOptions(options: any) {

--- a/test/src/windows/squirrelWindowsProjectUrlTest.ts
+++ b/test/src/windows/squirrelWindowsProjectUrlTest.ts
@@ -1,0 +1,9 @@
+import { addProjectUrl } from "electron-builder-squirrel-windows"
+
+test("escapes the project URL inserted into the nuspec template", ({ expect }) => {
+  const template = "<metadata><copyright><%- copyright %></copyright></metadata>"
+
+  expect(addProjectUrl(template, "https://example.com/app?channel=stable&source=<build>")).toContain(
+    "<projectUrl>https://example.com/app?channel=stable&amp;source=&lt;build&gt;</projectUrl>"
+  )
+})


### PR DESCRIPTION
## Summary
- XML-escape project URLs before inserting them into Squirrel nuspec metadata
- add a regression covering ampersands and angle brackets

## Why
The computed package URL was inserted as raw XML text. Valid URLs containing query separators produced malformed nuspec files, while markup characters could alter the generated metadata.

## Tests
- `TEST_FILES=windows/squirrelWindowsProjectUrlTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.