### PR TITLE
feat(nsis): "store-asar" mode for proportional differential updates

### DIFF
--- a/.changeset/differential-store-asar.md
+++ b/.changeset/differential-store-asar.md
@@ -2,4 +2,4 @@
 "app-builder-lib": minor
 ---
 
-feat(nsis): opt-in `differentialPackageStoreAsar` — store `resources/app.asar` uncompressed (7-Zip `Copy`) in the differential-aware app package so a small app-code change costs a proportionally small differential download instead of re-downloading the entire recompressed asar (measured on a ~32 MB asar: 0.2% instead of 100% for a one-line change). Backed by a generic `ArchiveOptions.storedPaths` in `archive()`.
+feat(nsis): `differentialPackage: "store-asar"` — store `resources/app.asar` uncompressed (7-Zip `Copy`) in the differential-aware app package so a small app-code change costs a proportionally small differential download instead of re-downloading the entire recompressed asar (measured on a ~32 MB asar: 0.2% instead of 100% for a one-line change). `nsis.differentialPackage` is widened to `boolean | "compressed" | "store-asar" | null`: `false` disables differential support as before, `"store-asar"` opts into the stored asar, and everything else (`true`, `"compressed"`, `null`, unset) keeps today's fully compressed differential package. Backed by a generic `ArchiveOptions.storedPaths` in `archive()`.

--- a/.changeset/differential-store-asar.md
+++ b/.changeset/differential-store-asar.md
@@ -1,0 +1,5 @@
+---
+"app-builder-lib": minor
+---
+
+feat(nsis): opt-in `differentialPackageStoreAsar` — store `resources/app.asar` uncompressed (7-Zip `Copy`) in the differential-aware app package so a small app-code change costs a proportionally small differential download instead of re-downloading the entire recompressed asar (measured on a ~32 MB asar: 0.2% instead of 100% for a one-line change). Backed by a generic `ArchiveOptions.storedPaths` in `archive()`.

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4359,13 +4359,21 @@
           "type": "boolean"
         },
         "differentialPackage": {
-          "description": "Marks the package as built with differential download support for the update server.",
-          "type": "boolean"
-        },
-        "differentialPackageStoreAsar": {
-          "default": false,
-          "description": "Store the app's `resources/app.asar` uncompressed (7-Zip `Copy`) inside the differential-aware app package.\n\nThe differential updater diffs the *compressed* package with a content-defined blockmap, and the asar is a\nsingle compressed member — so any change to app code re-downloads the entire compressed asar (~100% of the\nmember; its header rewrite alone diverges every block). Storing it keeps unchanged regions byte-identical\nbetween releases, making the delta proportional to what actually changed (measured on a ~32 MB asar: a\none-line source change cost 0.2% instead of 100%).\n\nTrade-off: the installer grows by roughly what compressing the asar saved. Has no effect when\n`differentialPackage` is `false`.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "enum": [
+                "compressed",
+                false,
+                "store-asar",
+                true
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "description": "Marks the package as built with differential download support for the update server, and selects how the\napp package is compressed:\n\n- `false` — no differential download support.\n- `\"store-asar\"` — differential-aware, with the app's `resources/app.asar` stored uncompressed (7-Zip\n  `Copy`) inside the package. The differential updater diffs the *compressed* package with a\n  content-defined blockmap, and the asar is a single compressed member — so any change to app code\n  re-downloads the entire compressed asar (~100% of the member; its header rewrite alone diverges every\n  block). Storing it keeps unchanged regions byte-identical between releases, making the delta\n  proportional to what actually changed (measured on a ~32 MB asar: a one-line source change cost 0.2%\n  instead of 100%). Trade-off: the installer and full package grow by roughly what compressing the asar\n  saved.\n- anything else (`true`, `\"compressed\"`, `null`, unset) — differential-aware, whole package compressed."
         },
         "displayLanguageSelector": {
           "default": false,
@@ -4720,13 +4728,21 @@
           "type": "boolean"
         },
         "differentialPackage": {
-          "description": "Marks the package as built with differential download support for the update server.",
-          "type": "boolean"
-        },
-        "differentialPackageStoreAsar": {
-          "default": false,
-          "description": "Store the app's `resources/app.asar` uncompressed (7-Zip `Copy`) inside the differential-aware app package.\n\nThe differential updater diffs the *compressed* package with a content-defined blockmap, and the asar is a\nsingle compressed member — so any change to app code re-downloads the entire compressed asar (~100% of the\nmember; its header rewrite alone diverges every block). Storing it keeps unchanged regions byte-identical\nbetween releases, making the delta proportional to what actually changed (measured on a ~32 MB asar: a\none-line source change cost 0.2% instead of 100%).\n\nTrade-off: the installer grows by roughly what compressing the asar saved. Has no effect when\n`differentialPackage` is `false`.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "enum": [
+                "compressed",
+                false,
+                "store-asar",
+                true
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "description": "Marks the package as built with differential download support for the update server, and selects how the\napp package is compressed:\n\n- `false` — no differential download support.\n- `\"store-asar\"` — differential-aware, with the app's `resources/app.asar` stored uncompressed (7-Zip\n  `Copy`) inside the package. The differential updater diffs the *compressed* package with a\n  content-defined blockmap, and the asar is a single compressed member — so any change to app code\n  re-downloads the entire compressed asar (~100% of the member; its header rewrite alone diverges every\n  block). Storing it keeps unchanged regions byte-identical between releases, making the delta\n  proportional to what actually changed (measured on a ~32 MB asar: a one-line source change cost 0.2%\n  instead of 100%). Trade-off: the installer and full package grow by roughly what compressing the asar\n  saved.\n- anything else (`true`, `\"compressed\"`, `null`, unset) — differential-aware, whole package compressed."
         },
         "displayLanguageSelector": {
           "default": false,

--- a/packages/app-builder-lib/scheme.json
+++ b/packages/app-builder-lib/scheme.json
@@ -4362,6 +4362,11 @@
           "description": "Marks the package as built with differential download support for the update server.",
           "type": "boolean"
         },
+        "differentialPackageStoreAsar": {
+          "default": false,
+          "description": "Store the app's `resources/app.asar` uncompressed (7-Zip `Copy`) inside the differential-aware app package.\n\nThe differential updater diffs the *compressed* package with a content-defined blockmap, and the asar is a\nsingle compressed member — so any change to app code re-downloads the entire compressed asar (~100% of the\nmember; its header rewrite alone diverges every block). Storing it keeps unchanged regions byte-identical\nbetween releases, making the delta proportional to what actually changed (measured on a ~32 MB asar: a\none-line source change cost 0.2% instead of 100%).\n\nTrade-off: the installer grows by roughly what compressing the asar saved. Has no effect when\n`differentialPackage` is `false`.",
+          "type": "boolean"
+        },
         "displayLanguageSelector": {
           "default": false,
           "description": "Whether to display a language selection dialog. Not recommended (by default will be detected using OS language).",
@@ -4716,6 +4721,11 @@
         },
         "differentialPackage": {
           "description": "Marks the package as built with differential download support for the update server.",
+          "type": "boolean"
+        },
+        "differentialPackageStoreAsar": {
+          "default": false,
+          "description": "Store the app's `resources/app.asar` uncompressed (7-Zip `Copy`) inside the differential-aware app package.\n\nThe differential updater diffs the *compressed* package with a content-defined blockmap, and the asar is a\nsingle compressed member — so any change to app code re-downloads the entire compressed asar (~100% of the\nmember; its header rewrite alone diverges every block). Storing it keeps unchanged regions byte-identical\nbetween releases, making the delta proportional to what actually changed (measured on a ~32 MB asar: a\none-line source change cost 0.2% instead of 100%).\n\nTrade-off: the installer grows by roughly what compressing the asar saved. Has no effect when\n`differentialPackage` is `false`.",
           "type": "boolean"
         },
         "displayLanguageSelector": {

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -109,7 +109,8 @@ export interface ArchiveOptions {
    * builds, so the delta stays proportional to what actually changed. The stored members are excluded
    * from the main (compressed) pass and appended in a second 7za invocation with `-mx=0`; the
    * `ELECTRON_BUILDER_COMPRESSION_LEVEL` override deliberately does not apply to them (byte-stability
-   * is the point). Paths that do not exist are skipped. Not supported by the native-zip NFD fallback.
+   * is the point), while `preserveSymlinks` and `isArchiveHeaderCompressed` are mirrored into the
+   * append pass. Paths that do not exist are skipped. Not supported by the native-zip NFD fallback.
    */
   storedPaths?: Array<string> | null
 
@@ -291,13 +292,21 @@ export async function archive(format: string, outFile: string, dirToArchive: str
 
     if (storedMembers.length > 0) {
       // Second pass: append the stored members with no compression. -mx=0 unconditionally — the
-      // compression-level env override must not reach these members (see storedPaths docs).
+      // compression-level env override must not reach these members (see storedPaths docs). The
+      // main pass's symlink, timestamp, and header-compression flags are mirrored so the option
+      // stays generic: the append rewrites the archive header and may itself store a symlink.
       const appendArgs = debug7zArgs("a")
       appendArgs.push("-mx=0")
+      if (options.preserveSymlinks) {
+        appendArgs.push("-snl")
+      }
       if (!options.isRegularFile) {
         appendArgs.push("-mtc=off")
       }
       if (format === "7z" || format.endsWith(".7z")) {
+        if (options.isArchiveHeaderCompressed === false) {
+          appendArgs.push("-mhc=off")
+        }
         appendArgs.push("-mtm=off", "-mta=off")
       } else if (format === "zip") {
         appendArgs.push("-mm=Copy", "-mcu")

--- a/packages/app-builder-lib/src/targets/archive.ts
+++ b/packages/app-builder-lib/src/targets/archive.ts
@@ -102,6 +102,18 @@ export interface ArchiveOptions {
   preserveSymlinks?: boolean
 
   /**
+   * Paths, relative to the archived directory, to append as uncompressed (`Copy`) members instead of
+   * compressing them with the rest of the archive. Differential updates diff the *compressed* archive
+   * with a content-defined blockmap, and a large compressed member (an asar) diverges wholesale from
+   * its previous version on any change — storing it keeps unchanged regions byte-identical between
+   * builds, so the delta stays proportional to what actually changed. The stored members are excluded
+   * from the main (compressed) pass and appended in a second 7za invocation with `-mx=0`; the
+   * `ELECTRON_BUILDER_COMPRESSION_LEVEL` override deliberately does not apply to them (byte-stability
+   * is the point). Paths that do not exist are skipped. Not supported by the native-zip NFD fallback.
+   */
+  storedPaths?: Array<string> | null
+
+  /**
    * Restrict the 7z filter to one the install-time extractor (the self-vendored Nsis7z plugin) can
    * decode. Modern 7za (24.09) auto-applies a CPU branch converter to executable content at
    * `-mx>=1` — `BCJ2` on x86/x64 and `ARM64` on arm64 — which that decoder silently skips, dropping
@@ -235,6 +247,22 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     use7z = false
   }
 
+  // Resolve storedPaths before the main pass so they can be excluded from it. Member names are
+  // native-separator, relative to the 7za cwd (which differs with withoutDir), so the same string
+  // works as both the exact `-x!` exclude mask and the append argument.
+  const storedMembers: Array<string> = []
+  for (const storedPath of options.storedPaths ?? []) {
+    if (storedPath.includes("..")) {
+      throw new Error(`Stored archive path contains path traversal sequence: "${storedPath}"`)
+    }
+    if (await exists(path.join(dirToArchive, storedPath))) {
+      storedMembers.push(path.normalize(options.withoutDir ? storedPath : path.join(path.basename(dirToArchive), storedPath)))
+    }
+  }
+  if (storedMembers.length > 0 && !use7z) {
+    throw new Error("storedPaths is not supported with the native zip fallback")
+  }
+
   if (use7z) {
     const args = compute7zCompressArgs(format, options)
     // Modern 7-Zip (24.09) dereferences symlinks by default; the 7-Zip 16.02 bundled before
@@ -247,15 +275,35 @@ export async function archive(format: string, outFile: string, dirToArchive: str
     await unlinkIfExists(outFile)
     args.push(outFile, options.withoutDir ? "." : path.basename(dirToArchive))
     args.push(...buildExcludeArgs(options.excluded, "-xr!"))
+    // `-x!` (exact, non-recursive) so only the member itself is skipped, never a same-named sibling
+    args.push(...storedMembers.map(member => `-x!${member}`))
 
+    const cwd = options.withoutDir ? dirToArchive : path.dirname(dirToArchive)
     try {
-      await exec(await getPath7za(), args, { cwd: options.withoutDir ? dirToArchive : path.dirname(dirToArchive) }, debug7z.enabled)
+      await exec(await getPath7za(), args, { cwd }, debug7z.enabled)
     } catch (e: any) {
       if (e.code === "ENOENT" && !(await exists(dirToArchive))) {
         throw new Error(`Cannot create archive: "${dirToArchive}" doesn't exist`)
       } else {
         throw e
       }
+    }
+
+    if (storedMembers.length > 0) {
+      // Second pass: append the stored members with no compression. -mx=0 unconditionally — the
+      // compression-level env override must not reach these members (see storedPaths docs).
+      const appendArgs = debug7zArgs("a")
+      appendArgs.push("-mx=0")
+      if (!options.isRegularFile) {
+        appendArgs.push("-mtc=off")
+      }
+      if (format === "7z" || format.endsWith(".7z")) {
+        appendArgs.push("-mtm=off", "-mta=off")
+      } else if (format === "zip") {
+        appendArgs.push("-mm=Copy", "-mcu")
+      }
+      appendArgs.push(outFile, ...storedMembers)
+      await exec(await getPath7za(), appendArgs, { cwd }, debug7z.enabled)
     }
   } else {
     // macOS native zip (NFD fallback): -y preserves symlinks

--- a/packages/app-builder-lib/src/targets/win/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/win/nsis/NsisTarget.ts
@@ -121,9 +121,10 @@ export class NsisTarget extends Target {
       // install. Pin the payload to a filter it can decode. See #9983.
       installTimeDecodable: true,
       excluded: preCompressedFileExtensions == null ? null : preCompressedFileExtensions.map(it => `*${it}`),
-      // Opt-in: keep the asar a byte-stable Copy member so a differential update pays only for its
-      // changed blocks instead of re-downloading the whole recompressed asar (see nsisOptions docs).
-      storedPaths: isBuildDifferentialAware && options.differentialPackageStoreAsar === true ? ["resources/app.asar"] : null,
+      // Opt-in via differentialPackage: "store-asar" — keep the asar a byte-stable Copy member so a
+      // differential update pays only for its changed blocks instead of re-downloading the whole
+      // recompressed asar (see nsisOptions docs).
+      storedPaths: isBuildDifferentialAware && options.differentialPackage === "store-asar" ? ["resources/app.asar"] : null,
     }
 
     const timer = time(`nsis package, ${Arch[arch]}`)

--- a/packages/app-builder-lib/src/targets/win/nsis/NsisTarget.ts
+++ b/packages/app-builder-lib/src/targets/win/nsis/NsisTarget.ts
@@ -121,6 +121,9 @@ export class NsisTarget extends Target {
       // install. Pin the payload to a filter it can decode. See #9983.
       installTimeDecodable: true,
       excluded: preCompressedFileExtensions == null ? null : preCompressedFileExtensions.map(it => `*${it}`),
+      // Opt-in: keep the asar a byte-stable Copy member so a differential update pays only for its
+      // changed blocks instead of re-downloading the whole recompressed asar (see nsisOptions docs).
+      storedPaths: isBuildDifferentialAware && options.differentialPackageStoreAsar === true ? ["resources/app.asar"] : null,
     }
 
     const timer = time(`nsis package, ${Arch[arch]}`)

--- a/packages/app-builder-lib/src/targets/win/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/win/nsis/nsisOptions.ts
@@ -212,6 +212,21 @@ export interface NsisOptions extends CommonNsisOptions, CommonWindowsInstallerCo
   readonly differentialPackage?: boolean
 
   /**
+   * Store the app's `resources/app.asar` uncompressed (7-Zip `Copy`) inside the differential-aware app package.
+   *
+   * The differential updater diffs the *compressed* package with a content-defined blockmap, and the asar is a
+   * single compressed member — so any change to app code re-downloads the entire compressed asar (~100% of the
+   * member; its header rewrite alone diverges every block). Storing it keeps unchanged regions byte-identical
+   * between releases, making the delta proportional to what actually changed (measured on a ~32 MB asar: a
+   * one-line source change cost 0.2% instead of 100%).
+   *
+   * Trade-off: the installer grows by roughly what compressing the asar saved. Has no effect when
+   * `differentialPackage` is `false`.
+   * @default false
+   */
+  readonly differentialPackageStoreAsar?: boolean
+
+  /**
    * Whether to display a language selection dialog. Not recommended (by default will be detected using OS language).
    * @default false
    */

--- a/packages/app-builder-lib/src/targets/win/nsis/nsisOptions.ts
+++ b/packages/app-builder-lib/src/targets/win/nsis/nsisOptions.ts
@@ -207,24 +207,22 @@ export interface NsisOptions extends CommonNsisOptions, CommonWindowsInstallerCo
   readonly deleteAppDataOnUninstall?: boolean
 
   /**
-   * Marks the package as built with differential download support for the update server.
-   */
-  readonly differentialPackage?: boolean
-
-  /**
-   * Store the app's `resources/app.asar` uncompressed (7-Zip `Copy`) inside the differential-aware app package.
+   * Marks the package as built with differential download support for the update server, and selects how the
+   * app package is compressed:
    *
-   * The differential updater diffs the *compressed* package with a content-defined blockmap, and the asar is a
-   * single compressed member — so any change to app code re-downloads the entire compressed asar (~100% of the
-   * member; its header rewrite alone diverges every block). Storing it keeps unchanged regions byte-identical
-   * between releases, making the delta proportional to what actually changed (measured on a ~32 MB asar: a
-   * one-line source change cost 0.2% instead of 100%).
-   *
-   * Trade-off: the installer grows by roughly what compressing the asar saved. Has no effect when
-   * `differentialPackage` is `false`.
-   * @default false
+   * - `false` — no differential download support.
+   * - `"store-asar"` — differential-aware, with the app's `resources/app.asar` stored uncompressed (7-Zip
+   *   `Copy`) inside the package. The differential updater diffs the *compressed* package with a
+   *   content-defined blockmap, and the asar is a single compressed member — so any change to app code
+   *   re-downloads the entire compressed asar (~100% of the member; its header rewrite alone diverges every
+   *   block). Storing it keeps unchanged regions byte-identical between releases, making the delta
+   *   proportional to what actually changed (measured on a ~32 MB asar: a one-line source change cost 0.2%
+   *   instead of 100%). Trade-off: the installer and full package grow by roughly what compressing the asar
+   *   saved.
+   * - anything else (`true`, `"compressed"`, `null`, unset) — differential-aware, whole package compressed.
+   * @default true
    */
-  readonly differentialPackageStoreAsar?: boolean
+  readonly differentialPackage?: boolean | "compressed" | "store-asar" | null
 
   /**
    * Whether to display a language selection dialog. Not recommended (by default will be detected using OS language).

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -3,7 +3,7 @@ import { Platform } from "app-builder-lib/src/core"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { afterEach, vi } from "vitest"
-import { listArchiveEntries, listArchiveEntryMethods, listArchiveMethods, NON_DECODABLE_NSIS_FILTER } from "./helpers/archiveHelper"
+import { listArchiveEntries, listArchiveEntryMethods, listArchiveEntryPackedSizes, listArchiveMethods, NON_DECODABLE_NSIS_FILTER } from "./helpers/archiveHelper"
 
 async function makeSrcDir(tmpDir: string, files: Record<string, string> = { "hello.txt": "hello world", "sub/nested.txt": "nested" }): Promise<string> {
   const src = path.join(tmpDir, "src")
@@ -388,7 +388,7 @@ describe("archive() exclude masks", () => {
 // compressed member (the asar) diverges wholesale on any change, so the delta costs the whole
 // member. storedPaths keeps such members byte-identical between builds by excluding them from the
 // compressed pass and appending them with -mx=0 (Copy). NsisTarget wires resources/app.asar through
-// this when nsis.differentialPackageStoreAsar is set.
+// this when nsis.differentialPackage is "store-asar".
 
 describe("archive() storedPaths", { sequential: true }, () => {
   afterEach(() => {
@@ -474,6 +474,83 @@ describe("archive() storedPaths", { sequential: true }, () => {
     const methods = await listArchiveEntryMethods(outFile)
     expect(methods.get("src/resources/app.asar")).toBe("Copy")
     expect((await listArchiveEntries(outFile)).filter(e => e.endsWith("resources/app.asar"))).toHaveLength(1)
+  })
+
+  // The other half of the blockmap property: the append pass must not disturb what the compressed
+  // pass wrote. Asserted at the byte level — an archive built with the asar stored must contain,
+  // verbatim, the file packed streams of an archive built from the same compressed-pass member set
+  // (same files, asar absent). 7z layout: the file packed streams sit back-to-back immediately
+  // after the 32-byte signature header (the — legitimately differing — archive header lives after
+  // them), so [32, 32 + Σ packed sizes) is exactly the compressed pass's stream region, and the
+  // appended Copy member must follow right behind it.
+  test("append pass leaves the compressed pass's packed streams byte-identical", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+    const storedOut = path.join(tmpDirPath, "with-stored.7z")
+    await archive("7z", storedOut, dir, { withoutDir: true, storedPaths: ["resources/app.asar"] })
+
+    // Baseline: the compressed pass's exact member set — same files with the asar absent, keeping
+    // the (now empty) resources directory entry the -x! exclude leaves behind.
+    const baselineDir = path.join(tmpDirPath, "baseline-src")
+    await fs.mkdir(path.join(baselineDir, "resources"), { recursive: true })
+    await fs.writeFile(path.join(baselineDir, "app.txt"), appFiles["app.txt"])
+    const baselineOut = path.join(tmpDirPath, "baseline.7z")
+    await archive("7z", baselineOut, baselineDir, { withoutDir: true })
+
+    const packedStreamsEnd = [...(await listArchiveEntryPackedSizes(baselineOut)).values()].reduce((sum, size) => sum + size, 0)
+    expect(packedStreamsEnd).toBeGreaterThan(0)
+
+    const storedBytes = await fs.readFile(storedOut)
+    const baselineBytes = await fs.readFile(baselineOut)
+    expect(storedBytes.subarray(32, 32 + packedStreamsEnd).equals(baselineBytes.subarray(32, 32 + packedStreamsEnd))).toBe(true)
+    // …and the stored member's verbatim bytes start exactly where the compressed streams end.
+    const asarBytes = await fs.readFile(path.join(dir, "resources", "app.asar"))
+    expect(storedBytes.indexOf(asarBytes)).toBe(32 + packedStreamsEnd)
+  })
+
+  // The append pass rewrites the archive's end header, so it must honor the same header-compression
+  // setting as the main pass. An uncompressed end header starts with the kHeader marker (0x01);
+  // a compressed one with kEncodedHeader (0x17). The default-settings archive guards against the
+  // assertion passing vacuously (tiny headers could conceivably skip encoding).
+  test("append pass mirrors isArchiveHeaderCompressed=false into the final header", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+
+    const endHeaderMarker = async (outFile: string) => {
+      const bytes = await fs.readFile(outFile)
+      return bytes[32 + Number(bytes.readBigUInt64LE(12))]
+    }
+
+    const plainHeaderOut = path.join(tmpDirPath, "plain-header.7z")
+    await archive("7z", plainHeaderOut, dir, { withoutDir: true, isArchiveHeaderCompressed: false, storedPaths: ["resources/app.asar"] })
+    expect(await endHeaderMarker(plainHeaderOut)).toBe(0x01)
+
+    const defaultHeaderOut = path.join(tmpDirPath, "default-header.7z")
+    await archive("7z", defaultHeaderOut, dir, { withoutDir: true, storedPaths: ["resources/app.asar"] })
+    expect(await endHeaderMarker(defaultHeaderOut)).toBe(0x17)
+  })
+
+  // The append pass must also honor preserveSymlinks (-snl): a stored path that is itself a symlink
+  // stays a link instead of being dereferenced into a copy of its target. The link target is a
+  // sibling (not `../…`) because 7za refuses to extract parent-escaping link targets.
+  test.ifNotWindows("append pass mirrors preserveSymlinks for a stored symlink member", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, { "app.txt": appFiles["app.txt"], "resources/real.asar": appFiles["resources/app.asar"] })
+    await fs.symlink("real.asar", path.join(dir, "resources", "app.asar"))
+
+    const outFile = path.join(tmpDirPath, "stored-symlink.7z")
+    await archive("7z", outFile, dir, { withoutDir: true, preserveSymlinks: true, storedPaths: ["resources/app.asar"] })
+
+    const extractDir = path.join(tmpDirPath, "extracted-stored-symlink")
+    await fs.mkdir(extractDir, { recursive: true })
+    const { getPath7za } = await import("app-builder-lib/src/toolsets/7zip")
+    const { exec: cpExec } = await import("child_process")
+    const { promisify } = await import("util")
+    await promisify(cpExec)(`"${await getPath7za()}" x -o"${extractDir}" "${outFile}"`)
+
+    const linkStat = await fs.lstat(path.join(extractDir, "resources", "app.asar"))
+    expect(linkStat.isSymbolicLink()).toBe(true)
+    expect(await fs.readlink(path.join(extractDir, "resources", "app.asar"))).toBe("real.asar")
   })
 
   // Byte-stability is the point: the compression-level override must not recompress stored members.

--- a/test/src/archiveUtilTest.ts
+++ b/test/src/archiveUtilTest.ts
@@ -3,7 +3,7 @@ import { Platform } from "app-builder-lib/src/core"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { afterEach, vi } from "vitest"
-import { listArchiveEntries, listArchiveMethods, NON_DECODABLE_NSIS_FILTER } from "./helpers/archiveHelper"
+import { listArchiveEntries, listArchiveEntryMethods, listArchiveMethods, NON_DECODABLE_NSIS_FILTER } from "./helpers/archiveHelper"
 
 async function makeSrcDir(tmpDir: string, files: Record<string, string> = { "hello.txt": "hello world", "sub/nested.txt": "nested" }): Promise<string> {
   const src = path.join(tmpDir, "src")
@@ -380,5 +380,110 @@ describe("archive() exclude masks", () => {
       entries.some(e => e.endsWith(".log")),
       `no *.log should remain, got: ${entries.join(", ")}`
     ).toBe(false)
+  })
+})
+
+// ─── archive() — storedPaths (differential-friendly Copy members) ────────────
+// The differential updater diffs the *compressed* archive with a content-defined blockmap; a large
+// compressed member (the asar) diverges wholesale on any change, so the delta costs the whole
+// member. storedPaths keeps such members byte-identical between builds by excluding them from the
+// compressed pass and appending them with -mx=0 (Copy). NsisTarget wires resources/app.asar through
+// this when nsis.differentialPackageStoreAsar is set.
+
+describe("archive() storedPaths", { sequential: true }, () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  const appFiles = {
+    "app.txt": "compressible ".repeat(2000),
+    "resources/app.asar": "asar-payload-".repeat(2000),
+  }
+
+  test("stored member is appended with Copy while the rest stays compressed", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+    const outFile = path.join(tmpDirPath, "stored.7z")
+    await archive("7z", outFile, dir, { withoutDir: true, solid: false, storedPaths: ["resources/app.asar"] })
+
+    const methods = await listArchiveEntryMethods(outFile)
+    expect(methods.get("resources/app.asar")).toBe("Copy")
+    expect(methods.get("app.txt")).toMatch(/LZMA/)
+    // exactly once: excluded from the compressed pass, added only by the append pass
+    const entries = await listArchiveEntries(outFile)
+    expect(entries.filter(e => e === "resources/app.asar")).toHaveLength(1)
+  })
+
+  // The blockmap-relevant property, asserted directly: a Copy member's payload sits verbatim in the
+  // archive, so regions of it that don't change between releases stay byte-identical (downloadable
+  // as ranges of the old file). A recompressed member would never contain the raw bytes.
+  test("stored member's raw bytes appear verbatim in the archive", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+    const outFile = path.join(tmpDirPath, "verbatim.7z")
+    await archive("7z", outFile, dir, { withoutDir: true, storedPaths: ["resources/app.asar"] })
+
+    const asarBytes = await fs.readFile(path.join(dir, "resources", "app.asar"))
+    const archiveBytes = await fs.readFile(outFile)
+    expect(archiveBytes.includes(asarBytes)).toBe(true)
+  })
+
+  test("works with the exact differential-aware NSIS options (Copy is install-time decodable)", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+    const outFile = path.join(tmpDirPath, "differential.7z")
+    // the options NsisTarget passes for a differential-aware app package
+    // (configureDifferentialAwareArchiveOptions + installTimeDecodable) plus storedPaths
+    await archive("7z", outFile, dir, {
+      withoutDir: true,
+      installTimeDecodable: true,
+      dictSize: 1,
+      solid: false,
+      compression: "normal",
+      storedPaths: ["resources/app.asar"],
+    })
+
+    const methods = await listArchiveEntryMethods(outFile)
+    expect(methods.get("resources/app.asar")).toBe("Copy")
+    expect([...methods.values()].join("\n")).not.toMatch(NON_DECODABLE_NSIS_FILTER)
+  })
+
+  test("stored paths that do not exist are skipped", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+    const outFile = path.join(tmpDirPath, "missing.7z")
+    await archive("7z", outFile, dir, { withoutDir: true, storedPaths: ["resources/app.asar", "missing.bin"] })
+
+    const entries = await listArchiveEntries(outFile)
+    expect(entries).not.toContain("missing.bin")
+    expect((await listArchiveEntryMethods(outFile)).get("resources/app.asar")).toBe("Copy")
+  })
+
+  test("stored path with '..' throws", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+    await expect(archive("7z", path.join(tmpDirPath, "traversal.7z"), dir, { withoutDir: true, storedPaths: ["../secret"] })).rejects.toThrow("path traversal sequence")
+  })
+
+  test("without withoutDir the stored member is prefixed with the directory name", async ({ expect, tmpDir }) => {
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles) // lands at <tmp>/src
+    const outFile = path.join(tmpDirPath, "prefixed.7z")
+    await archive("7z", outFile, dir, { storedPaths: ["resources/app.asar"] })
+
+    const methods = await listArchiveEntryMethods(outFile)
+    expect(methods.get("src/resources/app.asar")).toBe("Copy")
+    expect((await listArchiveEntries(outFile)).filter(e => e.endsWith("resources/app.asar"))).toHaveLength(1)
+  })
+
+  // Byte-stability is the point: the compression-level override must not recompress stored members.
+  test("ELECTRON_BUILDER_COMPRESSION_LEVEL does not reach stored members", async ({ expect, tmpDir }) => {
+    vi.stubEnv("ELECTRON_BUILDER_COMPRESSION_LEVEL", "9")
+    const tmpDirPath = await tmpDir.createTempDir()
+    const dir = await makeSrcDir(tmpDirPath, appFiles)
+    const outFile = path.join(tmpDirPath, "env-override.7z")
+    await archive("7z", outFile, dir, { withoutDir: true, storedPaths: ["resources/app.asar"] })
+
+    expect((await listArchiveEntryMethods(outFile)).get("resources/app.asar")).toBe("Copy")
   })
 })

--- a/test/src/helpers/archiveHelper.ts
+++ b/test/src/helpers/archiveHelper.ts
@@ -40,6 +40,26 @@ export async function listArchiveMethods(archivePath: string): Promise<Array<str
     .filter(method => method.length > 0)
 }
 
+// Maps each entry path to its `Packed Size` from the `-slt` technical listing (the archive-level
+// summary block is skipped). In a 7z archive the file packed streams sit back-to-back right after
+// the 32-byte signature header, so the sum of these is the size of the packed-streams region.
+export async function listArchiveEntryPackedSizes(archivePath: string): Promise<Map<string, number>> {
+  const stdout = await exec(await getPath7za(), ["l", "-slt", archivePath])
+  const archiveAsEntry = archivePath.replace(/\\/g, "/")
+  const result = new Map<string, number>()
+  let current: string | null = null
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.startsWith("Path = ")) {
+      const entry = line.slice("Path = ".length).trim().replace(/\\/g, "/")
+      current = entry === archiveAsEntry ? null : entry
+    } else if (line.startsWith("Packed Size = ") && current != null) {
+      const value = line.slice("Packed Size = ".length).trim()
+      result.set(current, value.length === 0 ? 0 : parseInt(value, 10))
+    }
+  }
+  return result
+}
+
 // Maps each entry path to its reported codec (the `Path = …` line followed by that entry's
 // `Method = …` line in the `-slt` technical listing). The archive-level summary block (whose Path
 // is the archive file itself) is skipped. Entries stored with no compression report `Copy`.

--- a/test/src/helpers/archiveHelper.ts
+++ b/test/src/helpers/archiveHelper.ts
@@ -39,3 +39,22 @@ export async function listArchiveMethods(archivePath: string): Promise<Array<str
     .map(line => line.slice("Method = ".length).trim())
     .filter(method => method.length > 0)
 }
+
+// Maps each entry path to its reported codec (the `Path = …` line followed by that entry's
+// `Method = …` line in the `-slt` technical listing). The archive-level summary block (whose Path
+// is the archive file itself) is skipped. Entries stored with no compression report `Copy`.
+export async function listArchiveEntryMethods(archivePath: string): Promise<Map<string, string>> {
+  const stdout = await exec(await getPath7za(), ["l", "-slt", archivePath])
+  const archiveAsEntry = archivePath.replace(/\\/g, "/")
+  const result = new Map<string, string>()
+  let current: string | null = null
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.startsWith("Path = ")) {
+      const entry = line.slice("Path = ".length).trim().replace(/\\/g, "/")
+      current = entry === archiveAsEntry ? null : entry
+    } else if (line.startsWith("Method = ") && current != null) {
+      result.set(current, line.slice("Method = ".length).trim())
+    }
+  }
+  return result
+}

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -120,7 +120,7 @@ asar:
 : The downloaded update file is corrupt or the wrong file is being served. Verify that the artifact and the `.yml` metadata file were generated together in the same build and not mixed from different builds. As of electron-builder 27, the manifest `sha512` should be base64-encoded — a 128-hex-character "expected" value in the error message is the tell that a hand-rolled manifest still uses hex, which is accepted but deprecated in v27 and will be removed in v28; convert it with `sha512sum file.ext | cut -d' ' -f1 | xxd -r -p | base64 -w0`.
 
 **Delta updates (AppImage / NSIS-Web) fail**
-: For AppImage delta updates, electron-builder embeds a blockmap directly in the AppImage binary — no separate file needs to be published. If delta updates aren't working, verify the AppImage was built with electron-builder and that a publish provider is configured. For NSIS differential packages, `nsis.differentialPackage` must be `true`.
+: For AppImage delta updates, electron-builder embeds a blockmap directly in the AppImage binary — no separate file needs to be published. If delta updates aren't working, verify the AppImage was built with electron-builder and that a publish provider is configured. For NSIS differential packages, `nsis.differentialPackage` must not be `false` (any other value — `true`, `"compressed"`, `"store-asar"`, or unset — builds a differential-aware package; `"store-asar"` additionally stores `resources/app.asar` uncompressed so app-code deltas stay proportional to what changed).
 
 ---
 


### PR DESCRIPTION
**Before:** The differential updater diffs the compressed NSIS package with a content-defined blockmap, and `resources/app.asar` is a single LZMA member. Any app-code change, even one line, rewrites the asar header and shifts every compressed block, so users re-download the entire asar on every release (measured: 536,260 B, 100% of the member, for a one-line renderer change on a ~32 MB asar).

**After:** With `nsis.differentialPackage: "store-asar"`, the asar is stored uncompressed (7-Zip `Copy`) inside the package. Unchanged regions stay byte-identical between releases, so the same one-line change costs 81,857 B (~3% of the asar). The trade-off, and why it is opt-in: the installer and full package grow by roughly what LZMA saved on the asar (30.8 MB to 33.1 MB here).

Apps whose releases are mostly app-code changes currently get little benefit from differential updates; this makes the delta proportional to what actually changed.

**How:** A generic `ArchiveOptions.storedPaths` in `archive()`. Listed paths are excluded from the compressed pass with exact `-x!` masks, then appended in a second 7za invocation with `-mx=0`, mirroring the first pass's `-snl` / `-mhc=off` flags so the final header matches. The append leaves the first pass's packed streams byte-identical. `ELECTRON_BUILDER_COMPRESSION_LEVEL` deliberately does not reach stored members. `Copy` needs no 7z filter, so members stay decodable by the install-time Nsis7z extractor. `NsisTarget` wires `resources/app.asar` through it when the package is differential-aware.

Config semantics (`nsis.differentialPackage`, default `true`):
- `false`: no differential download support (unchanged).
- `true` / `"compressed"` / unset: differential-aware, whole package compressed (today's behaviour).
- `"store-asar"`: differential-aware, asar stored uncompressed.

Misspelled values fail schema validation and the error lists the accepted values.

**Testing:** `archiveUtilTest`: `archive() storedPaths` (stored member appended as Copy while the rest stays compressed; raw bytes appear verbatim; exact differential-aware NSIS options; missing stored paths skipped; `..` throws; withoutDir prefixing; append pass leaves packed streams byte-identical; mirrors `isArchiveHeaderCompressed=false`; mirrors `preserveSymlinks`; `ELECTRON_BUILDER_COMPRESSION_LEVEL` does not reach stored members) and `archive() exclude masks`, all against real 7za.

**Changeset:** `app-builder-lib`: minor.