### PR TITLE
fix: preserve sibling paths in logs

### DIFF
--- a/.changeset/long-cougars-double.md
+++ b/.changeset/long-cougars-double.md
@@ -1,0 +1,5 @@
+---
+"builder-util": patch
+---
+
+fix: preserve sibling paths in diagnostic path logging

--- a/packages/builder-util/src/log.ts
+++ b/packages/builder-util/src/log.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk"
 import { Chalk } from "chalk"
 import _debug from "debug"
+import * as path from "path"
 type WritableStream = NodeJS.WritableStream
 
 let printer: ((message: string) => void) | null = null
@@ -28,7 +29,8 @@ export class Logger {
 
   filePath(file: string) {
     const cwd = process.cwd()
-    return file.startsWith(cwd) ? file.substring(cwd.length + 1) : file
+    const relative = path.relative(cwd, file)
+    return relative === "" || (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`)) ? relative : file
   }
 
   // noinspection JSMethodCanBeStatic

--- a/test/src/builder-util/logTest.ts
+++ b/test/src/builder-util/logTest.ts
@@ -1,0 +1,14 @@
+import { Logger } from "builder-util"
+import * as path from "path"
+
+const logger = new Logger(process.stdout)
+
+test("shortens paths inside the working directory", ({ expect }) => {
+  expect(logger.filePath(path.join(process.cwd(), "build", "artifact.zip"))).toBe(path.join("build", "artifact.zip"))
+})
+
+test("preserves paths in directories that only share the working-directory prefix", ({ expect }) => {
+  const siblingPath = `${process.cwd()}-other${path.sep}artifact.zip`
+
+  expect(logger.filePath(siblingPath)).toBe(siblingPath)
+})


### PR DESCRIPTION
## Summary
- derive shortened log paths with `path.relative`
- keep paths outside the working directory absolute
- add regressions for nested and prefix-sharing sibling paths

## Why
The previous raw prefix check treated a sibling such as `/project-other` as if it were inside `/project`, then removed part of its path and produced misleading diagnostics.

## Tests
- `TEST_FILES=logTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None. Only incorrectly shortened out-of-tree log paths change.