### PR TITLE
fix(updater): make multi-range differential downloads work on real servers

### DIFF
--- a/.changeset/differential-multipart-parsing.md
+++ b/.changeset/differential-multipart-parsing.md
@@ -1,0 +1,9 @@
+---
+"electron-updater": patch
+---
+
+fix: make multi-range differential downloads work on real servers. Three independent defects made `downloadUpdate` fall back to a full download with `Response ends without calling any handlers`:
+
+- `DataSplitter` only recognised CRLF. Some CDNs answer `multipart/byteranges` with bare LF line endings, so no part was ever split and the whole response accumulated in memory. Header lists now end at whichever of `\r\n\r\n` / `\n\n` comes first, and the `<EOL>--boundary` separator size follows the line ending the server actually uses.
+- A header-list terminator split across two chunks was never found: only the new chunk was searched, the buffered bytes never were, so the parser locked onto the next part's header instead. Only the last few bytes of an unfinished header list are now carried over and searched together with the next chunk, instead of accumulating the whole list.
+- The 10s watchdog armed when a batch response ends was never disarmed after that batch succeeded. With more than 1000 operations (several range requests) it failed the whole download whenever a later batch took longer than the grace period.

--- a/packages/electron-updater/src/differentialDownloader/DataSplitter.ts
+++ b/packages/electron-updater/src/differentialDownloader/DataSplitter.ts
@@ -5,7 +5,33 @@ import { Writable } from "stream"
 import { Operation, OperationKind } from "./downloadPlanBuilder.js"
 import { ProgressInfo } from "./ProgressDifferentialDownloadCallbackTransform.js"
 
-const DOUBLE_CRLF = Buffer.from("\r\n\r\n")
+const CRLF_HEADER_LIST_END = Buffer.from("\r\n\r\n")
+// RFC 2046 requires CRLF, but some CDNs (e.g. Qiniu's "web cache") emit bare LF in multipart/byteranges responses.
+const LF_HEADER_LIST_END = Buffer.from("\n\n")
+// A terminator may be split across two chunks: keep this many trailing bytes of an unfinished header list.
+const HEADER_LIST_END_CARRY = CRLF_HEADER_LIST_END.length - 1
+// Parts are separated by "<EOL>--boundary"; these are the sizes of the "<EOL>--" prefix.
+const CRLF_DELIMITER_PREFIX_LENGTH = "\r\n--".length
+const LF_DELIMITER_PREFIX_LENGTH = "\n--".length
+
+interface HeaderListEnd {
+  // offset just past the terminator
+  readonly end: number
+  readonly lineFeedOnly: boolean
+}
+
+function findHeaderListEnd(data: Buffer): HeaderListEnd | null {
+  const crlf = data.indexOf(CRLF_HEADER_LIST_END)
+  // "\r\n\r\n" never contains "\n\n", so whichever terminator comes first tells the line ending in use
+  const lf = data.indexOf(LF_HEADER_LIST_END)
+  if (lf !== -1 && (crlf === -1 || lf < crlf)) {
+    return { end: lf + LF_HEADER_LIST_END.length, lineFeedOnly: true }
+  }
+  if (crlf !== -1) {
+    return { end: crlf + CRLF_HEADER_LIST_END.length, lineFeedOnly: false }
+  }
+  return null
+}
 
 enum ReadState {
   INIT,
@@ -47,12 +73,16 @@ export class DataSplitter extends Writable {
 
   partIndex = -1
 
-  private headerListBuffer: Buffer | null = null
+  // Trailing bytes (at most HEADER_LIST_END_CARRY) of a header list that is not complete yet. Header lists are ignored,
+  // so nothing more needs to be kept — only enough to find a terminator that straddles two chunks.
+  private headerListTail: Buffer | null = null
   private readState = ReadState.INIT
   private ignoreByteCount = 0
   private remainingPartDataCount = 0
 
-  private readonly boundaryLength: number
+  private readonly boundaryTextLength: number
+  // size of "<EOL>--boundary" between parts; corrected once the line ending used by the server is known
+  private boundaryLength: number
 
   constructor(
     private readonly out: Writable,
@@ -67,6 +97,7 @@ export class DataSplitter extends Writable {
   ) {
     super()
 
+    this.boundaryTextLength = boundary.length
     this.boundaryLength = boundary.length + 4 /* size of \r\n-- */
     // first chunk doesn't start with \r\n
     this.ignoreByteCount = this.boundaryLength - 2
@@ -136,8 +167,6 @@ export class DataSplitter extends Writable {
 
       start = headerListEnd
       this.readState = ReadState.BODY
-      // header list is ignored, we don't need it
-      this.headerListBuffer = null
     }
 
     while (true) {
@@ -217,18 +246,20 @@ export class DataSplitter extends Writable {
   }
 
   private searchHeaderListEnd(chunk: Buffer, readOffset: number): number {
-    const headerListEnd = chunk.indexOf(DOUBLE_CRLF, readOffset)
-    if (headerListEnd !== -1) {
-      return headerListEnd + DOUBLE_CRLF.length
+    const tail = this.headerListTail
+    const carried = tail == null ? 0 : tail.length
+    const data = tail == null ? chunk.subarray(readOffset) : Buffer.concat([tail, chunk.subarray(readOffset)])
+    const found = findHeaderListEnd(data)
+    if (found != null) {
+      this.headerListTail = null
+      // the separator size follows the line ending the server actually uses
+      this.boundaryLength = this.boundaryTextLength + (found.lineFeedOnly ? LF_DELIMITER_PREFIX_LENGTH : CRLF_DELIMITER_PREFIX_LENGTH)
+      // the carried bytes were already searched, so the terminator always ends inside the current chunk
+      return readOffset + found.end - carried
     }
 
-    // not all headers data were received, save to buffer
-    const partialChunk = readOffset === 0 ? chunk : chunk.slice(readOffset)
-    if (this.headerListBuffer == null) {
-      this.headerListBuffer = partialChunk
-    } else {
-      this.headerListBuffer = Buffer.concat([this.headerListBuffer, partialChunk])
-    }
+    // not all headers data were received; copy the tail so the chunk itself is not retained
+    this.headerListTail = Buffer.from(data.subarray(Math.max(0, data.length - HEADER_LIST_END_CARRY)))
     return -1
   }
 

--- a/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
+++ b/packages/electron-updater/src/differentialDownloader/multipleRangeDownloader.ts
@@ -107,13 +107,27 @@ function doExecuteTasks(differentialDownloader: DifferentialDownloader, options:
       return
     }
 
+    // The watchdog below only exists for a response that ends before every part was handled. It must not outlive a
+    // successful batch: the next batch reuses the same `reject`, so a stale watchdog used to fail any multi-batch
+    // download whose later batches took longer than the grace period.
+    let isBatchFinished = false
+    let watchdog: ReturnType<typeof setTimeout> | null = null
+    const onBatchFinished = (): void => {
+      isBatchFinished = true
+      if (watchdog != null) {
+        clearTimeout(watchdog)
+        watchdog = null
+      }
+      resolve()
+    }
+
     const dicer = new DataSplitter(
       out,
       options,
       partIndexToTaskIndex,
       m[1] || m[2],
       partIndexToLength,
-      resolve,
+      onBatchFinished,
       grandTotalBytes,
       differentialDownloader.options.onProgress,
       differentialDownloader.logger
@@ -122,7 +136,14 @@ function doExecuteTasks(differentialDownloader: DifferentialDownloader, options:
     response.pipe(dicer)
 
     response.on("end", () => {
-      setTimeout(() => {
+      if (isBatchFinished) {
+        return
+      }
+      watchdog = setTimeout(() => {
+        watchdog = null
+        if (isBatchFinished) {
+          return
+        }
         request.abort()
         reject(new Error("Response ends without calling any handlers"))
       }, 10000)

--- a/test/src/updater/differentialMultipartTest.ts
+++ b/test/src/updater/differentialMultipartTest.ts
@@ -1,0 +1,244 @@
+import { DataSplitter, PartListDataTask } from "electron-updater/src/differentialDownloader/DataSplitter"
+import { Operation, OperationKind } from "electron-updater/src/differentialDownloader/downloadPlanBuilder"
+import { executeTasksUsingMultipleRangeRequests } from "electron-updater/src/differentialDownloader/multipleRangeDownloader"
+import { closeSync, mkdtempSync, openSync, rmSync, writeFileSync } from "fs"
+import { createServer, IncomingMessage, request as httpRequest, RequestOptions, Server, ServerResponse } from "http"
+import { AddressInfo } from "net"
+import { tmpdir } from "os"
+import * as path from "path"
+import { Writable } from "stream"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+// Deterministic, non-repeating content so a misaligned part cannot accidentally produce the expected bytes.
+function patternBuffer(size: number, seed: number): Buffer {
+  const buffer = Buffer.alloc(size)
+  let x = seed
+  for (let i = 0; i < size; i++) {
+    x = (x * 1103515245 + 12345) & 0x7fffffff
+    buffer[i] = x >> 16
+  }
+  return buffer
+}
+
+// Alternating DOWNLOAD / COPY operations covering [0, fileSize); sizes vary so parts do not line up with chunk sizes.
+function makeTasks(count: number, fileSize: number): Array<Operation> {
+  const tasks: Array<Operation> = []
+  const step = Math.floor(fileSize / count)
+  for (let i = 0; i < count; i++) {
+    const start = i * step
+    const end = i === count - 1 ? fileSize : start + step
+    tasks.push({ kind: i % 2 === 0 ? OperationKind.DOWNLOAD : OperationKind.COPY, start, end })
+  }
+  return tasks
+}
+
+interface MultipartOptions {
+  readonly eol: "\r\n" | "\n"
+  readonly boundary: string
+  readonly leadingEol: boolean
+}
+
+// Builds a multipart/byteranges body the way servers do: every part is "<EOL>--boundary<EOL>headers<EOL><EOL>data".
+function multipartBody(ranges: Array<[number, number]>, newFile: Buffer, options: MultipartOptions): Buffer {
+  const { eol, boundary } = options
+  const chunks: Array<Buffer> = []
+  ranges.forEach(([start, endInclusive], index) => {
+    const lead = index === 0 && !options.leadingEol ? "" : eol
+    chunks.push(Buffer.from(`${lead}--${boundary}${eol}Content-Type: application/octet-stream${eol}Content-Range: bytes ${start}-${endInclusive}/${newFile.length}${eol}${eol}`))
+    chunks.push(newFile.subarray(start, endInclusive + 1))
+  })
+  chunks.push(Buffer.from(`${eol}--${boundary}--${eol}`))
+  return Buffer.concat(chunks)
+}
+
+function collector(): { out: Writable; data: () => Buffer } {
+  const received: Array<Buffer> = []
+  const out = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      received.push(Buffer.from(chunk))
+      callback()
+    },
+  })
+  return { out, data: () => Buffer.concat(received) }
+}
+
+function expectedOutput(tasks: Array<Operation>, oldFile: Buffer, newFile: Buffer): Buffer {
+  return Buffer.concat(tasks.map(task => (task.kind === OperationKind.COPY ? oldFile : newFile).subarray(task.start, task.end)))
+}
+
+describe("differential multipart download", () => {
+  const fileSize = 8 * 1024
+  const newFile = patternBuffer(fileSize, 1)
+  const oldFile = patternBuffer(fileSize, 2)
+  let dir: string
+  let oldFileFd: number
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "differential-multipart-"))
+    const oldFilePath = path.join(dir, "old.bin")
+    writeFileSync(oldFilePath, oldFile)
+    oldFileFd = openSync(oldFilePath, "r")
+  })
+
+  afterEach(() => {
+    closeSync(oldFileFd)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // Feeds `body` in `chunkSize` pieces and resolves once the splitter reports the batch finished.
+  async function split(tasks: Array<Operation>, body: Buffer, boundary: string, chunkSize: number): Promise<Buffer> {
+    const options: PartListDataTask = { oldFileFd, tasks, start: 0, end: tasks.length }
+    const partIndexToTaskIndex = new Map<number, number>()
+    const partIndexToLength: Array<number> = []
+    tasks.forEach((task, index) => {
+      if (task.kind === OperationKind.DOWNLOAD) {
+        partIndexToTaskIndex.set(partIndexToLength.length, index)
+        partIndexToLength.push(task.end - task.start)
+      }
+    })
+
+    const { out, data } = collector()
+    let finishedCount = 0
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`splitter did not finish (chunk size ${chunkSize})`)), 5000)
+      const splitter = new DataSplitter(
+        out,
+        options,
+        partIndexToTaskIndex,
+        boundary,
+        partIndexToLength,
+        () => {
+          finishedCount++
+          clearTimeout(timer)
+          resolve()
+        },
+        0
+      )
+      splitter.on("error", error => {
+        clearTimeout(timer)
+        reject(error)
+      })
+      // A finished splitter deliberately stops accepting data, so write without waiting for the trailing callbacks.
+      const writeFrom = (offset: number): void => {
+        if (offset >= body.length || finishedCount > 0) {
+          return
+        }
+        splitter.write(body.subarray(offset, offset + chunkSize), () => writeFrom(offset + chunkSize))
+      }
+      writeFrom(0)
+    })
+    expect(finishedCount).toBe(1)
+    return data()
+  }
+
+  const chunkSizes = [1, 2, 3, 5, 7, 16, 64, 1000, Number.MAX_SAFE_INTEGER]
+  const cases: Array<{ name: string; options: MultipartOptions }> = [
+    { name: "CRLF without leading line break", options: { eol: "\r\n", boundary: "3d6b6a416f9b5", leadingEol: false } },
+    { name: "CRLF with leading line break (nginx)", options: { eol: "\r\n", boundary: "00000000000000000001", leadingEol: true } },
+    // Qiniu CDN: bare LF line endings, quoted boundary containing a space and a colon, body starting with a line break
+    { name: "bare LF with leading line break (Qiniu)", options: { eol: "\n", boundary: "web cache:4af23fc9de0dc88ebd8552fbafe6f2a1", leadingEol: true } },
+    { name: "bare LF without leading line break", options: { eol: "\n", boundary: "lf-boundary", leadingEol: false } },
+  ]
+
+  for (const { name, options } of cases) {
+    test(`splits every part correctly: ${name}, any chunking`, async () => {
+      const tasks = makeTasks(12, fileSize)
+      const ranges = tasks.filter(task => task.kind === OperationKind.DOWNLOAD).map(task => [task.start, task.end - 1] as [number, number])
+      const body = multipartBody(ranges, newFile, options)
+      const expected = expectedOutput(tasks, oldFile, newFile)
+      for (const chunkSize of chunkSizes) {
+        const actual = await split(tasks, body, options.boundary, chunkSize)
+        expect(actual.equals(expected), `${name}, chunk size ${chunkSize}`).toBe(true)
+      }
+    })
+  }
+
+  describe("multiple batches", () => {
+    let server: Server | null = null
+
+    afterEach(async () => {
+      vi.useRealTimers()
+      if (server != null) {
+        server.closeAllConnections()
+        await new Promise<void>(resolve => server!.close(() => resolve()))
+        server = null
+      }
+    })
+
+    // The watchdog armed when a batch response ends must not fail the download while a later batch is still running.
+    test("a finished batch does not fail a slower next batch", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] })
+
+      // > 1000 operations => two range requests
+      const tasks = makeTasks(1200, 1200 * 6)
+      const bigNewFile = patternBuffer(1200 * 6, 3)
+      const bigOldFile = patternBuffer(1200 * 6, 4)
+      const bigOldFilePath = path.join(dir, "big-old.bin")
+      writeFileSync(bigOldFilePath, bigOldFile)
+      const bigOldFileFd = openSync(bigOldFilePath, "r")
+
+      const boundary = "batch-boundary"
+      const requests: Array<{ ranges: Array<[number, number]>; response: ServerResponse }> = []
+      let onRequest: (() => void) | null = null
+      server = createServer((req: IncomingMessage, res: ServerResponse) => {
+        const ranges = req.headers
+          .range!.slice("bytes=".length)
+          .split(", ")
+          .map(range => range.split("-").map(Number) as [number, number])
+        requests.push({ ranges, response: res })
+        onRequest?.()
+      })
+      await new Promise<void>(resolve => server!.listen(0, "127.0.0.1", resolve))
+      const port = (server.address() as AddressInfo).port
+
+      const respond = (index: number): void => {
+        const { ranges, response } = requests[index]
+        response.writeHead(206, { "Content-Type": `multipart/byteranges; boundary=${boundary}` })
+        response.end(multipartBody(ranges, bigNewFile, { eol: "\r\n", boundary, leadingEol: true }))
+      }
+      const waitForRequest = (count: number): Promise<void> =>
+        new Promise(resolve => {
+          const check = (): void => {
+            if (requests.length >= count) {
+              onRequest = null
+              resolve()
+            }
+          }
+          onRequest = check
+          check()
+        })
+
+      const differentialDownloader: any = {
+        fileMetadataBuffer: null,
+        options: { onProgress: undefined },
+        createRequestOptions: (): RequestOptions => ({ hostname: "127.0.0.1", port, path: "/new.bin", method: "GET", headers: {} }),
+        httpExecutor: {
+          createRequest: (options: RequestOptions, callback: (response: IncomingMessage) => void) => httpRequest(options, callback),
+          addErrorAndTimeoutHandlers: (request: any, reject: (error: Error) => void) => request.on("error", reject),
+        },
+      }
+
+      const { out, data } = collector()
+      let failure: Error | null = null
+      const finished = new Promise<void>(resolve => out.on("finish", resolve))
+      executeTasksUsingMultipleRangeRequests(differentialDownloader, tasks, out, bigOldFileFd, error => {
+        failure = error
+      })(0)
+
+      await waitForRequest(1)
+      respond(0)
+      // the second request is only sent after the first batch was fully handled
+      await waitForRequest(2)
+
+      // well past the 10s grace period of the first batch, while the second batch is still in flight
+      await vi.advanceTimersByTimeAsync(11_000)
+      expect(failure).toBeNull()
+
+      respond(1)
+      await finished
+      expect(failure).toBeNull()
+      expect(data().equals(expectedOutput(tasks, bigOldFile, bigNewFile))).toBe(true)
+      closeSync(bigOldFileFd)
+    })
+  })
+})


### PR DESCRIPTION
**Before:** `downloadUpdate` regularly abandons the differential path and re-downloads the whole installer with

```
Cannot download differentially, fallback to full download: Error: Response ends without calling any handlers
```

Three independent defects end in that same message.

**1. `DataSplitter` only recognises CRLF.** RFC 2046 requires CRLF, but real servers do not always send it. Qiniu CDN (`Server: openresty`, `Content-Type: multipart/byteranges; boundary="web cache:<hash>"`) answers multi-range requests with bare LF — the body starts `0a 2d 2d` (`\n--`), not `0d 0a 2d 2d`. `searchHeaderListEnd` looks for `\r\n\r\n` only, so not a single part is ever recognised: every chunk is appended to `headerListBuffer` (a `Buffer.concat` per chunk), the response ends without one `finishHandler` call, and the watchdog rejects 10s later. Measured on a 397 MB plan: ~1 GB RSS in the main process and zero bytes written before it gave up.

**2. A header-list terminator split across two chunks is never found.** `searchHeaderListEnd` searches only the new chunk; the bytes saved into `headerListBuffer` are never searched again. When a chunk boundary happens to fall inside `\r\n\r\n`, that part's header end is missed, the parser locks onto the next part's header, the output is misaligned and the final sha512 check fails — a full re-download, on a spec-compliant server. Tests that feed the whole body in one chunk cannot see this.

**3. The 10s watchdog outlives a successful batch.** With more than 1000 operations the plan is split into several range requests. `response.on("end")` arms `setTimeout(reject, 10000)` unconditionally and nothing clears it when that batch finishes, so a download whose *remaining* batches take longer than the grace period is failed while it is still making progress. The next batch reuses the same `reject`, so the stale timer takes the whole download down.

**After:**

- header lists end at whichever of `\r\n\r\n` / `\n\n` comes first, and the `<EOL>--boundary` separator length follows the line ending the server actually uses (`\r\n--` vs `\n--`);
- only the last few bytes of an unfinished header list are carried over and searched together with the next chunk — which also removes the unbounded buffering of the whole response;
- the watchdog is cleared once the batch has been fully handled.

**Tests** — `test/src/updater/differentialMultipartTest.ts`:

- CRLF and bare-LF bodies, with and without a leading line break, including a quoted boundary containing a space and a colon, each fed at chunk sizes 1, 2, 3, 5, 7, 16, 64, 1000 and all-at-once (chunk size 1 exercises every possible split of a terminator);
- a two-batch download against a local, spec-compliant HTTP server where the second batch outlives the grace period (fake timers advance 11s while it is still in flight).

All five fail on `master` today: the four splitter cases time out with `splitter did not finish (chunk size 1)`, the batch case fails with `Response ends without calling any handlers`.

**Real-world verification** (Windows, Electron 43.6.0 via `ElectronHttpExecutor`, 543 MB NSIS installer, Qiniu CDN, blockmap plan = 41% of the file):

| | upstream 6.8.9 | with this change |
| --- | --- | --- |
| differential download | `Response ends without calling any handlers` after 68s, then a full 543 MB download | OK in 41s; sha512 of the reconstructed installer matches the published one |

Also verified in the shipping app on a plan that needed two range requests (151 MB + 70 MB, the second one ~21s): it completes now and failed on the same build before the change.

A changeset is included (`electron-updater`, patch).
