### PR TITLE
fix: resolve retina backgrounds by terminal extension

### DIFF
--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -245,14 +245,20 @@ export async function transformBackgroundFileIfNeed(file: string, tmpDir: TmpDir
     return file
   }
 
-  const retinaFile = file.replace(/\.([a-z]+)$/, "@2x.$1")
-  if (await exists(retinaFile)) {
+  const retinaFile = getRetinaFilePath(file)
+  if (retinaFile != null && (await exists(retinaFile))) {
     const tiffFile = await tmpDir.getTempFile({ suffix: ".tiff" })
     await exec("tiffutil", ["-cathidpicheck", file, retinaFile, "-out", tiffFile])
     return tiffFile
   }
 
   return file
+}
+
+/** @internal */
+export function getRetinaFilePath(file: string): string | null {
+  const extension = path.extname(file)
+  return extension === "" ? null : `${file.slice(0, -extension.length)}@2x${extension}`
 }
 
 export async function getImageSizeUsingSips(background: string) {

--- a/test/src/mac/dmgBackgroundTest.ts
+++ b/test/src/mac/dmgBackgroundTest.ts
@@ -1,0 +1,6 @@
+import { getRetinaFilePath } from "dmg-builder"
+
+test("derives retina background paths without changing extension case", ({ expect }) => {
+  expect(getRetinaFilePath("background.PNG")).toBe("background@2x.PNG")
+  expect(getRetinaFilePath("background")).toBeNull()
+})


### PR DESCRIPTION
## Summary
- derive `@2x` background names from the actual terminal extension
- preserve uppercase and mixed-case extensions
- avoid treating extensionless source files as their own retina companion
- add focused regressions

## Why
The lowercase-only replacement did not change `.PNG` and extensionless paths. If the original file existed, it was then incorrectly passed to `tiffutil` as both the base and retina image.

## Tests
- `TEST_FILES=mac/dmgBackgroundTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.