### PR TITLE
chore(CI): auto-label PRs targeting backports to release/v26 (#10158)

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -30,3 +30,5 @@
   - changed-files:
     - any-glob-to-any-file:
       - packages/electron-updater/**/*
+  release/v26:
+  - base-branch: '^release/v26$'


### PR DESCRIPTION
Backporting https://github.com/electron-userland/electron-builder/commit/5f153b0cfdae1ce437ab2055e4cb8a85927c75c9 so that the GHA CI picks up the branch logic