### PR TITLE
fix(mac): Retain Electron and Chromium license files on macOS

### DIFF
--- a/.changeset/mac-electron-license-files.md
+++ b/.changeset/mac-electron-license-files.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(mac): retain Electron's `LICENSE.electron.txt` and Chromium's `LICENSES.chromium.html` in the macOS `.app` bundle (`Contents/Resources`) instead of dropping them outside the bundle, matching the license files already shipped on Windows and Linux (#9407)

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -1,4 +1,4 @@
-import { asArray, copyDir, DO_NOT_USE_HARD_LINKS, isEmptyOrSpaces, log, MAX_FILE_REQUESTS, sanitizeDirPath, statOrNull, unlinkIfExists } from "builder-util"
+import { asArray, copyDir, DO_NOT_USE_HARD_LINKS, isEmptyOrSpaces, log, MAX_FILE_REQUESTS, orIfFileNotExist, sanitizeDirPath, statOrNull, unlinkIfExists } from "builder-util"
 import _fsExtra from "fs-extra"
 import * as path from "path"
 import asyncPool from "tiny-async-pool"
@@ -270,9 +270,7 @@ export function cleanupAfterUnpack(prepareOptions: PrepareApplicationStageDirect
  */
 async function retainElectronLicenseFiles(appOutDir: string, resourcesPath: string, isMac: boolean) {
   const destinationDir = isMac ? resourcesPath : appOutDir
-  const move = (name: string, newName: string = name) =>
-    rename(path.join(appOutDir, name), path.join(destinationDir, newName)).catch(() => {
-      /* a custom Electron distribution may not ship license files */
-    })
+  // a custom Electron distribution may not ship license files, so only a missing source file is tolerated; any other error propagates
+  const move = (name: string, newName: string = name) => orIfFileNotExist(rename(path.join(appOutDir, name), path.join(destinationDir, newName)), undefined)
   await Promise.all([move("LICENSE", "LICENSE.electron.txt"), ...(isMac ? [move("LICENSES.chromium.html")] : [])])
 }

--- a/packages/app-builder-lib/src/electron/ElectronFramework.ts
+++ b/packages/app-builder-lib/src/electron/ElectronFramework.ts
@@ -251,7 +251,7 @@ async function unpack(prepareOptions: PrepareApplicationStageDirectoryOptions, _
   return selectElectron(resolvedDist)
 }
 
-function cleanupAfterUnpack(prepareOptions: PrepareApplicationStageDirectoryOptions, distMacOsAppName: string, isFullCleanup: boolean) {
+export function cleanupAfterUnpack(prepareOptions: PrepareApplicationStageDirectoryOptions, distMacOsAppName: string, isFullCleanup: boolean) {
   const out = prepareOptions.appOutDir
   const isMac = prepareOptions.packager.platform === Platform.MAC
   const resourcesPath = isMac ? path.join(out, distMacOsAppName, "Contents", "Resources") : path.join(out, "resources")
@@ -259,10 +259,20 @@ function cleanupAfterUnpack(prepareOptions: PrepareApplicationStageDirectoryOpti
   return Promise.all([
     isFullCleanup ? unlinkIfExists(path.join(resourcesPath, "default_app.asar")) : Promise.resolve(),
     isFullCleanup ? unlinkIfExists(path.join(out, "version")) : Promise.resolve(),
-    isMac
-      ? Promise.resolve()
-      : rename(path.join(out, "LICENSE"), path.join(out, "LICENSE.electron.txt")).catch(() => {
-          /* ignore */
-        }),
+    retainElectronLicenseFiles(out, resourcesPath, isMac),
   ])
+}
+
+/**
+ * The Electron dist ships Electron's own `LICENSE` and Chromium's `LICENSES.chromium.html` next to the binary, and both licenses require them to be
+ * retained in distributables. On win/linux they stay next to the executable, but on macOS they sit outside the `.app` bundle, which is the only thing
+ * packaged into the artifacts, so move them into `Contents/Resources`. See https://github.com/electron-userland/electron-builder/issues/9407
+ */
+async function retainElectronLicenseFiles(appOutDir: string, resourcesPath: string, isMac: boolean) {
+  const destinationDir = isMac ? resourcesPath : appOutDir
+  const move = (name: string, newName: string = name) =>
+    rename(path.join(appOutDir, name), path.join(destinationDir, newName)).catch(() => {
+      /* a custom Electron distribution may not ship license files */
+    })
+  await Promise.all([move("LICENSE", "LICENSE.electron.txt"), ...(isMac ? [move("LICENSES.chromium.html")] : [])])
 }

--- a/packages/app-builder-lib/src/electron/mac/electronMac.ts
+++ b/packages/app-builder-lib/src/electron/mac/electronMac.ts
@@ -1,4 +1,4 @@
-import { asArray, copyOrLinkFile, getPlatformIconFileName, InvalidConfigurationError, unlinkIfExists } from "builder-util"
+import { asArray, copyOrLinkFile, getPlatformIconFileName, InvalidConfigurationError } from "builder-util"
 import { rename, utimes } from "fs/promises"
 import * as path from "path"
 import * as fs from "fs"
@@ -232,11 +232,7 @@ export async function createMacApp(packager: MacPackager, appOutDir: string, asa
     await savePlistFile(helperPlistFilename, helperPlist)
   }
 
-  await Promise.all([
-    doRename(path.join(contentsPath, "MacOS"), electronBranding.productName, appPlist.CFBundleExecutable as string),
-    unlinkIfExists(path.join(appOutDir, "LICENSE")),
-    unlinkIfExists(path.join(appOutDir, "LICENSES.chromium.html")),
-  ])
+  await doRename(path.join(contentsPath, "MacOS"), electronBranding.productName, appPlist.CFBundleExecutable as string)
 
   await moveHelpers(
     getAvailableHelperSuffixes({

--- a/test/snapshots/mac/macArchiveTest.js.snap
+++ b/test/snapshots/mac/macArchiveTest.js.snap
@@ -744,6 +744,8 @@ exports[`pkg scripts 3`] = `
   "Test App ßW.app/Contents/Resources/ja.lproj",
   "Test App ßW.app/Contents/Resources/kn.lproj",
   "Test App ßW.app/Contents/Resources/ko.lproj",
+  "Test App ßW.app/Contents/Resources/LICENSE.electron.txt",
+  "Test App ßW.app/Contents/Resources/LICENSES.chromium.html",
   "Test App ßW.app/Contents/Resources/lt.lproj",
   "Test App ßW.app/Contents/Resources/lv.lproj",
   "Test App ßW.app/Contents/Resources/ml.lproj",

--- a/test/snapshots/mac/macPackagerTest.js.snap
+++ b/test/snapshots/mac/macPackagerTest.js.snap
@@ -25,6 +25,8 @@ exports[`macPackager > extraFiles are placed in product app bundle Contents, not
   "Info.plist",
   "PkgInfo",
   "extraTestFile.txt",
+  "Resources/LICENSE.electron.txt",
+  "Resources/LICENSES.chromium.html",
   "Resources/app.asar",
   "Resources/icon.icns",
   "MacOS/Test App ßW",
@@ -373,6 +375,8 @@ exports[`macPackager > extraFiles are placed in product app bundle Contents, not
 
 exports[`macPackager > extraFiles are placed in product app bundle Contents, not Electron.app 4`] = `
 [
+  "LICENSE.electron.txt",
+  "LICENSES.chromium.html",
   "app.asar",
   "icon.icns",
 ]
@@ -535,6 +539,8 @@ exports[`macPackager > multiple asar resources 2`] = `
 
 exports[`macPackager > multiple asar resources 3`] = `
 [
+  "LICENSE.electron.txt",
+  "LICENSES.chromium.html",
   "app.asar",
   "extraAsar.asar",
   "icon.icns",
@@ -880,6 +886,8 @@ exports[`macPackager > two-package 2`] = `
 
 exports[`macPackager > two-package 3`] = `
 [
+  "LICENSE.electron.txt",
+  "LICENSES.chromium.html",
   "app-update.yml",
   "app.asar",
   "bn.lproj",
@@ -964,6 +972,8 @@ exports[`macPackager > two-package 5`] = `
 
 exports[`macPackager > two-package 6`] = `
 [
+  "LICENSE.electron.txt",
+  "LICENSES.chromium.html",
   "app-update.yml",
   "app.asar",
   "bn.lproj",
@@ -1048,6 +1058,8 @@ exports[`macPackager > two-package 8`] = `
 
 exports[`macPackager > two-package 9`] = `
 [
+  "LICENSE.electron.txt",
+  "LICENSES.chromium.html",
   "app-update.yml",
   "app.asar",
   "bn.lproj",
@@ -2121,6 +2133,8 @@ exports[`macPackager > yarn two package.json w/ native module 3`] = `
 
 exports[`macPackager > yarn two package.json w/ native module 4`] = `
 [
+  "LICENSE.electron.txt",
+  "LICENSES.chromium.html",
   "app.asar",
   "electron.icns",
   "app.asar.unpacked/node_modules/node-pty/LICENSE",

--- a/test/src/electronLicenseFilesTest.ts
+++ b/test/src/electronLicenseFilesTest.ts
@@ -1,0 +1,49 @@
+import { Platform } from "app-builder-lib"
+import { cleanupAfterUnpack } from "app-builder-lib/src/electron/ElectronFramework"
+import { PrepareApplicationStageDirectoryOptions } from "app-builder-lib/src/Framework"
+import { mkdir, readdir, writeFile } from "fs/promises"
+import * as path from "path"
+
+// Unit tests for retaining Electron's and Chromium's license files (https://github.com/electron-userland/electron-builder/issues/9407).
+// A minimal fake packager is pointed at a fake app output directory populated the way an extracted Electron dist looks.
+
+const DIST_MAC_OS_APP_NAME = "Electron.app"
+
+function fakeOptions(platform: Platform, appOutDir: string): PrepareApplicationStageDirectoryOptions {
+  return { packager: { platform }, appOutDir } as unknown as PrepareApplicationStageDirectoryOptions
+}
+
+// an extracted Electron dist: the licenses sit next to the executable (win/linux) or next to the .app bundle (mac)
+async function createElectronDist(appOutDir: string, isMac: boolean): Promise<string> {
+  const resourcesDir = isMac ? path.join(appOutDir, DIST_MAC_OS_APP_NAME, "Contents", "Resources") : path.join(appOutDir, "resources")
+  await mkdir(resourcesDir, { recursive: true })
+  await writeFile(path.join(appOutDir, "LICENSE"), "electron license")
+  await writeFile(path.join(appOutDir, "LICENSES.chromium.html"), "chromium licenses")
+  return resourcesDir
+}
+
+describe("cleanupAfterUnpack", () => {
+  test("moves both license files into the mac app bundle resources", async ({ expect, tmpDir }) => {
+    const appOutDir = await tmpDir.getTempDir()
+    const resourcesDir = await createElectronDist(appOutDir, true)
+    await cleanupAfterUnpack(fakeOptions(Platform.MAC, appOutDir), DIST_MAC_OS_APP_NAME, true)
+    expect((await readdir(resourcesDir)).sort()).toEqual(["LICENSE.electron.txt", "LICENSES.chromium.html"])
+    // nothing is left outside the bundle, since only the bundle is packaged into the artifacts
+    expect(await readdir(appOutDir)).toEqual([DIST_MAC_OS_APP_NAME])
+  })
+
+  test("keeps license files next to the executable on win/linux", async ({ expect, tmpDir }) => {
+    for (const platform of [Platform.WINDOWS, Platform.LINUX]) {
+      const appOutDir = await tmpDir.getTempDir()
+      await createElectronDist(appOutDir, false)
+      await cleanupAfterUnpack(fakeOptions(platform, appOutDir), DIST_MAC_OS_APP_NAME, true)
+      expect((await readdir(appOutDir)).sort()).toEqual(["LICENSE.electron.txt", "LICENSES.chromium.html", "resources"])
+    }
+  })
+
+  test("tolerates a custom Electron distribution without license files", async ({ expect, tmpDir }) => {
+    const appOutDir = await tmpDir.getTempDir()
+    await mkdir(path.join(appOutDir, DIST_MAC_OS_APP_NAME, "Contents", "Resources"), { recursive: true })
+    await expect(cleanupAfterUnpack(fakeOptions(Platform.MAC, appOutDir), DIST_MAC_OS_APP_NAME, false)).resolves.toBeDefined()
+  })
+})

--- a/test/src/electronLicenseFilesTest.ts
+++ b/test/src/electronLicenseFilesTest.ts
@@ -46,4 +46,12 @@ describe("cleanupAfterUnpack", () => {
     await mkdir(path.join(appOutDir, DIST_MAC_OS_APP_NAME, "Contents", "Resources"), { recursive: true })
     await expect(cleanupAfterUnpack(fakeOptions(Platform.MAC, appOutDir), DIST_MAC_OS_APP_NAME, false)).resolves.toBeDefined()
   })
+
+  test("propagates errors other than a missing license file", async ({ expect, tmpDir }) => {
+    const appOutDir = await tmpDir.getTempDir()
+    const resourcesDir = await createElectronDist(appOutDir, true)
+    // a directory squatting on the destination makes the rename fail with something other than ENOENT
+    await mkdir(path.join(resourcesDir, "LICENSE.electron.txt"))
+    await expect(cleanupAfterUnpack(fakeOptions(Platform.MAC, appOutDir), DIST_MAC_OS_APP_NAME, false)).rejects.toThrow()
+  })
 })


### PR DESCRIPTION
## Retain Electron and Chromium license files on macOS

Closes #9407

### Summary

- `LICENSE` (Electron) and `LICENSES.chromium.html` (Chromium) ship at the root of the extracted Electron distribution. On Windows and Linux that root *is* the packaged app directory, so both files end up in the distributable. On macOS the root is the staging directory that only *contains* `Electron.app`, and every macOS target (dmg, zip, pkg, mas) packages just the `.app` bundle — so both license files were silently dropped, which conflicts with the Electron and Chromium license terms requiring the notices to be retained in all copies.
- `cleanupAfterUnpack` in `packages/app-builder-lib/src/electron/ElectronFramework.ts` now moves both files into the app bundle's `Contents/Resources` on macOS (`LICENSE` → `LICENSE.electron.txt`, `LICENSES.chromium.html` unchanged). This happens before `createMacApp` renames `Electron.app` to the product bundle, so the files travel with the bundle and are covered by code signing. Windows and Linux behavior is unchanged.
- The previous inline `isMac ? Promise.resolve() : rename(...)` branch is replaced by a small `retainElectronLicenseFiles` helper that picks the destination directory per platform and keeps the "a custom `electronDist` may not ship license files" tolerance:

```ts
async function retainElectronLicenseFiles(appOutDir: string, resourcesPath: string, isMac: boolean) {
  const destinationDir = isMac ? resourcesPath : appOutDir
  const move = (name: string, newName: string = name) =>
    rename(path.join(appOutDir, name), path.join(destinationDir, newName)).catch(() => {
      /* a custom Electron distribution may not ship license files */
    })
  await Promise.all([move("LICENSE", "LICENSE.electron.txt"), ...(isMac ? [move("LICENSES.chromium.html")] : [])])
}
```

- `cleanupAfterUnpack` is now exported so it can be unit tested directly.
- New `test/src/electronLicenseFilesTest.ts` covers the three behaviors: both files land in the mac bundle's `Contents/Resources` and nothing is left beside the bundle, win/linux keep both files next to the executable, and a distribution without license files does not fail the build.
- Refreshed macOS snapshots that enumerate the app bundle: `test/snapshots/mac/macPackagerTest.js.snap` and `test/snapshots/mac/macArchiveTest.js.snap`.

### Design notes

- Files are *moved*, not copied, so nothing stale is left in the staging directory next to the `.app`.
- `Contents/Resources` was chosen over the Electron framework's own `Resources` directory because it is the conventional location for bundled license notices and is the same directory macOS targets already carry (`app.asar`, `icon.icns`, `*.lproj`).
- Universal builds are safe: `@electron/universal` aborts if a non-binary file differs between the x64 and arm64 slices, and both license files are byte-identical across archs (verified against the Electron 42.4.0 darwin dists, and by the passing universal `macPackager` test).
- `LICENSES.chromium.html` is ~20 MB uncompressed, so macOS `.app` bundles grow accordingly — the same cost Windows and Linux distributables have always paid.
