### PR TITLE
fix: normalize Snap Store channels

### DIFF
--- a/.changeset/funky-hounds-study.md
+++ b/.changeset/funky-hounds-study.md
@@ -1,0 +1,5 @@
+---
+"electron-publish": patch
+---
+
+fix: normalize Snap Store channels

--- a/packages/electron-publish/src/snapStorePublisher.ts
+++ b/packages/electron-publish/src/snapStorePublisher.ts
@@ -35,6 +35,7 @@ export class SnapStorePublisher extends Publisher {
     if (typeof channels === "string") {
       channels = channels.split(",")
     }
+    channels = channels.map(channel => channel.trim()).filter(channel => channel.length > 0)
 
     // `snapcraft upload <snap-file> --release <channels>` uploads the snap and
     // immediately releases it to the specified channels upon store review.

--- a/test/src/publisher/snap/SnapStorePublisherTest.ts
+++ b/test/src/publisher/snap/SnapStorePublisherTest.ts
@@ -149,6 +149,16 @@ describe("SnapStorePublisher", { sequential: true }, () => {
       expectSpawnCall(["upload", FILE, "--release", "stable,beta"])(expect)
     })
 
+    test("trims and removes empty comma-separated channels", async ({ expect }) => {
+      await makePublisher(" stable, beta, ,edge ").upload(makeTask())
+      expectSpawnCall(["upload", FILE, "--release", "stable,beta,edge"])(expect)
+    })
+
+    test("empty string omits --release flag", async ({ expect }) => {
+      await makePublisher("  ").upload(makeTask())
+      expect(vi.mocked(spawn)).toHaveBeenCalledWith("snapcraft", ["upload", FILE], expect.objectContaining(STDIO))
+    })
+
     test("handles single-element array", async ({ expect }) => {
       await makePublisher(["candidate"]).upload(makeTask())
       expectSpawnCall(["upload", FILE, "--release", "candidate"])(expect)


### PR DESCRIPTION
## Summary
- trim configured Snap Store channel entries
- discard empty comma-separated entries
- omit `--release` when a string contains no channels
- add regressions for whitespace and empty values

## Why
Comma-separated strings were passed through verbatim. Common values such as `stable, beta` sent an invalid leading-space channel, while an empty string still emitted an empty `--release` argument.

## Tests
- `TEST_FILES=SnapStorePublisherTest corepack pnpm ci:test` (37 passing)
- `corepack pnpm compile`
- `corepack pnpm ci:validate`
- `git diff --check`

## Breaking changes
Empty channel entries are now ignored instead of being sent to snapcraft.