### PR TITLE
fix: reject aborted S3 upload responses

### DIFF
--- a/packages/app-builder-lib/src/util/AppFileWalker.ts
+++ b/packages/app-builder-lib/src/util/AppFileWalker.ts
@@ -34,7 +34,7 @@ export abstract class FileCopyHelper {
   private handleSymlink(fileStat: fsExtra.Stats, file: string, parent: string, linkTarget: string): Promise<fsExtra.Stats> | null {
     const resolvedLinkTarget = path.resolve(parent, linkTarget)
     const link = path.relative(this.matcher.from, resolvedLinkTarget)
-    if (link.startsWith("..")) {
+    if (isOutsidePath(link)) {
       // outside of project, linked module (https://github.com/electron-userland/electron-builder/issues/675)
       return fsExtra.stat(resolvedLinkTarget).then(targetFileStat => {
         this.metadata.set(file, targetFileStat)
@@ -47,6 +47,11 @@ export abstract class FileCopyHelper {
     }
     return null
   }
+}
+
+/** @internal */
+export function isOutsidePath(relativePath: string): boolean {
+  return relativePath === ".." || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)
 }
 
 function createAppFilter(matcher: FileMatcher, packager: PlatformPackager<any>): Filter | null {

--- a/packages/electron-publish/src/s3/s3UploadHelper.ts
+++ b/packages/electron-publish/src/s3/s3UploadHelper.ts
@@ -99,9 +99,20 @@ export function startS3PutObject(params: S3PutObjectParams): { req: http.ClientR
 
   let resolvePromise!: () => void
   let rejectPromise!: (err: Error) => void
+  let settled = false
   const done = new Promise<void>((res, rej) => {
-    resolvePromise = res
-    rejectPromise = rej
+    resolvePromise = () => {
+      if (!settled) {
+        settled = true
+        res()
+      }
+    }
+    rejectPromise = error => {
+      if (!settled) {
+        settled = true
+        rej(error)
+      }
+    }
   })
 
   const req = transport.request(
@@ -113,6 +124,8 @@ export function startS3PutObject(params: S3PutObjectParams): { req: http.ClientR
       headers: signed.headers,
     },
     res => {
+      res.on("aborted", () => rejectPromise(new Error("S3 PutObject response aborted")))
+      res.on("error", rejectPromise)
       if (res.statusCode === 200) {
         res.resume()
         res.on("end", resolvePromise)
@@ -133,7 +146,10 @@ export function startS3PutObject(params: S3PutObjectParams): { req: http.ClientR
 
   req.on("error", rejectPromise)
   const fileStream = fs.createReadStream(params.file)
-  fileStream.on("error", rejectPromise)
+  fileStream.on("error", error => {
+    req.destroy(error)
+    rejectPromise(error)
+  })
   req.on("close", () => fileStream.destroy())
   fileStream.pipe(req)
 

--- a/packages/electron-publish/src/s3/s3UploadHelper.ts
+++ b/packages/electron-publish/src/s3/s3UploadHelper.ts
@@ -29,30 +29,39 @@ interface S3RequestTarget {
   forcePathStyle?: boolean
 }
 
-function resolveS3Request(params: S3RequestTarget): { hostname: string; urlPath: string; isHttp: boolean } {
+function resolveS3Request(params: S3RequestTarget): { host: string; hostname: string; port: number | undefined; urlPath: string; isHttp: boolean } {
   const region = params.region
 
+  let host: string
   let hostname: string
+  let port: number | undefined
   let rawPath: string
   let isHttp = false
 
   if (params.endpoint != null) {
     const u = new URL(params.endpoint)
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      throw new Error(`Unsupported S3 endpoint protocol: ${u.protocol}`)
+    }
     isHttp = u.protocol === "http:"
-    hostname = u.port ? `${u.hostname}:${u.port}` : u.hostname
+    host = u.host
+    hostname = u.hostname.startsWith("[") ? u.hostname.slice(1, -1) : u.hostname
+    port = u.port ? Number(u.port) : undefined
     // path-style for custom endpoints (handles buckets whose names contain dots)
     rawPath = `/${params.bucket}/${params.key}`
   } else if (params.forcePathStyle) {
     hostname = `s3.${region}.amazonaws.com`
+    host = hostname
     rawPath = `/${params.bucket}/${params.key}`
   } else {
     hostname = `${params.bucket}.s3.${region}.amazonaws.com`
+    host = hostname
     rawPath = `/${params.key}`
   }
 
   // URL-encode each path segment individually so forward-slashes in keys are preserved
   const urlPath = "/" + rawPath.slice(1).split("/").map(encodeURIComponent).join("/")
-  return { hostname, urlPath, isHttp }
+  return { host, hostname, port, urlPath, isHttp }
 }
 
 /**
@@ -64,7 +73,7 @@ function resolveS3Request(params: S3RequestTarget): { hostname: string; urlPath:
 export function startS3PutObject(params: S3PutObjectParams): { req: http.ClientRequest; done: Promise<void> } {
   const stat = fs.statSync(params.file)
   const region = params.region
-  const { hostname, urlPath, isHttp } = resolveS3Request(params)
+  const { host, hostname, port, urlPath, isHttp } = resolveS3Request(params)
 
   const headers: Record<string, string> = {
     "Content-Type": params.contentType,
@@ -88,7 +97,7 @@ export function startS3PutObject(params: S3PutObjectParams): { req: http.ClientR
       service: "s3",
       region,
       method: "PUT",
-      host: hostname,
+      host,
       path: urlPath,
       headers,
     },
@@ -117,8 +126,8 @@ export function startS3PutObject(params: S3PutObjectParams): { req: http.ClientR
 
   const req = transport.request(
     {
-      hostname: hostname.split(":")[0],
-      port: hostname.includes(":") ? Number(hostname.split(":")[1]) : undefined,
+      hostname,
+      port,
       path: urlPath,
       method: "PUT",
       headers: signed.headers,
@@ -165,14 +174,14 @@ export interface S3DeleteObjectParams extends S3RequestTarget {
  * Primarily used by credential-gated live tests to clean up uploaded artifacts.
  */
 export function deleteS3Object(params: S3DeleteObjectParams): Promise<void> {
-  const { hostname, urlPath, isHttp } = resolveS3Request(params)
+  const { host, hostname, port, urlPath, isHttp } = resolveS3Request(params)
 
   const signed = sign(
     {
       service: "s3",
       region: params.region,
       method: "DELETE",
-      host: hostname,
+      host,
       path: urlPath,
       headers: {
         "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
@@ -186,8 +195,8 @@ export function deleteS3Object(params: S3DeleteObjectParams): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const req = transport.request(
       {
-        hostname: hostname.split(":")[0],
-        port: hostname.includes(":") ? Number(hostname.split(":")[1]) : undefined,
+        hostname,
+        port,
         path: urlPath,
         method: "DELETE",
         headers: signed.headers,

--- a/test/src/appFileWalkerPathTest.ts
+++ b/test/src/appFileWalkerPathTest.ts
@@ -1,0 +1,6 @@
+import { isOutsidePath } from "app-builder-lib/src/util/AppFileWalker"
+
+test("distinguishes parent traversal from dot-prefixed child names", ({ expect }) => {
+  expect(isOutsidePath("../outside")).toBe(true)
+  expect(isOutsidePath("..cache/module")).toBe(false)
+})

--- a/test/src/s3PublishTest.ts
+++ b/test/src/s3PublishTest.ts
@@ -353,6 +353,25 @@ describe("BaseS3Publisher.upload — key construction and S3 request", { sequent
     await uploadPromise.catch(() => null)
     expect(destroyCalled).toBe(true)
   })
+
+  it("rejects when the S3 response is aborted", async ({ expect }) => {
+    vi.mocked(https.request).mockImplementationOnce((_opts: unknown, callback: unknown) => {
+      const req = new EventEmitter() as ReturnType<typeof https.request>
+      ;(req as any).end = vi.fn()
+      ;(req as any).destroy = vi.fn()
+      ;(req as any).write = vi.fn()
+      setImmediate(() => {
+        const res = new EventEmitter() as any
+        res.statusCode = 200
+        res.resume = vi.fn()
+        ;(callback as (response: unknown) => void)(res)
+        setImmediate(() => res.emit("aborted"))
+      })
+      return req
+    })
+
+    await expect(makeS3Publisher().upload(makeTask(testFile))).rejects.toThrow("response aborted")
+  })
 })
 
 // ─── Upload — test mode bypass ────────────────────────────────────────────────

--- a/test/src/s3PublishTest.ts
+++ b/test/src/s3PublishTest.ts
@@ -272,6 +272,20 @@ describe("BaseS3Publisher.upload — key construction and S3 request", { sequent
     expect(capturedOpts()?.hostname).toBe("minio.example.com")
   })
 
+  it("preserves IPv6 custom endpoint hosts and ports", async () => {
+    const { capturedOpts } = mockSuccessfulUpload()
+    const publisher = makeS3Publisher({ endpoint: "https://[::1]:9000" })
+    await publisher.upload(makeTask(testFile))
+    expect(capturedOpts()?.hostname).toBe("::1")
+    expect(capturedOpts()?.port).toBe(9000)
+    expect(capturedOpts()?.headers?.Host).toBe("[::1]:9000")
+  })
+
+  it("rejects custom endpoint protocols other than HTTP and HTTPS", async ({ expect }) => {
+    await expect(makeS3Publisher({ endpoint: "ftp://minio.example.com" }).upload(makeTask(testFile))).rejects.toThrow("Unsupported S3 endpoint protocol: ftp:")
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled()
+  })
+
   it("sets x-amz-acl header when ACL is public-read", async () => {
     const { capturedOpts } = mockSuccessfulUpload()
     await makeS3Publisher({ acl: "public-read" }).upload(makeTask(testFile))


### PR DESCRIPTION
## Summary
- reject S3 uploads when the HTTP response aborts or errors
- settle the upload promise only once
- destroy the request when the source file stream fails
- parse custom endpoint host and port structurally, including IPv6 literals
- reject unsupported custom endpoint protocols
- add regressions for aborted responses, IPv6 endpoints, and protocol validation

## Why
The upload promise only observed response `end`. A server or proxy that aborted a nominally successful response could leave publishing pending indefinitely, while source stream failures rejected without stopping the request. Custom endpoints were also split on `:`, which corrupted IPv6 hosts and silently routed non-HTTP schemes through HTTPS.

## Tests
- `TEST_FILES=s3PublishTest corepack pnpm ci:test` (57 passing)
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
Unsupported non-HTTP(S) S3 endpoint URLs now fail with an explicit configuration error. Interrupted uploads now fail promptly instead of hanging.