### PR TITLE
docs: EV certificates no longer skip the SmartScreen reputation period

### DIFF
--- a/website/docs/features/code-signing/code-signing-win.md
+++ b/website/docs/features/code-signing/code-signing-win.md
@@ -20,7 +20,7 @@ electron-builder offers several signing backends, selected by the `type` field o
 For file- or store-based signing you need a Windows code signing certificate from a CA (DigiCert, Sectigo, SSL.com, …). They come in two grades:
 
 - **OV (Organization Validation)** — the common, lower-cost option. New publishers see a SmartScreen "unknown publisher" warning during install that fades as your download reputation grows. OV certificates export to a `.pfx`, so they work in CI with the `signtool` method.
-- **EV (Extended Validation)** — earns SmartScreen reputation immediately, but its private key is bound to a hardware token and **cannot** be exported to a file. Identify an EV certificate by `certificateSubjectName` or `certificateSha1` rather than a file path, and sign with the `hsm` (Windows) or `pkcs11` (macOS/Linux) method — or switch to `azure` to avoid managing hardware at all.
+- **EV (Extended Validation)** — since 2024 no longer earns SmartScreen reputation immediately; Microsoft treats EV and OV code signing certificates the same for SmartScreen ([details](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/distribution-feature-status#smartscreen-reputation-ev-certificates-no-longer-grant-instant-bypass)). Its private key is bound to a hardware token and **cannot** be exported to a file. Identify an EV certificate by `certificateSubjectName` or `certificateSha1` rather than a file path, and sign with the `hsm` (Windows) or `pkcs11` (macOS/Linux) method — or switch to `azure` to avoid managing hardware at all.
 
 Both grades work with auto-update.
 

--- a/website/docs/features/code-signing/code-signing.md
+++ b/website/docs/features/code-signing/code-signing.md
@@ -7,8 +7,8 @@ Code signing proves your application's identity and confirms it hasn't been tamp
 | Platform | Without Signing | With Signing |
 |---|---|---|
 | macOS | Gatekeeper blocks app; user must override in System Preferences | Runs normally; no warning |
-| Windows | SmartScreen warning on first run ("Unknown publisher") | Trusted install; SmartScreen learns from reputation |
-| Windows (EV cert) | N/A | Instant trust, no reputation period needed |
+| Windows | SmartScreen warning on first run ("Unknown publisher") | Publisher name shown; SmartScreen warning until reputation builds |
+| Windows (EV cert) | N/A | Same as OV since 2024 — no instant trust (see [Windows Code Signing](code-signing-win.md)) |
 
 On **macOS 10.15+**, notarization is additionally required for apps distributed outside the Mac App Store. An app that is code-signed but not notarized will be blocked by Gatekeeper unless the user explicitly overrides it.
 
@@ -39,9 +39,9 @@ All Apple certificates require membership in the [Apple Developer Program](https
 
 | Certificate Type | Trust | CI/CD Compatible | Notes |
 |---|---|---|---|
-| Standard OV Certificate | After reputation builds (days-weeks) | Yes (exportable `.pfx`) | Most common choice |
-| EV (Extended Validation) Certificate | Immediate | Yes, via a hardware-token method | Key bound to a hardware dongle/HSM; not exportable to a file |
-| Azure Trusted Signing | Immediate | Yes | Microsoft's cloud signing service; see [code-signing-win.md](code-signing-win.md) |
+| Standard OV Certificate | After reputation builds (weeks) | Yes (exportable `.pfx`) | Most common choice |
+| EV (Extended Validation) Certificate | After reputation builds — same as OV since 2024 | Yes, via a hardware-token method | Key bound to a hardware dongle/HSM; not exportable to a file |
+| Azure Trusted Signing | After reputation builds | Yes | Microsoft's cloud signing service; see [code-signing-win.md](code-signing-win.md). Microsoft: it "does not provide instant SmartScreen trust" ([source](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options)) |
 
 For Windows, purchase from any major CA (DigiCert, Sectigo, SSL.com). See [Get a Code Signing Certificate](https://msdn.microsoft.com/windows/hardware/drivers/dashboard/get-a-code-signing-certificate) (select "Microsoft Authenticode" platform).
 
@@ -188,7 +188,7 @@ Without this option, electron-builder proceeds without signing if no credentials
 : The `publisher` in `appx` config must exactly match the Subject of the certificate. Copy it from the certificate properties.
 
 **SmartScreen warning appears even after signing** (Windows)
-: Normal for standard OV certificates. SmartScreen trust builds over time based on download count. EV certificates skip this reputation period. See [Windows Code Signing](code-signing-win.md).
+: Normal for any certificate. SmartScreen trust builds over time from downloads of the file and of other files signed with the same certificate; since 2024, EV certificates no longer skip this period ([Microsoft](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/distribution-feature-status#smartscreen-reputation-ev-certificates-no-longer-grant-instant-bypass)). See [Windows Code Signing](code-signing-win.md).
 
 **"Command requires admin privileges"** (Windows)
 : Some signing tools require elevated permissions. Run from an elevated prompt or check CI runner permissions.

--- a/website/docs/glossary.md
+++ b/website/docs/glossary.md
@@ -52,7 +52,7 @@ Quick reference for terms used throughout the electron-builder documentation.
 : macOS security declarations that grant your app specific capabilities. Required when Hardened Runtime is enabled. Stored in `.plist` XML files referenced by `mac.sign.entitlements` and `mac.sign.entitlementsInherit`. Examples: `com.apple.security.cs.allow-jit` (required by Electron), `com.apple.security.network.client` (outbound networking).
 
 **EV Certificate (Extended Validation)**
-: A Windows code signing certificate with higher trust than standard OV certificates. EV certificates are physically bound to a USB security key and cannot be exported — which makes them incompatible with most CI/CD systems. SmartScreen immediately trusts EV-signed installers without requiring a reputation-building period.
+: A Windows code signing certificate with higher trust than standard OV certificates. EV certificates are physically bound to a USB security key and cannot be exported — which makes them incompatible with most CI/CD systems. Since 2024, SmartScreen no longer treats EV-signed installers differently from OV-signed ones; both build reputation over time.
 
 ---
 
@@ -146,7 +146,7 @@ Quick reference for terms used throughout the electron-builder documentation.
 : The name of a code signing certificate as it appears in the macOS Keychain (e.g., `Developer ID Application: My Company (ABCDE12345)`). Referenced by `CSC_NAME` or `mac.sign.identity` in electron-builder config.
 
 **SmartScreen**
-: Windows Defender's application reputation service. It warns users when they run unsigned apps or apps from publishers with low download reputation. EV certificates bypass the reputation-building period; standard OV certificates require time.
+: Windows Defender's application reputation service. It warns users when they run unsigned apps or apps from publishers with low download reputation. Since 2024, no certificate type bypasses the reputation-building period; EV and OV certificates both require time.
 
 **Snap**
 : Canonical's Linux packaging format, primarily for Ubuntu. Snap apps run in a sandbox with declared "interface plugs" controlling system access. electron-builder's `snap` target produces Snap packages for Snap Store distribution. See [Snap](snap.md).


### PR DESCRIPTION
Docs only. The code-signing pages say an EV certificate gives "instant trust" / "immediate" SmartScreen reputation and "skips the reputation period". That stopped being true in 2024: Microsoft removed the special handling of EV code-signing certificates from its Trusted Root Program (no longer recognised from February 2024, EV OIDs removed from roots in August 2024), and its developer docs now state that EV and OV certificates build SmartScreen reputation the same way.

Changes:
- `features/code-signing/code-signing.md`: the platform table, the certificate-type table, and the "SmartScreen warning appears even after signing" troubleshooting entry. The Azure Trusted Signing row also said "Immediate"; Microsoft's own page says it "does not provide instant SmartScreen trust", so that cell is corrected too with the citation.
- `features/code-signing/code-signing-win.md`: the OV vs. EV bullet.
- `glossary.md`: the EV Certificate and SmartScreen entries.

Sources (all Microsoft):
- Trusted Root Program requirements, §3.D.3: https://learn.microsoft.com/en-us/security/trusted-root/program-requirements
- "Current status of Windows app distribution features": https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/distribution-feature-status#smartscreen-reputation-ev-certificates-no-longer-grant-instant-bypass
- "SmartScreen reputation for Windows app developers": https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation
- "Code signing options for Windows app developers" (Azure Trusted Signing row): https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options

No changeset: no published package is affected.
