### PR TITLE
fix: log dynamic import failures

### DIFF
--- a/.changeset/wacky-regions-play.md
+++ b/.changeset/wacky-regions-play.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix: log dynamic import failures

--- a/packages/app-builder-lib/src/util/resolve.ts
+++ b/packages/app-builder-lib/src/util/resolve.ts
@@ -10,7 +10,7 @@ const _dynamicImportMaybe: (modulePath: string) => Promise<any> = _require("../.
 
 export async function resolveModule<T>(type: string | undefined, name: string): Promise<T> {
   try {
-    return _dynamicImportMaybe(name)
+    return await _dynamicImportMaybe(name)
   } catch (error: any) {
     log.error({ moduleName: name, message: error.message ?? error.stack }, "Unable to dynamically `import` or `require`")
     throw error

--- a/test/src/resolveModuleTest.ts
+++ b/test/src/resolveModuleTest.ts
@@ -1,0 +1,15 @@
+import { resolveModule } from "app-builder-lib/src/util/resolve"
+import { log } from "builder-util"
+import { vi } from "vitest"
+
+test("logs dynamic import failures before rejecting", async ({ expect }) => {
+  const error = vi.spyOn(log, "error").mockImplementation(() => undefined)
+  const moduleName = `electron-builder-missing-module-${Date.now()}`
+
+  try {
+    await expect(resolveModule(undefined, moduleName)).rejects.toThrow()
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ moduleName }), "Unable to dynamically `import` or `require`")
+  } finally {
+    error.mockRestore()
+  }
+})


### PR DESCRIPTION
## Summary
- await dynamic module loading inside its diagnostic boundary
- add a regression proving failed imports are logged before rejection

## Why
Returning the import promise directly let asynchronous rejections escape the surrounding `try/catch`, so the intended module-name diagnostic never ran.

## Tests
- `TEST_FILES=resolveModuleTest corepack pnpm ci:test`
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
None.