### PR TITLE
feat(dmg): allow "position" as a dmg.contents type

### DIFF
--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -935,7 +935,8 @@
           "enum": [
             "dir",
             "file",
-            "link"
+            "link",
+            "position"
           ],
           "type": "string"
         },

--- a/packages/app-builder-lib/src/options/macOptions.ts
+++ b/packages/app-builder-lib/src/options/macOptions.ts
@@ -396,7 +396,7 @@ export interface DmgContent {
    * The device-independent pixel offset from the top of the window to the **center** of the icon.
    */
   y: number
-  type?: "link" | "file" | "dir"
+  type?: "link" | "file" | "dir" | "position"
 
   /**
    * The name of the file within the DMG. Defaults to basename of `path`.


### PR DESCRIPTION
## Problem

Currently, `dmg.contents` entries accept `type: "dir" | "file" | "link"`. Passing `"position"` is rejected during config validation, but it is already handled everywhere else:

- `packages/dmg-builder/src/dmgUtil.ts` forwards `type` into the dmgbuild settings JSON, rewriting only `"dir"` → `"file"`.
- `dmg-builder` handles `position` explicitly — it skips the copy/symlink step but still records `icon_locations[name] = (x, y)` into the volume's `.DS_Store`.

The schema enum is the only thing blocking it.

## Why

`position` is used to place an existing file, instead of copying a new one in. My use case: users who have "show hidden files" enabled see hidden files auto-placed in the default grid (e.g. `.VolumeIcon.icns` and `.background.tiff`). With this option, I can position them out of the way of my custom DMG background.

## Change

No runtime changes — this only lets config through to a code path that already handles it.

## Testing

- Applied the equivalent two-line change to `app-builder-lib` in a real Electron project (via `yarn patch`); a `dmg.contents` entry with `type: "position"` now passes validation, where it previously threw the error above.
- Confirmed the resulting DMG places `.background.tiff` and `.VolumeIcon.icns` at the requested coordinates with hidden files shown in Finder.