### PR TITLE
fix: preserve dot-prefixed internal symlinks

### DIFF
--- a/packages/app-builder-lib/src/util/AppFileWalker.ts
+++ b/packages/app-builder-lib/src/util/AppFileWalker.ts
@@ -34,7 +34,7 @@ export abstract class FileCopyHelper {
   private handleSymlink(fileStat: fsExtra.Stats, file: string, parent: string, linkTarget: string): Promise<fsExtra.Stats> | null {
     const resolvedLinkTarget = path.resolve(parent, linkTarget)
     const link = path.relative(this.matcher.from, resolvedLinkTarget)
-    if (link.startsWith("..")) {
+    if (isOutsidePath(link)) {
       // outside of project, linked module (https://github.com/electron-userland/electron-builder/issues/675)
       return fsExtra.stat(resolvedLinkTarget).then(targetFileStat => {
         this.metadata.set(file, targetFileStat)
@@ -47,6 +47,11 @@ export abstract class FileCopyHelper {
     }
     return null
   }
+}
+
+/** @internal */
+export function isOutsidePath(relativePath: string): boolean {
+  return relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)
 }
 
 function createAppFilter(matcher: FileMatcher, packager: PlatformPackager<any>): Filter | null {

--- a/test/src/appFileWalkerPathTest.ts
+++ b/test/src/appFileWalkerPathTest.ts
@@ -1,0 +1,6 @@
+import { isOutsidePath } from "app-builder-lib/src/util/AppFileWalker"
+
+test("distinguishes parent traversal from dot-prefixed child names", ({ expect }) => {
+  expect(isOutsidePath("../outside")).toBe(true)
+  expect(isOutsidePath("..cache/module")).toBe(false)
+})


### PR DESCRIPTION
## Summary
- distinguish actual parent traversal from child names beginning with `..`
- preserve in-project symlink metadata for paths such as `..cache/module`
- add a focused path-classification regression

## Why
The raw `startsWith("..")` check classified dot-prefixed child names as outside the project. Those symlinks were dereferenced and packaged differently even though their targets remained within the source root.

## Tests
- `TEST_FILES=appFileWalkerPathTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.