### PR TITLE
fix: replace only the final Squirrel exe extension

### DIFF
--- a/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
+++ b/packages/electron-builder-squirrel-windows/src/SquirrelWindowsTarget.ts
@@ -273,7 +273,7 @@ export default class SquirrelWindowsTarget extends Target {
     options.fixUpPaths = true
     options.setupExe = setupFile
     if (this.options.msi) {
-      options.setupMsi = setupFile.replace(".exe", ".msi")
+      options.setupMsi = replaceExecutableExtension(setupFile)
     }
 
     if (isEmptyOrSpaces(options.description)) {
@@ -307,6 +307,11 @@ export default class SquirrelWindowsTarget extends Target {
 
     return options
   }
+}
+
+/** @internal */
+export function replaceExecutableExtension(fileName: string): string {
+  return fileName.replace(/\.exe$/i, ".msi")
 }
 
 function checkConflictingOptions(options: any) {

--- a/test/src/windows/squirrelWindowsFilenameTest.ts
+++ b/test/src/windows/squirrelWindowsFilenameTest.ts
@@ -1,0 +1,5 @@
+import { replaceExecutableExtension } from "electron-builder-squirrel-windows"
+
+test("only replaces the terminal executable extension", ({ expect }) => {
+  expect(replaceExecutableExtension("My.exe App Setup.EXE")).toBe("My.exe App Setup.msi")
+})


### PR DESCRIPTION
## Summary
- derive the MSI filename from the terminal `.exe` extension only
- handle uppercase executable extensions
- add a regression for product names containing `.exe`

## Why
A plain string replacement changed the first `.exe` occurrence. Product names containing `.exe` therefore produced an `options.setupMsi` name that did not match the generated MSI artifact.

## Tests
- `TEST_FILES=windows/squirrelWindowsFilenameTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.