### PR TITLE
perf: deduplicate concurrent module cache lookups

### DIFF
--- a/.changeset/neat-coats-knock.md
+++ b/.changeset/neat-coats-knock.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+perf: deduplicate concurrent module cache lookups

--- a/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
@@ -62,11 +62,11 @@ export class ModuleManager {
   /** For logging purposes, just track all dependencies for each key */
   readonly logSummary: LogSummaryCache
 
-  private readonly jsonMap: Map<string, PackageJson | null> = new Map()
-  private readonly realPathMap: Map<string, string> = new Map()
-  private readonly existsMap: Map<string, boolean> = new Map()
-  private readonly lstatMap: Map<string, fs.Stats | null> = new Map()
-  private readonly packageDataMap: Map<string, Package | null> = new Map()
+  private readonly jsonMap = new Map<string, Promise<PackageJson | null>>()
+  private readonly realPathMap = new Map<string, Promise<string>>()
+  private readonly existsMap = new Map<string, Promise<boolean>>()
+  private readonly lstatMap = new Map<string, Promise<fs.Stats | null>>()
+  private readonly packageDataMap = new Map<string, Promise<Package | null>>()
   private readonly logSummaryMap: Map<LogMessageByKey, string[]> = new Map()
 
   constructor() {
@@ -116,19 +116,24 @@ export class ModuleManager {
 
   // this allows dot-notation access while still supporting async retrieval
   // e.g., cache.packageJson[somePath] returns Promise<PackageJson>
-  private createAsyncProxy<T>(map: Map<string, T>, compute: (key: string) => T | Promise<T>): Record<string, Promise<T>> {
+  private createAsyncProxy<T>(map: Map<string, Promise<T>>, compute: (key: string) => T | Promise<T>): Record<string, Promise<T>> {
     return new Proxy({} as Record<string, Promise<T>>, {
-      async get(_, key: string) {
-        if (map.has(key)) {
-          return Promise.resolve(map.get(key)!)
+      get(_, key: string) {
+        const cached = map.get(key)
+        if (cached != null) {
+          return cached
         }
-        return await Promise.resolve(compute(key)).then(value => {
-          map.set(key, value)
-          return value
-        })
+        const pending = Promise.resolve()
+          .then(() => compute(key))
+          .catch(error => {
+            map.delete(key)
+            throw error
+          })
+        map.set(key, pending)
+        return pending
       },
       set(_, key: string, value: T) {
-        map.set(key, value)
+        map.set(key, Promise.resolve(value))
         return true
       },
       has(_, key: string) {

--- a/test/src/node-module-collector/moduleManagerTest.ts
+++ b/test/src/node-module-collector/moduleManagerTest.ts
@@ -29,6 +29,22 @@ async function buildTempTree(packages: Record<string, { name: string; version: s
 // ---------------------------------------------------------------------------
 
 describe("ModuleManager.locatePackageVersion", () => {
+  test("shares in-flight cache lookups for the same key", async ({ expect }) => {
+    const manager = new ModuleManager()
+    const root = await projectTmpDir.createTempDir()
+    const file = path.join(root, "missing")
+
+    try {
+      const first = manager.exists[file]
+      const second = manager.exists[file]
+
+      expect(second).toBe(first)
+      await expect(first).resolves.toBe(false)
+    } finally {
+      await fse.rm(root, { recursive: true, force: true })
+    }
+  })
+
   describe("basic resolution", () => {
     test("returns null when parentDir is undefined", async ({ expect }) => {
       const manager = new ModuleManager()


### PR DESCRIPTION
## Summary
- cache in-flight filesystem and package lookup promises
- share one lookup among concurrent callers for the same key
- evict rejected lookups so later calls can retry
- add a concurrent-cache regression test

## Why
The cache stored values only after asynchronous work completed. Concurrent node-module traversal requests for the same path therefore repeated filesystem and package resolution work.

## Tests
- `TEST_FILES=moduleManagerTest corepack pnpm ci:test` (23 passing)
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.