### PR TITLE
fix: detach DMGs after mount parsing failures

### DIFF
--- a/packages/dmg-builder/src/dmgUtil.ts
+++ b/packages/dmg-builder/src/dmgUtil.ts
@@ -70,22 +70,39 @@ export async function attachAndExecute(dmgPath: string, readWrite: boolean, forc
   if (device == null) {
     throw new Error(`Cannot mount: ${attachResult}`)
   }
-  // Find the volume mount path directly from hdiutil attach output.
-  // APFS images synthesize a new disk device (e.g. disk9) separate from the container disk
-  // (e.g. disk8), so device-name matching via hdiutil info misses the APFS volume.
-  let volumePath: string | null = null
-  for (const line of attachResult!.split("\n")) {
-    const match = /\s+(\/Volumes\/.+?)\s*$/.exec(line)
-    if (match) {
-      volumePath = match[1].trim()
-      break
-    }
-  }
-  if (volumePath == null) {
-    throw new Error(`Cannot find volume mount path for device: ${device}`)
-  }
 
-  return await executeFinally(task(volumePath), () => detach(device, forceDetach))
+  return executeAndDetach(attachResult!, device, forceDetach, task)
+}
+
+/** @internal */
+export async function executeAndDetach(
+  attachResult: string,
+  device: string,
+  forceDetach: boolean,
+  task: (volumePath: string) => Promise<any>,
+  detacher: (device: string, forceDetach: boolean) => Promise<any> = detach
+) {
+  return executeFinally(
+    (async () => {
+      // Find the volume mount path directly from hdiutil attach output.
+      // APFS images synthesize a new disk device (e.g. disk9) separate from the container disk
+      // (e.g. disk8), so device-name matching via hdiutil info misses the APFS volume.
+      let volumePath: string | null = null
+      for (const line of attachResult.split("\n")) {
+        const match = /\s+(\/Volumes\/.+?)\s*$/.exec(line)
+        if (match) {
+          volumePath = match[1].trim()
+          break
+        }
+      }
+      if (volumePath == null) {
+        throw new Error(`Cannot find volume mount path for device: ${device}`)
+      }
+
+      return task(volumePath)
+    })(),
+    () => detacher(device, forceDetach)
+  )
 }
 
 export async function detach(name: string, alwaysForce: boolean) {

--- a/test/src/mac/dmgAttachTest.ts
+++ b/test/src/mac/dmgAttachTest.ts
@@ -1,0 +1,12 @@
+import { executeAndDetach } from "dmg-builder"
+import { vi } from "vitest"
+
+test("detaches an image when its volume path cannot be parsed", async ({ expect }) => {
+  const task = vi.fn()
+  const detacher = vi.fn().mockResolvedValue(undefined)
+
+  await expect(executeAndDetach("/dev/disk9\tApple_APFS", "/dev/disk9", true, task, detacher)).rejects.toThrow("Cannot find volume mount path for device: /dev/disk9")
+  expect(task).not.toHaveBeenCalled()
+  expect(detacher).toHaveBeenCalledOnce()
+  expect(detacher).toHaveBeenCalledWith("/dev/disk9", true)
+})


### PR DESCRIPTION
## Summary
- place volume-path parsing inside the mounted-image cleanup boundary
- detach the device when parsing fails before the callback starts
- add a regression for unrecognized `hdiutil` output

## Why
Once `hdiutil attach` returned a device, a missing volume-path match threw before `executeFinally` was installed. The mounted image was therefore leaked on that error path.

## Tests
- `TEST_FILES=dmgAttachTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.