### PR TITLE
fix: clean up publish SIGINT listeners

### DIFF
--- a/.changeset/eighty-peas-flash.md
+++ b/.changeset/eighty-peas-flash.md
@@ -1,0 +1,5 @@
+---
+"electron-builder": patch
+---
+
+fix: clean up publish SIGINT listeners

--- a/packages/electron-builder/src/publish.ts
+++ b/packages/electron-builder/src/publish.ts
@@ -94,29 +94,39 @@ async function publishPackageWithTasks(
     packager.cancellationToken.cancel()
     publishManager.cancelTasks()
   }
-  process.once("SIGINT", sigIntHandler)
 
-  try {
-    const publishConfigurations = await publishManager.getGlobalPublishConfigurations()
-    if (publishConfigurations == null || publishConfigurations.length === 0) {
-      throw new InvalidConfigurationError("unable to find any publish configuration")
-    }
-
-    for (const newArtifact of uploadTasks) {
-      for (const publishConfiguration of publishConfigurations) {
-        await publishManager.scheduleUpload(publishConfiguration, newArtifact, appInfo)
+  return withPublishSigIntHandler(sigIntHandler, async () => {
+    try {
+      const publishConfigurations = await publishManager.getGlobalPublishConfigurations()
+      if (publishConfigurations == null || publishConfigurations.length === 0) {
+        throw new InvalidConfigurationError("unable to find any publish configuration")
       }
-    }
 
-    await publishManager.awaitTasks()
-    return uploadTasks
-  } catch (error: any) {
-    packager.cancellationToken.cancel()
-    publishManager.cancelTasks()
-    process.removeListener("SIGINT", sigIntHandler)
-    log.error({ message: (error.stack || error.message || error).toString() }, "error publishing")
+      for (const newArtifact of uploadTasks) {
+        for (const publishConfiguration of publishConfigurations) {
+          await publishManager.scheduleUpload(publishConfiguration, newArtifact, appInfo)
+        }
+      }
+
+      await publishManager.awaitTasks()
+      return uploadTasks
+    } catch (error: any) {
+      packager.cancellationToken.cancel()
+      publishManager.cancelTasks()
+      log.error({ message: (error.stack || error.message || error).toString() }, "error publishing")
+      return null
+    }
+  })
+}
+
+/** @internal */
+export async function withPublishSigIntHandler<T>(handler: () => void, task: () => Promise<T>): Promise<T> {
+  process.once("SIGINT", handler)
+  try {
+    return await task()
+  } finally {
+    process.removeListener("SIGINT", handler)
   }
-  return null
 }
 
 function main() {

--- a/test/src/publishSignalTest.ts
+++ b/test/src/publishSignalTest.ts
@@ -1,0 +1,15 @@
+import { withPublishSigIntHandler } from "../../packages/electron-builder/src/publish"
+import { expect, vi } from "vitest"
+
+test.each(["resolve", "reject"] as const)("removes the publish SIGINT handler after tasks %s", async outcome => {
+  const handler = vi.fn()
+  const operation = withPublishSigIntHandler(handler, async () => {
+    expect(process.listeners("SIGINT")).toContain(handler)
+    if (outcome === "reject") {
+      throw new Error("failed")
+    }
+  })
+
+  await operation.catch(() => undefined)
+  expect(process.listeners("SIGINT")).not.toContain(handler)
+})


### PR DESCRIPTION
## Summary
- scope the publish SIGINT handler to the active publish operation
- remove the handler after both successful and failed publishes
- add regressions for resolve and reject paths

## Why
The publish command removed its one-time SIGINT listener only in the error path. Every successful programmatic publish left a listener attached, eventually causing listener warnings and cancelling stale packagers when a later SIGINT arrived.

## Tests
- `TEST_FILES=publishSignalTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.