### PR TITLE
fix: pnpm collector: transitive deps of a `link:`ed package in an isolated store

### DIFF
--- a/.changeset/pnpm-isolated-store-sibling-deps.md
+++ b/.changeset/pnpm-isolated-store-sibling-deps.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": patch
+---
+
+fix(pnpm): bundle the transitive dependencies of a `link:`ed package. A located package is now resolved to its real directory before its own dependencies are searched for — in an isolated pnpm store those are siblings inside `.pnpm/<name>@<ver>/node_modules/`, reachable only from the link target — and a package that cannot locate itself by name (a workspace directory such as `packages/builder-util-runtime`) now has its dependencies read straight from that directory instead of contributing none. Previously an app whose `electron-updater` came from a local checkout shipped an asar missing `universalify`, `jsonfile` and `argparse`, and died at startup with `Cannot find module 'universalify'`. Dependencies that cannot be resolved are now reported in the collector log summary rather than skipped silently.

--- a/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
+++ b/packages/app-builder-lib/src/node-module-collector/moduleManager.ts
@@ -79,7 +79,10 @@ export class ModuleManager {
     this.realPath = this.createAsyncProxy(this.realPathMap, async (p: string) => {
       const filePath = path.resolve(p)
       const stat = await this.lstat[filePath]
-      return stat?.isSymbolicLink() ? fs.realpath(filePath) : filePath
+      // A dangling link, or a Windows junction pointing at another drive, makes `realpath` throw.
+      // Degrading to the path we were given keeps collection going with the next-best answer
+      // instead of failing the whole build.
+      return stat?.isSymbolicLink() ? fs.realpath(filePath).catch(() => filePath) : filePath
     })
   }
 

--- a/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
+++ b/packages/app-builder-lib/src/node-module-collector/pnpmNodeModulesCollector.ts
@@ -162,12 +162,37 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
         return fromDep
       }
       return this.cache.locatePackageVersion({ pkgName, parentDir: this.rootDir, requiredRange, skipDownwardSearch })
-    })()
+    })().then(pkg => this.toRealPackage(pkg))
 
     if (memoKey != null) {
       this.locateMemo.set(memoKey, promise)
     }
     return promise
+  }
+
+  /**
+   * Resolve a located package to its real directory (the symlink target), leaving a non-symlinked
+   * hit untouched.
+   *
+   * `locatePackageVersion` returns the path it *walked*, which in pnpm's isolated store is the
+   * `node_modules/<name>` symlink rather than `.pnpm/<name>@<ver>/node_modules/<name>`. That
+   * distinction matters because the store keeps a package's dependencies as SIBLINGS inside
+   * `.pnpm/<name>@<ver>/node_modules/`, reachable only from the real path: searching upward from
+   * the symlink walks the *linking* project instead of the store and finds nothing. That is how
+   * `fs-extra`'s `universalify`/`jsonfile` (and `js-yaml`'s `argparse`) were silently dropped from
+   * the asar of an app whose `electron-updater` came from a `link:`ed checkout — pnpm reports such
+   * packages with no dependency tree, so `visitDep` resolves their deps from disk through here.
+   *
+   * Resolving the link is what Node itself does (`--preserve-symlinks` is off by default), which is
+   * why the same require works before packaging. `ModuleManager.locatePackageVersionFromCacheKey`
+   * and `TraversalNodeModulesCollector` already normalize this way.
+   */
+  private async toRealPackage(pkg: Package | null): Promise<Package | null> {
+    if (pkg == null) {
+      return null
+    }
+    const packageDir = await this.cache.realPath[pkg.packageDir]
+    return packageDir === pkg.packageDir ? pkg : { ...pkg, packageDir }
   }
 
   // pnpm 10+ does not automatically preserve transitive optional platform-specific
@@ -317,19 +342,28 @@ export class PnpmNodeModulesCollector extends NodeModulesCollector<PnpmDependenc
     this.allDependencies.set(id, { ...value, path: resolvedPath })
 
     // For transitive-dep discovery of entries pnpm did not expand (link: packages), use the
-    // located package.json; fall back to the link target's own package.json when the junction
-    // could not be resolved (again, the cross-drive case).
-    const pkg = located ?? (linkTarget != null ? await this.readPackageJsonAt(linkTarget) : null)
+    // located package.json; fall back to reading it straight from the resolved directory when the
+    // by-name lookup came up empty. That happens whenever the package does not sit inside a
+    // `node_modules/<name>` directory it can find itself in: a cross-drive link target whose
+    // junction is unreadable, and a workspace package such as `packages/builder-util-runtime`,
+    // which nothing above it exposes under `node_modules/`. Without this fallback such a package
+    // contributes no dependencies at all (its `debug`/`sax` would vanish from the asar).
+    const pkg = located ?? (resolvedPath != null ? await this.readPackageJsonAt(resolvedPath) : null)
     const hasTreeDeps = Object.keys(value.dependencies ?? {}).length > 0 || Object.keys(value.optionalDependencies ?? {}).length > 0
     if (!hasTreeDeps && pkg?.packageJson) {
       // pnpm list omits sub-deps for link: packages and for entries where the reported path
       // doesn't expand transitive deps (e.g. a link: package's nested dep). Use the on-disk
       // package.json to discover what to include, and pass the declared version range so that
       // resolution skips wrong-version hoisted packages and finds the correct nested copy.
-      const pkgDepsDecl = { ...(pkg.packageJson.dependencies || {}), ...(pkg.packageJson.optionalDependencies || {}) }
+      const pkgOptionalDecl = pkg.packageJson.optionalDependencies || {}
+      const pkgDepsDecl = { ...(pkg.packageJson.dependencies || {}), ...pkgOptionalDecl }
       for (const [depName, depRange] of Object.entries(pkgDepsDecl)) {
         const resolved = await this.locateFromDepOrRoot(depName, pkg.packageDir, typeof depRange === "string" ? depRange : undefined)
         if (!resolved) {
+          // A miss here silently ships a broken app (the dependency is simply absent from the
+          // asar and only fails at runtime with MODULE_NOT_FOUND), so surface it in the log
+          // summary. Optional deps are an expected miss and get the quieter bucket.
+          this.logMissingDependency(`${depName}@${depRange}`, pkgOptionalDecl[depName] != null)
           continue
         }
         await this.visitDep(depName, {

--- a/test/src/node-module-collector/pnpmLinkDependencyTest.ts
+++ b/test/src/node-module-collector/pnpmLinkDependencyTest.ts
@@ -4,6 +4,8 @@ import * as os from "os"
 import * as path from "path"
 import { spawn } from "builder-util"
 import { PnpmNodeModulesCollector } from "app-builder-lib/internal"
+import { LogMessageByKey } from "app-builder-lib/src/node-module-collector/moduleManager"
+import type { PnpmDependency } from "app-builder-lib/src/node-module-collector/types"
 import { TmpDir } from "temp-file"
 
 const REPO_ROOT = path.resolve(__dirname, "../../..")
@@ -54,23 +56,23 @@ describe("PnpmNodeModulesCollector.resolveLinkTarget", () => {
 // dropped electron-updater from the asar (MODULE_NOT_FOUND at runtime).
 // ---------------------------------------------------------------------------
 
+function flattenNames(deps: any[]): string[] {
+  const names = new Set<string>()
+  const visit = (d: any) => {
+    if (!d) {
+      return
+    }
+    names.add(d.name)
+    for (const c of d.dependencies || []) {
+      visit(c)
+    }
+  }
+  deps.forEach(visit)
+  return [...names].sort()
+}
+
 describe("PnpmNodeModulesCollector link: dependency bundling", () => {
   let root = ""
-
-  function flattenNames(deps: any[]): string[] {
-    const names = new Set<string>()
-    const visit = (d: any) => {
-      if (!d) {
-        return
-      }
-      names.add(d.name)
-      for (const c of d.dependencies || []) {
-        visit(c)
-      }
-    }
-    deps.forEach(visit)
-    return [...names].sort()
-  }
 
   test("bundles a link: package and its transitive deps, resolved to the real source dir", { timeout: 120_000 }, async ({ expect, tmpDir }) => {
     root = await tmpDir.createTempDir()
@@ -126,5 +128,105 @@ describe("PnpmNodeModulesCollector link: dependency bundling", () => {
     expect(utilEntry?.[1]?.path).toBe(utilPath)
     const nmJunction = path.join(appDir, "node_modules")
     expect(updaterEntry![1].path.startsWith(nmJunction)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: a link:ed package whose own dependencies live in an ISOLATED pnpm
+// store. There, `node_modules/<name>` is a link into `.pnpm/<name>@<ver>/node_modules/<name>`
+// and that package's dependencies sit as SIBLINGS next to it — reachable only from the link
+// target. Resolving a dependency to the link path instead searched upward through the *linking*
+// project and found nothing, so the whole sub-closure was dropped from the asar and the packaged
+// app died with `Cannot find module 'universalify'` (fs-extra's dep, via electron-updater linked
+// from a local electron-builder checkout).
+//
+// The integration test above cannot catch this: it spreads the linked packages' dependencies into
+// the test app's own `dependencies` and installs hoisted, so every transitive dep is also a
+// top-level package of the app and the root-dir fallback finds it regardless.
+// ---------------------------------------------------------------------------
+
+describe("PnpmNodeModulesCollector isolated-store transitive deps", () => {
+  class StubbedPnpmNodeModulesCollector extends PnpmNodeModulesCollector {
+    constructor(
+      rootDir: string,
+      tempDirManager: TmpDir,
+      private readonly cannedTree: PnpmDependency
+    ) {
+      super(rootDir, tempDirManager)
+    }
+
+    protected override getDependenciesTree(): Promise<PnpmDependency> {
+      // Mirror parseDependenciesTree's side effect without shelling out to `pnpm list`.
+      ;(this as any)._allWorkspacePackages = [this.cannedTree]
+      return Promise.resolve(this.cannedTree)
+    }
+  }
+
+  function findNode(deps: any[], name: string): any {
+    for (const d of deps) {
+      if (d?.name === name) {
+        return d
+      }
+      const found = findNode(d?.dependencies || [], name)
+      if (found) {
+        return found
+      }
+    }
+    return undefined
+  }
+
+  test("bundles a link: package's deps that live as siblings in the .pnpm store", async ({ expect, tmpDir }) => {
+    const root = await tmpDir.createTempDir()
+    const appDir = path.join(root, "app")
+    const libDir = path.join(root, "lib")
+    // The store belongs to the *linked checkout*, outside the app entirely.
+    const storeNm = path.join(root, "checkout", "node_modules", ".pnpm", "outer@1.0.0", "node_modules")
+
+    // A workspace sibling of the linked package, reached by a plain (non-link:) version — the
+    // `builder-util-runtime` shape. Its own deps live in its own node_modules.
+    const siblingDir = path.join(root, "sibling")
+
+    await fse.outputJson(path.join(appDir, "package.json"), { private: true, name: "TestApp", version: "1.0.0", dependencies: { "linked-lib": "link:../lib" } })
+    await fse.outputJson(path.join(libDir, "package.json"), { name: "linked-lib", version: "1.0.0", dependencies: { outer: "^1.0.0", "sibling-lib": "workspace:*" } })
+    await fse.outputJson(path.join(storeNm, "outer", "package.json"), { name: "outer", version: "1.0.0", dependencies: { inner: "^1.0.0" } })
+    // `inner` is a SIBLING of `outer`, not nested under it — the shape that only the real path reaches.
+    await fse.outputJson(path.join(storeNm, "inner", "package.json"), { name: "inner", version: "1.0.0" })
+    await fse.outputJson(path.join(siblingDir, "package.json"), { name: "sibling-lib", version: "2.0.0", dependencies: { "sib-dep": "^1.0.0" } })
+    await fse.outputJson(path.join(siblingDir, "node_modules", "sib-dep", "package.json"), { name: "sib-dep", version: "1.0.0" })
+
+    await fse.ensureSymlink(libDir, path.join(appDir, "node_modules", "linked-lib"), "junction")
+    await fse.ensureSymlink(path.join(storeNm, "outer"), path.join(libDir, "node_modules", "outer"), "junction")
+    await fse.ensureSymlink(siblingDir, path.join(libDir, "node_modules", "sibling-lib"), "junction")
+
+    // What `pnpm list --prod --json` actually emits for a link: dep: a `link:` version, the resolved
+    // source path, and NO nested dependency tree — which is what forces the on-disk fallback.
+    const tree = {
+      name: "TestApp",
+      from: "TestApp",
+      version: "1.0.0",
+      path: appDir,
+      dependencies: { "linked-lib": { from: "linked-lib", name: "linked-lib", version: "link:../lib", path: libDir } },
+      optionalDependencies: {},
+    } as unknown as PnpmDependency
+
+    const collector = new StubbedPnpmNodeModulesCollector(appDir, new TmpDir("eb-pnpm-store-test"), tree)
+    const { nodeModules, logSummary } = await collector.getNodeModules({ packageName: "TestApp" })
+
+    const names = flattenNames(nodeModules)
+    expect(names).toContain("linked-lib")
+    expect(names).toContain("outer")
+    // `inner` was the one silently dropped: reachable only from `outer`'s real directory.
+    expect(names).toContain("inner")
+    // A workspace package's real directory is not inside any `node_modules/<name>`, so it cannot
+    // locate itself by name; its dependencies must still be discovered by reading its package.json
+    // at that directory, or the whole sub-closure disappears.
+    expect(names).toContain("sibling-lib")
+    expect(names).toContain("sib-dep")
+
+    // ...and it must be copied from the store, not from some same-named package elsewhere.
+    expect(findNode(nodeModules, "inner").dir).toBe(await fse.realpath(path.join(storeNm, "inner")))
+
+    expect(logSummary[LogMessageByKey.PKG_NOT_ON_DISK] ?? []).toEqual([])
+    expect(logSummary[LogMessageByKey.PKG_NOT_FOUND] ?? []).toEqual([])
   })
 })


### PR DESCRIPTION
An app whose production dependency is `link:`ed to a local checkout (`pnpm.overrides` -> `link:../electron-builder/packages/electron-updater`) shipped an incomplete `app.asar`: `fs-extra`'s `universalify` and `jsonfile` and `js-yaml`'s `argparse` were missing, and the packaged app died at startup with `Cannot find module 'universalify'`.

`pnpm list --prod --json` reports a `link:` package with no nested dependency tree, so `PnpmNodeModulesCollector.visitDep` falls back to reading the package's `package.json` and resolving each declared dependency from disk. Two problems on that path:

- **`locatePackageVersion` returns the path it walked, not the real path** — for a linked checkout that is the `node_modules/<name>` symlink (`packages/electron-updater/node_modules/fs-extra`). In an isolated pnpm store a package's dependencies are *siblings* inside `.pnpm/<name>@<ver>/node_modules/`, reachable only from the link target, so the upward search walked the linking project instead and found nothing. Resolving the link matches Node's own resolution (`--preserve-symlinks` is off by default), which is why the same `require` works before packaging. `TraversalNodeModulesCollector` and `ModuleManager.locatePackageVersionFromCacheKey` already normalize this way; the pnpm collector was the outlier because it calls `locatePackageVersion` directly.

  ```ts
  })().then(pkg => this.toRealPackage(pkg))
  ```

- **A package that cannot locate *itself* by name contributed no dependencies at all.** Once resolved to its real directory, a workspace package such as `packages/builder-util-runtime` sits outside any `node_modules/<name>`, so the by-name lookup returns null and the dependency-discovery branch was skipped entirely — dropping its `debug`/`sax`. `visitDep` now falls back to reading `package.json` straight from the resolved directory, the same trick `extractProductionDependencyGraph` already uses for the app root:

  ```ts
  const pkg = located ?? (resolvedPath != null ? await this.readPackageJsonAt(resolvedPath) : null)
  ```

- **Unresolvable transitive dependencies are no longer dropped silently.** The bare `continue` became a `logMissingDependency` call, so a miss lands in the `PKG_NOT_ON_DISK` summary bucket (and is therefore subject to `allowMissingDependencies`) instead of producing an app that only fails at runtime. Declared-optional misses keep the quieter optional bucket.

- **`ModuleManager`'s `realPath` cache degrades instead of throwing.** `realpath` throws on a dangling link or a cross-drive Windows junction; it now falls back to the given path, which also removes a pre-existing crash path in `_getNodeModules`.