### PR TITLE
fix: encode Bitbucket delete filenames

### DIFF
--- a/.changeset/green-cases-wave.md
+++ b/.changeset/green-cases-wave.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: encode Bitbucket delete filenames

--- a/packages/electron-publish/src/bitbucketPublisher.ts
+++ b/packages/electron-publish/src/bitbucketPublisher.ts
@@ -65,7 +65,7 @@ export class BitbucketPublisher extends HttpPublisher {
   async deleteRelease(filename: string): Promise<void> {
     const req: RequestOptions = {
       hostname: this.hostname,
-      path: `${this.basePath}/${filename}`,
+      path: `${this.basePath}/${encodeURIComponent(filename)}`,
       timeout: this.info.timeout || undefined,
     }
     await httpExecutor.request(configureRequestOptions(req, this.auth, "DELETE"), this.context.cancellationToken)

--- a/test/src/bitbucketPublisherTest.ts
+++ b/test/src/bitbucketPublisherTest.ts
@@ -1,0 +1,28 @@
+import { httpExecutor } from "builder-util"
+import { CancellationToken } from "builder-util-runtime"
+import { BitbucketPublisher, PublishContext } from "electron-publish"
+import { vi } from "vitest"
+
+test("encodes artifact filenames when deleting releases", async ({ expect }) => {
+  const publishContext: PublishContext = {
+    cancellationToken: new CancellationToken(),
+    progress: null,
+  }
+  const publisher = new BitbucketPublisher(publishContext, {
+    provider: "bitbucket",
+    owner: "test-owner",
+    slug: "test-repo",
+    token: "access-token-123",
+  })
+  const request = vi.spyOn(httpExecutor, "request").mockResolvedValue(null)
+
+  try {
+    await publisher.deleteRelease("My App #1.zip")
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "/2.0/repositories/test-owner/test-repo/downloads/My%20App%20%231.zip" }),
+      publishContext.cancellationToken
+    )
+  } finally {
+    request.mockRestore()
+  }
+})


### PR DESCRIPTION
## Summary
- percent-encode artifact filenames in Bitbucket delete requests
- add a regression for spaces and fragment characters

## Why
Artifact filenames were appended to the request path verbatim. Names containing spaces could make Node reject the request, while `#` and other reserved characters could target the wrong URL.

## Tests
- `TEST_FILES=bitbucketPublisherTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.