### PR TITLE
fix: parse GitHub repo shorthand correctly

### DIFF
--- a/.changeset/nine-tools-lay.md
+++ b/.changeset/nine-tools-lay.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: parse GitHub repo shorthand correctly

--- a/packages/app-builder-lib/src/publish/PublishManager.ts
+++ b/packages/app-builder-lib/src/publish/PublishManager.ts
@@ -545,6 +545,12 @@ function isDetectUpdateChannel(platformSpecificConfiguration: PlatformSpecificBu
 // is called per target and arch - without leaking state between programmatic builds running in the same process
 const reportedInferredUpdateFeeds = new WeakMap<CancellationToken, Set<string>>()
 
+/** @internal */
+export function parseGithubRepoShorthand(repo: string): { owner: string; repo: string } | null {
+  const separator = repo.indexOf("/")
+  return separator > 0 ? { owner: repo.substring(0, separator), repo: repo.substring(separator + 1) } : null
+}
+
 // the inferred repository becomes the publish/update destination and, for auto-update-capable targets, is written
 // verbatim into app-update.yml inside every shipped build as its permanent update feed - so the developer has to be
 // told which repository they are committing to. A repository taken from package.json "repository" is deliberate
@@ -636,11 +642,10 @@ async function getResolvedPublishConfig(
   let project = isGithub ? (options as GithubOptions).repo : (options as BitbucketOptions).slug
 
   if (isGithub && owner == null && project != null) {
-    const index = project.indexOf("/")
-    if (index > 0) {
-      const repo = project
-      project = repo.substring(0, index)
-      owner = repo.substring(index + 1)
+    const shorthand = parseGithubRepoShorthand(project)
+    if (shorthand != null) {
+      owner = shorthand.owner
+      project = shorthand.repo
     }
   }
 

--- a/test/src/publisher/githubPublishConfigTest.ts
+++ b/test/src/publisher/githubPublishConfigTest.ts
@@ -1,0 +1,12 @@
+import { parseGithubRepoShorthand } from "app-builder-lib/src/publish/PublishManager"
+
+test("parses owner and repository from GitHub repo shorthand", ({ expect }) => {
+  expect(parseGithubRepoShorthand("electron-userland/electron-builder")).toEqual({
+    owner: "electron-userland",
+    repo: "electron-builder",
+  })
+})
+
+test("ignores repository names without an owner", ({ expect }) => {
+  expect(parseGithubRepoShorthand("electron-builder")).toBeNull()
+})


### PR DESCRIPTION
## Summary
- split `repo: owner/name` into the correct owner and repository fields
- add distinct owner/repository regression coverage

## Why
The shorthand parser assigned the segment before `/` to `repo` and the segment after it to `owner`. Configurations only appeared correct when both names happened to be identical.

## Tests
- `TEST_FILES=githubPublishConfigTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
GitHub shorthand configurations now resolve to their intended repository instead of the reversed destination.