### PR TITLE
perf: make module downward search linear

### DIFF
--- a/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
@@ -307,9 +307,10 @@ export class ModuleManager {
     const visited = new Set<string>()
     const queue: Array<{ dir: string; depth: number }> = [{ dir: start, depth: 0 }]
     let explored = 0
+    let queueIndex = 0
 
-    while (queue.length > 0) {
-      const { dir, depth } = queue.shift()!
+    while (queueIndex < queue.length) {
+      const { dir, depth } = queue[queueIndex++]
       if (explored++ > maxExplored) {
         break
       }


### PR DESCRIPTION
## Summary
- replace repeated queue `shift()` calls with an advancing index
- preserve breadth-first traversal order and search limits

## Why
Downward node-module discovery can explore up to 2,000 directories. Removing from the front of the array shifts every remaining entry, turning queue management into quadratic work.

## Tests
- `TEST_FILES=moduleManagerTest corepack pnpm ci:test` (22 passing)
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.